### PR TITLE
[codex] Add owner organization bootstrap foundation

### DIFF
--- a/app/api/admin/cleanup/studio-assets/route.ts
+++ b/app/api/admin/cleanup/studio-assets/route.ts
@@ -1,17 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/app/lib/auth';
-import { isAdminUser } from '@/app/lib/admin-auth';
+import { requireInstanceAdmin } from '@/app/lib/admin-auth';
 import { cleanupOrphanedStudioAssets } from '@/app/lib/cleanup/orphaned-assets';
 
 export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
-
-  if (!isAdminUser(session.user)) {
-    return NextResponse.json({ success: false, error: 'Forbidden: admin only' }, { status: 403 });
-  }
+  const admin = await requireInstanceAdmin(request);
+  if (!admin.ok) return admin.response;
 
   try {
     const result = await cleanupOrphanedStudioAssets();

--- a/app/api/admin/organization/status/route.ts
+++ b/app/api/admin/organization/status/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireInstanceAdmin } from '@/app/lib/admin-auth';
+import {
+  ensureOrganizationBootstrapStatus,
+  OrganizationBootstrapError,
+} from '@/app/lib/organization/bootstrap';
+
+export async function GET(request: NextRequest) {
+  const admin = await requireInstanceAdmin(request);
+  if (!admin.ok) return admin.response;
+
+  try {
+    const status = ensureOrganizationBootstrapStatus();
+    return NextResponse.json({ success: true, data: status });
+  } catch (error) {
+    if (error instanceof OrganizationBootstrapError) {
+      const status = error.code === 'ORGANIZATION_ID_CONFLICT' ? 409 : 400;
+      return NextResponse.json(
+        { success: false, code: error.code, error: error.message },
+        { status },
+      );
+    }
+
+    console.error('[admin/organization/status] Failed to resolve organization status:', error);
+    return NextResponse.json(
+      { success: false, code: 'DATABASE_ERROR', error: 'Could not resolve organization status.' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/admin/organization/status/route.ts
+++ b/app/api/admin/organization/status/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { requireInstanceAdmin } from '@/app/lib/admin-auth';
 import {
-  ensureOrganizationBootstrapStatus,
+  getOrganizationBootstrapStatus,
+  openOrganizationBootstrapDatabase,
   OrganizationBootstrapError,
 } from '@/app/lib/organization/bootstrap';
 
@@ -11,8 +12,13 @@ export async function GET(request: NextRequest) {
   if (!admin.ok) return admin.response;
 
   try {
-    const status = ensureOrganizationBootstrapStatus();
-    return NextResponse.json({ success: true, data: status });
+    const sqlite = openOrganizationBootstrapDatabase();
+    try {
+      const status = getOrganizationBootstrapStatus(sqlite);
+      return NextResponse.json({ success: true, data: status });
+    } finally {
+      sqlite.close();
+    }
   } catch (error) {
     if (error instanceof OrganizationBootstrapError) {
       const status = error.code === 'ORGANIZATION_ID_CONFLICT' ? 409 : 400;

--- a/app/components/settings/WorkspaceSettingsPanel.tsx
+++ b/app/components/settings/WorkspaceSettingsPanel.tsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   Bot,
   CheckCircle2,
+  Building2,
   Database,
   Download,
   FileArchive,
@@ -20,6 +21,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -47,6 +49,39 @@ interface WorkspaceSettingsPanelProps {
 }
 
 type DownloadScope = 'workspace' | 'data';
+
+interface OrganizationBootstrapStatus {
+  configured: boolean;
+  organizationId: string | null;
+  ownerUserId: string | null;
+  ownerEmail: string | null;
+  deploymentMode: string;
+  teamFeaturesEnabled: boolean;
+  databaseProvider: string;
+  permission: {
+    role: string;
+    canWriteTeamWorkspace: boolean;
+    canCreatePublicLinks: boolean;
+    canCreateTeamAutomations: boolean;
+    canSharePluginsAndSkills: boolean;
+    canExport: boolean;
+    canDeleteTeamFiles: boolean;
+    canDeleteStudioAssets: boolean;
+    canManageBackups: boolean;
+    canMigrateDatabase: boolean;
+    canEnableKnowledge: boolean;
+    canRecoverWorkspaces: boolean;
+  } | null;
+  paths: {
+    personalWorkspace: string | null;
+    userSettings: string | null;
+    userSecrets: string | null;
+    organizationRoot: string | null;
+    teamWorkspace: string | null;
+    systemBackups: string;
+  };
+  warnings: string[];
+}
 
 const COMPONENT_ICONS: Record<MigrationComponentKey, LucideIcon> = {
   database: Database,
@@ -76,6 +111,9 @@ export function WorkspaceSettingsPanel({ isAdmin = false }: WorkspaceSettingsPan
   const t = useTranslations('settings');
   const [stats, setStats] = useState<WorkspaceStats | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [organizationStatus, setOrganizationStatus] = useState<OrganizationBootstrapStatus | null>(null);
+  const [isOrganizationLoading, setIsOrganizationLoading] = useState(isAdmin);
+  const [organizationError, setOrganizationError] = useState<string | null>(null);
   const [activeDownload, setActiveDownload] = useState<DownloadScope | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [migrationComponents, setMigrationComponents] = useState<MigrationComponents>(() => ({
@@ -98,6 +136,28 @@ export function WorkspaceSettingsPanel({ isAdmin = false }: WorkspaceSettingsPan
 
   const inspection: MigrationInspection | undefined = uploadStatus?.inspection;
 
+  const loadOrganizationStatus = useCallback(async () => {
+    if (!isAdmin) return;
+    setIsOrganizationLoading(true);
+    setOrganizationError(null);
+    try {
+      const response = await fetch('/api/admin/organization/status', {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || t('workspacePanel.organization.errors.load'));
+      }
+      setOrganizationStatus(payload.data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('workspacePanel.organization.errors.load');
+      setOrganizationError(message);
+    } finally {
+      setIsOrganizationLoading(false);
+    }
+  }, [isAdmin, t]);
+
   const loadStats = useCallback(async () => {
     setIsLoading(true);
     setError(null);
@@ -119,6 +179,11 @@ export function WorkspaceSettingsPanel({ isAdmin = false }: WorkspaceSettingsPan
   useEffect(() => {
     startTransition(() => { void loadStats(); });
   }, [loadStats]);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    startTransition(() => { void loadOrganizationStatus(); });
+  }, [isAdmin, loadOrganizationStatus]);
 
   useEffect(() => {
     if (!exportJob || !['queued', 'running'].includes(exportJob.status)) return;
@@ -314,6 +379,126 @@ export function WorkspaceSettingsPanel({ isAdmin = false }: WorkspaceSettingsPan
 
   return (
     <div className="space-y-4">
+      {isAdmin ? (
+        <Card>
+          <CardHeader className="px-4 sm:px-6">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0">
+                <CardTitle className="flex min-w-0 items-center gap-2">
+                  <Building2 className="h-5 w-5 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 truncate">{t('workspacePanel.organization.title')}</span>
+                </CardTitle>
+                <CardDescription>{t('workspacePanel.organization.description')}</CardDescription>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full justify-center sm:w-auto"
+                onClick={() => void loadOrganizationStatus()}
+                disabled={isOrganizationLoading}
+              >
+                {isOrganizationLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                )}
+                {t('workspacePanel.organization.refresh')}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4 px-4 pb-4 sm:px-6 sm:pb-6">
+            {isOrganizationLoading && !organizationStatus ? (
+              <div className="flex items-center text-sm text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {t('workspacePanel.organization.loading')}
+              </div>
+            ) : organizationError ? (
+              <div className="flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{organizationError}</span>
+              </div>
+            ) : organizationStatus ? (
+              <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={organizationStatus.configured ? 'default' : 'outline'}>
+                    {t(organizationStatus.configured ? 'workspacePanel.organization.ready' : 'workspacePanel.organization.notReady')}
+                  </Badge>
+                  <Badge variant="outline">{organizationStatus.deploymentMode}</Badge>
+                  <Badge variant={organizationStatus.databaseProvider === 'postgres' ? 'default' : 'outline'}>
+                    {organizationStatus.databaseProvider}
+                  </Badge>
+                  <Badge variant={organizationStatus.teamFeaturesEnabled ? 'default' : 'outline'}>
+                    {t(organizationStatus.teamFeaturesEnabled ? 'workspacePanel.organization.teamEnabled' : 'workspacePanel.organization.teamDisabled')}
+                  </Badge>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="min-w-0 rounded-lg border border-border p-3">
+                    <p className="text-xs font-medium uppercase text-muted-foreground">{t('workspacePanel.organization.organizationId')}</p>
+                    <p className="mt-1 truncate font-mono text-sm">{organizationStatus.organizationId || '-'}</p>
+                  </div>
+                  <div className="min-w-0 rounded-lg border border-border p-3">
+                    <p className="text-xs font-medium uppercase text-muted-foreground">{t('workspacePanel.organization.owner')}</p>
+                    <p className="mt-1 truncate text-sm">{organizationStatus.ownerEmail || organizationStatus.ownerUserId || '-'}</p>
+                  </div>
+                </div>
+
+                {organizationStatus.permission ? (
+                  <div className="space-y-2">
+                    <p className="text-sm font-semibold">{t('workspacePanel.organization.criticalRights')}</p>
+                    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                      {[
+                        ['canManageBackups', organizationStatus.permission.canManageBackups],
+                        ['canMigrateDatabase', organizationStatus.permission.canMigrateDatabase],
+                        ['canEnableKnowledge', organizationStatus.permission.canEnableKnowledge],
+                        ['canRecoverWorkspaces', organizationStatus.permission.canRecoverWorkspaces],
+                        ['canCreateTeamAutomations', organizationStatus.permission.canCreateTeamAutomations],
+                        ['canSharePluginsAndSkills', organizationStatus.permission.canSharePluginsAndSkills],
+                      ].map(([key, enabled]) => (
+                        <div key={String(key)} className="flex min-w-0 items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
+                          <CheckCircle2 className={`h-4 w-4 shrink-0 ${enabled ? 'text-green-600' : 'text-muted-foreground'}`} />
+                          <span className="min-w-0 truncate">{t(`workspacePanel.organization.permissions.${key}`)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className="space-y-2">
+                  <p className="text-sm font-semibold">{t('workspacePanel.organization.scopedPaths')}</p>
+                  <div className="grid gap-2">
+                    {[
+                      ['personalWorkspace', organizationStatus.paths.personalWorkspace],
+                      ['userSettings', organizationStatus.paths.userSettings],
+                      ['userSecrets', organizationStatus.paths.userSecrets],
+                      ['organizationRoot', organizationStatus.paths.organizationRoot],
+                      ['teamWorkspace', organizationStatus.paths.teamWorkspace],
+                      ['systemBackups', organizationStatus.paths.systemBackups],
+                    ].map(([key, value]) => (
+                      <div key={String(key)} className="grid gap-1 rounded-md border border-border px-3 py-2 text-sm sm:grid-cols-[11rem_minmax(0,1fr)]">
+                        <span className="text-muted-foreground">{t(`workspacePanel.organization.paths.${key}`)}</span>
+                        <span className="min-w-0 truncate font-mono text-xs">{value || t('workspacePanel.organization.notCreated')}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {organizationStatus.warnings.length > 0 ? (
+                  <div className="space-y-2">
+                    {organizationStatus.warnings.map((warning) => (
+                      <div key={warning} className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
+                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                        <span>{warning}</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </CardContent>
+        </Card>
+      ) : null}
+
       <Card>
         <CardHeader className="px-4 sm:px-6">
           <CardTitle>{t('workspacePanel.title')}</CardTitle>

--- a/app/lib/admin-auth.ts
+++ b/app/lib/admin-auth.ts
@@ -1,5 +1,8 @@
 import 'server-only';
 
+import { NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@/app/lib/auth';
 import { isBootstrapAdminEmail } from '@/app/lib/bootstrap-admin';
 
 export type AdminUserCandidate = {
@@ -9,4 +12,23 @@ export type AdminUserCandidate = {
 
 export function isAdminUser(user: AdminUserCandidate | null | undefined): boolean {
   return Boolean(user?.role === 'admin' || isBootstrapAdminEmail(user?.email));
+}
+
+export async function requireInstanceAdmin(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }),
+    };
+  }
+
+  if (!isAdminUser(session.user)) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ success: false, error: 'Forbidden: admin only' }, { status: 403 }),
+    };
+  }
+
+  return { ok: true as const, session };
 }

--- a/app/lib/auth-setup.ts
+++ b/app/lib/auth-setup.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'node:crypto';
 import { hashPassword } from 'better-auth/crypto';
 
 import { runMigrations } from '@/app/lib/db/migrate';
+import { ensureOrganizationBootstrapForUser } from '@/app/lib/organization/bootstrap';
 
 export const SETUP_PASSWORD_MIN_LENGTH = 8;
 export const SETUP_PASSWORD_MAX_LENGTH = 128;
@@ -151,6 +152,8 @@ export async function createInitialOwner(input: unknown): Promise<InitialOwner> 
         id, account_id, provider_id, user_id, password, created_at, updated_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?)
     `).run(accountId, userId, 'credential', userId, passwordHash, now, now);
+
+    ensureOrganizationBootstrapForUser(sqlite, userId);
 
     sqlite.exec('COMMIT');
     return { id: userId, name, email };

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -105,6 +105,38 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       updated_at INTEGER
     );
 
+    CREATE TABLE IF NOT EXISTS canvas_organization_settings (
+      organization_id TEXT PRIMARY KEY NOT NULL,
+      owner_user_id TEXT NOT NULL,
+      deployment_mode TEXT NOT NULL DEFAULT 'single_user',
+      team_features_enabled INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (owner_user_id) REFERENCES user(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS organization_user_permissions (
+      organization_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'member',
+      can_write_team_workspace INTEGER NOT NULL DEFAULT 0,
+      can_create_public_links INTEGER NOT NULL DEFAULT 1,
+      can_create_team_automations INTEGER NOT NULL DEFAULT 0,
+      can_share_plugins_and_skills INTEGER NOT NULL DEFAULT 0,
+      can_export INTEGER NOT NULL DEFAULT 0,
+      can_delete_team_files INTEGER NOT NULL DEFAULT 0,
+      can_delete_studio_assets INTEGER NOT NULL DEFAULT 1,
+      can_manage_backups INTEGER NOT NULL DEFAULT 0,
+      can_migrate_database INTEGER NOT NULL DEFAULT 0,
+      can_enable_knowledge INTEGER NOT NULL DEFAULT 0,
+      can_recover_workspaces INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (organization_id, user_id),
+      FOREIGN KEY (organization_id) REFERENCES canvas_organization_settings(organization_id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES user(id)
+    );
+
     CREATE TABLE IF NOT EXISTS pi_sessions (
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
       session_id TEXT NOT NULL,
@@ -967,6 +999,11 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
 
   // ── Deferred indexes on columns added via ALTER TABLE ──────────────────────
   sqlite.exec(`
+    CREATE INDEX IF NOT EXISTS idx_canvas_org_settings_owner ON canvas_organization_settings (owner_user_id);
+    CREATE INDEX IF NOT EXISTS idx_org_user_permissions_user ON organization_user_permissions (user_id);
+    CREATE INDEX IF NOT EXISTS idx_org_user_permissions_role ON organization_user_permissions (organization_id, role);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_org_user_permissions_single_owner ON organization_user_permissions (organization_id) WHERE role = 'owner';
+
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_last_message ON pi_sessions (last_message_at);
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_user_created ON pi_sessions (user_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_user_session ON pi_sessions (user_id, session_id);

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -96,6 +96,41 @@ export const verification = sqliteTable("verification", {
   updatedAt: integer("updated_at", { mode: "timestamp" })
 });
 
+export const canvasOrganizationSettings = sqliteTable("canvas_organization_settings", {
+  organizationId: text("organization_id").primaryKey(),
+  ownerUserId: text("owner_user_id").notNull().references(() => user.id),
+  deploymentMode: text("deployment_mode").notNull().default("single_user"),
+  teamFeaturesEnabled: integer("team_features_enabled", { mode: "boolean" }).notNull().default(false),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  ownerIdx: index("idx_canvas_org_settings_owner").on(table.ownerUserId),
+}));
+
+export const organizationUserPermissions = sqliteTable("organization_user_permissions", {
+  organizationId: text("organization_id").notNull().references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  userId: text("user_id").notNull().references(() => user.id),
+  role: text("role").notNull().default("member"),
+  canWriteTeamWorkspace: integer("can_write_team_workspace", { mode: "boolean" }).notNull().default(false),
+  canCreatePublicLinks: integer("can_create_public_links", { mode: "boolean" }).notNull().default(true),
+  canCreateTeamAutomations: integer("can_create_team_automations", { mode: "boolean" }).notNull().default(false),
+  canSharePluginsAndSkills: integer("can_share_plugins_and_skills", { mode: "boolean" }).notNull().default(false),
+  canExport: integer("can_export", { mode: "boolean" }).notNull().default(false),
+  canDeleteTeamFiles: integer("can_delete_team_files", { mode: "boolean" }).notNull().default(false),
+  canDeleteStudioAssets: integer("can_delete_studio_assets", { mode: "boolean" }).notNull().default(true),
+  canManageBackups: integer("can_manage_backups", { mode: "boolean" }).notNull().default(false),
+  canMigrateDatabase: integer("can_migrate_database", { mode: "boolean" }).notNull().default(false),
+  canEnableKnowledge: integer("can_enable_knowledge", { mode: "boolean" }).notNull().default(false),
+  canRecoverWorkspaces: integer("can_recover_workspaces", { mode: "boolean" }).notNull().default(false),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  pk: primaryKey(table.organizationId, table.userId),
+  userIdx: index("idx_org_user_permissions_user").on(table.userId),
+  roleIdx: index("idx_org_user_permissions_role").on(table.organizationId, table.role),
+  singleOwnerIdx: uniqueIndex("idx_org_user_permissions_single_owner").on(table.organizationId).where(sql`${table.role} = 'owner'`),
+}));
+
 export const aiSessions = sqliteTable("ai_sessions", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   sessionId: text("session_id").notNull(),

--- a/app/lib/migration/auth.ts
+++ b/app/lib/migration/auth.ts
@@ -1,24 +1,8 @@
 import 'server-only';
 
-import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/app/lib/auth';
-import { isAdminUser } from '@/app/lib/admin-auth';
+import { NextRequest } from 'next/server';
+import { requireInstanceAdmin } from '@/app/lib/admin-auth';
 
 export async function requireMigrationAdmin(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return {
-      ok: false as const,
-      response: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }),
-    };
-  }
-
-  if (!isAdminUser(session.user)) {
-    return {
-      ok: false as const,
-      response: NextResponse.json({ success: false, error: 'Forbidden: admin only' }, { status: 403 }),
-    };
-  }
-
-  return { ok: true as const, session };
+  return requireInstanceAdmin(request);
 }

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -262,17 +262,6 @@ function ensurePermissionRow(
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(organization_id, user_id) DO UPDATE SET
       role = excluded.role,
-      can_write_team_workspace = excluded.can_write_team_workspace,
-      can_create_public_links = excluded.can_create_public_links,
-      can_create_team_automations = excluded.can_create_team_automations,
-      can_share_plugins_and_skills = excluded.can_share_plugins_and_skills,
-      can_export = excluded.can_export,
-      can_delete_team_files = excluded.can_delete_team_files,
-      can_delete_studio_assets = excluded.can_delete_studio_assets,
-      can_manage_backups = excluded.can_manage_backups,
-      can_migrate_database = excluded.can_migrate_database,
-      can_enable_knowledge = excluded.can_enable_knowledge,
-      can_recover_workspaces = excluded.can_recover_workspaces,
       updated_at = excluded.updated_at
   `).run(
     organizationId,
@@ -293,7 +282,7 @@ function ensurePermissionRow(
     now,
   );
 
-  return defaults;
+  return getPermissionRow(sqlite, organizationId, userId) || defaults;
 }
 
 function getPermissionRow(

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -1,0 +1,501 @@
+import 'server-only';
+
+import Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { getBootstrapAdminEmail } from '@/app/lib/bootstrap-admin';
+import { runMigrations } from '@/app/lib/db/migrate';
+import { resolveWorkspaceDataRoot } from '@/app/lib/workspaces/context';
+
+export const LOCAL_ORGANIZATION_ID_PREFIX = 'org_';
+
+export type OrganizationRole = 'owner' | 'admin' | 'member' | 'external';
+
+export type OrganizationPermissionSnapshot = {
+  role: OrganizationRole;
+  canWriteTeamWorkspace: boolean;
+  canCreatePublicLinks: boolean;
+  canCreateTeamAutomations: boolean;
+  canSharePluginsAndSkills: boolean;
+  canExport: boolean;
+  canDeleteTeamFiles: boolean;
+  canDeleteStudioAssets: boolean;
+  canManageBackups: boolean;
+  canMigrateDatabase: boolean;
+  canEnableKnowledge: boolean;
+  canRecoverWorkspaces: boolean;
+};
+
+export type OrganizationBootstrapStatus = {
+  configured: boolean;
+  organizationId: string | null;
+  ownerUserId: string | null;
+  ownerEmail: string | null;
+  deploymentMode: string;
+  teamFeaturesEnabled: boolean;
+  databaseProvider: string;
+  permission: OrganizationPermissionSnapshot | null;
+  paths: {
+    personalWorkspace: string | null;
+    userSettings: string | null;
+    userSecrets: string | null;
+    organizationRoot: string | null;
+    teamWorkspace: string | null;
+    systemBackups: string;
+  };
+  warnings: string[];
+};
+
+type UserRow = {
+  id: string;
+  email: string | null;
+  role: string | null;
+  created_at: number;
+};
+
+type OrganizationRow = {
+  organization_id: string;
+  owner_user_id: string;
+  deployment_mode: string;
+  team_features_enabled: number;
+  created_at: number;
+  updated_at: number;
+};
+
+type PermissionRow = {
+  role: string;
+  can_write_team_workspace: number;
+  can_create_public_links: number;
+  can_create_team_automations: number;
+  can_share_plugins_and_skills: number;
+  can_export: number;
+  can_delete_team_files: number;
+  can_delete_studio_assets: number;
+  can_manage_backups: number;
+  can_migrate_database: number;
+  can_enable_knowledge: number;
+  can_recover_workspaces: number;
+};
+
+export class OrganizationBootstrapError extends Error {
+  constructor(
+    public readonly code: 'NO_USERS' | 'ORGANIZATION_ID_CONFLICT' | 'DATABASE_ERROR',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'OrganizationBootstrapError';
+  }
+}
+
+function normalizeRole(role: string | null | undefined): OrganizationRole {
+  if (role === 'owner' || role === 'admin' || role === 'external') return role;
+  return 'member';
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  return value === 'true' || value === '1' || value === 'yes';
+}
+
+export function getConfiguredOrganizationId(): string | null {
+  const value = process.env.CANVAS_ORGANIZATION_ID?.trim();
+  return value || null;
+}
+
+export function getDatabaseProvider(): string {
+  return process.env.CANVAS_DATABASE_PROVIDER?.trim().toLowerCase() || 'sqlite';
+}
+
+export function getDeploymentMode(): string {
+  const explicit = process.env.CANVAS_DEPLOYMENT_MODE?.trim();
+  if (explicit) return explicit;
+  if (process.env.CANVAS_MANAGED_SERVICES_ENABLED === 'true' || process.env.CANVAS_INSTANCE_TOKEN?.trim()) {
+    return 'managed-single';
+  }
+  return 'single_user';
+}
+
+export function areTeamFeaturesEnabled(deploymentMode = getDeploymentMode()): boolean {
+  return isTruthyEnv(process.env.CANVAS_TEAM_FEATURES_ENABLED) || deploymentMode.toLowerCase().includes('team');
+}
+
+function booleanFromDb(value: number | null | undefined): boolean {
+  return value === 1;
+}
+
+function organizationIdFromEnvironmentOrLocal(): string {
+  return getConfiguredOrganizationId() || `${LOCAL_ORGANIZATION_ID_PREFIX}${randomUUID()}`;
+}
+
+function getDataRoot(): string {
+  return resolveWorkspaceDataRoot();
+}
+
+function buildScopedPaths(organizationId: string, userId: string, teamFeaturesEnabled: boolean) {
+  const dataRoot = getDataRoot();
+  return {
+    personalWorkspace: path.join(dataRoot, 'workspaces', 'personal', userId, 'files'),
+    userSettings: path.join(dataRoot, 'users', userId, 'settings'),
+    userSecrets: path.join(dataRoot, 'users', userId, 'secrets'),
+    userAgents: path.join(dataRoot, 'users', userId, 'agents'),
+    userSkills: path.join(dataRoot, 'users', userId, 'skills'),
+    userPlugins: path.join(dataRoot, 'users', userId, 'plugins'),
+    userMcp: path.join(dataRoot, 'users', userId, 'mcp'),
+    userMail: path.join(dataRoot, 'users', userId, 'mail'),
+    organizationRoot: path.join(dataRoot, 'organizations', organizationId),
+    organizationSecrets: path.join(dataRoot, 'organizations', organizationId, 'secrets'),
+    organizationPolicies: path.join(dataRoot, 'organizations', organizationId, 'policies'),
+    organizationAgentTemplates: path.join(dataRoot, 'organizations', organizationId, 'agent-templates'),
+    organizationMcpTemplates: path.join(dataRoot, 'organizations', organizationId, 'mcp-templates'),
+    organizationSkillTemplates: path.join(dataRoot, 'organizations', organizationId, 'skill-templates'),
+    organizationPluginTemplates: path.join(dataRoot, 'organizations', organizationId, 'plugin-templates'),
+    teamWorkspace: teamFeaturesEnabled
+      ? path.join(dataRoot, 'workspaces', 'team', organizationId, 'files')
+      : null,
+    systemBackups: path.join(dataRoot, 'system', 'backups'),
+    systemMigration: path.join(dataRoot, 'system', 'migration'),
+    systemLogs: path.join(dataRoot, 'system', 'logs'),
+  };
+}
+
+function ensureScopedDirectories(organizationId: string, userId: string, teamFeaturesEnabled: boolean): void {
+  const paths = buildScopedPaths(organizationId, userId, teamFeaturesEnabled);
+  for (const directory of Object.values(paths)) {
+    if (directory) {
+      mkdirSync(directory, { recursive: true });
+    }
+  }
+}
+
+function getPrimaryOrganization(sqlite: Database.Database): OrganizationRow | null {
+  return sqlite.prepare(`
+    SELECT organization_id, owner_user_id, deployment_mode, team_features_enabled, created_at, updated_at
+    FROM canvas_organization_settings
+    ORDER BY created_at ASC
+    LIMIT 1
+  `).get() as OrganizationRow | undefined || null;
+}
+
+function getUserById(sqlite: Database.Database, userId: string): UserRow | null {
+  return sqlite.prepare(`
+    SELECT id, email, role, created_at
+    FROM user
+    WHERE id = ?
+    LIMIT 1
+  `).get(userId) as UserRow | undefined || null;
+}
+
+function getOwnerCandidate(sqlite: Database.Database): UserRow | null {
+  const bootstrapEmail = getBootstrapAdminEmail();
+  if (bootstrapEmail) {
+    const bootstrapUser = sqlite.prepare(`
+      SELECT id, email, role, created_at
+      FROM user
+      WHERE lower(email) = ?
+      LIMIT 1
+    `).get(bootstrapEmail) as UserRow | undefined;
+    if (bootstrapUser) return bootstrapUser;
+  }
+
+  return sqlite.prepare(`
+    SELECT id, email, role, created_at
+    FROM user
+    ORDER BY
+      CASE WHEN role = 'admin' THEN 0 ELSE 1 END,
+      created_at ASC
+    LIMIT 1
+  `).get() as UserRow | undefined || null;
+}
+
+function assertOrganizationIdMatchesEnvironment(organizationId: string): void {
+  const configuredOrganizationId = getConfiguredOrganizationId();
+  if (configuredOrganizationId && configuredOrganizationId !== organizationId) {
+    throw new OrganizationBootstrapError(
+      'ORGANIZATION_ID_CONFLICT',
+      `Persisted organization ${organizationId} does not match CANVAS_ORGANIZATION_ID ${configuredOrganizationId}.`,
+    );
+  }
+}
+
+function permissionDefaults(role: OrganizationRole): OrganizationPermissionSnapshot {
+  const isAdminLike = role === 'owner' || role === 'admin';
+  return {
+    role,
+    canWriteTeamWorkspace: isAdminLike,
+    canCreatePublicLinks: true,
+    canCreateTeamAutomations: isAdminLike,
+    canSharePluginsAndSkills: isAdminLike,
+    canExport: isAdminLike,
+    canDeleteTeamFiles: isAdminLike,
+    canDeleteStudioAssets: true,
+    canManageBackups: isAdminLike,
+    canMigrateDatabase: isAdminLike,
+    canEnableKnowledge: isAdminLike,
+    canRecoverWorkspaces: isAdminLike,
+  };
+}
+
+function ensurePermissionRow(
+  sqlite: Database.Database,
+  organizationId: string,
+  userId: string,
+  requestedRole: OrganizationRole,
+): OrganizationPermissionSnapshot {
+  const existing = sqlite.prepare(`
+    SELECT role
+    FROM organization_user_permissions
+    WHERE organization_id = ? AND user_id = ?
+    LIMIT 1
+  `).get(organizationId, userId) as { role?: string } | undefined;
+  const role = existing?.role === 'owner' ? 'owner' : requestedRole;
+  const defaults = permissionDefaults(role);
+  const now = Date.now();
+
+  sqlite.prepare(`
+    INSERT INTO organization_user_permissions (
+      organization_id, user_id, role,
+      can_write_team_workspace, can_create_public_links, can_create_team_automations,
+      can_share_plugins_and_skills, can_export, can_delete_team_files, can_delete_studio_assets,
+      can_manage_backups, can_migrate_database, can_enable_knowledge, can_recover_workspaces,
+      created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(organization_id, user_id) DO UPDATE SET
+      role = excluded.role,
+      can_write_team_workspace = excluded.can_write_team_workspace,
+      can_create_public_links = excluded.can_create_public_links,
+      can_create_team_automations = excluded.can_create_team_automations,
+      can_share_plugins_and_skills = excluded.can_share_plugins_and_skills,
+      can_export = excluded.can_export,
+      can_delete_team_files = excluded.can_delete_team_files,
+      can_delete_studio_assets = excluded.can_delete_studio_assets,
+      can_manage_backups = excluded.can_manage_backups,
+      can_migrate_database = excluded.can_migrate_database,
+      can_enable_knowledge = excluded.can_enable_knowledge,
+      can_recover_workspaces = excluded.can_recover_workspaces,
+      updated_at = excluded.updated_at
+  `).run(
+    organizationId,
+    userId,
+    defaults.role,
+    defaults.canWriteTeamWorkspace ? 1 : 0,
+    defaults.canCreatePublicLinks ? 1 : 0,
+    defaults.canCreateTeamAutomations ? 1 : 0,
+    defaults.canSharePluginsAndSkills ? 1 : 0,
+    defaults.canExport ? 1 : 0,
+    defaults.canDeleteTeamFiles ? 1 : 0,
+    defaults.canDeleteStudioAssets ? 1 : 0,
+    defaults.canManageBackups ? 1 : 0,
+    defaults.canMigrateDatabase ? 1 : 0,
+    defaults.canEnableKnowledge ? 1 : 0,
+    defaults.canRecoverWorkspaces ? 1 : 0,
+    now,
+    now,
+  );
+
+  return defaults;
+}
+
+function getPermissionRow(
+  sqlite: Database.Database,
+  organizationId: string,
+  userId: string,
+): OrganizationPermissionSnapshot | null {
+  const row = sqlite.prepare(`
+    SELECT role, can_write_team_workspace, can_create_public_links, can_create_team_automations,
+      can_share_plugins_and_skills, can_export, can_delete_team_files, can_delete_studio_assets,
+      can_manage_backups, can_migrate_database, can_enable_knowledge, can_recover_workspaces
+    FROM organization_user_permissions
+    WHERE organization_id = ? AND user_id = ?
+    LIMIT 1
+  `).get(organizationId, userId) as PermissionRow | undefined;
+
+  if (!row) return null;
+
+  return {
+    role: normalizeRole(row.role),
+    canWriteTeamWorkspace: booleanFromDb(row.can_write_team_workspace),
+    canCreatePublicLinks: booleanFromDb(row.can_create_public_links),
+    canCreateTeamAutomations: booleanFromDb(row.can_create_team_automations),
+    canSharePluginsAndSkills: booleanFromDb(row.can_share_plugins_and_skills),
+    canExport: booleanFromDb(row.can_export),
+    canDeleteTeamFiles: booleanFromDb(row.can_delete_team_files),
+    canDeleteStudioAssets: booleanFromDb(row.can_delete_studio_assets),
+    canManageBackups: booleanFromDb(row.can_manage_backups),
+    canMigrateDatabase: booleanFromDb(row.can_migrate_database),
+    canEnableKnowledge: booleanFromDb(row.can_enable_knowledge),
+    canRecoverWorkspaces: booleanFromDb(row.can_recover_workspaces),
+  };
+}
+
+export function ensureOrganizationBootstrapForUser(
+  sqlite: Database.Database,
+  userId: string,
+): OrganizationBootstrapStatus {
+  const targetUser = getUserById(sqlite, userId);
+  if (!targetUser) {
+    throw new OrganizationBootstrapError('NO_USERS', 'Cannot bootstrap organization without a valid user.');
+  }
+
+  const deploymentMode = getDeploymentMode();
+  const teamFeaturesEnabled = areTeamFeaturesEnabled(deploymentMode);
+  const now = Date.now();
+  let organization = getPrimaryOrganization(sqlite);
+
+  if (organization) {
+    assertOrganizationIdMatchesEnvironment(organization.organization_id);
+    sqlite.prepare(`
+      UPDATE canvas_organization_settings
+      SET deployment_mode = ?, team_features_enabled = ?, updated_at = ?
+      WHERE organization_id = ?
+    `).run(deploymentMode, teamFeaturesEnabled ? 1 : 0, now, organization.organization_id);
+    organization = {
+      ...organization,
+      deployment_mode: deploymentMode,
+      team_features_enabled: teamFeaturesEnabled ? 1 : 0,
+      updated_at: now,
+    };
+  } else {
+    const organizationId = organizationIdFromEnvironmentOrLocal();
+    sqlite.prepare(`
+      INSERT INTO canvas_organization_settings (
+        organization_id, owner_user_id, deployment_mode, team_features_enabled, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+    `).run(organizationId, userId, deploymentMode, teamFeaturesEnabled ? 1 : 0, now, now);
+    organization = {
+      organization_id: organizationId,
+      owner_user_id: userId,
+      deployment_mode: deploymentMode,
+      team_features_enabled: teamFeaturesEnabled ? 1 : 0,
+      created_at: now,
+      updated_at: now,
+    };
+  }
+
+  const ownerUser = getUserById(sqlite, organization.owner_user_id) || targetUser;
+  sqlite.prepare('UPDATE user SET role = ?, updated_at = ? WHERE id = ?').run('admin', now, ownerUser.id);
+
+  const ownerPermission = ensurePermissionRow(sqlite, organization.organization_id, ownerUser.id, 'owner');
+  if (targetUser.id !== ownerUser.id) {
+    sqlite.prepare('UPDATE user SET role = ?, updated_at = ? WHERE id = ?').run('admin', now, targetUser.id);
+    ensurePermissionRow(sqlite, organization.organization_id, targetUser.id, 'admin');
+  }
+
+  ensureScopedDirectories(organization.organization_id, ownerUser.id, teamFeaturesEnabled);
+  if (targetUser.id !== ownerUser.id) {
+    ensureScopedDirectories(organization.organization_id, targetUser.id, teamFeaturesEnabled);
+  }
+
+  return buildStatus(sqlite, organization, ownerUser, ownerPermission);
+}
+
+export function ensureOrganizationBootstrapForExistingUsers(sqlite: Database.Database): OrganizationBootstrapStatus {
+  const organization = getPrimaryOrganization(sqlite);
+  if (organization) {
+    assertOrganizationIdMatchesEnvironment(organization.organization_id);
+    const ownerUser = getUserById(sqlite, organization.owner_user_id);
+    if (ownerUser) {
+      return ensureOrganizationBootstrapForUser(sqlite, ownerUser.id);
+    }
+  }
+
+  const ownerCandidate = getOwnerCandidate(sqlite);
+  if (!ownerCandidate) {
+    throw new OrganizationBootstrapError('NO_USERS', 'Cannot bootstrap organization before the first user exists.');
+  }
+
+  return ensureOrganizationBootstrapForUser(sqlite, ownerCandidate.id);
+}
+
+function buildStatus(
+  sqlite: Database.Database,
+  organization: OrganizationRow | null,
+  ownerUser: UserRow | null,
+  permission: OrganizationPermissionSnapshot | null,
+): OrganizationBootstrapStatus {
+  const deploymentMode = organization?.deployment_mode || getDeploymentMode();
+  const teamFeaturesEnabled = organization
+    ? booleanFromDb(organization.team_features_enabled)
+    : areTeamFeaturesEnabled(deploymentMode);
+  const databaseProvider = getDatabaseProvider();
+  const organizationId = organization?.organization_id || null;
+  const ownerUserId = organization?.owner_user_id || ownerUser?.id || null;
+  const paths = organizationId && ownerUserId
+    ? buildScopedPaths(organizationId, ownerUserId, teamFeaturesEnabled)
+    : null;
+  const warnings: string[] = [];
+
+  if (teamFeaturesEnabled && databaseProvider !== 'postgres') {
+    warnings.push('Team features are enabled but CANVAS_DATABASE_PROVIDER is not postgres.');
+  }
+
+  const configuredOrganizationId = getConfiguredOrganizationId();
+  if (configuredOrganizationId && organizationId && configuredOrganizationId !== organizationId) {
+    warnings.push('Persisted organization does not match CANVAS_ORGANIZATION_ID.');
+  }
+
+  if (organization && ownerUserId && !permission) {
+    permission = getPermissionRow(sqlite, organization.organization_id, ownerUserId);
+  }
+
+  return {
+    configured: Boolean(organization && ownerUser),
+    organizationId,
+    ownerUserId,
+    ownerEmail: ownerUser?.email || null,
+    deploymentMode,
+    teamFeaturesEnabled,
+    databaseProvider,
+    permission,
+    paths: {
+      personalWorkspace: paths?.personalWorkspace || null,
+      userSettings: paths?.userSettings || null,
+      userSecrets: paths?.userSecrets || null,
+      organizationRoot: paths?.organizationRoot || null,
+      teamWorkspace: paths?.teamWorkspace || null,
+      systemBackups: paths?.systemBackups || path.join(getDataRoot(), 'system', 'backups'),
+    },
+    warnings,
+  };
+}
+
+export function getOrganizationBootstrapStatus(sqlite: Database.Database): OrganizationBootstrapStatus {
+  const organization = getPrimaryOrganization(sqlite);
+  const ownerUser = organization ? getUserById(sqlite, organization.owner_user_id) : getOwnerCandidate(sqlite);
+  const permission = organization && ownerUser
+    ? getPermissionRow(sqlite, organization.organization_id, ownerUser.id)
+    : null;
+  return buildStatus(sqlite, organization, ownerUser, permission);
+}
+
+function getSqlitePath(): string {
+  return path.join(getDataRoot(), 'sqlite.db');
+}
+
+export function openOrganizationBootstrapDatabase(): Database.Database {
+  const sqlite = new Database(getSqlitePath());
+  sqlite.pragma('foreign_keys = ON');
+  sqlite.pragma('busy_timeout = 5000');
+  runMigrations(sqlite);
+  return sqlite;
+}
+
+export function ensureOrganizationBootstrapStatus(): OrganizationBootstrapStatus {
+  const sqlite = openOrganizationBootstrapDatabase();
+  try {
+    sqlite.exec('BEGIN IMMEDIATE');
+    const status = ensureOrganizationBootstrapForExistingUsers(sqlite);
+    sqlite.exec('COMMIT');
+    return status;
+  } catch (error) {
+    if (sqlite.inTransaction) {
+      sqlite.exec('ROLLBACK');
+    }
+    if (error instanceof OrganizationBootstrapError) {
+      throw error;
+    }
+    throw new OrganizationBootstrapError('DATABASE_ERROR', 'Could not ensure organization bootstrap state.');
+  } finally {
+    sqlite.close();
+  }
+}

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -192,7 +192,7 @@ function getOwnerCandidate(sqlite: Database.Database): UserRow | null {
     const bootstrapUser = sqlite.prepare(`
       SELECT id, email, role, created_at
       FROM user
-      WHERE lower(email) = ?
+      WHERE lower(email) = lower(?)
       LIMIT 1
     `).get(bootstrapEmail) as UserRow | undefined;
     if (bootstrapUser) return bootstrapUser;

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-18",
+  "updatedAt": "2026-06-19",
   "source": "Canvas Notebook Team Workspace Plan",
   "tasks": [
     {
@@ -26,7 +26,7 @@
     {
       "id": 4,
       "title": "Initiales Admin-/Owner-Setup und Admin-only Rechte fuer kritische App-Funktionen absichern",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/04-auth-roles-model.md",

--- a/messages/de.json
+++ b/messages/de.json
@@ -2025,6 +2025,40 @@
       "downloading": "Download wird vorbereitet...",
       "refresh": "Aktualisieren",
       "emptyWorkspace": "Dein Workspace ist leer.",
+      "organization": {
+        "title": "Organisations-Setup",
+        "description": "Zeigt lokalen Owner, Deployment-Modus, kritische Admin-Rechte und die fuer Team-Workspaces vorbereiteten Datenpfade.",
+        "refresh": "Aktualisieren",
+        "loading": "Organisations-Setup wird geprüft...",
+        "ready": "Bereit",
+        "notReady": "Unvollständig",
+        "teamEnabled": "Team aktiv",
+        "teamDisabled": "Team aus",
+        "organizationId": "Organisations-ID",
+        "owner": "Owner",
+        "criticalRights": "Kritische Rechte",
+        "scopedPaths": "Scoped Datenpfade",
+        "notCreated": "In diesem Modus nicht angelegt",
+        "permissions": {
+          "canManageBackups": "Full Backup",
+          "canMigrateDatabase": "Datenbank-Migration",
+          "canEnableKnowledge": "Knowledge aktivieren",
+          "canRecoverWorkspaces": "Recovery-Flow",
+          "canCreateTeamAutomations": "Team-Automationen",
+          "canSharePluginsAndSkills": "Plugin- und Skill-Freigabe"
+        },
+        "paths": {
+          "personalWorkspace": "Persönlicher Workspace",
+          "userSettings": "User-Settings",
+          "userSecrets": "User-Secrets",
+          "organizationRoot": "Organisations-Root",
+          "teamWorkspace": "Team-Workspace",
+          "systemBackups": "System-Backups"
+        },
+        "errors": {
+          "load": "Organisations-Setup-Status konnte nicht geladen werden."
+        }
+      },
       "migration": {
         "title": "VM-Migration",
         "description": "Erstelle ein versioniertes Migrations-Bundle oder stelle eines in dieser VM wieder her.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2026,6 +2026,40 @@
       "downloading": "Preparing download...",
       "refresh": "Refresh",
       "emptyWorkspace": "Your workspace is empty.",
+      "organization": {
+        "title": "Organization setup",
+        "description": "Shows the local owner, deployment mode, critical admin rights, and scoped data roots prepared for team workspaces.",
+        "refresh": "Refresh",
+        "loading": "Checking organization setup...",
+        "ready": "Ready",
+        "notReady": "Incomplete",
+        "teamEnabled": "Team enabled",
+        "teamDisabled": "Team disabled",
+        "organizationId": "Organization ID",
+        "owner": "Owner",
+        "criticalRights": "Critical rights",
+        "scopedPaths": "Scoped data paths",
+        "notCreated": "Not created in this mode",
+        "permissions": {
+          "canManageBackups": "Full backup",
+          "canMigrateDatabase": "Database migration",
+          "canEnableKnowledge": "Knowledge enable",
+          "canRecoverWorkspaces": "Recovery flow",
+          "canCreateTeamAutomations": "Team automations",
+          "canSharePluginsAndSkills": "Plugin and skill sharing"
+        },
+        "paths": {
+          "personalWorkspace": "Personal workspace",
+          "userSettings": "User settings",
+          "userSecrets": "User secrets",
+          "organizationRoot": "Organization root",
+          "teamWorkspace": "Team workspace",
+          "systemBackups": "System backups"
+        },
+        "errors": {
+          "load": "Failed to load organization setup status."
+        }
+      },
       "migration": {
         "title": "VM Migration",
         "description": "Create a versioned migration bundle or restore one into this VM.",

--- a/scripts/auth-setup-test.ts
+++ b/scripts/auth-setup-test.ts
@@ -65,6 +65,7 @@ async function main() {
     hasAnyAuthUser,
     InitialOwnerSetupError,
   } = await import('../app/lib/auth-setup');
+  const { getOrganizationBootstrapStatus } = await import('../app/lib/organization/bootstrap');
 
   assert.equal(hasAnyAuthUser(), false);
 
@@ -109,6 +110,21 @@ async function main() {
   assert.ok(accounts[0].password);
   assert.equal(await verifyPassword({ hash: accounts[0].password!, password: 'SetupPassword123!' }), true);
   assertOrganizationBootstrapState(sqlite, owner.id, 'setup@example.test');
+
+  sqlite.prepare(`
+    UPDATE organization_user_permissions
+    SET can_manage_backups = 0
+    WHERE user_id = ?
+  `).run(owner.id);
+  const readOnlyStatus = getOrganizationBootstrapStatus(sqlite);
+  assert.equal(readOnlyStatus.permission?.canManageBackups, false);
+  const customizedPermission = sqlite.prepare(`
+    SELECT can_manage_backups AS canManageBackups
+    FROM organization_user_permissions
+    WHERE user_id = ?
+  `).get(owner.id) as { canManageBackups: number };
+  assert.equal(customizedPermission.canManageBackups, 0);
+
   sqlite.close();
 
   await assert.rejects(

--- a/scripts/auth-setup-test.ts
+++ b/scripts/auth-setup-test.ts
@@ -9,7 +9,12 @@ import { verifyPassword } from 'better-auth/crypto';
 const dataDir = mkdtempSync(path.join(tmpdir(), 'canvas-auth-setup-'));
 process.env.DATA = dataDir;
 
-function assertOrganizationBootstrapState(sqlite: Database.Database, expectedUserId: string, expectedEmail: string) {
+function assertOrganizationBootstrapState(
+  sqlite: Database.Database,
+  expectedUserId: string,
+  expectedEmail: string,
+  expectedPermissionOverrides: Partial<{ canManageBackups: number }> = {},
+) {
   const organization = sqlite.prepare(`
     SELECT organization_id AS organizationId, owner_user_id AS ownerUserId, deployment_mode AS deploymentMode,
       team_features_enabled AS teamFeaturesEnabled
@@ -41,8 +46,9 @@ function assertOrganizationBootstrapState(sqlite: Database.Database, expectedUse
     canCreateTeamAutomations: number;
   };
 
+  const expectedCanManageBackups = expectedPermissionOverrides.canManageBackups ?? 1;
   assert.equal(permission.role, 'owner');
-  assert.equal(permission.canManageBackups, 1);
+  assert.equal(permission.canManageBackups, expectedCanManageBackups);
   assert.equal(permission.canMigrateDatabase, 1);
   assert.equal(permission.canEnableKnowledge, 1);
   assert.equal(permission.canRecoverWorkspaces, 1);
@@ -65,7 +71,7 @@ async function main() {
     hasAnyAuthUser,
     InitialOwnerSetupError,
   } = await import('../app/lib/auth-setup');
-  const { getOrganizationBootstrapStatus } = await import('../app/lib/organization/bootstrap');
+  const { ensureOrganizationBootstrapForUser, getOrganizationBootstrapStatus } = await import('../app/lib/organization/bootstrap');
 
   assert.equal(hasAnyAuthUser(), false);
 
@@ -124,6 +130,14 @@ async function main() {
     WHERE user_id = ?
   `).get(owner.id) as { canManageBackups: number };
   assert.equal(customizedPermission.canManageBackups, 0);
+  const rebootstrapStatus = ensureOrganizationBootstrapForUser(sqlite, owner.id);
+  assert.equal(rebootstrapStatus.permission?.canManageBackups, false);
+  const preservedPermission = sqlite.prepare(`
+    SELECT can_manage_backups AS canManageBackups
+    FROM organization_user_permissions
+    WHERE user_id = ?
+  `).get(owner.id) as { canManageBackups: number };
+  assert.equal(preservedPermission.canManageBackups, 0);
 
   sqlite.close();
 
@@ -170,7 +184,7 @@ async function main() {
   assert.equal(migratedAccount.userId, owner.id);
   assert.ok(migratedAccount.password);
   assert.equal(await verifyPassword({ hash: migratedAccount.password!, password: 'OverridePassword123!' }), true);
-  assertOrganizationBootstrapState(migrated, owner.id, 'override@example.test');
+  assertOrganizationBootstrapState(migrated, owner.id, 'override@example.test', { canManageBackups: 0 });
   migrated.close();
 
   execFileSync('node', ['scripts/bootstrap-admin.js', '--email', 'cli-reset@example.test', '--name', 'CLI Reset Admin', '--password-stdin'], {
@@ -208,7 +222,7 @@ async function main() {
   assert.equal(cliResetAccount.userId, owner.id);
   assert.ok(cliResetAccount.password);
   assert.equal(await verifyPassword({ hash: cliResetAccount.password!, password: 'CliResetPassword123!' }), true);
-  assertOrganizationBootstrapState(cliReset, owner.id, 'cli-reset@example.test');
+  assertOrganizationBootstrapState(cliReset, owner.id, 'cli-reset@example.test', { canManageBackups: 0 });
   cliReset.close();
 
   console.log('auth setup tests passed');

--- a/scripts/auth-setup-test.ts
+++ b/scripts/auth-setup-test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
@@ -8,6 +8,56 @@ import { verifyPassword } from 'better-auth/crypto';
 
 const dataDir = mkdtempSync(path.join(tmpdir(), 'canvas-auth-setup-'));
 process.env.DATA = dataDir;
+
+function assertOrganizationBootstrapState(sqlite: Database.Database, expectedUserId: string, expectedEmail: string) {
+  const organization = sqlite.prepare(`
+    SELECT organization_id AS organizationId, owner_user_id AS ownerUserId, deployment_mode AS deploymentMode,
+      team_features_enabled AS teamFeaturesEnabled
+    FROM canvas_organization_settings
+  `).get() as {
+    organizationId: string;
+    ownerUserId: string;
+    deploymentMode: string;
+    teamFeaturesEnabled: number;
+  };
+
+  assert.ok(organization.organizationId.startsWith('org_'));
+  assert.equal(organization.ownerUserId, expectedUserId);
+  assert.equal(organization.deploymentMode, 'single_user');
+  assert.equal(organization.teamFeaturesEnabled, 0);
+
+  const permission = sqlite.prepare(`
+    SELECT role, can_manage_backups AS canManageBackups, can_migrate_database AS canMigrateDatabase,
+      can_enable_knowledge AS canEnableKnowledge, can_recover_workspaces AS canRecoverWorkspaces,
+      can_create_team_automations AS canCreateTeamAutomations
+    FROM organization_user_permissions
+    WHERE organization_id = ? AND user_id = ?
+  `).get(organization.organizationId, expectedUserId) as {
+    role: string;
+    canManageBackups: number;
+    canMigrateDatabase: number;
+    canEnableKnowledge: number;
+    canRecoverWorkspaces: number;
+    canCreateTeamAutomations: number;
+  };
+
+  assert.equal(permission.role, 'owner');
+  assert.equal(permission.canManageBackups, 1);
+  assert.equal(permission.canMigrateDatabase, 1);
+  assert.equal(permission.canEnableKnowledge, 1);
+  assert.equal(permission.canRecoverWorkspaces, 1);
+  assert.equal(permission.canCreateTeamAutomations, 1);
+
+  const owner = sqlite.prepare('SELECT email FROM user WHERE id = ?').get(expectedUserId) as { email: string };
+  assert.equal(owner.email, expectedEmail);
+
+  assert.equal(existsSync(path.join(dataDir, 'workspaces', 'personal', expectedUserId, 'files')), true);
+  assert.equal(existsSync(path.join(dataDir, 'users', expectedUserId, 'settings')), true);
+  assert.equal(existsSync(path.join(dataDir, 'users', expectedUserId, 'secrets')), true);
+  assert.equal(existsSync(path.join(dataDir, 'organizations', organization.organizationId, 'policies')), true);
+  assert.equal(existsSync(path.join(dataDir, 'system', 'backups')), true);
+  assert.equal(existsSync(path.join(dataDir, 'workspaces', 'team', organization.organizationId, 'files')), false);
+}
 
 async function main() {
   const {
@@ -58,6 +108,7 @@ async function main() {
   assert.equal(accounts[0].userId, owner.id);
   assert.ok(accounts[0].password);
   assert.equal(await verifyPassword({ hash: accounts[0].password!, password: 'SetupPassword123!' }), true);
+  assertOrganizationBootstrapState(sqlite, owner.id, 'setup@example.test');
   sqlite.close();
 
   await assert.rejects(
@@ -103,6 +154,7 @@ async function main() {
   assert.equal(migratedAccount.userId, owner.id);
   assert.ok(migratedAccount.password);
   assert.equal(await verifyPassword({ hash: migratedAccount.password!, password: 'OverridePassword123!' }), true);
+  assertOrganizationBootstrapState(migrated, owner.id, 'override@example.test');
   migrated.close();
 
   execFileSync('node', ['scripts/bootstrap-admin.js', '--email', 'cli-reset@example.test', '--name', 'CLI Reset Admin', '--password-stdin'], {
@@ -140,6 +192,7 @@ async function main() {
   assert.equal(cliResetAccount.userId, owner.id);
   assert.ok(cliResetAccount.password);
   assert.equal(await verifyPassword({ hash: cliResetAccount.password!, password: 'CliResetPassword123!' }), true);
+  assertOrganizationBootstrapState(cliReset, owner.id, 'cli-reset@example.test');
   cliReset.close();
 
   console.log('auth setup tests passed');

--- a/scripts/bootstrap-admin.js
+++ b/scripts/bootstrap-admin.js
@@ -328,17 +328,6 @@ function ensurePermissionRow(db, organizationId, userId, requestedRole) {
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(organization_id, user_id) DO UPDATE SET
       role = excluded.role,
-      can_write_team_workspace = excluded.can_write_team_workspace,
-      can_create_public_links = excluded.can_create_public_links,
-      can_create_team_automations = excluded.can_create_team_automations,
-      can_share_plugins_and_skills = excluded.can_share_plugins_and_skills,
-      can_export = excluded.can_export,
-      can_delete_team_files = excluded.can_delete_team_files,
-      can_delete_studio_assets = excluded.can_delete_studio_assets,
-      can_manage_backups = excluded.can_manage_backups,
-      can_migrate_database = excluded.can_migrate_database,
-      can_enable_knowledge = excluded.can_enable_knowledge,
-      can_recover_workspaces = excluded.can_recover_workspaces,
       updated_at = excluded.updated_at
   `).run(
     organizationId,

--- a/scripts/bootstrap-admin.js
+++ b/scripts/bootstrap-admin.js
@@ -1,5 +1,6 @@
 const path = require('node:path');
 const { randomUUID } = require('node:crypto');
+const { mkdirSync } = require('node:fs');
 const Database = require('better-sqlite3');
 const { hashPassword } = require('better-auth/crypto');
 const { loadAppEnv } = require('../server/load-app-env.js');
@@ -169,6 +170,43 @@ CREATE TABLE IF NOT EXISTS account (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS user_email_unique ON user (email);
+
+CREATE TABLE IF NOT EXISTS canvas_organization_settings (
+  organization_id TEXT PRIMARY KEY NOT NULL,
+  owner_user_id TEXT NOT NULL,
+  deployment_mode TEXT NOT NULL DEFAULT 'single_user',
+  team_features_enabled INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (owner_user_id) REFERENCES user(id)
+);
+
+CREATE TABLE IF NOT EXISTS organization_user_permissions (
+  organization_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'member',
+  can_write_team_workspace INTEGER NOT NULL DEFAULT 0,
+  can_create_public_links INTEGER NOT NULL DEFAULT 1,
+  can_create_team_automations INTEGER NOT NULL DEFAULT 0,
+  can_share_plugins_and_skills INTEGER NOT NULL DEFAULT 0,
+  can_export INTEGER NOT NULL DEFAULT 0,
+  can_delete_team_files INTEGER NOT NULL DEFAULT 0,
+  can_delete_studio_assets INTEGER NOT NULL DEFAULT 1,
+  can_manage_backups INTEGER NOT NULL DEFAULT 0,
+  can_migrate_database INTEGER NOT NULL DEFAULT 0,
+  can_enable_knowledge INTEGER NOT NULL DEFAULT 0,
+  can_recover_workspaces INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (organization_id, user_id),
+  FOREIGN KEY (organization_id) REFERENCES canvas_organization_settings(organization_id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES user(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canvas_org_settings_owner ON canvas_organization_settings (owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_org_user_permissions_user ON organization_user_permissions (user_id);
+CREATE INDEX IF NOT EXISTS idx_org_user_permissions_role ON organization_user_permissions (organization_id, role);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_org_user_permissions_single_owner ON organization_user_permissions (organization_id) WHERE role = 'owner';
 `);
 
   for (const [column, definition] of [
@@ -205,6 +243,194 @@ function findBootstrapTargetUser(db) {
       created_at ASC
     LIMIT 1
   `).get() || null;
+}
+
+function getDataRoot() {
+  const dataDir = process.env.DATA || path.resolve(process.cwd(), 'data');
+  return path.isAbsolute(dataDir) ? dataDir : path.resolve(process.cwd(), dataDir);
+}
+
+function getConfiguredOrganizationId() {
+  const value = process.env.CANVAS_ORGANIZATION_ID?.trim();
+  return value || null;
+}
+
+function getDeploymentMode() {
+  const explicit = process.env.CANVAS_DEPLOYMENT_MODE?.trim();
+  if (explicit) return explicit;
+  if (process.env.CANVAS_MANAGED_SERVICES_ENABLED === 'true' || process.env.CANVAS_INSTANCE_TOKEN?.trim()) {
+    return 'managed-single';
+  }
+  return 'single_user';
+}
+
+function teamFeaturesEnabled(deploymentMode) {
+  const explicit = process.env.CANVAS_TEAM_FEATURES_ENABLED;
+  return explicit === 'true' || explicit === '1' || explicit === 'yes' || deploymentMode.toLowerCase().includes('team');
+}
+
+function getPrimaryOrganization(db) {
+  return db.prepare(`
+    SELECT organization_id, owner_user_id, deployment_mode, team_features_enabled
+    FROM canvas_organization_settings
+    ORDER BY created_at ASC
+    LIMIT 1
+  `).get() || null;
+}
+
+function findUserById(db, userId) {
+  return db.prepare('SELECT id, email, role, created_at FROM user WHERE id = ? LIMIT 1').get(userId) || null;
+}
+
+function assertOrganizationIdMatchesEnvironment(organizationId) {
+  const configuredOrganizationId = getConfiguredOrganizationId();
+  if (configuredOrganizationId && configuredOrganizationId !== organizationId) {
+    throw new Error(`Persisted organization ${organizationId} does not match CANVAS_ORGANIZATION_ID ${configuredOrganizationId}.`);
+  }
+}
+
+function permissionDefaults(role) {
+  const isAdminLike = role === 'owner' || role === 'admin';
+  return {
+    role,
+    canWriteTeamWorkspace: isAdminLike,
+    canCreatePublicLinks: true,
+    canCreateTeamAutomations: isAdminLike,
+    canSharePluginsAndSkills: isAdminLike,
+    canExport: isAdminLike,
+    canDeleteTeamFiles: isAdminLike,
+    canDeleteStudioAssets: true,
+    canManageBackups: isAdminLike,
+    canMigrateDatabase: isAdminLike,
+    canEnableKnowledge: isAdminLike,
+    canRecoverWorkspaces: isAdminLike,
+  };
+}
+
+function ensurePermissionRow(db, organizationId, userId, requestedRole) {
+  const existing = db.prepare(`
+    SELECT role
+    FROM organization_user_permissions
+    WHERE organization_id = ? AND user_id = ?
+    LIMIT 1
+  `).get(organizationId, userId);
+  const role = existing?.role === 'owner' ? 'owner' : requestedRole;
+  const defaults = permissionDefaults(role);
+  const now = Date.now();
+
+  db.prepare(`
+    INSERT INTO organization_user_permissions (
+      organization_id, user_id, role,
+      can_write_team_workspace, can_create_public_links, can_create_team_automations,
+      can_share_plugins_and_skills, can_export, can_delete_team_files, can_delete_studio_assets,
+      can_manage_backups, can_migrate_database, can_enable_knowledge, can_recover_workspaces,
+      created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(organization_id, user_id) DO UPDATE SET
+      role = excluded.role,
+      can_write_team_workspace = excluded.can_write_team_workspace,
+      can_create_public_links = excluded.can_create_public_links,
+      can_create_team_automations = excluded.can_create_team_automations,
+      can_share_plugins_and_skills = excluded.can_share_plugins_and_skills,
+      can_export = excluded.can_export,
+      can_delete_team_files = excluded.can_delete_team_files,
+      can_delete_studio_assets = excluded.can_delete_studio_assets,
+      can_manage_backups = excluded.can_manage_backups,
+      can_migrate_database = excluded.can_migrate_database,
+      can_enable_knowledge = excluded.can_enable_knowledge,
+      can_recover_workspaces = excluded.can_recover_workspaces,
+      updated_at = excluded.updated_at
+  `).run(
+    organizationId,
+    userId,
+    defaults.role,
+    defaults.canWriteTeamWorkspace ? 1 : 0,
+    defaults.canCreatePublicLinks ? 1 : 0,
+    defaults.canCreateTeamAutomations ? 1 : 0,
+    defaults.canSharePluginsAndSkills ? 1 : 0,
+    defaults.canExport ? 1 : 0,
+    defaults.canDeleteTeamFiles ? 1 : 0,
+    defaults.canDeleteStudioAssets ? 1 : 0,
+    defaults.canManageBackups ? 1 : 0,
+    defaults.canMigrateDatabase ? 1 : 0,
+    defaults.canEnableKnowledge ? 1 : 0,
+    defaults.canRecoverWorkspaces ? 1 : 0,
+    now,
+    now,
+  );
+}
+
+function ensureScopedDirectories(organizationId, userId, includeTeamWorkspace) {
+  const dataRoot = getDataRoot();
+  const directories = [
+    path.join(dataRoot, 'workspaces', 'personal', userId, 'files'),
+    path.join(dataRoot, 'users', userId, 'settings'),
+    path.join(dataRoot, 'users', userId, 'secrets'),
+    path.join(dataRoot, 'users', userId, 'agents'),
+    path.join(dataRoot, 'users', userId, 'skills'),
+    path.join(dataRoot, 'users', userId, 'plugins'),
+    path.join(dataRoot, 'users', userId, 'mcp'),
+    path.join(dataRoot, 'users', userId, 'mail'),
+    path.join(dataRoot, 'organizations', organizationId, 'secrets'),
+    path.join(dataRoot, 'organizations', organizationId, 'policies'),
+    path.join(dataRoot, 'organizations', organizationId, 'agent-templates'),
+    path.join(dataRoot, 'organizations', organizationId, 'mcp-templates'),
+    path.join(dataRoot, 'organizations', organizationId, 'skill-templates'),
+    path.join(dataRoot, 'organizations', organizationId, 'plugin-templates'),
+    path.join(dataRoot, 'system', 'backups'),
+    path.join(dataRoot, 'system', 'migration'),
+    path.join(dataRoot, 'system', 'logs'),
+  ];
+  if (includeTeamWorkspace) {
+    directories.push(path.join(dataRoot, 'workspaces', 'team', organizationId, 'files'));
+  }
+  for (const directory of directories) {
+    mkdirSync(directory, { recursive: true });
+  }
+}
+
+function ensureOrganizationBootstrap(db, userId) {
+  const targetUser = findUserById(db, userId);
+  if (!targetUser) {
+    throw new Error('Cannot bootstrap organization without a valid user.');
+  }
+
+  const deploymentMode = getDeploymentMode();
+  const includeTeamWorkspace = teamFeaturesEnabled(deploymentMode);
+  const now = Date.now();
+  let organization = getPrimaryOrganization(db);
+
+  if (organization) {
+    assertOrganizationIdMatchesEnvironment(organization.organization_id);
+    db.prepare(`
+      UPDATE canvas_organization_settings
+      SET deployment_mode = ?, team_features_enabled = ?, updated_at = ?
+      WHERE organization_id = ?
+    `).run(deploymentMode, includeTeamWorkspace ? 1 : 0, now, organization.organization_id);
+  } else {
+    const organizationId = getConfiguredOrganizationId() || `org_${randomUUID()}`;
+    db.prepare(`
+      INSERT INTO canvas_organization_settings (
+        organization_id, owner_user_id, deployment_mode, team_features_enabled, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+    `).run(organizationId, userId, deploymentMode, includeTeamWorkspace ? 1 : 0, now, now);
+    organization = {
+      organization_id: organizationId,
+      owner_user_id: userId,
+    };
+  }
+
+  const ownerUser = findUserById(db, organization.owner_user_id) || targetUser;
+  db.prepare('UPDATE user SET role = ?, updated_at = ? WHERE id = ?').run('admin', now, ownerUser.id);
+  ensurePermissionRow(db, organization.organization_id, ownerUser.id, 'owner');
+  if (targetUser.id !== ownerUser.id) {
+    db.prepare('UPDATE user SET role = ?, updated_at = ? WHERE id = ?').run('admin', now, targetUser.id);
+    ensurePermissionRow(db, organization.organization_id, targetUser.id, 'admin');
+  }
+  ensureScopedDirectories(organization.organization_id, ownerUser.id, includeTeamWorkspace);
+  if (targetUser.id !== ownerUser.id) {
+    ensureScopedDirectories(organization.organization_id, targetUser.id, includeTeamWorkspace);
+  }
 }
 
 function ensureCredentialPassword(db, userId, passwordHash) {
@@ -271,6 +497,7 @@ async function main() {
     if (existingUser) {
       updateExistingUser(db, existingUser.id, email, name);
       ensureCredentialPassword(db, existingUser.id, passwordHash);
+      ensureOrganizationBootstrap(db, existingUser.id);
       db.exec('COMMIT');
 
       const verifiedUser = findUserByEmail(db, email);
@@ -286,6 +513,7 @@ async function main() {
     if (targetUser) {
       updateExistingUser(db, targetUser.id, email, name);
       ensureCredentialPassword(db, targetUser.id, passwordHash);
+      ensureOrganizationBootstrap(db, targetUser.id);
       db.exec('COMMIT');
 
       const verifiedUser = findUserByEmail(db, email);
@@ -299,6 +527,7 @@ async function main() {
 
     const userId = insertUser(db, email, name);
     ensureCredentialPassword(db, userId, passwordHash);
+    ensureOrganizationBootstrap(db, userId);
     db.exec('COMMIT');
 
     const verifiedUser = findUserByEmail(db, email);


### PR DESCRIPTION
## Summary

- adds persistent local organization and owner bootstrap tables
- makes first-run setup and `scripts/bootstrap-admin.js` converge on the same owner/admin organization state
- adds an admin-only organization setup status API and Workspace settings UI card
- centralizes the instance-admin guard for critical admin APIs
- preserves manually customized owner permission bits across re-bootstrap runs

## Validation

- `npm run test:auth:setup`
- `npm run test:workspace:foundation`
- `npm run lint`
- `npm run build`

## Greploop

- Greptile score: 4/5 on commit `24c93507`.
- The remaining Greptile P1 note about permission bits being reset on re-bootstrap was fixed in follow-up commit `a2129e2`.
- No additional Greptile rerun was requested after `a2129e2` per maintainer instruction.

## Notes

- Browser/UI automation was not run because this repository asks to use Playwright only after explicit approval.
