### PR TITLE
[codex] Add workspace model service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,10 @@ eröffne ausschließlich auf localhost 3000 einen dev server. starte keine neuen
 - Use short, descriptive commit messages (e.g., `Fix terminal copy on iPad`).
 - PRs should include: summary, screenshots for UI changes, and steps to verify.
 - Before any PR is merged into `main`, run a `greploop` review for that PR and document the resulting score in the PR.
-- Only PRs with a `greploop` score of 4 or 5 may be merged into `main`; scores 1-3 block the merge until the issues are fixed and `greploop` is rerun.
-- If `greploop` is unavailable or cannot produce a score, treat the PR as blocked for merge into `main`.
+- Trigger Greptile/greploop at most once per PR head SHA. If Greptile accepts the trigger but does not publish an updated score, wait and report the PR as pending or blocked; do not post another `@greptile review` for the same head.
+- After addressing review feedback and pushing a new commit, the new head SHA may be reviewed once.
+- Only PRs with a `greploop` score of 4 or 5 and zero unresolved review threads may be merged into `main`; scores 1-3 block the merge until the issues are fixed and a new head SHA is reviewed.
+- If `greploop` is unavailable or cannot produce a score for the current head SHA, treat the PR as blocked for merge into `main`.
 
 ## Security & Configuration Tips
 - Production uses `systemd` (`canvas-notebook.service`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,9 @@ eröffne ausschließlich auf localhost 3000 einen dev server. starte keine neuen
 - Use short, descriptive commit messages (e.g., `Fix terminal copy on iPad`).
 - PRs should include: summary, screenshots for UI changes, and steps to verify.
 - Before any PR is merged into `main`, run a `greploop` review for that PR and document the resulting score in the PR.
-- Trigger Greptile/greploop at most once per PR head SHA. If Greptile accepts the trigger but does not publish an updated score, wait and report the PR as pending or blocked; do not post another `@greptile review` for the same head.
+- Trigger Greptile/greploop at most once per PR head SHA. If Greptile accepts the trigger but does not publish an updated score, wait and treat the PR as blocked; do not post another `@greptile review` for the same head.
 - After addressing review feedback and pushing a new commit, the new head SHA may be reviewed once.
-- Only PRs with a `greploop` score of 4 or 5 and zero unresolved review threads may be merged into `main`; scores 1-3 block the merge until the issues are fixed and a new head SHA is reviewed.
+- Only PRs with a `greploop` score of 4 or 5 and zero unresolved review threads may be merged into `main`; scores 0-3 block the merge until the issues are fixed and a new head SHA is reviewed.
 - If `greploop` is unavailable or cannot produce a score for the current head SHA, treat the PR as blocked for merge into `main`.
 
 ## Security & Configuration Tips

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ eröffne ausschließlich auf localhost 3000 einen dev server. starte keine neuen
 - Before any PR is merged into `main`, run a `greploop` review for that PR and document the resulting score in the PR.
 - Trigger Greptile/greploop at most once per PR head SHA. If Greptile accepts the trigger but does not publish an updated score, wait and treat the PR as blocked; do not post another `@greptile review` for the same head.
 - After addressing review feedback and pushing a new commit, the new head SHA may be reviewed once.
+- A `greploop` score of 4 out of 5 is sufficient for merge; a perfect 5 out of 5 is not required.
+- Every Greptile/greploop comment must still be reviewed. Actionable comments must be fixed; non-actionable or false-positive comments must be documented and resolved.
 - Only PRs with a `greploop` score of 4 or 5 and zero unresolved review threads may be merged into `main`; scores 0-3 block the merge until the issues are fixed and a new head SHA is reviewed.
 - If `greploop` is unavailable or cannot produce a score for the current head SHA, treat the PR as blocked for merge into `main`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - immer ein npm run build testen bevor ein container gebaut wird.
 - Sicherstellen, dass nie mehrere Test-Container parallel laufen.
 - Test-Container bei neuem Testlauf immer mit aktuellem Stand neu laden (recreate/rebuild), statt alte Container weiterzuverwenden.
-- commmit sauber die einzelnen fertigen to dos, aber nicht pushen. 
+- committe sauber die einzelnen fertigen to dos; pushen ist erlaubt, wenn ein PR erstellt/aktualisiert werden soll oder der User es explizit fordert.
 - container auf nur bauen wenn es explizit gefordert wird 
 - login für die app über `BOOTSTRAP_ADMIN_EMAIL` und `BOOTSTRAP_ADMIN_PASSWORD` aus der lokalen Env-Konfiguration
 - mach mit keinem to do weiter wenn der vorherige to do noch nicht fertig ist

--- a/app/api/workspaces/route.ts
+++ b/app/api/workspaces/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+
+import { auth } from '@/app/lib/auth';
+import {
+  ensureOrganizationBootstrapForUser,
+  openOrganizationBootstrapDatabase,
+} from '@/app/lib/organization/bootstrap';
+import { resolveWorkspaceActor } from '@/app/lib/workspaces/context';
+import {
+  listWorkspaceContextsForUser,
+  resolveDefaultWorkspaceContext,
+} from '@/app/lib/workspaces/service';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
+
+function serializeWorkspace(workspace: WorkspaceContext) {
+  return {
+    id: workspace.workspaceId,
+    type: workspace.workspaceType,
+    name: workspace.displayName || workspace.workspaceType,
+    organizationId: workspace.organizationId,
+    ownerUserId: workspace.ownerUserId,
+    rootRelativePath: workspace.rootRelativePath,
+    status: workspace.status || 'active',
+    permissions: workspace.permissions,
+    legacy: workspace.legacy,
+  };
+}
+
+export async function GET(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const sqlite = openOrganizationBootstrapDatabase();
+  try {
+    sqlite.exec('BEGIN IMMEDIATE');
+    const status = ensureOrganizationBootstrapForUser(sqlite, session.user.id);
+    if (!status.organizationId) {
+      sqlite.exec('ROLLBACK');
+      return NextResponse.json({ success: false, error: 'Organization is not configured' }, { status: 409 });
+    }
+
+    const actor = resolveWorkspaceActor({
+      id: session.user.id,
+      email: session.user.email,
+      role: session.user.role,
+    });
+    const defaultWorkspace = resolveDefaultWorkspaceContext(sqlite, {
+      actor,
+      organizationId: status.organizationId,
+    });
+    const workspaces = listWorkspaceContextsForUser(sqlite, {
+      actor,
+      organizationId: status.organizationId,
+    });
+    sqlite.exec('COMMIT');
+
+    return NextResponse.json({
+      success: true,
+      organizationId: status.organizationId,
+      teamFeaturesEnabled: status.teamFeaturesEnabled,
+      databaseProvider: status.databaseProvider,
+      activeWorkspaceId: defaultWorkspace?.workspaceId || null,
+      defaultWorkspace: defaultWorkspace ? serializeWorkspace(defaultWorkspace) : null,
+      workspaces: workspaces.map(serializeWorkspace),
+      warnings: status.warnings,
+    });
+  } catch (error) {
+    if (sqlite.inTransaction) {
+      sqlite.exec('ROLLBACK');
+    }
+    const message = error instanceof Error ? error.message : 'Could not resolve workspaces';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  } finally {
+    sqlite.close();
+  }
+}

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -115,6 +115,20 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       FOREIGN KEY (owner_user_id) REFERENCES user(id)
     );
 
