### PR TITLE
[codex] Workspace context foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,9 @@ eröffne ausschließlich auf localhost 3000 einen dev server. starte keine neuen
 - Git history has a single initial commit; no enforced convention.
 - Use short, descriptive commit messages (e.g., `Fix terminal copy on iPad`).
 - PRs should include: summary, screenshots for UI changes, and steps to verify.
+- Before any PR is merged into `main`, run a `greploop` review for that PR and document the resulting score in the PR.
+- Only PRs with a `greploop` score of 4 or 5 may be merged into `main`; scores 1-3 block the merge until the issues are fixed and `greploop` is rerun.
+- If `greploop` is unavailable or cannot produce a score, treat the PR as blocked for merge into `main`.
 
 ## Security & Configuration Tips
 - Production uses `systemd` (`canvas-notebook.service`).

--- a/app/api/files/copy/route.ts
+++ b/app/api/files/copy/route.ts
@@ -8,12 +8,13 @@ import {
   jsonServerError,
   jsonSuccess,
   readJsonBody,
-  requireApiSession,
 } from '@/app/lib/api/route-helpers';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export async function POST(request: NextRequest) {
-  const unauthorized = await requireApiSession(request);
-  if (unauthorized) return unauthorized;
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canWrite' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const rateLimitResponse = applyRateLimit(request, {
@@ -44,7 +45,7 @@ export async function POST(request: NextRequest) {
       return jsonError(`Protected app output folder(s) cannot be copied: ${protectedPaths.join(', ')}`, 403);
     }
 
-    const result = await batchCopy(sources, destDir, overwrite, renameOnCollision);
+    const result = await batchCopy(sources, destDir, overwrite, renameOnCollision, fileOptions);
 
     invalidateWorkspaceFileViews({ subtreeDirs: [destDir] });
 

--- a/app/api/files/copy/route.ts
+++ b/app/api/files/copy/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
 
     const result = await batchCopy(sources, destDir, overwrite, renameOnCollision, fileOptions);
 
-    invalidateWorkspaceFileViews({ subtreeDirs: [destDir] });
+    invalidateWorkspaceFileViews({ fileOptions, subtreeDirs: [destDir] });
 
     return jsonSuccess({
       copied: result.copied,

--- a/app/api/files/create/route.ts
+++ b/app/api/files/create/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
       return jsonError('Invalid type', 400);
     }
 
-    invalidateWorkspaceFileViews({ fullTree: true });
+    invalidateWorkspaceFileViews({ fileOptions, fullTree: true });
 
     return jsonSuccess();
   } catch (error) {

--- a/app/api/files/create/route.ts
+++ b/app/api/files/create/route.ts
@@ -8,12 +8,13 @@ import {
   jsonServerError,
   jsonSuccess,
   readJsonBody,
-  requireApiSession,
 } from '@/app/lib/api/route-helpers';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export async function POST(request: NextRequest) {
-  const unauthorized = await requireApiSession(request);
-  if (unauthorized) return unauthorized;
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canWrite' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const rateLimitResponse = applyRateLimit(request, {
@@ -35,13 +36,14 @@ export async function POST(request: NextRequest) {
     }
 
     if (type === 'directory') {
-      await createDirectory(path);
+      await createDirectory(path, fileOptions);
     } else if (type === 'file') {
       await writeFile(
         path,
         template === 'excalidraw' || isExcalidrawFilePath(path)
           ? createEmptyExcalidrawFileContent()
-          : ''
+          : '',
+        fileOptions
       );
     } else {
       return jsonError('Invalid type', 400);

--- a/app/api/files/delete/route.ts
+++ b/app/api/files/delete/route.ts
@@ -10,12 +10,13 @@ import {
   jsonServerError,
   jsonSuccess,
   readJsonBody,
-  requireApiSession,
 } from '@/app/lib/api/route-helpers';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export async function DELETE(request: NextRequest) {
-  const unauthorized = await requireApiSession(request);
-  if (unauthorized) return unauthorized;
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canDelete' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const rateLimitResponse = applyRateLimit(request, {
@@ -40,7 +41,7 @@ export async function DELETE(request: NextRequest) {
       return jsonError(`Protected app output folder(s) cannot be deleted: ${protectedPaths.join(', ')}`, 403);
     }
 
-    const result = await batchDelete(pathsToDelete);
+    const result = await batchDelete(pathsToDelete, fileOptions);
     await syncPublicSharesAfterDelete(result.deleted);
 
     invalidateWorkspaceFileViews({

--- a/app/api/files/delete/route.ts
+++ b/app/api/files/delete/route.ts
@@ -45,6 +45,7 @@ export async function DELETE(request: NextRequest) {
     await syncPublicSharesAfterDelete(result.deleted);
 
     invalidateWorkspaceFileViews({
+      fileOptions,
       subtreeDirs: result.deleted.map(getParentDirectory),
     });
 

--- a/app/api/files/download/route.ts
+++ b/app/api/files/download/route.ts
@@ -3,10 +3,10 @@ import { createReadStream as createNodeReadStream, promises as fs } from 'fs';
 import path from 'path';
 import { createReadStream, getFileStats, validatePath } from '@/app/lib/filesystem/workspace-files';
 import { Readable } from 'stream';
-import { auth } from '@/app/lib/auth';
 import ZipStream from 'zip-stream';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 import { isAdminUser } from '@/app/lib/admin-auth';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const MAX_ZIP_DOWNLOAD_SIZE = 1024 * 1024 * 1024;
 const MAX_SINGLE_FILE_SIZE = 2 * 1024 * 1024 * 1024;
@@ -101,10 +101,10 @@ function createZipResponse(fullPath: string, downloadName: string) {
 }
 
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const { session, workspace } = workspaceResult;
+  const fileOptions = workspaceFileOptions(workspace);
 
   const limited = rateLimit(request, {
     limit: 30,
@@ -144,7 +144,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const stats = await getFileStats(filePath);
+    const stats = await getFileStats(filePath, fileOptions);
     const downloadName = resolveDownloadName(filePath);
 
     if (stats.isDirectory) {
@@ -155,7 +155,7 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      const fullPath = validatePath(filePath);
+      const fullPath = validatePath(filePath, fileOptions);
       return createZipResponse(fullPath, downloadName);
     } else {
       if (stats.size > MAX_SINGLE_FILE_SIZE) {
@@ -165,7 +165,7 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      const { stream } = await createReadStream(filePath);
+      const { stream } = await createReadStream(filePath, undefined, fileOptions);
       const webStream = Readable.toWeb(stream) as ReadableStream<Uint8Array>;
 
       return new NextResponse(webStream, {

--- a/app/api/files/exists/route.ts
+++ b/app/api/files/exists/route.ts
@@ -1,17 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getFileStats } from '@/app/lib/filesystem/workspace-files';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
-import { auth } from '@/app/lib/auth';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 function hasNodeErrorCode(error: unknown, code: string): boolean {
   return Boolean(error && typeof error === 'object' && 'code' in error && error.code === code);
 }
 
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const limited = rateLimit(request, {
@@ -33,7 +32,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const stats = await getFileStats(path);
+    const stats = await getFileStats(path, fileOptions);
 
     return NextResponse.json({
       success: true,

--- a/app/api/files/html-pdf/route.ts
+++ b/app/api/files/html-pdf/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/app/lib/auth';
 import { getFileStats } from '@/app/lib/filesystem/workspace-files';
 import { generatePdfFromUrl } from '@/app/lib/pdf/browser';
 import { toHtmlPreviewUrl } from '@/app/lib/utils/media-url';
 import path from 'path';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const PDF_TIMEOUT_MS = 30_000;
 
@@ -18,10 +18,9 @@ function getInternalRenderOrigin(requestUrl: string) {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const body = await request.json().catch(() => null);
@@ -42,7 +41,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    await getFileStats(filePath);
+    await getFileStats(filePath, fileOptions);
 
     const origin = getInternalRenderOrigin(request.url);
     const fileName = path.basename(filePath, ext);

--- a/app/api/files/list/route.ts
+++ b/app/api/files/list/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/app/lib/auth';
 import { getCachedFileReferenceEntries } from '@/app/lib/filesystem/file-reference-cache';
 import { searchFileReferenceEntries } from '@/app/lib/filesystem/file-reference-search';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 import { getPublicShareAnnotations } from '@/app/lib/public-sharing/public-file-shares';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   const limited = rateLimit(request, { limit: 60, windowMs: 60_000, keyPrefix: 'files-list' });
   if (!limited.ok) return limited.response;
@@ -19,7 +18,7 @@ export async function GET(request: NextRequest) {
     const query = searchParams.get('q')?.toLowerCase() || '';
     const limit = parseInt(searchParams.get('limit') || '50', 10);
     
-    const allFiles = await getCachedFileReferenceEntries();
+    const allFiles = await getCachedFileReferenceEntries(false, fileOptions);
 
     const filteredFiles = searchFileReferenceEntries(allFiles, query);
     

--- a/app/api/files/markdown-export/route.ts
+++ b/app/api/files/markdown-export/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/app/lib/auth';
 import { getCachedMarkdownHtmlDocument } from '@/app/lib/pdf/markdown-export-cache';
 import path from 'path';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const { searchParams } = new URL(request.url);
@@ -28,7 +27,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const htmlDocument = await getCachedMarkdownHtmlDocument(filePath);
+    const htmlDocument = await getCachedMarkdownHtmlDocument(filePath, fileOptions);
 
     return new NextResponse(htmlDocument, {
       status: 200,

--- a/app/api/files/markdown-pdf/route.ts
+++ b/app/api/files/markdown-pdf/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/app/lib/auth';
 import { assertMarkdownPdfExportPath, getMarkdownPdfAttachmentName, renderMarkdownWorkspaceFileToPdf } from '@/app/lib/pdf/markdown-pdf';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const body = await request.json().catch(() => null);
@@ -28,7 +27,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const pdfBuffer = await renderMarkdownWorkspaceFileToPdf(filePath);
+    const pdfBuffer = await renderMarkdownWorkspaceFileToPdf(filePath, fileOptions);
 
     return new NextResponse(new Uint8Array(pdfBuffer), {
       status: 200,

--- a/app/api/files/marp-detect/route.ts
+++ b/app/api/files/marp-detect/route.ts
@@ -1,16 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'path';
-import { auth } from '@/app/lib/auth';
 import { getFileStats, readFile } from '@/app/lib/filesystem/workspace-files';
 import { isMarpMarkdown } from '@/app/lib/marp/detect';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const READ_SIZE_LIMIT = 512 * 1024;
 
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const { searchParams } = new URL(request.url);
@@ -25,12 +24,12 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ success: true, isMarp: false });
     }
 
-    const stats = await getFileStats(filePath);
+    const stats = await getFileStats(filePath, fileOptions);
     if (stats.size > READ_SIZE_LIMIT) {
       return NextResponse.json({ success: true, isMarp: isMarpMarkdown(filePath) });
     }
 
-    const content = (await readFile(filePath)).toString('utf-8');
+    const content = (await readFile(filePath, fileOptions)).toString('utf-8');
     return NextResponse.json({ success: true, isMarp: isMarpMarkdown(filePath, content) });
   } catch (error) {
     console.error('[API] Marp detect error:', error);

--- a/app/api/files/marp-images/route.ts
+++ b/app/api/files/marp-images/route.ts
@@ -3,11 +3,11 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import JSZip from 'jszip';
-import { auth } from '@/app/lib/auth';
 import { getFileStats, readFile } from '@/app/lib/filesystem/workspace-files';
 import { findChromiumExecutable } from '@/app/lib/pdf/browser';
 import { isMarpMarkdown } from '@/app/lib/marp/detect';
 import { getMarpExportBaseName, runMarpCli, writeMarpCliInput } from '@/app/lib/marp/cli';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const READ_SIZE_LIMIT = 5 * 1024 * 1024;
 
@@ -22,10 +22,9 @@ function getZipDownloadName(filePath: string, format: ImageFormat) {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   let tempDir: string | null = null;
 
@@ -47,12 +46,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'File must be a markdown file (.md, .markdown)' }, { status: 400 });
     }
 
-    const stats = await getFileStats(filePath);
+    const stats = await getFileStats(filePath, fileOptions);
     if (stats.size > READ_SIZE_LIMIT) {
       return NextResponse.json({ success: false, error: 'File is too large to export' }, { status: 413 });
     }
 
-    const markdown = (await readFile(filePath)).toString('utf-8');
+    const markdown = (await readFile(filePath, fileOptions)).toString('utf-8');
     if (!isMarpMarkdown(filePath, markdown)) {
       return NextResponse.json({ success: false, error: 'File is not a Marp slide deck' }, { status: 400 });
     }
@@ -62,6 +61,7 @@ export async function POST(request: NextRequest) {
       tempDir,
       filePath,
       markdown,
+      fileOptions,
     });
     const outputPath = path.join(tempDir, `slide.${format === 'jpeg' ? 'jpg' : 'png'}`);
     const chromiumPath = findChromiumExecutable();

--- a/app/api/files/marp-pdf/route.ts
+++ b/app/api/files/marp-pdf/route.ts
@@ -2,19 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { auth } from '@/app/lib/auth';
 import { getFileStats, readFile } from '@/app/lib/filesystem/workspace-files';
 import { getMarpExportBaseName, runMarpCli, writeMarpCliInput } from '@/app/lib/marp/cli';
 import { isMarpMarkdown } from '@/app/lib/marp/detect';
 import { findChromiumExecutable } from '@/app/lib/pdf/browser';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const READ_SIZE_LIMIT = 5 * 1024 * 1024;
 
 export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   let tempDir: string | null = null;
 
@@ -31,12 +30,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'File must be a markdown file (.md, .markdown)' }, { status: 400 });
     }
 
-    const stats = await getFileStats(filePath);
+    const stats = await getFileStats(filePath, fileOptions);
     if (stats.size > READ_SIZE_LIMIT) {
       return NextResponse.json({ success: false, error: 'File is too large to export' }, { status: 413 });
     }
 
-    const markdown = (await readFile(filePath)).toString('utf-8');
+    const markdown = (await readFile(filePath, fileOptions)).toString('utf-8');
     if (!isMarpMarkdown(filePath, markdown)) {
       return NextResponse.json({ success: false, error: 'File is not a Marp slide deck' }, { status: 400 });
     }
@@ -46,6 +45,7 @@ export async function POST(request: NextRequest) {
       tempDir,
       filePath,
       markdown,
+      fileOptions,
     });
     const outputPath = path.join(tempDir, 'slides.pdf');
     const chromiumPath = findChromiumExecutable();

--- a/app/api/files/marp-preview/route.ts
+++ b/app/api/files/marp-preview/route.ts
@@ -1,17 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'path';
-import { auth } from '@/app/lib/auth';
 import { getFileStats } from '@/app/lib/filesystem/workspace-files';
 import { isMarpMarkdown } from '@/app/lib/marp/detect';
 import { renderMarpMarkdownToHtmlDocument } from '@/app/lib/marp/render';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const READ_SIZE_LIMIT = 5 * 1024 * 1024;
 
 export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const body = await request.json().catch(() => null);
@@ -39,11 +38,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'File is too large to preview' }, { status: 413 });
     }
 
-    await getFileStats(filePath);
+    await getFileStats(filePath, fileOptions);
 
     const html = await renderMarpMarkdownToHtmlDocument(markdown, {
       filePath,
       title: path.basename(filePath),
+      fileOptions,
     });
 
     return new NextResponse(html, {

--- a/app/api/files/preview/route.ts
+++ b/app/api/files/preview/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'node:path';
 import { promises as fs } from 'fs';
-import { auth } from '@/app/lib/auth';
 import { resolveExistingWorkspacePath, validatePath } from '@/app/lib/filesystem/workspace-files';
 import { 
   resolveValidatedStudioEditPath,
@@ -17,6 +16,7 @@ import {
   renderCachedMediaPreview,
   resolvePreviewWidth,
 } from '@/app/lib/files/media-preview';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 function buildMediaUrl(filePath: string) {
   const encodedPath = filePath
@@ -50,10 +50,9 @@ export async function GET(request: NextRequest) {
       return limited.response;
     }
 
-    const session = await auth.api.getSession({ headers: request.headers });
-    if (!session) {
-      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-    }
+    const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+    if (workspaceResult.response) return workspaceResult.response;
+    const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
     const { searchParams } = new URL(request.url);
     const filePath = searchParams.get('path');
@@ -121,12 +120,12 @@ export async function GET(request: NextRequest) {
       fullPath = resolved;
     } else {
       try {
-        fullPath = await resolveExistingWorkspacePath(filePath);
+        fullPath = await resolveExistingWorkspacePath(filePath, fileOptions);
       } catch (error) {
         if (!(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')) {
           throw error;
         }
-        fullPath = validatePath(filePath);
+        fullPath = validatePath(filePath, fileOptions);
       }
     }
 

--- a/app/api/files/read/route.ts
+++ b/app/api/files/read/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readFile, getFileStats } from '@/app/lib/filesystem/workspace-files';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
-import { auth } from '@/app/lib/auth';
 import { isExcalidrawFilePath } from '@/app/lib/excalidraw-file';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const READ_SIZE_LIMIT = 5 * 1024 * 1024; // 5MB
 const EXCALIDRAW_READ_SIZE_LIMIT = 25 * 1024 * 1024; // embedded image data can make scenes larger
@@ -12,10 +12,9 @@ function hasNodeErrorCode(error: unknown, code: string): boolean {
 }
 
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const limited = rateLimit(request, {
@@ -37,7 +36,7 @@ export async function GET(request: NextRequest) {
       );
     }
     
-    const stats = await getFileStats(path);
+    const stats = await getFileStats(path, fileOptions);
     const metaOnly = searchParams.get('meta') === '1';
 
     if (metaOnly) {
@@ -63,7 +62,7 @@ export async function GET(request: NextRequest) {
         );
     }
 
-    const content = await readFile(path);
+    const content = await readFile(path, fileOptions);
     
     return NextResponse.json({
       success: true,

--- a/app/api/files/rename/route.ts
+++ b/app/api/files/rename/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
       if (overwrite && conflictError.code === 'FILE_EXISTS' && conflictError.type === 'file') {
         await renameFile(oldPath, newPath, true, fileOptions);
         await syncPublicSharesAfterMove(oldPath, newPath);
-        invalidateWorkspaceFileViews({ fullTree: true });
+        invalidateWorkspaceFileViews({ fileOptions, fullTree: true });
         return jsonSuccess();
       }
 
@@ -65,7 +65,7 @@ export async function POST(request: NextRequest) {
 
     await renameFile(oldPath, newPath, overwrite, fileOptions);
     await syncPublicSharesAfterMove(oldPath, newPath);
-    invalidateWorkspaceFileViews({ fullTree: true });
+    invalidateWorkspaceFileViews({ fileOptions, fullTree: true });
 
     return jsonSuccess();
   } catch (error) {

--- a/app/api/files/rename/route.ts
+++ b/app/api/files/rename/route.ts
@@ -9,8 +9,8 @@ import {
   jsonServerError,
   jsonSuccess,
   readJsonBody,
-  requireApiSession,
 } from '@/app/lib/api/route-helpers';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 interface RenameRequestBody {
   oldPath: string;
@@ -19,8 +19,9 @@ interface RenameRequestBody {
 }
 
 export async function POST(request: NextRequest) {
-  const unauthorized = await requireApiSession(request);
-  if (unauthorized) return unauthorized;
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: ['canWrite', 'canDelete'] });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const rateLimitResponse = applyRateLimit(request, {
@@ -44,11 +45,11 @@ export async function POST(request: NextRequest) {
     }
 
     // Check for conflicts first (for better error messages)
-    const conflict = await checkRenameConflict(oldPath, newPath);
+    const conflict = await checkRenameConflict(oldPath, newPath, fileOptions);
     if (conflict) {
       const conflictError = conflict as RenameConflictError;
       if (overwrite && conflictError.code === 'FILE_EXISTS' && conflictError.type === 'file') {
-        await renameFile(oldPath, newPath, true);
+        await renameFile(oldPath, newPath, true, fileOptions);
         await syncPublicSharesAfterMove(oldPath, newPath);
         invalidateWorkspaceFileViews({ fullTree: true });
         return jsonSuccess();
@@ -62,7 +63,7 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    await renameFile(oldPath, newPath, overwrite);
+    await renameFile(oldPath, newPath, overwrite, fileOptions);
     await syncPublicSharesAfterMove(oldPath, newPath);
     invalidateWorkspaceFileViews({ fullTree: true });
 

--- a/app/api/files/tree/route.ts
+++ b/app/api/files/tree/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { buildFileTree } from '@/app/lib/filesystem/workspace-files';
 import { buildFileTreeCacheKey, fileTreeCache } from '@/app/lib/utils/file-tree-cache';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
-import { auth } from '@/app/lib/auth';
 import { getPublicShareAnnotations } from '@/app/lib/public-sharing/public-file-shares';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 function collectFilePaths(nodes: Array<{ path: string; type: string; children?: unknown[] }>, result: string[] = []) {
   for (const node of nodes) {
@@ -34,10 +34,9 @@ function attachPublicShareAnnotations(
 }
 
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const limited = rateLimit(request, {
@@ -54,7 +53,7 @@ export async function GET(request: NextRequest) {
     const depth = parseInt(searchParams.get('depth') || '4');
     const noCache = searchParams.has('noCache');
 
-    const cacheKey = buildFileTreeCacheKey(path, depth);
+    const cacheKey = buildFileTreeCacheKey(path, depth, workspaceResult.workspace.workspaceId);
     if (!noCache) {
       const cached = fileTreeCache.get(cacheKey);
       if (cached) {
@@ -62,7 +61,7 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    const tree = await buildFileTree(path, depth);
+    const tree = await buildFileTree(path, depth, 0, fileOptions);
     const annotations = await getPublicShareAnnotations(collectFilePaths(tree));
     attachPublicShareAnnotations(tree, annotations);
     fileTreeCache.set(cacheKey, tree);

--- a/app/api/files/upload/route.ts
+++ b/app/api/files/upload/route.ts
@@ -149,8 +149,8 @@ export async function POST(request: NextRequest) {
     }
 
     await syncPublicSharesAfterWrite(uploadedPaths);
-    clearFileTreeCache();
-    invalidateFileReferenceCache();
+    clearFileTreeCache(fileOptions.workspace?.workspaceId);
+    invalidateFileReferenceCache(fileOptions);
 
     return NextResponse.json({ success: true, count: files.length, files: uploadedFiles });
   } catch (error) {

--- a/app/api/files/upload/route.ts
+++ b/app/api/files/upload/route.ts
@@ -4,11 +4,11 @@ import { writeFile, createDirectory } from '@/app/lib/filesystem/workspace-files
 import { clearFileTreeCache } from '@/app/lib/utils/file-tree-cache';
 import { invalidateFileReferenceCache } from '@/app/lib/filesystem/file-reference-cache';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
-import { auth } from '@/app/lib/auth';
 import { parseMultipartFormData } from '@/app/lib/api/form-data';
 import { getImageConversionErrorMessage } from '@/app/lib/images/convert';
 import { normalizeUploadImageBuffer, parseUploadConvertParams } from '@/app/lib/images/upload-conversion';
 import { syncPublicSharesAfterWrite } from '@/app/lib/public-sharing/public-file-shares';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const MAX_FILE_SIZE = 100 * 1024 * 1024;
 const MAX_TOTAL_SIZE = 500 * 1024 * 1024;
@@ -34,10 +34,9 @@ function sanitizeFilePath(filePath: string): string {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canWrite' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const limited = rateLimit(request, {
@@ -97,7 +96,7 @@ export async function POST(request: NextRequest) {
     const convertParamsList = parsedConvertParams.params;
 
     if (targetDir && targetDir !== '.') {
-      await createDirectory(targetDir);
+      await createDirectory(targetDir, fileOptions);
     }
 
     const uploadedFiles: string[] = [];
@@ -141,10 +140,10 @@ export async function POST(request: NextRequest) {
 
       const parentDir = path.posix.dirname(targetPath);
       if (parentDir !== '.' && parentDir !== targetDir && parentDir !== '/') {
-        await createDirectory(parentDir);
+        await createDirectory(parentDir, fileOptions);
       }
 
-      await writeFile(targetPath, normalized.buffer);
+      await writeFile(targetPath, normalized.buffer, fileOptions);
       uploadedFiles.push(filename);
       uploadedPaths.push(targetPath);
     }

--- a/app/api/files/workspace-stats/route.ts
+++ b/app/api/files/workspace-stats/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'path';
 import { promises as fs } from 'fs';
-import { auth } from '@/app/lib/auth';
-
-const DATA = process.env.DATA || path.join(process.cwd(), 'data');
-const WORKSPACE_BASE_DIR = path.join(DATA, 'workspace');
+import { requireRequestWorkspace } from '@/app/lib/workspaces/request';
 
 const IGNORED_DIRS = new Set(['node_modules', '.next', '.git', 'dist', 'build', '.cache']);
 
@@ -47,13 +44,11 @@ function formatSize(bytes: number): string {
 }
 
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
 
   try {
-    const { fileCount, totalSize } = await calculateStats(WORKSPACE_BASE_DIR);
+    const { fileCount, totalSize } = await calculateStats(workspaceResult.workspace.rootPath);
     return NextResponse.json({
       success: true,
       data: {

--- a/app/api/files/write/route.ts
+++ b/app/api/files/write/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
     }
 
     await writeFile(path, finalContent, fileOptions);
-    invalidateWorkspaceFileViews({ subtreeDirs: [getParentDirectory(path)] });
+    invalidateWorkspaceFileViews({ fileOptions, subtreeDirs: [getParentDirectory(path)] });
     queuePublicSharesAfterWrite([path]);
 
     return jsonSuccess();

--- a/app/api/files/write/route.ts
+++ b/app/api/files/write/route.ts
@@ -9,13 +9,14 @@ import {
   jsonServerError,
   jsonSuccess,
   readJsonBody,
-  requireApiSession,
 } from '@/app/lib/api/route-helpers';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export async function POST(request: NextRequest) {
   try {
-    const unauthorized = await requireApiSession(request);
-    if (unauthorized) return unauthorized;
+    const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canWrite' });
+    if (workspaceResult.response) return workspaceResult.response;
+    const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
     const rateLimitResponse = applyRateLimit(request, {
       limit: 20,
@@ -37,7 +38,7 @@ export async function POST(request: NextRequest) {
       finalContent = Buffer.from(content.substring(7), 'base64');
     }
 
-    await writeFile(path, finalContent);
+    await writeFile(path, finalContent, fileOptions);
     invalidateWorkspaceFileViews({ subtreeDirs: [getParentDirectory(path)] });
     queuePublicSharesAfterWrite([path]);
 

--- a/app/api/markdown/images/import/route.ts
+++ b/app/api/markdown/images/import/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/app/lib/auth';
 import { parseMultipartFormData } from '@/app/lib/api/form-data';
 import {
   fetchMarkdownImageUrl,
@@ -9,6 +8,7 @@ import {
 } from '@/app/lib/markdown/markdown-image-import';
 import { parseUploadConvertParams } from '@/app/lib/images/upload-conversion';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export const runtime = 'nodejs';
 
@@ -17,10 +17,9 @@ function isUploadFile(value: FormDataEntryValue): value is File {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canWrite' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   try {
     const limited = rateLimit(request, {
@@ -72,6 +71,7 @@ export async function POST(request: NextRequest) {
       images,
       markdownFilePath,
       targetDir,
+      fileOptions,
     });
 
     return NextResponse.json({ success: true, files: imported });

--- a/app/api/media/[...path]/route.ts
+++ b/app/api/media/[...path]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getFileStats, createReadStream } from '@/app/lib/filesystem/workspace-files';
-import { auth } from '@/app/lib/auth';
 import { Readable } from 'stream';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const MEDIA_TYPES: Record<string, string> = {
   pdf: 'application/pdf',
@@ -49,17 +49,16 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ path: string[] }> }
 ) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   const { path: pathParts } = await context.params;
   const filePath = pathParts.join('/');
   const contentType = getContentType(filePath);
 
   try {
-    const stats = await getFileStats(filePath);
+    const stats = await getFileStats(filePath, fileOptions);
     const fileSize = stats.size;
     const range = request.headers.get('range');
 
@@ -81,7 +80,7 @@ export async function GET(
       }
       const chunksize = end - start + 1;
       
-      const { stream } = await createReadStream(filePath, { start, end });
+      const { stream } = await createReadStream(filePath, { start, end }, fileOptions);
       const webStream = Readable.toWeb(stream) as unknown as ReadableStream<Uint8Array>;
 
       const headers = new Headers({
@@ -97,7 +96,7 @@ export async function GET(
 
       return new NextResponse(webStream, { status: 206, headers });
     } else {
-      const { stream } = await createReadStream(filePath);
+      const { stream } = await createReadStream(filePath, undefined, fileOptions);
       const webStream = Readable.toWeb(stream) as unknown as ReadableStream<Uint8Array>;
       
       const headers = new Headers({

--- a/app/api/media/preview/[...path]/route.ts
+++ b/app/api/media/preview/[...path]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getFileStats, createReadStream, readFile } from '@/app/lib/filesystem/workspace-files';
-import { auth } from '@/app/lib/auth';
 import { Readable } from 'stream';
 import {
   createHtmlPreviewDocument,
@@ -9,12 +8,13 @@ import {
   HTML_PREVIEW_CSP,
   isHtmlFile,
 } from '@/app/lib/html-preview';
+import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 const WORKSPACE_HTML_PREVIEW_PREFIX = '/api/media/preview';
 
-async function streamPreviewAsset(filePath: string) {
-  const stats = await getFileStats(filePath);
-  const { stream } = await createReadStream(filePath);
+async function streamPreviewAsset(filePath: string, fileOptions: ReturnType<typeof workspaceFileOptions>) {
+  const stats = await getFileStats(filePath, fileOptions);
+  const { stream } = await createReadStream(filePath, undefined, fileOptions);
   const webStream = Readable.toWeb(stream) as unknown as ReadableStream<Uint8Array>;
 
   return new NextResponse(webStream, {
@@ -32,20 +32,19 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ path: string[] }> }
 ) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
 
   const { path: pathParts } = await context.params;
   const filePath = pathParts.join('/');
 
   try {
     if (!isHtmlFile(filePath)) {
-      return await streamPreviewAsset(filePath);
+      return await streamPreviewAsset(filePath, fileOptions);
     }
 
-    const html = (await readFile(filePath)).toString('utf-8');
+    const html = (await readFile(filePath, fileOptions)).toString('utf-8');
     const document = createHtmlPreviewDocument(html, filePath, WORKSPACE_HTML_PREVIEW_PREFIX);
     const body = Buffer.from(document, 'utf-8');
     const headers = new Headers({

--- a/app/api/skills/reset/route.ts
+++ b/app/api/skills/reset/route.ts
@@ -1,0 +1,33 @@
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+import { auth } from '@/app/lib/auth';
+import { resetCanvasSkillsDirectory } from '@/app/lib/skills/canvas-skill-store';
+
+const RESET_CONFIRMATION = 'DELETE_SKILLS';
+
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json().catch(() => ({})) as { confirm?: unknown };
+    if (body.confirm !== RESET_CONFIRMATION) {
+      return NextResponse.json(
+        { success: false, error: `Type ${RESET_CONFIRMATION} to reset all skills.` },
+        { status: 400 },
+      );
+    }
+
+    const result = await resetCanvasSkillsDirectory(session.user.email || 'unknown');
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('[Skills API] Error resetting skills directory:', error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Failed to reset skills directory' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/skills/reset/route.ts
+++ b/app/api/skills/reset/route.ts
@@ -1,6 +1,7 @@
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 
+import { isAdminUser } from '@/app/lib/admin-auth';
 import { auth } from '@/app/lib/auth';
 import { resetCanvasSkillsDirectory } from '@/app/lib/skills/canvas-skill-store';
 
@@ -10,6 +11,9 @@ export async function POST(request: Request) {
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!isAdminUser(session.user)) {
+    return NextResponse.json({ success: false, error: 'Forbidden: admin only' }, { status: 403 });
   }
 
   try {

--- a/app/api/skills/reset/route.ts
+++ b/app/api/skills/reset/route.ts
@@ -1,20 +1,14 @@
-import { headers } from 'next/headers';
+import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-import { isAdminUser } from '@/app/lib/admin-auth';
-import { auth } from '@/app/lib/auth';
 import { resetCanvasSkillsDirectory } from '@/app/lib/skills/canvas-skill-store';
+import { requireRequestWorkspace } from '@/app/lib/workspaces/request';
 
 const RESET_CONFIRMATION = 'DELETE_SKILLS';
 
-export async function POST(request: Request) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
-  if (!isAdminUser(session.user)) {
-    return NextResponse.json({ success: false, error: 'Forbidden: admin only' }, { status: 403 });
-  }
+export async function POST(request: NextRequest) {
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canManageWorkspace' });
+  if (workspaceResult.response) return workspaceResult.response;
 
   try {
     const body = await request.json().catch(() => ({})) as { confirm?: unknown };
@@ -25,7 +19,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const result = await resetCanvasSkillsDirectory(session.user.email || 'unknown');
+    const result = await resetCanvasSkillsDirectory(workspaceResult.session.user.email || 'unknown');
     return NextResponse.json(result);
   } catch (error) {
     console.error('[Skills API] Error resetting skills directory:', error);

--- a/app/components/settings/SkillsPanel.tsx
+++ b/app/components/settings/SkillsPanel.tsx
@@ -1841,6 +1841,8 @@ export function SkillsPanel() {
   const [selectedSkill, setSelectedSkill] = useState<CanvasSkill | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
+  const [resetSkillsOpen, setResetSkillsOpen] = useState(false);
+  const [resetSkillsConfirm, setResetSkillsConfirm] = useState('');
   const [panelTab, setPanelTab] = useState<SkillsPanelTab>(() => readStoredTab(
     PANEL_TAB_STORAGE_KEY,
     ['plugins', 'skills'] as const,
@@ -2120,6 +2122,37 @@ export function SkillsPanel() {
       await loadSkillStore();
     } catch (error) {
       setSkillActionError(error instanceof Error ? error.message : t('detail.errors.deleteFailed'));
+    } finally {
+      setPendingSkillAction(null);
+    }
+  }
+
+  async function resetAllSkills() {
+    if (resetSkillsConfirm !== 'DELETE_SKILLS') return;
+
+    setPendingSkillAction('reset:all');
+    setSkillActionError(null);
+    try {
+      const response = await fetch('/api/skills/reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirm: resetSkillsConfirm }),
+      });
+      const data = await response.json();
+      if (!data.success) {
+        throw new Error(data.error || t('skillLibrary.errors.resetAll'));
+      }
+      setSelectedSkill(null);
+      setSelectedPath(null);
+      setRightView('info');
+      setExpandedDirs(new Set());
+      setResetSkillsOpen(false);
+      setResetSkillsConfirm('');
+      await loadSkills();
+      await loadSkillTree();
+      await loadSkillStore();
+    } catch (error) {
+      setSkillActionError(error instanceof Error ? error.message : t('skillLibrary.errors.resetAll'));
     } finally {
       setPendingSkillAction(null);
     }
@@ -2458,6 +2491,64 @@ export function SkillsPanel() {
                     <Upload className="h-3.5 w-3.5" />
                     {t('upload.button')}
                   </Button>
+                  <AlertDialog
+                    open={resetSkillsOpen}
+                    onOpenChange={(open) => {
+                      setResetSkillsOpen(open);
+                      if (!open) setResetSkillsConfirm('');
+                    }}
+                  >
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={pendingSkillAction === 'reset:all'}
+                        className="gap-1.5 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        {pendingSkillAction === 'reset:all' ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-3.5 w-3.5" />
+                        )}
+                        {t('skillLibrary.resetAll.button')}
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>{t('skillLibrary.resetAll.title')}</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          {t('skillLibrary.resetAll.description')}
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <div className="space-y-2">
+                        <p className="text-sm text-muted-foreground">
+                          {t('skillLibrary.resetAll.confirmLabel', { confirmation: 'DELETE_SKILLS' })}
+                        </p>
+                        <Input
+                          value={resetSkillsConfirm}
+                          onChange={(event) => setResetSkillsConfirm(event.target.value)}
+                          placeholder="DELETE_SKILLS"
+                          autoComplete="off"
+                        />
+                      </div>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>{t('skillLibrary.resetAll.cancel')}</AlertDialogCancel>
+                        <AlertDialogAction
+                          variant="destructive"
+                          disabled={resetSkillsConfirm !== 'DELETE_SKILLS' || pendingSkillAction === 'reset:all'}
+                          onClick={(event) => {
+                            event.preventDefault();
+                            void resetAllSkills();
+                          }}
+                        >
+                          {pendingSkillAction === 'reset:all' ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : null}
+                          {t('skillLibrary.resetAll.confirm')}
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </div>
 
                 <div

--- a/app/lib/api/route-helpers.ts
+++ b/app/lib/api/route-helpers.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/app/lib/auth';
 import { invalidateFileReferenceCache } from '@/app/lib/filesystem/file-reference-cache';
+import type { WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 import { clearFileTreeCache, clearSubtreeCache } from '@/app/lib/utils/file-tree-cache';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 
@@ -11,6 +12,7 @@ interface RateLimitOptions {
 }
 
 interface InvalidateWorkspaceFileViewsOptions {
+  fileOptions?: WorkspaceFileOperationOptions;
   fullTree?: boolean;
   subtreeDirs?: Iterable<string>;
   references?: boolean;
@@ -45,19 +47,21 @@ export function jsonServerError(scope: string, error: unknown, fallbackMessage: 
 }
 
 export function invalidateWorkspaceFileViews({
+  fileOptions,
   fullTree = false,
   subtreeDirs = [],
   references = true,
 }: InvalidateWorkspaceFileViewsOptions = {}): void {
+  const workspaceId = fileOptions?.workspace?.workspaceId;
   if (fullTree) {
-    clearFileTreeCache();
+    clearFileTreeCache(workspaceId);
   }
 
   for (const dirPath of subtreeDirs) {
-    clearSubtreeCache(dirPath);
+    clearSubtreeCache(dirPath, workspaceId);
   }
 
   if (references) {
-    invalidateFileReferenceCache();
+    invalidateFileReferenceCache(fileOptions);
   }
 }

--- a/app/lib/filesystem/file-reference-cache.ts
+++ b/app/lib/filesystem/file-reference-cache.ts
@@ -1,4 +1,4 @@
-import { listDirectory } from './workspace-files';
+import { listDirectory, type WorkspaceFileOperationOptions } from './workspace-files';
 import type { FileReferenceEntry } from './file-reference-search';
 
 const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp']);
@@ -9,18 +9,25 @@ interface FileReferenceCacheEntry {
   entries: FileReferenceEntry[];
 }
 
-let cacheEntry: FileReferenceCacheEntry | null = null;
-let pendingBuild: Promise<FileReferenceEntry[]> | null = null;
+const cacheEntries = new Map<string, FileReferenceCacheEntry>();
+const pendingBuilds = new Map<string, Promise<FileReferenceEntry[]>>();
 
-async function collectFilesRecursive(dirPath: string): Promise<FileReferenceEntry[]> {
+function getWorkspaceCacheKey(options?: WorkspaceFileOperationOptions): string {
+  return options?.workspace?.workspaceId ?? 'legacy';
+}
+
+async function collectFilesRecursive(
+  dirPath: string,
+  options?: WorkspaceFileOperationOptions
+): Promise<FileReferenceEntry[]> {
   try {
-    const entries = await listDirectory(dirPath);
+    const entries = await listDirectory(dirPath, options);
     const files: FileReferenceEntry[] = [];
 
     for (const entry of entries) {
       if (entry.type === 'directory') {
         try {
-          const subFiles = await collectFilesRecursive(entry.path);
+          const subFiles = await collectFilesRecursive(entry.path, options);
           files.push(...subFiles);
         } catch {
           // Skip directories we can't read.
@@ -46,31 +53,38 @@ async function collectFilesRecursive(dirPath: string): Promise<FileReferenceEntr
 }
 
 export function invalidateFileReferenceCache(): void {
-  cacheEntry = null;
-  pendingBuild = null;
+  cacheEntries.clear();
+  pendingBuilds.clear();
 }
 
-export async function getCachedFileReferenceEntries(forceRefresh = false): Promise<FileReferenceEntry[]> {
+export async function getCachedFileReferenceEntries(
+  forceRefresh = false,
+  options?: WorkspaceFileOperationOptions
+): Promise<FileReferenceEntry[]> {
+  const cacheKey = getWorkspaceCacheKey(options);
   const now = Date.now();
+  const cacheEntry = cacheEntries.get(cacheKey);
   if (!forceRefresh && cacheEntry && cacheEntry.expiresAt > now) {
     return cacheEntry.entries;
   }
 
+  const pendingBuild = pendingBuilds.get(cacheKey);
   if (pendingBuild) {
     return pendingBuild;
   }
 
-  pendingBuild = collectFilesRecursive('.')
+  const nextBuild = collectFilesRecursive('.', options)
     .then((entries) => {
-      cacheEntry = {
+      cacheEntries.set(cacheKey, {
         entries,
         expiresAt: Date.now() + FILE_REFERENCE_CACHE_TTL_MS,
-      };
+      });
       return entries;
     })
     .finally(() => {
-      pendingBuild = null;
+      pendingBuilds.delete(cacheKey);
     });
 
-  return pendingBuild;
+  pendingBuilds.set(cacheKey, nextBuild);
+  return nextBuild;
 }

--- a/app/lib/filesystem/file-reference-cache.ts
+++ b/app/lib/filesystem/file-reference-cache.ts
@@ -52,9 +52,16 @@ async function collectFilesRecursive(
   }
 }
 
-export function invalidateFileReferenceCache(): void {
-  cacheEntries.clear();
-  pendingBuilds.clear();
+export function invalidateFileReferenceCache(options?: WorkspaceFileOperationOptions): void {
+  if (!options?.workspace) {
+    cacheEntries.clear();
+    pendingBuilds.clear();
+    return;
+  }
+
+  const cacheKey = getWorkspaceCacheKey(options);
+  cacheEntries.delete(cacheKey);
+  pendingBuilds.delete(cacheKey);
 }
 
 export async function getCachedFileReferenceEntries(

--- a/app/lib/filesystem/file-watcher.ts
+++ b/app/lib/filesystem/file-watcher.ts
@@ -3,9 +3,12 @@ import path from 'path';
 import { clearFileTreeCache, clearSubtreeCache } from '@/app/lib/utils/file-tree-cache';
 import { invalidateFileReferenceCache } from '@/app/lib/filesystem/file-reference-cache';
 import { validatePath } from '@/app/lib/filesystem/workspace-files';
+import { createLegacyPersonalWorkspaceContext } from '@/app/lib/workspaces/context';
 
 const DATA = process.env.DATA || path.join(process.cwd(), 'data');
 const WORKSPACE_BASE_DIR = path.join(DATA, 'workspace');
+const LEGACY_WORKSPACE_FILE_OPTIONS = { workspace: createLegacyPersonalWorkspaceContext() };
+const LEGACY_WORKSPACE_ID = LEGACY_WORKSPACE_FILE_OPTIONS.workspace.workspaceId;
 
 const IGNORED_PATTERNS = [
   'node_modules',
@@ -299,8 +302,8 @@ class FileWatcherService {
       const dirPath = event.relativePath.includes('/')
         ? event.relativePath.substring(0, event.relativePath.lastIndexOf('/'))
         : '.';
-      clearSubtreeCache(dirPath);
-      invalidateFileReferenceCache();
+      clearSubtreeCache(dirPath, LEGACY_WORKSPACE_ID);
+      invalidateFileReferenceCache(LEGACY_WORKSPACE_FILE_OPTIONS);
       this.broadcastEvent({ ...event, dir: dirPath });
     }
 
@@ -395,7 +398,7 @@ class FileWatcherService {
   }
 
   public forceRefresh(): void {
-    clearFileTreeCache();
+    clearFileTreeCache(LEGACY_WORKSPACE_ID);
     this.broadcastEvent({
       type: 'change',
       path: WORKSPACE_BASE_DIR,

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -2,105 +2,60 @@ import {createReadStream as createLocalReadStream, promises as fs, accessSync} f
 import path from 'path';
 import {Readable} from 'stream';
 import type { FileNode } from '@/app/lib/files/types';
+import { createLegacyPersonalWorkspaceContext, resolveWorkspaceDataRoot } from '@/app/lib/workspaces/context';
+import {
+  ensureWorkspaceRoot,
+  resolveDirectoryCreationPath as resolveDirectoryCreationPathForContext,
+  resolveExistingWorkspacePath as resolveExistingWorkspacePathForContext,
+  resolveWritableWorkspacePath as resolveWritableWorkspacePathForContext,
+  resolveWorkspacePath,
+} from '@/app/lib/workspaces/path-guard';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
 
 export type { FileNode } from '@/app/lib/files/types';
 
-function getRuntimeCwd(): string {
-  return Reflect.apply(process.cwd, process, []) as string;
+export interface WorkspaceFileOperationOptions {
+  workspace?: WorkspaceContext;
 }
 
 function getDataDir(): string {
-  const configuredDataDir = process.env.DATA?.trim();
-  if (!configuredDataDir || configuredDataDir === './data' || configuredDataDir === 'data') {
-    return path.join(getRuntimeCwd(), 'data');
-  }
-
-  if (path.isAbsolute(configuredDataDir)) {
-    return configuredDataDir;
-  }
-
-  return path.join(getRuntimeCwd(), 'data');
+  return resolveWorkspaceDataRoot();
 }
 
-function getWorkspaceBaseDir(): string {
-  return path.join(getDataDir(), 'workspace');
+function getWorkspace(options?: WorkspaceFileOperationOptions): WorkspaceContext {
+  return options?.workspace ?? createLegacyPersonalWorkspaceContext();
 }
 
 const IGNORED_WORKSPACE_DIRS = new Set(['node_modules', '.next', '.git', 'dist', 'build', '.cache']);
 const HIDDEN_WORKSPACE_METADATA_FILES = new Set(['.gitkeep', '.keep']);
 
-export function validatePath(userPath: string): string {
-  const normalizedBase = path.resolve(getWorkspaceBaseDir());
-  const normalizedPath = path.resolve(normalizedBase, userPath);
-
-  if (normalizedPath !== normalizedBase && !normalizedPath.startsWith(`${normalizedBase}${path.sep}`)) {
-    throw new Error('Invalid path: directory traversal attempt detected');
-  }
-
-  return normalizedPath;
+export function validatePath(userPath: string, options?: WorkspaceFileOperationOptions): string {
+  return resolveWorkspacePath(getWorkspace(options), userPath).absolutePath;
 }
 
-function assertWithinBase(candidatePath: string, basePath: string) {
-  if (candidatePath !== basePath && !candidatePath.startsWith(`${basePath}${path.sep}`)) {
-    throw new Error('Invalid path: directory traversal attempt detected');
-  }
+async function getWorkspaceRealBase(options?: WorkspaceFileOperationOptions): Promise<string> {
+  return ensureWorkspaceRoot(getWorkspace(options));
 }
 
-async function getWorkspaceRealBase(): Promise<string> {
-  const basePath = validatePath('.');
-  await fs.mkdir(basePath, {recursive: true});
-  return fs.realpath(basePath);
+export async function resolveExistingWorkspacePath(
+  userPath: string,
+  options?: WorkspaceFileOperationOptions
+): Promise<string> {
+  return resolveExistingWorkspacePathForContext(getWorkspace(options), userPath);
 }
 
-export async function resolveExistingWorkspacePath(userPath: string): Promise<string> {
-  const candidatePath = validatePath(userPath);
-  const realBase = await getWorkspaceRealBase();
-  const realPath = await fs.realpath(candidatePath);
-  assertWithinBase(realPath, realBase);
-  return realPath;
+async function resolveWritableWorkspacePath(
+  userPath: string,
+  options?: WorkspaceFileOperationOptions
+): Promise<string> {
+  return resolveWritableWorkspacePathForContext(getWorkspace(options), userPath);
 }
 
-async function resolveWritableWorkspacePath(userPath: string): Promise<string> {
-  const candidatePath = validatePath(userPath);
-  const realBase = await getWorkspaceRealBase();
-  const parentPath = path.dirname(candidatePath);
-  const realParent = await fs.realpath(parentPath);
-  assertWithinBase(realParent, realBase);
-
-  try {
-    const realExistingPath = await fs.realpath(candidatePath);
-    assertWithinBase(realExistingPath, realBase);
-  } catch (error) {
-    if (error && typeof error === 'object' && 'code' in error && error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  return candidatePath;
-}
-
-async function resolveDirectoryCreationPath(userPath: string): Promise<string> {
-  const candidatePath = validatePath(userPath);
-  const realBase = await getWorkspaceRealBase();
-  let current = path.dirname(candidatePath);
-
-  while (current !== path.dirname(current)) {
-    try {
-      const realCurrent = await fs.realpath(current);
-      assertWithinBase(realCurrent, realBase);
-      return candidatePath;
-    } catch (error) {
-      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
-        const next = path.dirname(current);
-        if (next === current) break;
-        current = next;
-        continue;
-      }
-      throw error;
-    }
-  }
-
-  throw new Error('Invalid path: parent directory is outside workspace');
+async function resolveDirectoryCreationPath(
+  userPath: string,
+  options?: WorkspaceFileOperationOptions
+): Promise<string> {
+  return resolveDirectoryCreationPathForContext(getWorkspace(options), userPath);
 }
 
 function isAppOutputMetadataFile(_filePath: string, fileName: string): boolean {
@@ -108,8 +63,11 @@ function isAppOutputMetadataFile(_filePath: string, fileName: string): boolean {
   return false;
 }
 
-export async function listDirectory(dirPath: string = '.'): Promise<FileNode[]> {
-  const fullPath = await resolveExistingWorkspacePath(dirPath);
+export async function listDirectory(
+  dirPath: string = '.',
+  options?: WorkspaceFileOperationOptions
+): Promise<FileNode[]> {
+  const fullPath = await resolveExistingWorkspacePath(dirPath, options);
   const entries = await fs.readdir(fullPath, {withFileTypes: true});
 
   return Promise.all(
@@ -147,8 +105,8 @@ export async function listDirectory(dirPath: string = '.'): Promise<FileNode[]> 
   );
 }
 
-export async function readFile(filePath: string): Promise<Buffer> {
-  const fullPath = await resolveExistingWorkspacePath(filePath);
+export async function readFile(filePath: string, options?: WorkspaceFileOperationOptions): Promise<Buffer> {
+  const fullPath = await resolveExistingWorkspacePath(filePath, options);
   return fs.readFile(fullPath);
 }
 
@@ -177,17 +135,22 @@ export async function getDataFileStats(filePath: string) {
 
 export async function createReadStream(
   filePath: string,
-  options?: {start?: number; end?: number; highWaterMark?: number}
+  options?: {start?: number; end?: number; highWaterMark?: number},
+  workspaceOptions?: WorkspaceFileOperationOptions
 ): Promise<{stream: Readable; close: () => Promise<void>}> {
-  const fullPath = await resolveExistingWorkspacePath(filePath);
+  const fullPath = await resolveExistingWorkspacePath(filePath, workspaceOptions);
   return {
     stream: createLocalReadStream(fullPath, options) as unknown as Readable,
     close: async () => {},
   };
 }
 
-export async function writeFile(filePath: string, content: Buffer | string): Promise<void> {
-  const fullPath = await resolveWritableWorkspacePath(filePath);
+export async function writeFile(
+  filePath: string,
+  content: Buffer | string,
+  options?: WorkspaceFileOperationOptions
+): Promise<void> {
+  const fullPath = await resolveWritableWorkspacePath(filePath, options);
   const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
   await fs.writeFile(fullPath, buffer);
 }
@@ -198,17 +161,19 @@ export async function writeDataFile(filePath: string, content: Buffer | string):
   await fs.writeFile(fullPath, buffer);
 }
 
-export async function createDirectory(dirPath: string): Promise<void> {
-  const fullPath = await resolveDirectoryCreationPath(dirPath);
+export async function createDirectory(dirPath: string, options?: WorkspaceFileOperationOptions): Promise<void> {
+  const fullPath = await resolveDirectoryCreationPath(dirPath, options);
   await fs.mkdir(fullPath, {recursive: true});
 
-  const realBase = await getWorkspaceRealBase();
+  const realBase = await getWorkspaceRealBase(options);
   const realCreatedPath = await fs.realpath(fullPath);
-  assertWithinBase(realCreatedPath, realBase);
+  if (realCreatedPath !== realBase && !realCreatedPath.startsWith(`${realBase}${path.sep}`)) {
+    throw new Error('Invalid path: directory traversal attempt detected');
+  }
 }
 
-export async function deleteFile(filePath: string): Promise<void> {
-  const fullPath = await resolveExistingWorkspacePath(filePath);
+export async function deleteFile(filePath: string, options?: WorkspaceFileOperationOptions): Promise<void> {
+  const fullPath = await resolveExistingWorkspacePath(filePath, options);
   await fs.rm(fullPath, {recursive: true, force: true});
 }
 
@@ -219,13 +184,17 @@ export interface RenameConflictError extends Error {
   destPath: string;
 }
 
-export async function checkRenameConflict(oldPath: string, newPath: string): Promise<null | RenameConflictError> {
-  validatePath(oldPath);
-  validatePath(newPath);
+export async function checkRenameConflict(
+  oldPath: string,
+  newPath: string,
+  options?: WorkspaceFileOperationOptions
+): Promise<null | RenameConflictError> {
+  validatePath(oldPath, options);
+  validatePath(newPath, options);
 
   // Check if source exists
   try {
-    await resolveExistingWorkspacePath(oldPath);
+    await resolveExistingWorkspacePath(oldPath, options);
   } catch (cause) {
     if (!(cause && typeof cause === 'object' && 'code' in cause && cause.code === 'ENOENT')) {
       throw cause;
@@ -240,9 +209,9 @@ export async function checkRenameConflict(oldPath: string, newPath: string): Pro
 
   // Check if destination already exists
   try {
-    const realNewPath = await resolveExistingWorkspacePath(newPath);
+    const realNewPath = await resolveExistingWorkspacePath(newPath, options);
     const destStat = await fs.stat(realNewPath);
-    const realOldPath = await resolveExistingWorkspacePath(oldPath);
+    const realOldPath = await resolveExistingWorkspacePath(oldPath, options);
     const isSourceDirectory = (await fs.stat(realOldPath)).isDirectory();
 
     if (destStat.isDirectory()) {
@@ -271,19 +240,24 @@ export async function checkRenameConflict(oldPath: string, newPath: string): Pro
   }
 }
 
-export async function renameFile(oldPath: string, newPath: string, overwrite = false): Promise<void> {
-  const fullOldPath = await resolveExistingWorkspacePath(oldPath);
-  const fullNewPath = validatePath(newPath);
+export async function renameFile(
+  oldPath: string,
+  newPath: string,
+  overwrite = false,
+  options?: WorkspaceFileOperationOptions
+): Promise<void> {
+  const fullOldPath = await resolveExistingWorkspacePath(oldPath, options);
+  const fullNewPath = validatePath(newPath, options);
 
   // Ensure parent directory exists
   const parentDir = path.dirname(newPath);
   if (parentDir && parentDir !== '.') {
-    await createDirectory(parentDir);
+    await createDirectory(parentDir, options);
   }
-  await resolveWritableWorkspacePath(newPath);
+  await resolveWritableWorkspacePath(newPath, options);
 
   // Check for conflicts
-  const conflict = await checkRenameConflict(oldPath, newPath);
+  const conflict = await checkRenameConflict(oldPath, newPath, options);
   if (conflict) {
     if (conflict.code === 'FILE_EXISTS' && overwrite) {
       // Delete existing file and proceed
@@ -296,8 +270,8 @@ export async function renameFile(oldPath: string, newPath: string, overwrite = f
   await fs.rename(fullOldPath, fullNewPath);
 }
 
-export async function getFileStats(filePath: string) {
-  const fullPath = await resolveExistingWorkspacePath(filePath);
+export async function getFileStats(filePath: string, options?: WorkspaceFileOperationOptions) {
+  const fullPath = await resolveExistingWorkspacePath(filePath, options);
   const stats = await fs.stat(fullPath);
 
   // Calculate total size for directories
@@ -337,13 +311,14 @@ async function calculateDirectorySize(dirPath: string): Promise<number> {
 export async function buildFileTree(
   dirPath: string = '.',
   depth: number = 4,
-  currentDepth: number = 0
+  currentDepth: number = 0,
+  options?: WorkspaceFileOperationOptions
 ): Promise<FileNode[]> {
   if (currentDepth > depth) {
     return [];
   }
 
-  const files = await listDirectory(dirPath);
+  const files = await listDirectory(dirPath, options);
 
   files.sort((a, b) => {
     if (a.type === b.type) {
@@ -357,7 +332,7 @@ export async function buildFileTree(
       files.map(async (file) => {
         if (file.type === 'directory') {
           try {
-            file.children = await buildFileTree(file.path, depth, currentDepth + 1);
+            file.children = await buildFileTree(file.path, depth, currentDepth + 1, options);
           } catch (error) {
             console.warn(`Failed to read directory ${file.path}:`, error);
             file.children = [];
@@ -401,10 +376,11 @@ export async function copyFile(
   sourcePath: string,
   destDir: string,
   overwrite = false,
-  renameOnCollision = false
+  renameOnCollision = false,
+  options?: WorkspaceFileOperationOptions
 ): Promise<{copied: string; skipped: boolean}> {
-  const fullSource = await resolveExistingWorkspacePath(sourcePath);
-  const fullDestDir = await resolveExistingWorkspacePath(destDir);
+  const fullSource = await resolveExistingWorkspacePath(sourcePath, options);
+  const fullDestDir = await resolveExistingWorkspacePath(destDir, options);
   const fileName = path.basename(fullSource);
   let destFileName = fileName;
 
@@ -439,14 +415,15 @@ export async function batchCopy(
   sources: string[],
   destDir: string,
   overwrite = false,
-  renameOnCollision = false
+  renameOnCollision = false,
+  options?: WorkspaceFileOperationOptions
 ): Promise<CopyResult> {
   const results: CopyResult = {copied: [], failed: [], skipped: []};
 
   await Promise.allSettled(
     sources.map(async (sourcePath) => {
       try {
-        const result = await copyFile(sourcePath, destDir, overwrite, renameOnCollision);
+        const result = await copyFile(sourcePath, destDir, overwrite, renameOnCollision, options);
         if (result.skipped) {
           results.skipped.push(sourcePath);
         } else {
@@ -465,14 +442,15 @@ export async function batchCopy(
 }
 
 export async function batchDelete(
-  paths: string[]
+  paths: string[],
+  options?: WorkspaceFileOperationOptions
 ): Promise<{deleted: string[]; failed: {path: string; error: string}[]}> {
   const results = {deleted: [] as string[], failed: [] as {path: string; error: string}[]};
 
   await Promise.allSettled(
     paths.map(async (filePath) => {
       try {
-        await deleteFile(filePath);
+        await deleteFile(filePath, options);
         results.deleted.push(filePath);
       } catch (error) {
         results.failed.push({

--- a/app/lib/markdown/markdown-image-import.ts
+++ b/app/lib/markdown/markdown-image-import.ts
@@ -4,7 +4,12 @@ import path from 'path';
 import { getImageConversionErrorMessage } from '@/app/lib/images/convert';
 import { fetchRemoteImageBuffer } from '@/app/lib/images/remote-image-fetch';
 import { normalizeUploadImageBuffer, type UploadConvertParams } from '@/app/lib/images/upload-conversion';
-import { createDirectory, getFileStats, writeFile } from '@/app/lib/filesystem/workspace-files';
+import {
+  createDirectory,
+  getFileStats,
+  writeFile,
+  type WorkspaceFileOperationOptions,
+} from '@/app/lib/filesystem/workspace-files';
 import { invalidateFileReferenceCache } from '@/app/lib/filesystem/file-reference-cache';
 import { clearFileTreeCache } from '@/app/lib/utils/file-tree-cache';
 import { syncPublicSharesAfterWrite } from '@/app/lib/public-sharing/public-file-shares';
@@ -69,7 +74,11 @@ function sanitizeImageFileName(value: string, mimeType?: string): string {
   return `${cleanBase}${cleanExt}`;
 }
 
-async function allocateImagePath(targetDir: string, filename: string) {
+async function allocateImagePath(
+  targetDir: string,
+  filename: string,
+  fileOptions?: WorkspaceFileOperationOptions
+) {
   const ext = path.posix.extname(filename);
   const base = ext ? filename.slice(0, -ext.length) : filename;
   let candidate = filename;
@@ -79,7 +88,7 @@ async function allocateImagePath(targetDir: string, filename: string) {
     const candidatePath = targetDir === '.' ? candidate : path.posix.join(targetDir, candidate);
 
     try {
-      await getFileStats(candidatePath);
+      await getFileStats(candidatePath, fileOptions);
       candidate = ext ? `${base}-${index}${ext}` : `${base}-${index}`;
       index += 1;
     } catch (error) {
@@ -112,6 +121,7 @@ export async function fetchMarkdownImageUrl(rawUrl: string): Promise<MarkdownIma
 }
 
 export async function importMarkdownImages(params: {
+  fileOptions?: WorkspaceFileOperationOptions;
   images: MarkdownImageImportInput[];
   markdownFilePath?: string | null;
   targetDir?: string | null;
@@ -137,7 +147,7 @@ export async function importMarkdownImages(params: {
 
   const targetDir = normalizeWorkspaceMarkdownPath(params.targetDir || '.') || '.';
   if (targetDir !== '.') {
-    await createDirectory(targetDir);
+    await createDirectory(targetDir, params.fileOptions);
   }
 
   const imported: ImportedMarkdownImage[] = [];
@@ -160,8 +170,12 @@ export async function importMarkdownImages(params: {
       throw new Error(`"${image.sourceName}" is not a supported image.`);
     }
 
-    const allocated = await allocateImagePath(targetDir, sanitizeImageFileName(normalized.filename, normalized.mimeType));
-    await writeFile(allocated.workspacePath, normalized.buffer);
+    const allocated = await allocateImagePath(
+      targetDir,
+      sanitizeImageFileName(normalized.filename, normalized.mimeType),
+      params.fileOptions
+    );
+    await writeFile(allocated.workspacePath, normalized.buffer, params.fileOptions);
     writtenPaths.push(allocated.workspacePath);
 
     imported.push({
@@ -174,8 +188,8 @@ export async function importMarkdownImages(params: {
   }
 
   await syncPublicSharesAfterWrite(writtenPaths);
-  clearFileTreeCache();
-  invalidateFileReferenceCache();
+  clearFileTreeCache(params.fileOptions?.workspace?.workspaceId);
+  invalidateFileReferenceCache(params.fileOptions);
 
   return imported;
 }

--- a/app/lib/marp/cli.ts
+++ b/app/lib/marp/cli.ts
@@ -4,6 +4,7 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { inlineMarpMarkdownWorkspaceAssets } from './render';
+import type { WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 
 export const MARP_EXPORT_TIMEOUT_MS = 60_000;
 
@@ -60,10 +61,12 @@ export async function writeMarpCliInput(
     tempDir: string;
     filePath: string;
     markdown: string;
+    fileOptions?: WorkspaceFileOperationOptions;
   }
 ) {
   const markdown = await inlineMarpMarkdownWorkspaceAssets(options.markdown, {
     filePath: options.filePath,
+    fileOptions: options.fileOptions,
   });
   const inputPath = path.join(options.tempDir, 'deck.md');
 

--- a/app/lib/marp/render.ts
+++ b/app/lib/marp/render.ts
@@ -4,7 +4,11 @@ import { Marp } from '@marp-team/marp-core';
 import fs from 'node:fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
-import { readFile, resolveExistingWorkspacePath } from '@/app/lib/filesystem/workspace-files';
+import {
+  readFile,
+  resolveExistingWorkspacePath,
+  type WorkspaceFileOperationOptions,
+} from '@/app/lib/filesystem/workspace-files';
 
 const MAX_ASSET_INLINE_SIZE = 5 * 1024 * 1024;
 
@@ -146,19 +150,23 @@ function decodeUrlPath(url: string): string {
   }
 }
 
-async function resolveWorkspaceAssetDataUri(assetUrl: string, baseDir: string): Promise<string | null> {
+async function resolveWorkspaceAssetDataUri(
+  assetUrl: string,
+  baseDir: string,
+  fileOptions?: WorkspaceFileOperationOptions
+): Promise<string | null> {
   const trimmedUrl = assetUrl.trim();
   if (!trimmedUrl) {
     return null;
   }
 
-  const normalizedWorkspacePath = await resolveWorkspaceAssetPath(trimmedUrl, baseDir);
+  const normalizedWorkspacePath = await resolveWorkspaceAssetPath(trimmedUrl, baseDir, fileOptions);
   if (!normalizedWorkspacePath) {
     return null;
   }
 
   try {
-    const buffer = await readFile(normalizedWorkspacePath);
+    const buffer = await readFile(normalizedWorkspacePath, fileOptions);
     if (buffer.length > MAX_ASSET_INLINE_SIZE) {
       console.warn(`[Marp] Asset too large to inline: ${normalizedWorkspacePath}`);
       return null;
@@ -171,7 +179,11 @@ async function resolveWorkspaceAssetDataUri(assetUrl: string, baseDir: string): 
   }
 }
 
-async function resolveWorkspaceAssetPath(assetUrl: string, baseDir: string): Promise<string | null> {
+async function resolveWorkspaceAssetPath(
+  assetUrl: string,
+  baseDir: string,
+  fileOptions?: WorkspaceFileOperationOptions
+): Promise<string | null> {
   const appMediaPath = parseWorkspacePathFromAppMediaUrl(assetUrl);
   if (appMediaPath) {
     return normalizeWorkspacePath(appMediaPath);
@@ -179,7 +191,7 @@ async function resolveWorkspaceAssetPath(assetUrl: string, baseDir: string): Pro
 
   if (/^file:\/\//i.test(assetUrl)) {
     try {
-      return resolveAbsoluteWorkspaceAssetPath(fileURLToPath(assetUrl));
+      return resolveAbsoluteWorkspaceAssetPath(fileURLToPath(assetUrl), fileOptions);
     } catch {
       return null;
     }
@@ -191,7 +203,7 @@ async function resolveWorkspaceAssetPath(assetUrl: string, baseDir: string): Pro
   }
 
   if (path.isAbsolute(cleanUrl)) {
-    const absoluteWorkspacePath = await resolveAbsoluteWorkspaceAssetPath(cleanUrl);
+    const absoluteWorkspacePath = await resolveAbsoluteWorkspaceAssetPath(cleanUrl, fileOptions);
     if (absoluteWorkspacePath) {
       return absoluteWorkspacePath;
     }
@@ -230,9 +242,12 @@ function parseWorkspacePathFromAppMediaUrl(assetUrl: string): string | null {
   return null;
 }
 
-async function resolveAbsoluteWorkspaceAssetPath(filePath: string): Promise<string | null> {
+async function resolveAbsoluteWorkspaceAssetPath(
+  filePath: string,
+  fileOptions?: WorkspaceFileOperationOptions
+): Promise<string | null> {
   try {
-    const realWorkspaceRoot = await resolveExistingWorkspacePath('.');
+    const realWorkspaceRoot = await resolveExistingWorkspacePath('.', fileOptions);
     const realFilePath = await fs.realpath(filePath);
     const relativePath = path.relative(realWorkspaceRoot, realFilePath);
 
@@ -277,6 +292,7 @@ export async function inlineMarpMarkdownWorkspaceAssets(
   markdown: string,
   options: {
     filePath: string;
+    fileOptions?: WorkspaceFileOperationOptions;
   }
 ): Promise<string> {
   const baseDir = path.dirname(options.filePath);
@@ -290,7 +306,7 @@ export async function inlineMarpMarkdownWorkspaceAssets(
       const after = match[3] ?? '';
       const isAngled = rawSource.startsWith('<') && rawSource.endsWith('>');
       const source = isAngled ? rawSource.slice(1, -1) : rawSource;
-      const dataUri = await resolveWorkspaceAssetDataUri(source, baseDir);
+      const dataUri = await resolveWorkspaceAssetDataUri(source, baseDir, options.fileOptions);
 
       if (!dataUri) {
         return match[0];
@@ -300,7 +316,7 @@ export async function inlineMarpMarkdownWorkspaceAssets(
     }
   );
 
-  nextMarkdown = await inlineCssUrls(nextMarkdown, baseDir);
+  nextMarkdown = await inlineCssUrls(nextMarkdown, baseDir, options.fileOptions);
 
   nextMarkdown = await replaceAsync(
     nextMarkdown,
@@ -309,7 +325,7 @@ export async function inlineMarpMarkdownWorkspaceAssets(
       const before = match[1] ?? '';
       const source = match[2] ?? '';
       const after = match[3] ?? '';
-      const dataUri = await resolveWorkspaceAssetDataUri(source, baseDir);
+      const dataUri = await resolveWorkspaceAssetDataUri(source, baseDir, options.fileOptions);
 
       if (!dataUri) {
         return match[0];
@@ -322,14 +338,18 @@ export async function inlineMarpMarkdownWorkspaceAssets(
   return nextMarkdown;
 }
 
-async function inlineHtmlAssetSources(html: string, baseDir: string): Promise<string> {
+async function inlineHtmlAssetSources(
+  html: string,
+  baseDir: string,
+  fileOptions?: WorkspaceFileOperationOptions
+): Promise<string> {
   const sourceRegex = /(<(?:img|source|video|audio)\b[^>]*\b(?:src|poster)=["'])([^"']+)(["'][^>]*>)/gi;
   const matches = Array.from(html.matchAll(sourceRegex));
   let nextHtml = html;
 
   for (const match of matches) {
     const [fullMatch, before, source, after] = match;
-    const dataUri = await resolveWorkspaceAssetDataUri(source, baseDir);
+    const dataUri = await resolveWorkspaceAssetDataUri(source, baseDir, fileOptions);
     if (dataUri) {
       nextHtml = nextHtml.replace(fullMatch, `${before}${dataUri}${after}`);
     }
@@ -338,14 +358,18 @@ async function inlineHtmlAssetSources(html: string, baseDir: string): Promise<st
   return nextHtml;
 }
 
-async function inlineCssUrls(css: string, baseDir: string): Promise<string> {
+async function inlineCssUrls(
+  css: string,
+  baseDir: string,
+  fileOptions?: WorkspaceFileOperationOptions
+): Promise<string> {
   const urlRegex = /url\(\s*(["']?)([^"')]+)\1\s*\)/gi;
   const matches = Array.from(css.matchAll(urlRegex));
   let nextCss = css;
 
   for (const match of matches) {
     const [fullMatch, _quote, source] = match;
-    const dataUri = await resolveWorkspaceAssetDataUri(source, baseDir);
+    const dataUri = await resolveWorkspaceAssetDataUri(source, baseDir, fileOptions);
     if (dataUri) {
       nextCss = nextCss.replace(fullMatch, `url("${dataUri}")`);
     }
@@ -375,13 +399,14 @@ export async function renderMarpMarkdownToHtmlDocument(
   options: {
     filePath: string;
     title?: string;
+    fileOptions?: WorkspaceFileOperationOptions;
   }
 ): Promise<string> {
   const baseDir = path.dirname(options.filePath);
   const marp = createMarpRenderer();
   const rendered = marp.render(markdown);
-  const html = wrapMarpSlides(await inlineHtmlAssetSources(rendered.html, baseDir));
-  const css = await inlineCssUrls(rendered.css, baseDir);
+  const html = wrapMarpSlides(await inlineHtmlAssetSources(rendered.html, baseDir, options.fileOptions));
+  const css = await inlineCssUrls(rendered.css, baseDir, options.fileOptions);
   const title = options.title || path.basename(options.filePath);
 
   return `<!DOCTYPE html>

--- a/app/lib/pdf/markdown-export-cache.ts
+++ b/app/lib/pdf/markdown-export-cache.ts
@@ -1,5 +1,5 @@
 import { markdownFileToHtmlDocument } from '@/app/lib/pdf/markdown-to-html';
-import { resolveExistingWorkspacePath } from '@/app/lib/filesystem/workspace-files';
+import { resolveExistingWorkspacePath, type WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 import fs from 'fs/promises';
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -13,15 +13,16 @@ type CacheEntry = {
 
 const markdownHtmlCache = new Map<string, CacheEntry>();
 
-async function getCacheKey(filePath: string): Promise<string> {
-  const fullPath = await resolveExistingWorkspacePath(filePath);
+async function getCacheKey(filePath: string, fileOptions?: WorkspaceFileOperationOptions): Promise<string> {
+  const fullPath = await resolveExistingWorkspacePath(filePath, fileOptions);
   const stats = await fs.stat(fullPath);
 
   if (!stats.isFile()) {
     throw new Error('Path must point to a file');
   }
 
-  return `${filePath}\0${stats.size}\0${stats.mtimeMs}`;
+  const workspaceId = fileOptions?.workspace?.workspaceId ?? 'legacy';
+  return `${workspaceId}\0${filePath}\0${stats.size}\0${stats.mtimeMs}`;
 }
 
 function pruneCache(now: number) {
@@ -43,11 +44,14 @@ function pruneCache(now: number) {
   }
 }
 
-export async function getCachedMarkdownHtmlDocument(filePath: string): Promise<string> {
+export async function getCachedMarkdownHtmlDocument(
+  filePath: string,
+  fileOptions?: WorkspaceFileOperationOptions
+): Promise<string> {
   const now = Date.now();
   pruneCache(now);
 
-  const cacheKey = await getCacheKey(filePath);
+  const cacheKey = await getCacheKey(filePath, fileOptions);
   const cached = markdownHtmlCache.get(cacheKey);
 
   if (cached && cached.expiresAt > now) {
@@ -55,7 +59,7 @@ export async function getCachedMarkdownHtmlDocument(filePath: string): Promise<s
     return cached.html;
   }
 
-  const html = await markdownFileToHtmlDocument(filePath);
+  const html = await markdownFileToHtmlDocument(filePath, fileOptions);
   markdownHtmlCache.set(cacheKey, {
     html,
     expiresAt: now + CACHE_TTL_MS,

--- a/app/lib/pdf/markdown-pdf.ts
+++ b/app/lib/pdf/markdown-pdf.ts
@@ -8,6 +8,7 @@ import {
 } from '@/app/lib/email/attachment-types';
 import { generatePdfFromHtml } from '@/app/lib/pdf/browser';
 import { getCachedMarkdownHtmlDocument } from '@/app/lib/pdf/markdown-export-cache';
+import type { WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 
 const PDF_TIMEOUT_MS = 30_000;
 
@@ -21,10 +22,13 @@ export function getMarkdownPdfAttachmentName(filePath: string): string {
   return markdownEmailAttachmentPdfName(path.basename(filePath));
 }
 
-export async function renderMarkdownWorkspaceFileToPdf(filePath: string): Promise<Buffer> {
+export async function renderMarkdownWorkspaceFileToPdf(
+  filePath: string,
+  fileOptions?: WorkspaceFileOperationOptions
+): Promise<Buffer> {
   assertMarkdownPdfExportPath(filePath);
 
-  const html = await getCachedMarkdownHtmlDocument(filePath);
+  const html = await getCachedMarkdownHtmlDocument(filePath, fileOptions);
   return Promise.race([
     generatePdfFromHtml(html),
     new Promise<never>((_, reject) =>

--- a/app/lib/pdf/markdown-to-html.ts
+++ b/app/lib/pdf/markdown-to-html.ts
@@ -1,4 +1,4 @@
-import { readFile } from '@/app/lib/filesystem/workspace-files';
+import { readFile, type WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 import { createInlineColorRegex, isColorCode } from '@/app/lib/markdown/color-code';
 import { marked } from 'marked';
 import path from 'path';
@@ -150,7 +150,8 @@ function processInlineHexColors(htmlContent: string): string {
 
 async function inlineImagesAsBase64(
   htmlContent: string,
-  markdownDir: string
+  markdownDir: string,
+  fileOptions?: WorkspaceFileOperationOptions
 ): Promise<string> {
   const imgRegex = /<img([^>]*)src="([^"]+)"([^>]*)>/g;
   const matches: Array<{ full: string; before: string; src: string; after: string }> = [];
@@ -177,7 +178,7 @@ async function inlineImagesAsBase64(
 
       imagePath = path.normalize(imagePath).replace(/\\/g, '/');
 
-      const imageBuffer = await readFile(imagePath);
+      const imageBuffer = await readFile(imagePath, fileOptions);
 
       if (imageBuffer.length > MAX_IMAGE_SIZE) {
         console.warn(`[Markdown Export] Image too large to inline: ${imagePath} (${(imageBuffer.length / 1024 / 1024).toFixed(2)}MB)`);
@@ -198,8 +199,11 @@ async function inlineImagesAsBase64(
   return processedHtml;
 }
 
-export async function markdownFileToHtmlDocument(filePath: string): Promise<string> {
-  const contentBuffer = await readFile(filePath);
+export async function markdownFileToHtmlDocument(
+  filePath: string,
+  fileOptions?: WorkspaceFileOperationOptions
+): Promise<string> {
+  const contentBuffer = await readFile(filePath, fileOptions);
 
   if (contentBuffer.length > READ_SIZE_LIMIT) {
     const err = new Error('File is too large to export') as NodeJS.ErrnoException;
@@ -221,7 +225,7 @@ export async function markdownFileToHtmlDocument(filePath: string): Promise<stri
   const ext = path.extname(filePath);
   const fileName = path.basename(filePath, ext);
 
-  htmlContent = await inlineImagesAsBase64(htmlContent, fileDir);
+  htmlContent = await inlineImagesAsBase64(htmlContent, fileDir, fileOptions);
 
   return `<!DOCTYPE html>
 <html lang="de">

--- a/app/lib/skills/canvas-skill-store.ts
+++ b/app/lib/skills/canvas-skill-store.ts
@@ -22,7 +22,7 @@ import {
 import { loadSkillByName, getSkillNames } from '@/app/lib/skills/skill-loader';
 import { loadSkillSummaries, type SkillSummary } from '@/app/lib/skills/skill-summaries';
 import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
-import { enableSkillInConfig } from '@/app/lib/skills/enabled-skills';
+import { DISABLED_ALL_SKILLS_SENTINEL, enableSkillInConfig } from '@/app/lib/skills/enabled-skills';
 
 export const DEFAULT_CANVAS_SKILL_STORE_REGISTRY_URL =
   'https://raw.githubusercontent.com/canvascoding/canvas-notebook-plugin-marketplace/main/registry.json';
@@ -153,6 +153,12 @@ export interface CanvasSkillStoreInstallResult {
   storeSkill?: CanvasSkillStoreSkill;
   storeVersion?: CanvasSkillStoreVersion;
   backupPath?: string;
+}
+
+export interface CanvasSkillsResetResult {
+  success: boolean;
+  skillsDir: string;
+  deletedAt: string;
 }
 
 function nowIso(): string {
@@ -408,6 +414,27 @@ export async function removeCanvasSkillRegistryRecord(skillName: string): Promis
   await writeCanvasSkillRegistry(registry);
 }
 
+export async function resetCanvasSkillsDirectory(updatedBy = 'unknown'): Promise<CanvasSkillsResetResult> {
+  const skillsDir = resolveSkillsDataDir();
+  const deletedAt = nowIso();
+
+  await fs.rm(skillsDir, { recursive: true, force: true });
+  await fs.mkdir(skillsDir, { recursive: true });
+  await writeCanvasSkillRegistry(createEmptySkillRegistry());
+
+  const config = await readPiRuntimeConfig();
+  config.enabledSkills = [DISABLED_ALL_SKILLS_SENTINEL];
+  config.updatedAt = deletedAt;
+  config.updatedBy = updatedBy;
+  await writePiRuntimeConfig(config);
+
+  return {
+    success: true,
+    skillsDir,
+    deletedAt,
+  };
+}
+
 async function listStandaloneSkillSummaries(enabledSkills?: string[]): Promise<SkillSummary[]> {
   const summaries = await loadSkillSummaries(enabledSkills);
   return summaries.filter((skill) => !skill.plugin);
@@ -432,7 +459,7 @@ async function enrichStoreSkillsWithInstalledState(
   const skills = registry.skills.map((skill) => {
     const installedSummary = standaloneByName.get(skill.name);
     const installedSkill = localRegistry.skills[skill.name];
-    const installedVersion = installedSkill?.version;
+    const installedVersion = installedSkill?.version || installedSummary?.version;
     const updateAvailable = Boolean(
       installedSummary && installedVersion && compareVersions(skill.latestVersion, installedVersion) > 0,
     );

--- a/app/lib/skills/enabled-skills.ts
+++ b/app/lib/skills/enabled-skills.ts
@@ -31,7 +31,13 @@ export function resolveEnabledSkillNames(
 ): Set<string> {
   const canonicalSkillNames = normalizeSkillNames(allSkillNames);
   const canonicalSkillSet = new Set(canonicalSkillNames);
-  const configuredSkills = normalizeEnabledSkillsConfig(enabledSkills).filter((skillName) => skillName !== DISABLED_ALL_SKILLS_SENTINEL);
+  const normalizedConfig = normalizeEnabledSkillsConfig(enabledSkills);
+
+  if (normalizedConfig.includes(DISABLED_ALL_SKILLS_SENTINEL)) {
+    return new Set();
+  }
+
+  const configuredSkills = normalizedConfig.filter((skillName) => skillName !== DISABLED_ALL_SKILLS_SENTINEL);
 
   if (configuredSkills.length === 0) {
     return new Set(canonicalSkillNames);

--- a/app/lib/skills/skill-summaries.ts
+++ b/app/lib/skills/skill-summaries.ts
@@ -15,6 +15,7 @@ export type SkillSummary = {
   name: string;
   title: string;
   description: string;
+  version?: string;
   enabled: boolean;
   interface?: CanvasSkillInterface;
   plugin?: {
@@ -33,6 +34,7 @@ function parseSkillSummary(content: string, fallbackName: string): Omit<SkillSum
     name: frontmatter.name || fallbackName,
     title: frontmatter.name || fallbackName,
     description: frontmatter.description || '',
+    version: frontmatter.metadata?.version,
   };
 }
 
@@ -79,6 +81,7 @@ export async function loadSkillSummaries(enabledSkills?: string[]): Promise<Skil
         name: skill.name,
         title: skill.title,
         description: skill.description,
+        version: skill.version,
         enabled: skill.enabled,
         interface: skill.interface,
         plugin: skill.plugin,

--- a/app/lib/utils/file-tree-cache.ts
+++ b/app/lib/utils/file-tree-cache.ts
@@ -3,23 +3,24 @@ import { LruCache } from './lru-cache';
 
 export const fileTreeCache = new LruCache<FileNode[]>(50, 5 * 60 * 1000);
 
-export function buildFileTreeCacheKey(dirPath: string, depth: number) {
-  return `${dirPath}:${depth}`;
+export function buildFileTreeCacheKey(dirPath: string, depth: number, workspaceId = 'legacy') {
+  return `${workspaceId}\0${dirPath}:${depth}`;
 }
 
 export function parseFileTreeCacheKey(key: string) {
-  const separatorIndex = key.lastIndexOf(':');
+  const [, pathKey = key] = key.includes('\0') ? key.split('\0', 2) : [null, key];
+  const separatorIndex = pathKey.lastIndexOf(':');
   if (separatorIndex === -1) {
-    return { path: key, depth: null };
+    return { path: pathKey, depth: null };
   }
 
-  const depth = Number.parseInt(key.slice(separatorIndex + 1), 10);
+  const depth = Number.parseInt(pathKey.slice(separatorIndex + 1), 10);
   if (Number.isNaN(depth)) {
-    return { path: key, depth: null };
+    return { path: pathKey, depth: null };
   }
 
   return {
-    path: key.slice(0, separatorIndex),
+    path: pathKey.slice(0, separatorIndex),
     depth,
   };
 }

--- a/app/lib/utils/file-tree-cache.ts
+++ b/app/lib/utils/file-tree-cache.ts
@@ -8,31 +8,45 @@ export function buildFileTreeCacheKey(dirPath: string, depth: number, workspaceI
 }
 
 export function parseFileTreeCacheKey(key: string) {
-  const [, pathKey = key] = key.includes('\0') ? key.split('\0', 2) : [null, key];
+  const [workspaceId, pathKey = key] = key.includes('\0') ? key.split('\0', 2) : ['legacy', key];
   const separatorIndex = pathKey.lastIndexOf(':');
   if (separatorIndex === -1) {
-    return { path: pathKey, depth: null };
+    return { workspaceId, path: pathKey, depth: null };
   }
 
   const depth = Number.parseInt(pathKey.slice(separatorIndex + 1), 10);
   if (Number.isNaN(depth)) {
-    return { path: pathKey, depth: null };
+    return { workspaceId, path: pathKey, depth: null };
   }
 
   return {
+    workspaceId,
     path: pathKey.slice(0, separatorIndex),
     depth,
   };
 }
 
-export function clearFileTreeCache() {
-  fileTreeCache.clear();
+export function clearFileTreeCache(workspaceId?: string) {
+  if (!workspaceId) {
+    fileTreeCache.clear();
+    return;
+  }
+
+  for (const key of fileTreeCache.keys()) {
+    if (parseFileTreeCacheKey(key).workspaceId === workspaceId) {
+      fileTreeCache.delete(key);
+    }
+  }
 }
 
-export function clearSubtreeCache(dirPath: string) {
+export function clearSubtreeCache(dirPath: string, workspaceId?: string) {
   const keys = fileTreeCache.keys();
   for (const key of keys) {
-    const { path: cachedPath } = parseFileTreeCacheKey(key);
+    const { workspaceId: cachedWorkspaceId, path: cachedPath } = parseFileTreeCacheKey(key);
+    if (workspaceId && cachedWorkspaceId !== workspaceId) {
+      continue;
+    }
+
     const shouldDelete =
       dirPath === '.'
       || cachedPath === '.'

--- a/app/lib/workspaces/context.ts
+++ b/app/lib/workspaces/context.ts
@@ -22,7 +22,7 @@ export function resolveWorkspaceDataRoot(cwd: string = getRuntimeCwd()): string 
     return configuredDataDir;
   }
 
-  return path.join(cwd, 'data');
+  return path.join(cwd, configuredDataDir);
 }
 
 export function resolveLegacyWorkspaceRoot(cwd?: string): string {

--- a/app/lib/workspaces/context.ts
+++ b/app/lib/workspaces/context.ts
@@ -1,0 +1,62 @@
+import 'server-only';
+
+import path from 'node:path';
+
+import { isBootstrapAdminEmail } from '@/app/lib/bootstrap-admin';
+import { resolveWorkspacePermissions, normalizeWorkspaceRole } from './permissions';
+import type { WorkspaceActor, WorkspaceContext } from './types';
+
+export const LEGACY_PERSONAL_WORKSPACE_ID = 'legacy-personal-workspace';
+
+function getRuntimeCwd(): string {
+  return Reflect.apply(process.cwd, process, []) as string;
+}
+
+export function resolveWorkspaceDataRoot(cwd: string = getRuntimeCwd()): string {
+  const configuredDataDir = process.env.DATA?.trim();
+  if (!configuredDataDir || configuredDataDir === './data' || configuredDataDir === 'data') {
+    return path.join(cwd, 'data');
+  }
+
+  if (path.isAbsolute(configuredDataDir)) {
+    return configuredDataDir;
+  }
+
+  return path.join(cwd, 'data');
+}
+
+export function resolveLegacyWorkspaceRoot(cwd?: string): string {
+  return path.join(resolveWorkspaceDataRoot(cwd), 'workspace');
+}
+
+export function resolveWorkspaceActor(input: {
+  id: string;
+  email?: string | null;
+  role?: string | null;
+}): WorkspaceActor {
+  const role = isBootstrapAdminEmail(input.email) ? 'admin' : normalizeWorkspaceRole(input.role);
+  return {
+    userId: input.id,
+    email: input.email,
+    role,
+  };
+}
+
+export function createLegacyPersonalWorkspaceContext(actor?: WorkspaceActor): WorkspaceContext {
+  const role = actor?.role ?? 'member';
+  return {
+    workspaceId: LEGACY_PERSONAL_WORKSPACE_ID,
+    workspaceType: 'personal',
+    rootPath: resolveLegacyWorkspaceRoot(),
+    actor,
+    organizationId: null,
+    ownerUserId: actor?.userId ?? null,
+    permissions: resolveWorkspacePermissions({
+      role,
+      workspaceType: 'personal',
+      ownsPersonalWorkspace: true,
+      canCreatePublicLinks: true,
+    }),
+    legacy: true,
+  };
+}

--- a/app/lib/workspaces/path-guard.ts
+++ b/app/lib/workspaces/path-guard.ts
@@ -1,0 +1,124 @@
+import 'server-only';
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { WorkspaceContext, WorkspacePathResolution } from './types';
+
+export interface WorkspacePathError extends Error {
+  code: 'WORKSPACE_PATH_OUTSIDE_ROOT' | 'WORKSPACE_PARENT_OUTSIDE_ROOT';
+  status: number;
+}
+
+function createWorkspacePathError(
+  code: WorkspacePathError['code'],
+  message = 'Invalid path: directory traversal attempt detected'
+): WorkspacePathError {
+  const error = new Error(message) as WorkspacePathError;
+  error.code = code;
+  error.status = 400;
+  return error;
+}
+
+function normalizeRelativeWorkspacePath(userPath: string): string {
+  const trimmed = userPath.trim();
+  if (!trimmed) return '.';
+  if (trimmed.includes('\0') || path.isAbsolute(trimmed) || /^[A-Za-z]:[\\/]/.test(trimmed)) {
+    throw createWorkspacePathError('WORKSPACE_PATH_OUTSIDE_ROOT');
+  }
+
+  const normalized = trimmed.replace(/\\/g, '/');
+  return normalized || '.';
+}
+
+function assertWithinBase(candidatePath: string, basePath: string, code: WorkspacePathError['code']): void {
+  if (candidatePath !== basePath && !candidatePath.startsWith(`${basePath}${path.sep}`)) {
+    throw createWorkspacePathError(code);
+  }
+}
+
+export function resolveWorkspacePath(
+  workspace: WorkspaceContext,
+  userPath: string
+): WorkspacePathResolution {
+  const normalizedBase = path.resolve(workspace.rootPath);
+  const relativePath = normalizeRelativeWorkspacePath(userPath);
+  const absolutePath = path.resolve(normalizedBase, relativePath);
+
+  assertWithinBase(absolutePath, normalizedBase, 'WORKSPACE_PATH_OUTSIDE_ROOT');
+
+  return {
+    workspace,
+    relativePath,
+    absolutePath,
+  };
+}
+
+export async function ensureWorkspaceRoot(workspace: WorkspaceContext): Promise<string> {
+  const rootPath = resolveWorkspacePath(workspace, '.').absolutePath;
+  await fs.mkdir(rootPath, { recursive: true });
+  return fs.realpath(rootPath);
+}
+
+export async function resolveExistingWorkspacePath(
+  workspace: WorkspaceContext,
+  userPath: string
+): Promise<string> {
+  const candidatePath = resolveWorkspacePath(workspace, userPath).absolutePath;
+  const realBase = await ensureWorkspaceRoot(workspace);
+  const realPath = await fs.realpath(candidatePath);
+  assertWithinBase(realPath, realBase, 'WORKSPACE_PATH_OUTSIDE_ROOT');
+  return realPath;
+}
+
+export async function resolveWritableWorkspacePath(
+  workspace: WorkspaceContext,
+  userPath: string
+): Promise<string> {
+  const candidatePath = resolveWorkspacePath(workspace, userPath).absolutePath;
+  const realBase = await ensureWorkspaceRoot(workspace);
+  const parentPath = path.dirname(candidatePath);
+  const realParent = await fs.realpath(parentPath);
+  assertWithinBase(realParent, realBase, 'WORKSPACE_PARENT_OUTSIDE_ROOT');
+
+  try {
+    const realExistingPath = await fs.realpath(candidatePath);
+    assertWithinBase(realExistingPath, realBase, 'WORKSPACE_PATH_OUTSIDE_ROOT');
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  return candidatePath;
+}
+
+export async function resolveDirectoryCreationPath(
+  workspace: WorkspaceContext,
+  userPath: string
+): Promise<string> {
+  const candidatePath = resolveWorkspacePath(workspace, userPath).absolutePath;
+  const realBase = await ensureWorkspaceRoot(workspace);
+  let current = path.dirname(candidatePath);
+
+  while (current !== path.dirname(current)) {
+    try {
+      const realCurrent = await fs.realpath(current);
+      assertWithinBase(realCurrent, realBase, 'WORKSPACE_PARENT_OUTSIDE_ROOT');
+      return candidatePath;
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        const next = path.dirname(current);
+        if (next === current) break;
+        current = next;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw createWorkspacePathError(
+    'WORKSPACE_PARENT_OUTSIDE_ROOT',
+    'Invalid path: parent directory is outside workspace'
+  );
+}

--- a/app/lib/workspaces/path-guard.ts
+++ b/app/lib/workspaces/path-guard.ts
@@ -5,6 +5,11 @@ import path from 'node:path';
 
 import type { WorkspaceContext, WorkspacePathResolution } from './types';
 
+interface NormalizedWorkspacePath {
+  relativePath: string;
+  segments: string[];
+}
+
 export interface WorkspacePathError extends Error {
   code: 'WORKSPACE_PATH_OUTSIDE_ROOT' | 'WORKSPACE_PARENT_OUTSIDE_ROOT';
   status: number;
@@ -20,15 +25,31 @@ function createWorkspacePathError(
   return error;
 }
 
-function normalizeRelativeWorkspacePath(userPath: string): string {
+function normalizeRelativeWorkspacePath(userPath: string): NormalizedWorkspacePath {
   const trimmed = userPath.trim();
-  if (!trimmed) return '.';
+  if (!trimmed) {
+    return { relativePath: '.', segments: [] };
+  }
+
   if (trimmed.includes('\0') || path.isAbsolute(trimmed) || /^[A-Za-z]:[\\/]/.test(trimmed)) {
     throw createWorkspacePathError('WORKSPACE_PATH_OUTSIDE_ROOT');
   }
 
-  const normalized = trimmed.replace(/\\/g, '/');
-  return normalized || '.';
+  const segments: string[] = [];
+  for (const segment of trimmed.replace(/\\/g, '/').split('/')) {
+    if (!segment || segment === '.') {
+      continue;
+    }
+
+    if (segment === '..' || /^[A-Za-z]:$/.test(segment)) {
+      throw createWorkspacePathError('WORKSPACE_PATH_OUTSIDE_ROOT');
+    }
+
+    segments.push(segment);
+  }
+
+  const relativePath = segments.join('/') || '.';
+  return { relativePath, segments };
 }
 
 function assertWithinBase(candidatePath: string, basePath: string, code: WorkspacePathError['code']): void {
@@ -42,14 +63,14 @@ export function resolveWorkspacePath(
   userPath: string
 ): WorkspacePathResolution {
   const normalizedBase = path.resolve(workspace.rootPath);
-  const relativePath = normalizeRelativeWorkspacePath(userPath);
-  const absolutePath = path.resolve(normalizedBase, relativePath);
+  const normalizedPath = normalizeRelativeWorkspacePath(userPath);
+  const absolutePath = path.join(normalizedBase, ...normalizedPath.segments);
 
   assertWithinBase(absolutePath, normalizedBase, 'WORKSPACE_PATH_OUTSIDE_ROOT');
 
   return {
     workspace,
-    relativePath,
+    relativePath: normalizedPath.relativePath,
     absolutePath,
   };
 }

--- a/app/lib/workspaces/permissions.ts
+++ b/app/lib/workspaces/permissions.ts
@@ -1,0 +1,78 @@
+import 'server-only';
+
+import type { WorkspacePermissions, WorkspaceType, WorkspaceUserRole } from './types';
+
+const NO_WORKSPACE_PERMISSIONS: WorkspacePermissions = {
+  canRead: false,
+  canWrite: false,
+  canDelete: false,
+  canCreatePublicLinks: false,
+  canManageWorkspace: false,
+  canRunAgent: false,
+};
+
+export function normalizeWorkspaceRole(role: string | null | undefined): WorkspaceUserRole {
+  if (role === 'owner' || role === 'admin' || role === 'external') return role;
+  return 'member';
+}
+
+export function resolveWorkspacePermissions(params: {
+  role: WorkspaceUserRole;
+  workspaceType: WorkspaceType;
+  ownsPersonalWorkspace?: boolean;
+  canAccessTeamWorkspace?: boolean;
+  canWriteTeamWorkspace?: boolean;
+  canCreatePublicLinks?: boolean;
+}): WorkspacePermissions {
+  const {
+    role,
+    workspaceType,
+    ownsPersonalWorkspace = false,
+    canAccessTeamWorkspace = false,
+    canWriteTeamWorkspace = false,
+    canCreatePublicLinks = true,
+  } = params;
+
+  if (role === 'external') {
+    return NO_WORKSPACE_PERMISSIONS;
+  }
+
+  const isAdminLike = role === 'owner' || role === 'admin';
+
+  if (workspaceType === 'personal') {
+    const canUsePersonalWorkspace = isAdminLike || ownsPersonalWorkspace;
+    return {
+      canRead: canUsePersonalWorkspace,
+      canWrite: canUsePersonalWorkspace,
+      canDelete: canUsePersonalWorkspace,
+      canCreatePublicLinks: canUsePersonalWorkspace && canCreatePublicLinks,
+      canManageWorkspace: isAdminLike,
+      canRunAgent: canUsePersonalWorkspace,
+    };
+  }
+
+  const canReadTeam = isAdminLike || canAccessTeamWorkspace || canWriteTeamWorkspace;
+  const canWriteTeam = isAdminLike || canWriteTeamWorkspace;
+
+  return {
+    canRead: canReadTeam,
+    canWrite: canWriteTeam,
+    canDelete: canWriteTeam,
+    canCreatePublicLinks: canReadTeam && canCreatePublicLinks,
+    canManageWorkspace: isAdminLike,
+    canRunAgent: canReadTeam,
+  };
+}
+
+export function assertWorkspacePermission(
+  permissions: WorkspacePermissions,
+  permission: keyof WorkspacePermissions,
+  message = 'Workspace permission denied'
+): void {
+  if (!permissions[permission]) {
+    const error = new Error(message) as Error & { code: string; status: number };
+    error.code = 'WORKSPACE_PERMISSION_DENIED';
+    error.status = 403;
+    throw error;
+  }
+}

--- a/app/lib/workspaces/request.ts
+++ b/app/lib/workspaces/request.ts
@@ -1,0 +1,71 @@
+import 'server-only';
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { auth } from '@/app/lib/auth';
+import { createLegacyPersonalWorkspaceContext, resolveWorkspaceActor } from './context';
+import { assertWorkspacePermission } from './permissions';
+import type { WorkspaceContext, WorkspacePermissions } from './types';
+
+export type RequestWorkspaceSession = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>;
+export type RequestWorkspacePermission = keyof WorkspacePermissions;
+
+export interface RequestWorkspace {
+  session: RequestWorkspaceSession;
+  workspace: WorkspaceContext;
+}
+
+type RequestWorkspaceResult =
+  | (RequestWorkspace & { response: null })
+  | { session: null; workspace: null; response: NextResponse };
+
+function normalizePermissions(
+  permissions?: RequestWorkspacePermission | RequestWorkspacePermission[]
+): RequestWorkspacePermission[] {
+  if (!permissions) return [];
+  return Array.isArray(permissions) ? permissions : [permissions];
+}
+
+export async function requireRequestWorkspace(
+  request: NextRequest,
+  options: { permissions?: RequestWorkspacePermission | RequestWorkspacePermission[] } = {}
+): Promise<RequestWorkspaceResult> {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return {
+      session: null,
+      workspace: null,
+      response: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }),
+    };
+  }
+
+  const actor = resolveWorkspaceActor({
+    id: session.user.id,
+    email: session.user.email,
+    role: session.user.role,
+  });
+  const workspace = createLegacyPersonalWorkspaceContext(actor);
+
+  try {
+    for (const permission of normalizePermissions(options.permissions)) {
+      assertWorkspacePermission(workspace.permissions, permission);
+    }
+  } catch (error) {
+    const status = error && typeof error === 'object' && 'status' in error
+      ? Number(error.status)
+      : 403;
+    const message = error instanceof Error ? error.message : 'Workspace permission denied';
+    return {
+      session: null,
+      workspace: null,
+      response: NextResponse.json({ success: false, error: message }, { status }),
+    };
+  }
+
+  return { session, workspace, response: null };
+}
+
+export function workspaceFileOptions(workspace: WorkspaceContext) {
+  return { workspace };
+}

--- a/app/lib/workspaces/types.ts
+++ b/app/lib/workspaces/types.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+export type WorkspaceType = 'personal' | 'team';
+
+export type WorkspaceUserRole = 'owner' | 'admin' | 'member' | 'external';
+
+export interface WorkspaceActor {
+  userId: string;
+  email?: string | null;
+  role: WorkspaceUserRole;
+}
+
+export interface WorkspacePermissions {
+  canRead: boolean;
+  canWrite: boolean;
+  canDelete: boolean;
+  canCreatePublicLinks: boolean;
+  canManageWorkspace: boolean;
+  canRunAgent: boolean;
+}
+
+export interface WorkspaceContext {
+  workspaceId: string;
+  workspaceType: WorkspaceType;
+  rootPath: string;
+  actor?: WorkspaceActor;
+  organizationId?: string | null;
+  ownerUserId?: string | null;
+  permissions: WorkspacePermissions;
+  legacy: boolean;
+}
+
+export interface WorkspacePathResolution {
+  workspace: WorkspaceContext;
+  relativePath: string;
+  absolutePath: string;
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -3010,6 +3010,14 @@
       "modified": "Geändert",
       "fromPlugin": "Aus {name}",
       "updateAvailable": "Update verfügbar",
+      "resetAll": {
+        "button": "Skills zurücksetzen",
+        "title": "Alle Skills zurücksetzen?",
+        "description": "Dadurch wird der gesamte Skills-Ordner gelöscht, inklusive installierter Skills, lokaler Skill-Dateien, Registry-Daten und Backups. Installierte Plugins werden nicht entfernt, ihre gebündelten Skills können aber wieder über das Plugin erscheinen.",
+        "confirmLabel": "Gib {confirmation} ein, um fortzufahren.",
+        "cancel": "Abbrechen",
+        "confirm": "Skills-Ordner löschen"
+      },
       "pagination": {
         "status": "Seite {page} von {totalPages} · {totalItems} Skills",
         "previous": "Zurück",
@@ -3018,7 +3026,8 @@
       "errors": {
         "storeLoad": "Canvas Skill Library konnte nicht geladen werden.",
         "install": "Skill konnte nicht installiert werden.",
-        "restore": "Skill konnte nicht zurückgesetzt werden."
+        "restore": "Skill konnte nicht zurückgesetzt werden.",
+        "resetAll": "Skills konnten nicht zurückgesetzt werden."
       }
     },
     "integrationsHint": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -3011,6 +3011,14 @@
       "modified": "Modified",
       "fromPlugin": "From {name}",
       "updateAvailable": "Update available",
+      "resetAll": {
+        "button": "Reset skills",
+        "title": "Reset all skills?",
+        "description": "This deletes the entire skills folder, including installed skills, local skill files, registry data, and backups. Installed plugins are not removed, but their bundled skills can appear again through the plugin.",
+        "confirmLabel": "Type {confirmation} to continue.",
+        "cancel": "Cancel",
+        "confirm": "Delete skills folder"
+      },
       "pagination": {
         "status": "Page {page} of {totalPages} · {totalItems} skills",
         "previous": "Previous",
@@ -3019,7 +3027,8 @@
       "errors": {
         "storeLoad": "Failed to load Canvas Skill Library.",
         "install": "Failed to install skill.",
-        "restore": "Failed to restore skill."
+        "restore": "Failed to restore skill.",
+        "resetAll": "Failed to reset skills."
       }
     },
     "integrationsHint": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test:todos:email": "tsx --conditions react-server scripts/todo-email-notification-test.ts",
     "test:agents:runtime": "tsx --conditions react-server scripts/agent-runtime-config-test.ts",
     "test:onboarding:profile": "tsx --conditions react-server scripts/onboarding-profile-test.ts",
+    "test:workspace:foundation": "tsx --conditions react-server scripts/workspace-context-foundation-test.ts",
     "test:e2e": "playwright test --pass-with-no-tests",
     "test:all": "node scripts/test-all.mjs",
     "test:websocket:connection": "node scripts/test-websocket-connection.js",

--- a/scripts/canvas-skill-store-test.ts
+++ b/scripts/canvas-skill-store-test.ts
@@ -40,7 +40,7 @@ async function writeFile(filePath: string, content: string): Promise<void> {
   await fs.writeFile(filePath, content, 'utf-8');
 }
 
-async function createTestSkillPackage(): Promise<string> {
+async function createTestSkillPackage(version = '1.0.0'): Promise<string> {
   const skillRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-skill-package-'));
 
   await writeFile(path.join(skillRoot, 'SKILL.md'), `---
@@ -48,12 +48,12 @@ name: test-library-skill
 description: "Use this temporary library skill for Canvas skill store tests."
 license: "MIT"
 metadata:
-  version: "1.0.0"
+  version: "${version}"
 ---
 
 # Test Library Skill
 
-This is a temporary test skill.
+This is a temporary test skill at version ${version}.
 `);
 
   await writeFile(path.join(skillRoot, 'agents', 'canvas.yaml'), `interface:
@@ -71,9 +71,9 @@ This is a temporary test skill.
   return skillRoot;
 }
 
-async function createStoreArchive(skillRoot: string, checksum: string): Promise<string> {
+async function createStoreArchive(skillRoot: string, checksum: string, version = '1.0.0'): Promise<string> {
   const storeRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-skill-store-'));
-  const packagePrefix = 'canvas-plugin-marketplace-test/skills/test-library-skill/1.0.0';
+  const packagePrefix = `canvas-plugin-marketplace-test/skills/test-library-skill/${version}`;
   const zip = new JSZip();
 
   async function addDirectory(currentDir: string) {
@@ -106,13 +106,13 @@ async function createStoreArchive(skillRoot: string, checksum: string): Promise<
         displayName: 'Test Library Skill',
         description: 'Temporary skill store test.',
         category: 'Testing',
-        latestVersion: '1.0.0',
-        icon: 'skills/test-library-skill/1.0.0/icon.svg',
+        latestVersion: version,
+        icon: `skills/test-library-skill/${version}/icon.svg`,
         brandColor: '#2563EB',
         license: 'MIT',
         versions: {
-          '1.0.0': {
-            version: '1.0.0',
+          [version]: {
+            version,
             downloadUrl: pathToFileURL(zipPath).toString(),
             packagePath: packagePrefix,
             checksum: `sha256:${checksum}`,
@@ -129,6 +129,7 @@ async function createStoreArchive(skillRoot: string, checksum: string): Promise<
 async function main() {
   const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-skill-test-data-'));
   const skillRoot = await createTestSkillPackage();
+  const tempPaths: string[] = [];
   let storeRoot: string | null = null;
   process.env.CANVAS_DATA_ROOT = dataRoot;
 
@@ -145,8 +146,11 @@ async function main() {
       listCanvasSkillStore,
       readCanvasSkillRegistry,
       removeCanvasSkillRegistryRecord,
+      resetCanvasSkillsDirectory,
       restoreCanvasSkill,
     } = await import('../app/lib/skills/canvas-skill-store');
+    const { readPiRuntimeConfig } = await import('../app/lib/agents/storage');
+    const { DISABLED_ALL_SKILLS_SENTINEL, resolveEnabledSkillNames } = await import('../app/lib/skills/enabled-skills');
     const { deleteSkillDirectory, loadSkillsFromDisk } = await import('../app/lib/skills/skill-loader');
 
     const checksum = await computeCanvasPluginChecksum(skillRoot);
@@ -196,6 +200,26 @@ async function main() {
     skillRegistry = await readCanvasSkillRegistry();
     assert.equal(skillRegistry.skills['test-library-skill'].sourceType, 'store');
 
+    const upgradedSkillRoot = await createTestSkillPackage('1.1.0');
+    tempPaths.push(upgradedSkillRoot);
+    const upgradedChecksum = await computeCanvasPluginChecksum(upgradedSkillRoot);
+    const upgradedRegistryPath = await createStoreArchive(upgradedSkillRoot, upgradedChecksum, '1.1.0');
+    tempPaths.push(path.dirname(upgradedRegistryPath));
+    process.env.CANVAS_PLUGIN_STORE_REGISTRY_URL = pathToFileURL(upgradedRegistryPath).toString();
+
+    await removeCanvasSkillRegistryRecord('test-library-skill');
+    store = await listCanvasSkillStore();
+    assert.equal(store.skills[0].installed.installed, true);
+    assert.equal(store.skills[0].installed.version, '1.0.0');
+    assert.equal(store.skills[0].installed.updateAvailable, true);
+
+    const update = await installCanvasSkillFromStore('test-library-skill', undefined, { enable: true });
+    assert.equal(update.success, true, update.error);
+    skillRegistry = await readCanvasSkillRegistry();
+    assert.equal(skillRegistry.skills['test-library-skill'].version, '1.1.0');
+    store = await listCanvasSkillStore();
+    assert.equal(store.skills[0].installed.updateAvailable, false);
+
     const deleteResult = await deleteSkillDirectory('test-library-skill');
     assert.equal(deleteResult.success, true, deleteResult.error);
     await removeCanvasSkillRegistryRecord('test-library-skill');
@@ -206,10 +230,23 @@ async function main() {
     assert.equal(store.skills[0].installed.installed, false);
     assert.equal(store.skills[0].installed.version, undefined);
 
+    const reinstall = await installCanvasSkillFromStore('test-library-skill', undefined, { enable: true });
+    assert.equal(reinstall.success, true, reinstall.error);
+    assert.equal(resolveEnabledSkillNames(['alpha', 'beta'], [DISABLED_ALL_SKILLS_SENTINEL]).size, 0);
+
+    const reset = await resetCanvasSkillsDirectory('test@example.com');
+    assert.equal(reset.success, true);
+    await assert.rejects(fs.stat(path.join(dataRoot, 'skills', 'test-library-skill')));
+    skillRegistry = await readCanvasSkillRegistry();
+    assert.deepEqual(skillRegistry.skills, {});
+    const resetConfig = await readPiRuntimeConfig();
+    assert.deepEqual(resetConfig.enabledSkills, [DISABLED_ALL_SKILLS_SENTINEL]);
+
     console.log('canvas skill store test passed');
   } finally {
     await fs.rm(dataRoot, { recursive: true, force: true });
     await fs.rm(skillRoot, { recursive: true, force: true });
+    await Promise.all(tempPaths.map((tempPath) => fs.rm(tempPath, { recursive: true, force: true })));
     if (storeRoot) {
       await fs.rm(storeRoot, { recursive: true, force: true });
     }

--- a/scripts/workspace-context-foundation-test.ts
+++ b/scripts/workspace-context-foundation-test.ts
@@ -58,7 +58,19 @@ async function main() {
     /directory traversal/i
   );
   assert.throws(
+    () => workspaceFilesModule.validatePath('nested/../notes.md'),
+    /directory traversal/i
+  );
+  assert.throws(
     () => workspaceFilesModule.validatePath('/etc/passwd'),
+    /directory traversal/i
+  );
+  assert.throws(
+    () => workspaceFilesModule.validatePath('C:/Windows/System32/drivers/etc/hosts'),
+    /directory traversal/i
+  );
+  assert.throws(
+    () => workspaceFilesModule.validatePath('C:/'),
     /directory traversal/i
   );
   assert.throws(

--- a/scripts/workspace-context-foundation-test.ts
+++ b/scripts/workspace-context-foundation-test.ts
@@ -14,11 +14,15 @@ async function main() {
     pathGuardModule,
     permissionsModule,
     workspaceFilesModule,
+    fileReferenceCacheModule,
+    fileTreeCacheModule,
   ] = await Promise.all([
     import('../app/lib/workspaces/context'),
     import('../app/lib/workspaces/path-guard'),
     import('../app/lib/workspaces/permissions'),
     import('../app/lib/filesystem/workspace-files'),
+    import('../app/lib/filesystem/file-reference-cache'),
+    import('../app/lib/utils/file-tree-cache'),
   ]);
 
   const workspace = contextModule.createLegacyPersonalWorkspaceContext({
@@ -106,6 +110,30 @@ async function main() {
     () => pathGuardModule.resolveExistingWorkspacePath(workspace, 'missing.txt'),
     (error: unknown) => Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')
   );
+
+  const workspaceA = {
+    ...workspace,
+    workspaceId: 'workspace-a',
+    rootPath: path.join(tempRoot, 'workspace-a'),
+  };
+  const workspaceB = {
+    ...workspace,
+    workspaceId: 'workspace-b',
+    rootPath: path.join(tempRoot, 'workspace-b'),
+  };
+  await workspaceFilesModule.writeFile('a.md', 'A', { workspace: workspaceA });
+  await workspaceFilesModule.writeFile('b.md', 'B', { workspace: workspaceB });
+
+  const treeKey = fileTreeCacheModule.buildFileTreeCacheKey('docs', 4, 'workspace-a');
+  const parsedTreeKey = fileTreeCacheModule.parseFileTreeCacheKey(treeKey);
+  assert.equal(parsedTreeKey.path, 'docs');
+  assert.equal(parsedTreeKey.depth, 4);
+
+  fileReferenceCacheModule.invalidateFileReferenceCache();
+  const workspaceAFiles = await fileReferenceCacheModule.getCachedFileReferenceEntries(false, { workspace: workspaceA });
+  const workspaceBFiles = await fileReferenceCacheModule.getCachedFileReferenceEntries(false, { workspace: workspaceB });
+  assert.deepEqual(workspaceAFiles.map((entry) => entry.path), ['a.md']);
+  assert.deepEqual(workspaceBFiles.map((entry) => entry.path), ['b.md']);
 
   await fs.rm(tempRoot, { recursive: true, force: true });
   console.log('workspace-context-foundation-test: ok');

--- a/scripts/workspace-context-foundation-test.ts
+++ b/scripts/workspace-context-foundation-test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+async function main() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-workspace-foundation-'));
+  const dataRoot = path.join(tempRoot, 'data');
+  const outsideRoot = path.join(tempRoot, 'outside');
+  process.env.DATA = dataRoot;
+
+  const [
+    contextModule,
+    pathGuardModule,
+    permissionsModule,
+    workspaceFilesModule,
+  ] = await Promise.all([
+    import('../app/lib/workspaces/context'),
+    import('../app/lib/workspaces/path-guard'),
+    import('../app/lib/workspaces/permissions'),
+    import('../app/lib/filesystem/workspace-files'),
+  ]);
+
+  const workspace = contextModule.createLegacyPersonalWorkspaceContext({
+    userId: 'user-1',
+    email: 'user@example.com',
+    role: 'member',
+  });
+
+  assert.equal(workspace.workspaceType, 'personal');
+  assert.equal(workspace.legacy, true);
+  assert.equal(workspace.rootPath, path.join(dataRoot, 'workspace'));
+  assert.equal(workspace.permissions.canRead, true);
+  assert.equal(workspace.permissions.canWrite, true);
+  assert.equal(workspace.permissions.canDelete, true);
+  assert.equal(workspace.permissions.canCreatePublicLinks, true);
+
+  await fs.mkdir(workspace.rootPath, { recursive: true });
+  await fs.mkdir(outsideRoot, { recursive: true });
+  await fs.writeFile(path.join(workspace.rootPath, 'notes.md'), '# Notes');
+  await fs.writeFile(path.join(outsideRoot, 'secret.txt'), 'secret');
+
+  assert.equal(
+    workspaceFilesModule.validatePath('notes.md'),
+    path.join(workspace.rootPath, 'notes.md')
+  );
+  assert.equal(
+    await workspaceFilesModule.readFile('notes.md').then((buffer) => buffer.toString('utf8')),
+    '# Notes'
+  );
+
+  assert.throws(
+    () => workspaceFilesModule.validatePath('../outside/secret.txt'),
+    /directory traversal/i
+  );
+  assert.throws(
+    () => workspaceFilesModule.validatePath('/etc/passwd'),
+    /directory traversal/i
+  );
+  assert.throws(
+    () => workspaceFilesModule.validatePath('bad\0path'),
+    /directory traversal/i
+  );
+
+  const symlinkPath = path.join(workspace.rootPath, 'outside-link');
+  await fs.symlink(outsideRoot, symlinkPath);
+  await assert.rejects(
+    () => workspaceFilesModule.resolveExistingWorkspacePath('outside-link/secret.txt'),
+    /directory traversal/i
+  );
+  await assert.rejects(
+    () => workspaceFilesModule.writeFile('outside-link/new.txt', 'blocked'),
+    /directory traversal/i
+  );
+
+  await workspaceFilesModule.createDirectory('nested/folder');
+  await workspaceFilesModule.writeFile('nested/folder/file.txt', 'ok');
+  assert.equal(
+    await workspaceFilesModule.readFile('nested/folder/file.txt').then((buffer) => buffer.toString('utf8')),
+    'ok'
+  );
+
+  const teamMemberPermissions = permissionsModule.resolveWorkspacePermissions({
+    role: 'member',
+    workspaceType: 'team',
+    canAccessTeamWorkspace: true,
+    canWriteTeamWorkspace: true,
+  });
+  assert.equal(teamMemberPermissions.canRead, true);
+  assert.equal(teamMemberPermissions.canWrite, true);
+  assert.equal(teamMemberPermissions.canDelete, true);
+  assert.equal(teamMemberPermissions.canCreatePublicLinks, true);
+  assert.equal(teamMemberPermissions.canManageWorkspace, false);
+
+  const externalPermissions = permissionsModule.resolveWorkspacePermissions({
+    role: 'external',
+    workspaceType: 'team',
+    canAccessTeamWorkspace: true,
+    canWriteTeamWorkspace: true,
+  });
+  assert.equal(externalPermissions.canRead, false);
+  assert.equal(externalPermissions.canWrite, false);
+  assert.equal(externalPermissions.canCreatePublicLinks, false);
+
+  await assert.rejects(
+    () => pathGuardModule.resolveExistingWorkspacePath(workspace, 'missing.txt'),
+    (error: unknown) => Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')
+  );
+
+  await fs.rm(tempRoot, { recursive: true, force: true });
+  console.log('workspace-context-foundation-test: ok');
+}
+
+void main();

--- a/scripts/workspace-context-foundation-test.ts
+++ b/scripts/workspace-context-foundation-test.ts
@@ -25,6 +25,14 @@ async function main() {
     import('../app/lib/utils/file-tree-cache'),
   ]);
 
+  const previousData = process.env.DATA;
+  process.env.DATA = 'custom-data';
+  assert.equal(
+    contextModule.resolveWorkspaceDataRoot(path.join(tempRoot, 'runtime')),
+    path.join(tempRoot, 'runtime', 'custom-data')
+  );
+  process.env.DATA = previousData;
+
   const workspace = contextModule.createLegacyPersonalWorkspaceContext({
     userId: 'user-1',
     email: 'user@example.com',
@@ -138,6 +146,7 @@ async function main() {
 
   const treeKey = fileTreeCacheModule.buildFileTreeCacheKey('docs', 4, 'workspace-a');
   const parsedTreeKey = fileTreeCacheModule.parseFileTreeCacheKey(treeKey);
+  assert.equal(parsedTreeKey.workspaceId, 'workspace-a');
   assert.equal(parsedTreeKey.path, 'docs');
   assert.equal(parsedTreeKey.depth, 4);
 
@@ -146,6 +155,14 @@ async function main() {
   const workspaceBFiles = await fileReferenceCacheModule.getCachedFileReferenceEntries(false, { workspace: workspaceB });
   assert.deepEqual(workspaceAFiles.map((entry) => entry.path), ['a.md']);
   assert.deepEqual(workspaceBFiles.map((entry) => entry.path), ['b.md']);
+
+  await workspaceFilesModule.writeFile('a-2.md', 'A2', { workspace: workspaceA });
+  await workspaceFilesModule.writeFile('b-2.md', 'B2', { workspace: workspaceB });
+  fileReferenceCacheModule.invalidateFileReferenceCache({ workspace: workspaceA });
+  const refreshedWorkspaceAFiles = await fileReferenceCacheModule.getCachedFileReferenceEntries(false, { workspace: workspaceA });
+  const cachedWorkspaceBFiles = await fileReferenceCacheModule.getCachedFileReferenceEntries(false, { workspace: workspaceB });
+  assert.deepEqual(refreshedWorkspaceAFiles.map((entry) => entry.path).sort(), ['a-2.md', 'a.md']);
+  assert.deepEqual(cachedWorkspaceBFiles.map((entry) => entry.path), ['b.md']);
 
   await fs.rm(tempRoot, { recursive: true, force: true });
   console.log('workspace-context-foundation-test: ok');


### PR DESCRIPTION
## Summary
- Add a typed workspace context foundation with path guards, permission helpers, and request-derived workspace handling.
- Route file, media, and markdown image import writes through the workspace context while preserving the legacy workspace default.
- Make file tree and file reference caches workspace-aware with targeted invalidation where a workspace context is available.
- Include the accepted skill reset/update fix commit and add the greploop PR merge gate to AGENTS.md.

## Validation
- npm run test:workspace:foundation
- npm run lint
- npm run build
- CodeQL: success on PR #11
- Greptile: 5/5 on commit 6dba646d1d3368162f7f72ae619efad8c55e3c49

## Notes
- This PR is opened as a draft so the branch can be reviewed before merge.
- Per AGENTS.md, a greploop review score of 4 or 5 is required before merging into main; current score is 5/5.