+    CREATE TABLE IF NOT EXISTS canvas_workspaces (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      owner_user_id TEXT,
+      root_relative_path TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (organization_id) REFERENCES canvas_organization_settings(organization_id) ON DELETE CASCADE,
+      FOREIGN KEY (owner_user_id) REFERENCES user(id)
+    );
+
     CREATE TABLE IF NOT EXISTS organization_user_permissions (
       organization_id TEXT NOT NULL,
       user_id TEXT NOT NULL,
@@ -1000,6 +1014,11 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
   // ── Deferred indexes on columns added via ALTER TABLE ──────────────────────
   sqlite.exec(`
     CREATE INDEX IF NOT EXISTS idx_canvas_org_settings_owner ON canvas_organization_settings (owner_user_id);
+    CREATE INDEX IF NOT EXISTS idx_canvas_workspaces_organization ON canvas_workspaces (organization_id);
+    CREATE INDEX IF NOT EXISTS idx_canvas_workspaces_owner ON canvas_workspaces (owner_user_id);
+    CREATE INDEX IF NOT EXISTS idx_canvas_workspaces_organization_type ON canvas_workspaces (organization_id, type);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_canvas_workspaces_personal_owner ON canvas_workspaces (owner_user_id) WHERE type = 'personal';
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_canvas_workspaces_team_organization ON canvas_workspaces (organization_id) WHERE type = 'team';
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_user ON organization_user_permissions (user_id);
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_role ON organization_user_permissions (organization_id, role);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_org_user_permissions_single_owner ON organization_user_permissions (organization_id) WHERE role = 'owner';

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -107,6 +107,24 @@ export const canvasOrganizationSettings = sqliteTable("canvas_organization_setti
   ownerIdx: index("idx_canvas_org_settings_owner").on(table.ownerUserId),
 }));
 
+export const canvasWorkspaces = sqliteTable("canvas_workspaces", {
+  id: text("id").primaryKey(),
+  organizationId: text("organization_id").notNull().references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  type: text("type").notNull(),
+  ownerUserId: text("owner_user_id").references(() => user.id),
+  rootRelativePath: text("root_relative_path").notNull(),
+  displayName: text("display_name").notNull(),
+  status: text("status").notNull().default("active"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  organizationIdx: index("idx_canvas_workspaces_organization").on(table.organizationId),
+  ownerIdx: index("idx_canvas_workspaces_owner").on(table.ownerUserId),
+  organizationTypeIdx: index("idx_canvas_workspaces_organization_type").on(table.organizationId, table.type),
+  personalOwnerIdx: uniqueIndex("idx_canvas_workspaces_personal_owner").on(table.ownerUserId).where(sql`${table.type} = 'personal'`),
+  teamOrganizationIdx: uniqueIndex("idx_canvas_workspaces_team_organization").on(table.organizationId).where(sql`${table.type} = 'team'`),
+}));
+
 export const organizationUserPermissions = sqliteTable("organization_user_permissions", {
   organizationId: text("organization_id").notNull().references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
   userId: text("user_id").notNull().references(() => user.id),

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { getBootstrapAdminEmail } from '@/app/lib/bootstrap-admin';
 import { runMigrations } from '@/app/lib/db/migrate';
 import { resolveWorkspaceDataRoot } from '@/app/lib/workspaces/context';
+import { ensureDefaultWorkspaceRecords } from '@/app/lib/workspaces/service';
 
 export const LOCAL_ORGANIZATION_ID_PREFIX = 'org_';
 
@@ -381,8 +382,18 @@ export function ensureOrganizationBootstrapForUser(
   }
 
   ensureScopedDirectories(organization.organization_id, ownerUser.id, teamFeaturesEnabled);
+  ensureDefaultWorkspaceRecords(sqlite, {
+    organizationId: organization.organization_id,
+    userId: ownerUser.id,
+    teamFeaturesEnabled,
+  });
   if (targetUser.id !== ownerUser.id) {
     ensureScopedDirectories(organization.organization_id, targetUser.id, teamFeaturesEnabled);
+    ensureDefaultWorkspaceRecords(sqlite, {
+      organizationId: organization.organization_id,
+      userId: targetUser.id,
+      teamFeaturesEnabled,
+    });
   }
 
   return buildStatus(sqlite, organization, ownerUser, ownerPermission);

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -108,6 +108,33 @@ function isTruthyEnv(value: string | undefined): boolean {
   return value === 'true' || value === '1' || value === 'yes';
 }
 
+function normalizeDeploymentMode(value: string): string {
+  return value.trim().toLowerCase().replace(/_/g, '-');
+}
+
+export function isSingleUserDeploymentMode(deploymentMode = getDeploymentMode()): boolean {
+  const normalized = normalizeDeploymentMode(deploymentMode);
+  return normalized === 'community' ||
+    normalized === 'single-user' ||
+    normalized === 'singleuser' ||
+    normalized === 'managed-single' ||
+    normalized === 'local' ||
+    normalized === 'development' ||
+    normalized === 'dev';
+}
+
+export function isTeamDeploymentMode(deploymentMode = getDeploymentMode()): boolean {
+  const normalized = normalizeDeploymentMode(deploymentMode);
+  if (isSingleUserDeploymentMode(normalized)) return false;
+  return normalized.includes('team') ||
+    normalized.includes('enterprise') ||
+    normalized.includes('advanced');
+}
+
+export function canEnableTeamFeaturesForDeployment(deploymentMode = getDeploymentMode()): boolean {
+  return isTeamDeploymentMode(deploymentMode);
+}
+
 export function getConfiguredOrganizationId(): string | null {
   const value = process.env.CANVAS_ORGANIZATION_ID?.trim();
   return value || null;
@@ -127,7 +154,8 @@ export function getDeploymentMode(): string {
 }
 
 export function areTeamFeaturesEnabled(deploymentMode = getDeploymentMode()): boolean {
-  return isTruthyEnv(process.env.CANVAS_TEAM_FEATURES_ENABLED) || deploymentMode.toLowerCase().includes('team');
+  if (!canEnableTeamFeaturesForDeployment(deploymentMode)) return false;
+  return isTruthyEnv(process.env.CANVAS_TEAM_FEATURES_ENABLED) || isTeamDeploymentMode(deploymentMode);
 }
 
 function booleanFromDb(value: number | null | undefined): boolean {
@@ -434,6 +462,10 @@ function buildStatus(
     ? buildScopedPaths(organizationId, ownerUserId, teamFeaturesEnabled)
     : null;
   const warnings: string[] = [];
+
+  if (isTruthyEnv(process.env.CANVAS_TEAM_FEATURES_ENABLED) && !canEnableTeamFeaturesForDeployment(deploymentMode)) {
+    warnings.push('CANVAS_TEAM_FEATURES_ENABLED is ignored for this single-user deployment mode.');
+  }
 
   if (teamFeaturesEnabled && databaseProvider !== 'postgres') {
     warnings.push('Team features are enabled but CANVAS_DATABASE_PROVIDER is not postgres.');

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -132,7 +132,7 @@ export function isTeamDeploymentMode(deploymentMode = getDeploymentMode()): bool
 }
 
 export function canEnableTeamFeaturesForDeployment(deploymentMode = getDeploymentMode()): boolean {
-  return isTeamDeploymentMode(deploymentMode);
+  return !isSingleUserDeploymentMode(deploymentMode);
 }
 
 export function getConfiguredOrganizationId(): string | null {

--- a/app/lib/workspaces/permissions.ts
+++ b/app/lib/workspaces/permissions.ts
@@ -40,7 +40,7 @@ export function resolveWorkspacePermissions(params: {
   const isAdminLike = role === 'owner' || role === 'admin';
 
   if (workspaceType === 'personal') {
-    const canUsePersonalWorkspace = isAdminLike || ownsPersonalWorkspace;
+    const canUsePersonalWorkspace = ownsPersonalWorkspace;
     return {
       canRead: canUsePersonalWorkspace,
       canWrite: canUsePersonalWorkspace,

--- a/app/lib/workspaces/service.ts
+++ b/app/lib/workspaces/service.ts
@@ -1,0 +1,329 @@
+import 'server-only';
+
+import type Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { resolveWorkspaceDataRoot } from './context';
+import { resolveWorkspacePermissions } from './permissions';
+import type { WorkspaceActor, WorkspaceContext, WorkspaceStatus, WorkspaceType } from './types';
+
+export interface WorkspaceRecord {
+  id: string;
+  organizationId: string;
+  type: WorkspaceType;
+  ownerUserId: string | null;
+  rootRelativePath: string;
+  displayName: string;
+  status: WorkspaceStatus;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface DefaultWorkspaceRecords {
+  personal: WorkspaceRecord;
+  team: WorkspaceRecord | null;
+}
+
+type WorkspaceRow = {
+  id: string;
+  organization_id: string;
+  type: string;
+  owner_user_id: string | null;
+  root_relative_path: string;
+  display_name: string;
+  status: string;
+  created_at: number;
+  updated_at: number;
+};
+
+type PermissionRow = {
+  role: string;
+  can_write_team_workspace: number;
+  can_create_public_links: number;
+};
+
+function normalizeWorkspaceType(value: string): WorkspaceType {
+  if (value === 'team' || value === 'project') return value;
+  return 'personal';
+}
+
+function normalizeWorkspaceStatus(value: string): WorkspaceStatus {
+  if (value === 'archived' || value === 'disabled') return value;
+  return 'active';
+}
+
+function rowToWorkspaceRecord(row: WorkspaceRow): WorkspaceRecord {
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    type: normalizeWorkspaceType(row.type),
+    ownerUserId: row.owner_user_id,
+    rootRelativePath: row.root_relative_path,
+    displayName: row.display_name,
+    status: normalizeWorkspaceStatus(row.status),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function personalWorkspaceRootRelativePath(userId: string): string {
+  return path.posix.join('workspaces', 'personal', userId, 'files');
+}
+
+export function teamWorkspaceRootRelativePath(organizationId: string): string {
+  return path.posix.join('workspaces', 'team', organizationId, 'files');
+}
+
+export function workspaceAbsoluteRoot(rootRelativePath: string): string {
+  if (path.isAbsolute(rootRelativePath) || rootRelativePath.includes('\0')) {
+    throw new Error('Invalid workspace root path');
+  }
+
+  const segments = rootRelativePath.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (segments.some((segment) => segment === '..' || segment === '.')) {
+    throw new Error('Invalid workspace root path');
+  }
+
+  return path.join(resolveWorkspaceDataRoot(), ...segments);
+}
+
+function ensureWorkspaceDirectory(record: WorkspaceRecord): void {
+  mkdirSync(workspaceAbsoluteRoot(record.rootRelativePath), { recursive: true });
+}
+
+function createWorkspaceId(): string {
+  return `ws_${randomUUID()}`;
+}
+
+function getWorkspaceById(sqlite: Database.Database, workspaceId: string): WorkspaceRecord | null {
+  const row = sqlite.prepare(`
+    SELECT id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
+    FROM canvas_workspaces
+    WHERE id = ?
+    LIMIT 1
+  `).get(workspaceId) as WorkspaceRow | undefined;
+
+  return row ? rowToWorkspaceRecord(row) : null;
+}
+
+function getPersonalWorkspace(sqlite: Database.Database, userId: string): WorkspaceRecord | null {
+  const row = sqlite.prepare(`
+    SELECT id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
+    FROM canvas_workspaces
+    WHERE type = 'personal' AND owner_user_id = ?
+    LIMIT 1
+  `).get(userId) as WorkspaceRow | undefined;
+
+  return row ? rowToWorkspaceRecord(row) : null;
+}
+
+function getTeamWorkspace(sqlite: Database.Database, organizationId: string): WorkspaceRecord | null {
+  const row = sqlite.prepare(`
+    SELECT id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
+    FROM canvas_workspaces
+    WHERE type = 'team' AND organization_id = ?
+    LIMIT 1
+  `).get(organizationId) as WorkspaceRow | undefined;
+
+  return row ? rowToWorkspaceRecord(row) : null;
+}
+
+function insertWorkspace(
+  sqlite: Database.Database,
+  input: {
+    organizationId: string;
+    type: WorkspaceType;
+    ownerUserId: string | null;
+    rootRelativePath: string;
+    displayName: string;
+  },
+): WorkspaceRecord {
+  const now = Date.now();
+  const id = createWorkspaceId();
+  sqlite.prepare(`
+    INSERT INTO canvas_workspaces (
+      id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?)
+  `).run(
+    id,
+    input.organizationId,
+    input.type,
+    input.ownerUserId,
+    input.rootRelativePath,
+    input.displayName,
+    now,
+    now,
+  );
+
+  const record = getWorkspaceById(sqlite, id);
+  if (!record) throw new Error('Workspace insert failed');
+  ensureWorkspaceDirectory(record);
+  return record;
+}
+
+function updateWorkspaceRoot(
+  sqlite: Database.Database,
+  record: WorkspaceRecord,
+  input: {
+    rootRelativePath: string;
+    displayName: string;
+  },
+): WorkspaceRecord {
+  if (record.rootRelativePath === input.rootRelativePath && record.displayName === input.displayName && record.status === 'active') {
+    ensureWorkspaceDirectory(record);
+    return record;
+  }
+
+  sqlite.prepare(`
+    UPDATE canvas_workspaces
+    SET root_relative_path = ?, display_name = ?, status = 'active', updated_at = ?
+    WHERE id = ?
+  `).run(input.rootRelativePath, input.displayName, Date.now(), record.id);
+
+  const updated = getWorkspaceById(sqlite, record.id);
+  if (!updated) throw new Error('Workspace update failed');
+  ensureWorkspaceDirectory(updated);
+  return updated;
+}
+
+export function ensureDefaultWorkspaceRecords(
+  sqlite: Database.Database,
+  params: {
+    organizationId: string;
+    userId: string;
+    teamFeaturesEnabled: boolean;
+  },
+): DefaultWorkspaceRecords {
+  const personalRoot = personalWorkspaceRootRelativePath(params.userId);
+  const existingPersonal = getPersonalWorkspace(sqlite, params.userId);
+  const personal = existingPersonal
+    ? updateWorkspaceRoot(sqlite, existingPersonal, { rootRelativePath: personalRoot, displayName: 'Personal Workspace' })
+    : insertWorkspace(sqlite, {
+        organizationId: params.organizationId,
+        type: 'personal',
+        ownerUserId: params.userId,
+        rootRelativePath: personalRoot,
+        displayName: 'Personal Workspace',
+      });
+
+  if (!params.teamFeaturesEnabled) {
+    return { personal, team: null };
+  }
+
+  const teamRoot = teamWorkspaceRootRelativePath(params.organizationId);
+  const existingTeam = getTeamWorkspace(sqlite, params.organizationId);
+  const team = existingTeam
+    ? updateWorkspaceRoot(sqlite, existingTeam, { rootRelativePath: teamRoot, displayName: 'Team Workspace' })
+    : insertWorkspace(sqlite, {
+        organizationId: params.organizationId,
+        type: 'team',
+        ownerUserId: null,
+        rootRelativePath: teamRoot,
+        displayName: 'Team Workspace',
+      });
+
+  return { personal, team };
+}
+
+function getPermissionRow(sqlite: Database.Database, organizationId: string, userId: string): PermissionRow | null {
+  return sqlite.prepare(`
+    SELECT role, can_write_team_workspace, can_create_public_links
+    FROM organization_user_permissions
+    WHERE organization_id = ? AND user_id = ?
+    LIMIT 1
+  `).get(organizationId, userId) as PermissionRow | undefined || null;
+}
+
+function canReadWorkspace(record: WorkspaceRecord, actor: WorkspaceActor, permission: PermissionRow | null): boolean {
+  if (record.status !== 'active') return false;
+  if (record.type === 'personal') return record.ownerUserId === actor.userId;
+  if (record.type === 'team') return Boolean(permission && permission.role !== 'external');
+  return false;
+}
+
+export function workspaceContextFromRecord(
+  record: WorkspaceRecord,
+  actor: WorkspaceActor,
+  permission: PermissionRow | null = null,
+): WorkspaceContext {
+  const role = actor.role;
+  const ownsPersonalWorkspace = record.type === 'personal' && record.ownerUserId === actor.userId;
+  const canAccessTeamWorkspace = record.type === 'team' && Boolean(permission && permission.role !== 'external');
+  const canWriteTeamWorkspace = record.type === 'team' && (
+    role === 'owner' ||
+    role === 'admin' ||
+    permission?.can_write_team_workspace === 1
+  );
+
+  return {
+    workspaceId: record.id,
+    workspaceType: record.type,
+    rootPath: workspaceAbsoluteRoot(record.rootRelativePath),
+    rootRelativePath: record.rootRelativePath,
+    displayName: record.displayName,
+    status: record.status,
+    actor,
+    organizationId: record.organizationId,
+    ownerUserId: record.ownerUserId,
+    permissions: resolveWorkspacePermissions({
+      role,
+      workspaceType: record.type,
+      ownsPersonalWorkspace,
+      canAccessTeamWorkspace,
+      canWriteTeamWorkspace,
+      canCreatePublicLinks: permission?.can_create_public_links !== 0,
+    }),
+    legacy: false,
+  };
+}
+
+export function listWorkspaceContextsForUser(
+  sqlite: Database.Database,
+  params: {
+    actor: WorkspaceActor;
+    organizationId: string;
+  },
+): WorkspaceContext[] {
+  const rows = sqlite.prepare(`
+    SELECT id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
+    FROM canvas_workspaces
+    WHERE organization_id = ? AND status = 'active'
+    ORDER BY CASE type WHEN 'personal' THEN 0 WHEN 'team' THEN 1 ELSE 2 END, created_at ASC
+  `).all(params.organizationId) as WorkspaceRow[];
+  const permission = getPermissionRow(sqlite, params.organizationId, params.actor.userId);
+
+  return rows
+    .map(rowToWorkspaceRecord)
+    .filter((record) => canReadWorkspace(record, params.actor, permission))
+    .map((record) => workspaceContextFromRecord(record, params.actor, permission));
+}
+
+export function resolveDefaultWorkspaceContext(
+  sqlite: Database.Database,
+  params: {
+    actor: WorkspaceActor;
+    organizationId: string;
+  },
+): WorkspaceContext | null {
+  const personal = getPersonalWorkspace(sqlite, params.actor.userId);
+  if (!personal) return null;
+  const permission = getPermissionRow(sqlite, params.organizationId, params.actor.userId);
+  if (!canReadWorkspace(personal, params.actor, permission)) return null;
+  return workspaceContextFromRecord(personal, params.actor, permission);
+}
+
+export function resolveWorkspaceContextById(
+  sqlite: Database.Database,
+  params: {
+    actor: WorkspaceActor;
+    workspaceId: string;
+  },
+): WorkspaceContext | null {
+  const record = getWorkspaceById(sqlite, params.workspaceId);
+  if (!record) return null;
+  const permission = getPermissionRow(sqlite, record.organizationId, params.actor.userId);
+  if (!canReadWorkspace(record, params.actor, permission)) return null;
+  return workspaceContextFromRecord(record, params.actor, permission);
+}

--- a/app/lib/workspaces/service.ts
+++ b/app/lib/workspaces/service.ts
@@ -171,14 +171,14 @@ function updateWorkspaceRoot(
     displayName: string;
   },
 ): WorkspaceRecord {
-  if (record.rootRelativePath === input.rootRelativePath && record.displayName === input.displayName && record.status === 'active') {
+  if (record.rootRelativePath === input.rootRelativePath && record.displayName === input.displayName) {
     ensureWorkspaceDirectory(record);
     return record;
   }
 
   sqlite.prepare(`
     UPDATE canvas_workspaces
-    SET root_relative_path = ?, display_name = ?, status = 'active', updated_at = ?
+    SET root_relative_path = ?, display_name = ?, updated_at = ?
     WHERE id = ?
   `).run(input.rootRelativePath, input.displayName, Date.now(), record.id);
 
@@ -290,8 +290,9 @@ export function listWorkspaceContextsForUser(
     SELECT id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
     FROM canvas_workspaces
     WHERE organization_id = ? AND status = 'active'
+      AND (type != 'personal' OR owner_user_id = ?)
     ORDER BY CASE type WHEN 'personal' THEN 0 WHEN 'team' THEN 1 ELSE 2 END, created_at ASC
-  `).all(params.organizationId) as WorkspaceRow[];
+  `).all(params.organizationId, params.actor.userId) as WorkspaceRow[];
   const permission = getPermissionRow(sqlite, params.organizationId, params.actor.userId);
 
   return rows

--- a/app/lib/workspaces/service.ts
+++ b/app/lib/workspaces/service.ts
@@ -273,7 +273,7 @@ export function workspaceContextFromRecord(
       ownsPersonalWorkspace,
       canAccessTeamWorkspace,
       canWriteTeamWorkspace,
-      canCreatePublicLinks: permission?.can_create_public_links !== 0,
+      canCreatePublicLinks: permission?.can_create_public_links === 1,
     }),
     legacy: false,
   };

--- a/app/lib/workspaces/types.ts
+++ b/app/lib/workspaces/types.ts
@@ -1,6 +1,8 @@
 import 'server-only';
 
-export type WorkspaceType = 'personal' | 'team';
+export type WorkspaceType = 'personal' | 'team' | 'project';
+
+export type WorkspaceStatus = 'active' | 'archived' | 'disabled';
 
 export type WorkspaceUserRole = 'owner' | 'admin' | 'member' | 'external';
 
@@ -23,6 +25,9 @@ export interface WorkspaceContext {
   workspaceId: string;
   workspaceType: WorkspaceType;
   rootPath: string;
+  rootRelativePath?: string;
+  displayName?: string;
+  status?: WorkspaceStatus;
   actor?: WorkspaceActor;
   organizationId?: string | null;
   ownerUserId?: string | null;

--- a/docs/architecture/canvas-notebook/team-workspace/README.md
+++ b/docs/architecture/canvas-notebook/team-workspace/README.md
@@ -1,6 +1,6 @@
 # Canvas Notebook Team Workspace
 
-Stand: 2026-06-18
+Stand: 2026-06-20
 
 Dieses Verzeichnis ist der zentrale Arbeitsbereich fuer den Team-Workspace-Umbau in Canvas Notebook.
 
@@ -58,4 +58,5 @@ Dieses Verzeichnis ist der zentrale Arbeitsbereich fuer den Team-Workspace-Umbau
 - Collaboration- und File-Conflict-Policy fuer Text, Office/PDF und Assets ist dokumentiert.
 - Control-Plane-Status-Quo fuer Managed Env, Installer-Artefakte, VM-Agent, VM-Actions und VM-Detailseite ist in der Database-Provider-Policy mit konkreten Zielpfaden abgeglichen.
 - Control Plane Managed Mode, Team-Claims, Managed ENV und Organization-Runtime-Provisioning sind umgesetzt und in PR #3 gemerged.
-- Naechster Schritt: Workspace-Modell und Workspace-Service in Canvas Notebook einfuehren.
+- Workspace-Modell, Workspace-Service, Bootstrap-Erzeugung und `/api/workspaces` in Canvas Notebook sind eingefuehrt.
+- Naechster Schritt: Community-Lizenz auf Single-User-Betrieb begrenzen.

--- a/docs/architecture/canvas-notebook/team-workspace/README.md
+++ b/docs/architecture/canvas-notebook/team-workspace/README.md
@@ -59,4 +59,6 @@ Dieses Verzeichnis ist der zentrale Arbeitsbereich fuer den Team-Workspace-Umbau
 - Control-Plane-Status-Quo fuer Managed Env, Installer-Artefakte, VM-Agent, VM-Actions und VM-Detailseite ist in der Database-Provider-Policy mit konkreten Zielpfaden abgeglichen.
 - Control Plane Managed Mode, Team-Claims, Managed ENV und Organization-Runtime-Provisioning sind umgesetzt und in PR #3 gemerged.
 - Workspace-Modell, Workspace-Service, Bootstrap-Erzeugung und `/api/workspaces` in Canvas Notebook sind eingefuehrt.
-- Naechster Schritt: Community-Lizenz auf Single-User-Betrieb begrenzen.
+- Community-/Single-User-Installationen bleiben auch bei gesetztem Team-Flag auf Personal Workspace begrenzt.
+- Personal Workspaces werden pro User angelegt; Team Workspace wird nur in teamfaehigen Deployment Modes angelegt.
+- Naechster Schritt: Globalen Workspace-Switcher fuer Startseite, Chat Header und File Browser bauen.

--- a/docs/architecture/canvas-notebook/team-workspace/README.md
+++ b/docs/architecture/canvas-notebook/team-workspace/README.md
@@ -57,4 +57,5 @@ Dieses Verzeichnis ist der zentrale Arbeitsbereich fuer den Team-Workspace-Umbau
 - Database-Provider-Policy fuer SQLite, Postgres, RAG, Collaboration, Installer und Control Plane ist dokumentiert.
 - Collaboration- und File-Conflict-Policy fuer Text, Office/PDF und Assets ist dokumentiert.
 - Control-Plane-Status-Quo fuer Managed Env, Installer-Artefakte, VM-Agent, VM-Actions und VM-Detailseite ist in der Database-Provider-Policy mit konkreten Zielpfaden abgeglichen.
-- Naechster Schritt: Initiales Admin-/Owner-Setup und Admin-only Gates absichern.
+- Control Plane Managed Mode, Team-Claims, Managed ENV und Organization-Runtime-Provisioning sind umgesetzt und in PR #3 gemerged.
+- Naechster Schritt: Workspace-Modell und Workspace-Service in Canvas Notebook einfuehren.

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -133,30 +133,48 @@
     {
       "id": 11,
       "title": "Community-Lizenz auf Single-User-Betrieb begrenzen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
-      "planningArtifact": "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md"
+      "planningArtifact": "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md",
+      "implementationArtifacts": [
+        "app/lib/organization/bootstrap.ts",
+        "scripts/bootstrap-admin.js",
+        "scripts/auth-setup-test.ts"
+      ]
     },
     {
       "id": 12,
       "title": "User-spezifische persoenliche Workspaces anlegen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/06-workspace-switching-ux.md",
         "docs/architecture/canvas-notebook/team-workspace/07-filesystem-migration-and-write-policy.md",
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/workspaces/service.ts",
+        "app/lib/organization/bootstrap.ts",
+        "scripts/bootstrap-admin.js",
+        "scripts/workspace-model-service-test.ts",
+        "scripts/auth-setup-test.ts"
       ]
     },
     {
       "id": 13,
       "title": "Team Workspace fuer Team-/Managed-Lizenzen anlegen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/06-workspace-switching-ux.md",
         "docs/architecture/canvas-notebook/team-workspace/07-filesystem-migration-and-write-policy.md",
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/workspaces/service.ts",
+        "app/lib/organization/bootstrap.ts",
+        "scripts/bootstrap-admin.js",
+        "scripts/workspace-model-service-test.ts"
       ]
     },
     {

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -112,12 +112,22 @@
     {
       "id": 10,
       "title": "Workspace-Modell und Workspace-Service in Canvas Notebook einfuehren",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/06-workspace-switching-ux.md",
         "docs/architecture/canvas-notebook/team-workspace/07-filesystem-migration-and-write-policy.md",
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/db/schema.ts",
+        "app/lib/db/migrate.ts",
+        "app/lib/workspaces/types.ts",
+        "app/lib/workspaces/permissions.ts",
+        "app/lib/workspaces/service.ts",
+        "app/lib/organization/bootstrap.ts",
+        "app/api/workspaces/route.ts",
+        "scripts/workspace-model-service-test.ts"
       ]
     },
     {

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-19",
+  "updatedAt": "2026-06-20",
   "source": "Canvas Notebook Team Workspace Plan",
   "tasks": [
     {
@@ -56,37 +56,57 @@
     {
       "id": 6,
       "title": "Control Plane Managed Mode in Lizenz-Claims und Deployment Modes aufteilen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvas-control-plane",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/00-full-plan.md",
         "docs/architecture/canvas-notebook/team-workspace/17-database-provider-postgres-rag-collaboration-policy.md"
+      ],
+      "implementationArtifacts": [
+        "../canvas-control-plane/apps/api/src/services/licenses.ts",
+        "../canvas-control-plane/docs/team-workspace-plan.md"
       ]
     },
     {
       "id": 7,
       "title": "managedFeatures und managedQuotas im Control Plane um Teamrechte erweitern",
-      "status": "pending",
-      "repo": "canvas-control-plane"
+      "status": "completed",
+      "repo": "canvas-control-plane",
+      "implementationArtifacts": [
+        "../canvas-control-plane/apps/api/src/services/licenses.ts"
+      ]
     },
     {
       "id": 8,
       "title": "applyManagedEnvToVmConfig() und ensureManagedEnvForVmConfig() um Team-ENV-Werte erweitern",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvas-control-plane",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/00-full-plan.md",
         "docs/architecture/canvas-notebook/team-workspace/17-database-provider-postgres-rag-collaboration-policy.md"
+      ],
+      "implementationArtifacts": [
+        "../canvas-control-plane/apps/api/src/services/managedSecrets.ts",
+        "../canvas-control-plane/apps/api/src/services/agentConfig.ts",
+        "../canvas-control-plane/apps/api/src/routes/config.ts",
+        "../canvas-control-plane/apps/web/src/app/dashboard/vms/[id]/page.tsx"
       ]
     },
     {
       "id": 9,
       "title": "Control Plane Provisioning so anpassen, dass Team-Instanzen als Organization-Runtime verstanden werden",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvas-control-plane",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/00-full-plan.md",
         "docs/architecture/canvas-notebook/team-workspace/17-database-provider-postgres-rag-collaboration-policy.md"
+      ],
+      "implementationArtifacts": [
+        "../canvas-control-plane/apps/api/src/routes/vms.ts",
+        "../canvas-control-plane/apps/api/src/services/ionosProvisioningRecovery.ts",
+        "../canvas-control-plane/apps/api/src/services/cloudflare.ts",
+        "../canvas-control-plane/apps/proxy-api/src/server.ts",
+        "../canvas-control-plane/scripts/deploy-remote.sh"
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "test:agents:runtime": "tsx --conditions react-server scripts/agent-runtime-config-test.ts",
     "test:onboarding:profile": "tsx --conditions react-server scripts/onboarding-profile-test.ts",
     "test:workspace:foundation": "tsx --conditions react-server scripts/workspace-context-foundation-test.ts",
+    "test:workspace:model": "tsx --conditions react-server scripts/workspace-model-service-test.ts",
     "test:e2e": "playwright test --pass-with-no-tests",
     "test:all": "node scripts/test-all.mjs",
     "test:websocket:connection": "node scripts/test-websocket-connection.js",

--- a/scripts/auth-setup-test.ts
+++ b/scripts/auth-setup-test.ts
@@ -14,6 +14,8 @@ function assertOrganizationBootstrapState(
   expectedUserId: string,
   expectedEmail: string,
   expectedPermissionOverrides: Partial<{ canManageBackups: number }> = {},
+  rootDir = dataDir,
+  expectedDeploymentMode = 'single_user',
 ) {
   const organization = sqlite.prepare(`
     SELECT organization_id AS organizationId, owner_user_id AS ownerUserId, deployment_mode AS deploymentMode,
@@ -28,7 +30,7 @@ function assertOrganizationBootstrapState(
 
   assert.ok(organization.organizationId.startsWith('org_'));
   assert.equal(organization.ownerUserId, expectedUserId);
-  assert.equal(organization.deploymentMode, 'single_user');
+  assert.equal(organization.deploymentMode, expectedDeploymentMode);
   assert.equal(organization.teamFeaturesEnabled, 0);
 
   const permission = sqlite.prepare(`
@@ -57,12 +59,29 @@ function assertOrganizationBootstrapState(
   const owner = sqlite.prepare('SELECT email FROM user WHERE id = ?').get(expectedUserId) as { email: string };
   assert.equal(owner.email, expectedEmail);
 
-  assert.equal(existsSync(path.join(dataDir, 'workspaces', 'personal', expectedUserId, 'files')), true);
-  assert.equal(existsSync(path.join(dataDir, 'users', expectedUserId, 'settings')), true);
-  assert.equal(existsSync(path.join(dataDir, 'users', expectedUserId, 'secrets')), true);
-  assert.equal(existsSync(path.join(dataDir, 'organizations', organization.organizationId, 'policies')), true);
-  assert.equal(existsSync(path.join(dataDir, 'system', 'backups')), true);
-  assert.equal(existsSync(path.join(dataDir, 'workspaces', 'team', organization.organizationId, 'files')), false);
+  const workspaces = sqlite.prepare(`
+    SELECT type, owner_user_id AS ownerUserId, root_relative_path AS rootRelativePath, display_name AS displayName, status
+    FROM canvas_workspaces
+    ORDER BY type ASC
+  `).all() as Array<{
+    type: string;
+    ownerUserId: string | null;
+    rootRelativePath: string;
+    displayName: string;
+    status: string;
+  }>;
+  assert.deepEqual(workspaces.map((workspace) => workspace.type), ['personal']);
+  assert.equal(workspaces[0].ownerUserId, expectedUserId);
+  assert.equal(workspaces[0].rootRelativePath, path.posix.join('workspaces', 'personal', expectedUserId, 'files'));
+  assert.equal(workspaces[0].displayName, 'Personal Workspace');
+  assert.equal(workspaces[0].status, 'active');
+
+  assert.equal(existsSync(path.join(rootDir, 'workspaces', 'personal', expectedUserId, 'files')), true);
+  assert.equal(existsSync(path.join(rootDir, 'users', expectedUserId, 'settings')), true);
+  assert.equal(existsSync(path.join(rootDir, 'users', expectedUserId, 'secrets')), true);
+  assert.equal(existsSync(path.join(rootDir, 'organizations', organization.organizationId, 'policies')), true);
+  assert.equal(existsSync(path.join(rootDir, 'system', 'backups')), true);
+  assert.equal(existsSync(path.join(rootDir, 'workspaces', 'team', organization.organizationId, 'files')), false);
 }
 
 async function main() {
@@ -224,6 +243,44 @@ async function main() {
   assert.equal(await verifyPassword({ hash: cliResetAccount.password!, password: 'CliResetPassword123!' }), true);
   assertOrganizationBootstrapState(cliReset, owner.id, 'cli-reset@example.test', { canManageBackups: 0 });
   cliReset.close();
+
+  const communityBootstrapDir = mkdtempSync(path.join(tmpdir(), 'canvas-auth-community-bootstrap-'));
+  try {
+    execFileSync('node', ['scripts/bootstrap-admin.js'], {
+      cwd: process.cwd(),
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        DATA: communityBootstrapDir,
+        CANVAS_DEPLOYMENT_MODE: 'community',
+        CANVAS_TEAM_FEATURES_ENABLED: 'true',
+        CANVAS_DATABASE_PROVIDER: 'sqlite',
+        BOOTSTRAP_ADMIN_EMAIL: 'community@example.test',
+        BOOTSTRAP_ADMIN_PASSWORD: 'CommunityPassword123!',
+        BOOTSTRAP_ADMIN_NAME: 'Community Admin',
+      },
+    });
+
+    const communityBootstrap = new Database(path.join(communityBootstrapDir, 'sqlite.db'));
+    const communityUser = communityBootstrap.prepare('SELECT id, email, role FROM user').get() as {
+      id: string;
+      email: string;
+      role: string | null;
+    };
+    assert.equal(communityUser.email, 'community@example.test');
+    assert.equal(communityUser.role, 'admin');
+    assertOrganizationBootstrapState(
+      communityBootstrap,
+      communityUser.id,
+      'community@example.test',
+      {},
+      communityBootstrapDir,
+      'community',
+    );
+    communityBootstrap.close();
+  } finally {
+    rmSync(communityBootstrapDir, { recursive: true, force: true });
+  }
 
   console.log('auth setup tests passed');
 }

--- a/scripts/auth-setup-test.ts
+++ b/scripts/auth-setup-test.ts
@@ -277,7 +277,38 @@ async function main() {
       communityBootstrapDir,
       'community',
     );
+
+    communityBootstrap.prepare(`
+      UPDATE canvas_workspaces
+      SET status = 'disabled', display_name = 'Outdated Name'
+      WHERE owner_user_id = ?
+    `).run(communityUser.id);
     communityBootstrap.close();
+
+    execFileSync('node', ['scripts/bootstrap-admin.js'], {
+      cwd: process.cwd(),
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        DATA: communityBootstrapDir,
+        CANVAS_DEPLOYMENT_MODE: 'community',
+        CANVAS_TEAM_FEATURES_ENABLED: 'true',
+        CANVAS_DATABASE_PROVIDER: 'sqlite',
+        BOOTSTRAP_ADMIN_EMAIL: 'community@example.test',
+        BOOTSTRAP_ADMIN_PASSWORD: 'CommunityPassword123!',
+        BOOTSTRAP_ADMIN_NAME: 'Community Admin',
+      },
+    });
+
+    const rebootstrap = new Database(path.join(communityBootstrapDir, 'sqlite.db'));
+    const personalWorkspace = rebootstrap.prepare(`
+      SELECT status, display_name AS displayName
+      FROM canvas_workspaces
+      WHERE owner_user_id = ?
+    `).get(communityUser.id) as { status: string; displayName: string };
+    assert.equal(personalWorkspace.status, 'disabled');
+    assert.equal(personalWorkspace.displayName, 'Personal Workspace');
+    rebootstrap.close();
   } finally {
     rmSync(communityBootstrapDir, { recursive: true, force: true });
   }

--- a/scripts/auth-setup-test.ts
+++ b/scripts/auth-setup-test.ts
@@ -90,7 +90,23 @@ async function main() {
     hasAnyAuthUser,
     InitialOwnerSetupError,
   } = await import('../app/lib/auth-setup');
-  const { ensureOrganizationBootstrapForUser, getOrganizationBootstrapStatus } = await import('../app/lib/organization/bootstrap');
+  const {
+    areTeamFeaturesEnabled,
+    ensureOrganizationBootstrapForUser,
+    getOrganizationBootstrapStatus,
+  } = await import('../app/lib/organization/bootstrap');
+
+  const previousTeamFeaturesEnv = process.env.CANVAS_TEAM_FEATURES_ENABLED;
+  process.env.CANVAS_TEAM_FEATURES_ENABLED = 'true';
+  assert.equal(areTeamFeaturesEnabled('community'), false);
+  assert.equal(areTeamFeaturesEnabled('single_user'), false);
+  assert.equal(areTeamFeaturesEnabled('managed-single'), false);
+  assert.equal(areTeamFeaturesEnabled('production'), true);
+  if (previousTeamFeaturesEnv === undefined) {
+    delete process.env.CANVAS_TEAM_FEATURES_ENABLED;
+  } else {
+    process.env.CANVAS_TEAM_FEATURES_ENABLED = previousTeamFeaturesEnv;
+  }
 
   assert.equal(hasAnyAuthUser(), false);
 
@@ -311,6 +327,45 @@ async function main() {
     rebootstrap.close();
   } finally {
     rmSync(communityBootstrapDir, { recursive: true, force: true });
+  }
+
+  const genericTeamBootstrapDir = mkdtempSync(path.join(tmpdir(), 'canvas-auth-generic-team-bootstrap-'));
+  try {
+    execFileSync('node', ['scripts/bootstrap-admin.js'], {
+      cwd: process.cwd(),
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        DATA: genericTeamBootstrapDir,
+        CANVAS_DEPLOYMENT_MODE: 'production',
+        CANVAS_TEAM_FEATURES_ENABLED: 'true',
+        CANVAS_DATABASE_PROVIDER: 'postgres',
+        BOOTSTRAP_ADMIN_EMAIL: 'generic-team@example.test',
+        BOOTSTRAP_ADMIN_PASSWORD: 'GenericTeamPassword123!',
+        BOOTSTRAP_ADMIN_NAME: 'Generic Team Admin',
+      },
+    });
+
+    const genericTeamBootstrap = new Database(path.join(genericTeamBootstrapDir, 'sqlite.db'));
+    const organization = genericTeamBootstrap.prepare(`
+      SELECT organization_id AS organizationId, deployment_mode AS deploymentMode,
+        team_features_enabled AS teamFeaturesEnabled
+      FROM canvas_organization_settings
+    `).get() as {
+      organizationId: string;
+      deploymentMode: string;
+      teamFeaturesEnabled: number;
+    };
+    assert.equal(organization.deploymentMode, 'production');
+    assert.equal(organization.teamFeaturesEnabled, 1);
+    assert.equal(existsSync(path.join(genericTeamBootstrapDir, 'workspaces', 'team', organization.organizationId, 'files')), true);
+    const workspaceTypes = genericTeamBootstrap.prepare(`
+      SELECT type FROM canvas_workspaces ORDER BY type ASC
+    `).all() as Array<{ type: string }>;
+    assert.deepEqual(workspaceTypes.map((workspace) => workspace.type), ['personal', 'team']);
+    genericTeamBootstrap.close();
+  } finally {
+    rmSync(genericTeamBootstrapDir, { recursive: true, force: true });
   }
 
   console.log('auth setup tests passed');

--- a/scripts/bootstrap-admin.js
+++ b/scripts/bootstrap-admin.js
@@ -311,7 +311,7 @@ function isTeamDeploymentMode(deploymentMode) {
 }
 
 function canEnableTeamFeaturesForDeployment(deploymentMode) {
-  return isTeamDeploymentMode(deploymentMode);
+  return !isSingleUserDeploymentMode(deploymentMode);
 }
 
 function teamFeaturesEnabled(deploymentMode) {

--- a/scripts/bootstrap-admin.js
+++ b/scripts/bootstrap-admin.js
@@ -463,7 +463,7 @@ function ensureWorkspaceRecord(db, input) {
   if (existing) {
     db.prepare(`
       UPDATE canvas_workspaces
-      SET root_relative_path = ?, display_name = ?, status = 'active', updated_at = ?
+      SET root_relative_path = ?, display_name = ?, updated_at = ?
       WHERE id = ?
     `).run(input.rootRelativePath, input.displayName, now, existing.id);
     ensureWorkspaceDirectory(input.rootRelativePath);

--- a/scripts/bootstrap-admin.js
+++ b/scripts/bootstrap-admin.js
@@ -181,6 +181,20 @@ CREATE TABLE IF NOT EXISTS canvas_organization_settings (
   FOREIGN KEY (owner_user_id) REFERENCES user(id)
 );
 
+CREATE TABLE IF NOT EXISTS canvas_workspaces (
+  id TEXT PRIMARY KEY NOT NULL,
+  organization_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  owner_user_id TEXT,
+  root_relative_path TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (organization_id) REFERENCES canvas_organization_settings(organization_id) ON DELETE CASCADE,
+  FOREIGN KEY (owner_user_id) REFERENCES user(id)
+);
+
 CREATE TABLE IF NOT EXISTS organization_user_permissions (
   organization_id TEXT NOT NULL,
   user_id TEXT NOT NULL,
@@ -204,6 +218,11 @@ CREATE TABLE IF NOT EXISTS organization_user_permissions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_canvas_org_settings_owner ON canvas_organization_settings (owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_canvas_workspaces_organization ON canvas_workspaces (organization_id);
+CREATE INDEX IF NOT EXISTS idx_canvas_workspaces_owner ON canvas_workspaces (owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_canvas_workspaces_organization_type ON canvas_workspaces (organization_id, type);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_canvas_workspaces_personal_owner ON canvas_workspaces (owner_user_id) WHERE type = 'personal';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_canvas_workspaces_team_organization ON canvas_workspaces (organization_id) WHERE type = 'team';
 CREATE INDEX IF NOT EXISTS idx_org_user_permissions_user ON organization_user_permissions (user_id);
 CREATE INDEX IF NOT EXISTS idx_org_user_permissions_role ON organization_user_permissions (organization_id, role);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_org_user_permissions_single_owner ON organization_user_permissions (organization_id) WHERE role = 'owner';
@@ -264,9 +283,40 @@ function getDeploymentMode() {
   return 'single_user';
 }
 
+function normalizeDeploymentMode(value) {
+  return value.trim().toLowerCase().replace(/_/g, '-');
+}
+
+function isTruthyEnv(value) {
+  return value === 'true' || value === '1' || value === 'yes';
+}
+
+function isSingleUserDeploymentMode(deploymentMode) {
+  const normalized = normalizeDeploymentMode(deploymentMode);
+  return normalized === 'community' ||
+    normalized === 'single-user' ||
+    normalized === 'singleuser' ||
+    normalized === 'managed-single' ||
+    normalized === 'local' ||
+    normalized === 'development' ||
+    normalized === 'dev';
+}
+
+function isTeamDeploymentMode(deploymentMode) {
+  const normalized = normalizeDeploymentMode(deploymentMode);
+  if (isSingleUserDeploymentMode(normalized)) return false;
+  return normalized.includes('team') ||
+    normalized.includes('enterprise') ||
+    normalized.includes('advanced');
+}
+
+function canEnableTeamFeaturesForDeployment(deploymentMode) {
+  return isTeamDeploymentMode(deploymentMode);
+}
+
 function teamFeaturesEnabled(deploymentMode) {
-  const explicit = process.env.CANVAS_TEAM_FEATURES_ENABLED;
-  return explicit === 'true' || explicit === '1' || explicit === 'yes' || deploymentMode.toLowerCase().includes('team');
+  if (!canEnableTeamFeaturesForDeployment(deploymentMode)) return false;
+  return isTruthyEnv(process.env.CANVAS_TEAM_FEATURES_ENABLED) || isTeamDeploymentMode(deploymentMode);
 }
 
 function getPrimaryOrganization(db) {
@@ -379,6 +429,84 @@ function ensureScopedDirectories(organizationId, userId, includeTeamWorkspace) {
   }
 }
 
+function workspaceAbsoluteRoot(rootRelativePath) {
+  if (path.isAbsolute(rootRelativePath) || rootRelativePath.includes('\0')) {
+    throw new Error('Invalid workspace root path.');
+  }
+  const segments = rootRelativePath.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (segments.some((segment) => segment === '..' || segment === '.')) {
+    throw new Error('Invalid workspace root path.');
+  }
+  return path.join(getDataRoot(), ...segments);
+}
+
+function ensureWorkspaceDirectory(rootRelativePath) {
+  mkdirSync(workspaceAbsoluteRoot(rootRelativePath), { recursive: true });
+}
+
+function ensureWorkspaceRecord(db, input) {
+  const now = Date.now();
+  const existing = input.type === 'personal'
+    ? db.prepare(`
+        SELECT id, root_relative_path, display_name, status
+        FROM canvas_workspaces
+        WHERE type = 'personal' AND owner_user_id = ?
+        LIMIT 1
+      `).get(input.ownerUserId)
+    : db.prepare(`
+        SELECT id, root_relative_path, display_name, status
+        FROM canvas_workspaces
+        WHERE type = 'team' AND organization_id = ?
+        LIMIT 1
+      `).get(input.organizationId);
+
+  if (existing) {
+    db.prepare(`
+      UPDATE canvas_workspaces
+      SET root_relative_path = ?, display_name = ?, status = 'active', updated_at = ?
+      WHERE id = ?
+    `).run(input.rootRelativePath, input.displayName, now, existing.id);
+    ensureWorkspaceDirectory(input.rootRelativePath);
+    return;
+  }
+
+  db.prepare(`
+    INSERT INTO canvas_workspaces (
+      id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?)
+  `).run(
+    `ws_${randomUUID()}`,
+    input.organizationId,
+    input.type,
+    input.ownerUserId,
+    input.rootRelativePath,
+    input.displayName,
+    now,
+    now,
+  );
+  ensureWorkspaceDirectory(input.rootRelativePath);
+}
+
+function ensureDefaultWorkspaceRecords(db, organizationId, userId, includeTeamWorkspace) {
+  ensureWorkspaceRecord(db, {
+    organizationId,
+    type: 'personal',
+    ownerUserId: userId,
+    rootRelativePath: path.posix.join('workspaces', 'personal', userId, 'files'),
+    displayName: 'Personal Workspace',
+  });
+
+  if (includeTeamWorkspace) {
+    ensureWorkspaceRecord(db, {
+      organizationId,
+      type: 'team',
+      ownerUserId: null,
+      rootRelativePath: path.posix.join('workspaces', 'team', organizationId, 'files'),
+      displayName: 'Team Workspace',
+    });
+  }
+}
+
 function ensureOrganizationBootstrap(db, userId) {
   const targetUser = findUserById(db, userId);
   if (!targetUser) {
@@ -418,8 +546,10 @@ function ensureOrganizationBootstrap(db, userId) {
     ensurePermissionRow(db, organization.organization_id, targetUser.id, 'admin');
   }
   ensureScopedDirectories(organization.organization_id, ownerUser.id, includeTeamWorkspace);
+  ensureDefaultWorkspaceRecords(db, organization.organization_id, ownerUser.id, includeTeamWorkspace);
   if (targetUser.id !== ownerUser.id) {
     ensureScopedDirectories(organization.organization_id, targetUser.id, includeTeamWorkspace);
+    ensureDefaultWorkspaceRecords(db, organization.organization_id, targetUser.id, includeTeamWorkspace);
   }
 }
 

--- a/scripts/workspace-model-service-test.ts
+++ b/scripts/workspace-model-service-test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../app/lib/db/migrate';
+import { ensureOrganizationBootstrapForUser } from '../app/lib/organization/bootstrap';
+import { resolveWorkspaceActor } from '../app/lib/workspaces/context';
+import {
+  ensureDefaultWorkspaceRecords,
+  listWorkspaceContextsForUser,
+  resolveDefaultWorkspaceContext,
+  resolveWorkspaceContextById,
+  workspaceAbsoluteRoot,
+} from '../app/lib/workspaces/service';
+
+async function main() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-workspace-model-'));
+  const dataRoot = path.join(tempRoot, 'data');
+  process.env.DATA = dataRoot;
+  process.env.CANVAS_DEPLOYMENT_MODE = 'managed-team';
+  process.env.CANVAS_DATABASE_PROVIDER = 'postgres';
+
+  await fs.mkdir(dataRoot, { recursive: true });
+  const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+  try {
+    runMigrations(sqlite);
+    const now = Date.now();
+    sqlite.prepare(`
+      INSERT INTO user (id, name, email, email_verified, role, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('user-owner', 'Owner', 'owner@example.com', 1, 'admin', now, now);
+    sqlite.prepare(`
+      INSERT INTO user (id, name, email, email_verified, role, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('user-member', 'Member', 'member@example.com', 1, 'member', now, now);
+
+    sqlite.exec('BEGIN IMMEDIATE');
+    const ownerStatus = ensureOrganizationBootstrapForUser(sqlite, 'user-owner');
+    assert.equal(ownerStatus.configured, true);
+    assert.equal(ownerStatus.teamFeaturesEnabled, true);
+    assert.equal(ownerStatus.databaseProvider, 'postgres');
+    assert.ok(ownerStatus.organizationId);
+    sqlite.exec('COMMIT');
+
+    const organizationId = ownerStatus.organizationId!;
+    const ownerActor = resolveWorkspaceActor({
+      id: 'user-owner',
+      email: 'owner@example.com',
+      role: 'admin',
+    });
+    const ownerWorkspaces = listWorkspaceContextsForUser(sqlite, { actor: ownerActor, organizationId });
+    assert.deepEqual(ownerWorkspaces.map((workspace) => workspace.workspaceType), ['personal', 'team']);
+    assert.equal(ownerWorkspaces[0].permissions.canRead, true);
+    assert.equal(ownerWorkspaces[0].permissions.canWrite, true);
+    assert.equal(ownerWorkspaces[1].permissions.canRead, true);
+    assert.equal(ownerWorkspaces[1].permissions.canWrite, true);
+    assert.equal(
+      ownerWorkspaces[0].rootPath,
+      path.join(dataRoot, 'workspaces', 'personal', 'user-owner', 'files')
+    );
+    assert.equal(
+      ownerWorkspaces[1].rootPath,
+      path.join(dataRoot, 'workspaces', 'team', organizationId, 'files')
+    );
+    await fs.access(ownerWorkspaces[0].rootPath);
+    await fs.access(ownerWorkspaces[1].rootPath);
+
+    const defaultWorkspace = resolveDefaultWorkspaceContext(sqlite, { actor: ownerActor, organizationId });
+    assert.equal(defaultWorkspace?.workspaceId, ownerWorkspaces[0].workspaceId);
+
+    ensureDefaultWorkspaceRecords(sqlite, {
+      organizationId,
+      userId: 'user-member',
+      teamFeaturesEnabled: true,
+    });
+    sqlite.prepare(`
+      INSERT INTO organization_user_permissions (
+        organization_id, user_id, role, can_write_team_workspace, can_create_public_links,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(organizationId, 'user-member', 'member', 0, 1, now, now);
+
+    const memberActor = resolveWorkspaceActor({
+      id: 'user-member',
+      email: 'member@example.com',
+      role: 'member',
+    });
+    const memberWorkspaces = listWorkspaceContextsForUser(sqlite, { actor: memberActor, organizationId });
+    assert.deepEqual(memberWorkspaces.map((workspace) => workspace.workspaceType), ['personal', 'team']);
+    assert.equal(memberWorkspaces[0].ownerUserId, 'user-member');
+    assert.equal(memberWorkspaces[1].permissions.canRead, true);
+    assert.equal(memberWorkspaces[1].permissions.canWrite, false);
+
+    const ownerPersonalForMember = resolveWorkspaceContextById(sqlite, {
+      actor: memberActor,
+      workspaceId: ownerWorkspaces[0].workspaceId,
+    });
+    assert.equal(ownerPersonalForMember, null);
+
+    const ensured = ensureDefaultWorkspaceRecords(sqlite, {
+      organizationId,
+      userId: 'user-member',
+      teamFeaturesEnabled: true,
+    });
+    assert.equal(ensured.personal.id, memberWorkspaces[0].workspaceId);
+    assert.equal(ensured.team?.id, ownerWorkspaces[1].workspaceId);
+    assert.equal(
+      workspaceAbsoluteRoot(ensured.personal.rootRelativePath),
+      path.join(dataRoot, 'workspaces', 'personal', 'user-member', 'files')
+    );
+    assert.throws(() => workspaceAbsoluteRoot('../outside'), /Invalid workspace root path/);
+  } finally {
+    sqlite.close();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+
+  console.log('workspace-model-service-test: ok');
+}
+
+void main();

--- a/scripts/workspace-model-service-test.ts
+++ b/scripts/workspace-model-service-test.ts
@@ -36,6 +36,10 @@ async function main() {
       INSERT INTO user (id, name, email, email_verified, role, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?)
     `).run('user-member', 'Member', 'member@example.com', 1, 'member', now, now);
+    sqlite.prepare(`
+      INSERT INTO user (id, name, email, email_verified, role, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('user-no-permission', 'No Permission', 'no-permission@example.com', 1, 'member', now, now);
 
     sqlite.exec('BEGIN IMMEDIATE');
     const ownerStatus = ensureOrganizationBootstrapForUser(sqlite, 'user-owner');
@@ -126,6 +130,23 @@ async function main() {
     assert.equal(disabledEnsure.personal.displayName, 'Personal Workspace');
     const memberWorkspacesAfterDisable = listWorkspaceContextsForUser(sqlite, { actor: memberActor, organizationId });
     assert.deepEqual(memberWorkspacesAfterDisable.map((workspace) => workspace.workspaceType), ['team']);
+
+    ensureDefaultWorkspaceRecords(sqlite, {
+      organizationId,
+      userId: 'user-no-permission',
+      teamFeaturesEnabled: true,
+    });
+    const actorWithoutPermission = resolveWorkspaceActor({
+      id: 'user-no-permission',
+      email: 'no-permission@example.com',
+      role: 'member',
+    });
+    const noPermissionWorkspaces = listWorkspaceContextsForUser(sqlite, {
+      actor: actorWithoutPermission,
+      organizationId,
+    });
+    assert.deepEqual(noPermissionWorkspaces.map((workspace) => workspace.workspaceType), ['personal']);
+    assert.equal(noPermissionWorkspaces[0].permissions.canCreatePublicLinks, false);
     assert.throws(() => workspaceAbsoluteRoot('../outside'), /Invalid workspace root path/);
   } finally {
     sqlite.close();

--- a/scripts/workspace-model-service-test.ts
+++ b/scripts/workspace-model-service-test.ts
@@ -111,6 +111,21 @@ async function main() {
       workspaceAbsoluteRoot(ensured.personal.rootRelativePath),
       path.join(dataRoot, 'workspaces', 'personal', 'user-member', 'files')
     );
+
+    sqlite.prepare(`
+      UPDATE canvas_workspaces
+      SET status = 'disabled', display_name = 'Outdated Name'
+      WHERE id = ?
+    `).run(ensured.personal.id);
+    const disabledEnsure = ensureDefaultWorkspaceRecords(sqlite, {
+      organizationId,
+      userId: 'user-member',
+      teamFeaturesEnabled: true,
+    });
+    assert.equal(disabledEnsure.personal.status, 'disabled');
+    assert.equal(disabledEnsure.personal.displayName, 'Personal Workspace');
+    const memberWorkspacesAfterDisable = listWorkspaceContextsForUser(sqlite, { actor: memberActor, organizationId });
+    assert.deepEqual(memberWorkspacesAfterDisable.map((workspace) => workspace.workspaceType), ['team']);
     assert.throws(() => workspaceAbsoluteRoot('../outside'), /Invalid workspace root path/);
   } finally {
     sqlite.close();


### PR DESCRIPTION
## Summary

- add the Canvas Notebook workspace model table, migrations, workspace service, and `/api/workspaces`
- create personal workspace records for users and team workspace records only for team-capable deployment modes
- keep community/single-user deployments personal-only even when `CANVAS_TEAM_FEATURES_ENABLED=true`
- document completed tasks in the team workspace SSOT and allow pushing PR branches in `AGENTS.md`

## Validation

- `npm run test:workspace:model`
- `npm run test:workspace:foundation`
- `npm run test:organization:permissions`
- `npm run test:auth:setup`
- `npm run build`

Build note: Next/Turbopack still reports the existing broad dynamic path warnings in agent storage/system-prompt code; no new build failure was introduced.

## Greptile

Greploop completed for head `101ac6fb`: **5/5 confidence**, with zero unresolved Greptile review threads.
