### PR TITLE
Add global workspace switcher UI

### DIFF
--- a/app/[locale]/(routes)/chat/chat-shell.tsx
+++ b/app/[locale]/(routes)/chat/chat-shell.tsx
@@ -14,6 +14,7 @@ import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { AppLauncher } from '@/app/components/AppLauncher';
 import { NotificationBell } from '@/app/components/notifications/NotificationBell';
 import { CANVAS_CHAT_INITIAL_PROMPT_STORAGE_KEY } from '@/app/lib/chat/constants';
+import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 
 export function ChatShell() {
   const t = useTranslations('chat');
@@ -33,6 +34,7 @@ export function ChatShell() {
             <h1 className="hidden md:block text-lg md:text-2xl font-bold truncate">{t('title')}</h1>
           </div>
             <div className="flex items-center gap-1.5 md:gap-4">
+              <WorkspaceSwitcher source="navbar" variant="compact" />
               <NotificationBell />
               <AppLauncher />
               <ThemeToggle />

--- a/app/[locale]/(routes)/page.tsx
+++ b/app/[locale]/(routes)/page.tsx
@@ -14,6 +14,7 @@ import { isOnboardingHintsEnabled } from '@/app/lib/onboarding/status';
 import { LogoutButton } from '@/app/components/LogoutButton';
 import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { VersionUpdateIndicator } from '@/app/components/VersionUpdateIndicator';
+import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 
 const repositoryUrl = 'https://github.com/canvascoding/canvas-notebook';
 const releaseVersion = packageJson.version;
@@ -42,6 +43,7 @@ export default async function Home() {
             </div>
 
             <div className="ml-auto flex items-center gap-2 md:gap-3">
+              <WorkspaceSwitcher source="home" variant="compact" />
               <NotificationBell />
               <AppLauncher />
               <ThemeToggle />

--- a/app/components/DashboardShell.tsx
+++ b/app/components/DashboardShell.tsx
@@ -42,6 +42,7 @@ import { AppLayout } from '@/app/components/layout/AppLayout';
 import CanvasAgentChat from '@/app/components/canvas-agent-chat/CanvasAgentChat';
 import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { NotificationBell } from '@/app/components/notifications/NotificationBell';
+import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 
 import { useFileStore } from '@/app/store/file-store';
 import { FileWatcherProvider } from '@/app/hooks/FileWatcherContext';
@@ -859,6 +860,7 @@ export function DashboardShell({ hintEnabled = true }: { hintEnabled?: boolean }
 
           {/* Right side: help, theme, logout */}
           <div className="relative z-50 flex items-center gap-1.5 md:gap-4">
+            <WorkspaceSwitcher source="notebook" variant="compact" />
             <NotificationBell />
             <AppLauncher />
             <ThemeToggle />

--- a/app/components/SuitePageLayout.tsx
+++ b/app/components/SuitePageLayout.tsx
@@ -13,6 +13,7 @@ import { AppLauncher } from '@/app/components/AppLauncher';
 import { NotificationBell } from '@/app/components/notifications/NotificationBell';
 import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { HintProvider } from '@/app/components/onboarding/HintProvider';
+import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 
 import { Button } from '@/components/ui/button';
 
@@ -83,6 +84,7 @@ export function SuitePageLayout({
             </div>
 
             <div className="ml-auto flex items-center gap-2 md:gap-3">
+              <WorkspaceSwitcher source="navbar" variant="compact" />
               <NotificationBell />
               <AppLauncher />
               <ThemeToggle />

--- a/app/components/canvas-agent-chat/CanvasAgentChat.tsx
+++ b/app/components/canvas-agent-chat/CanvasAgentChat.tsx
@@ -35,6 +35,11 @@ import { useWebSocket } from '@/app/hooks/useWebSocket';
 import { ImagePreprocessDialog } from '@/app/components/shared/ImagePreprocessDialog';
 import { usePlanModeStore } from '@/app/store/plan-mode-store';
 import { useToolVerbosityStore } from '@/app/store/tool-verbosity-store';
+import {
+  selectActiveWorkspace,
+  useWorkspaceStore,
+  WORKSPACE_CHANGED_EVENT,
+} from '@/app/store/workspace-store';
 import { getToolDisplayInfo } from '@/app/lib/pi/tool-display';
 
 import { CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY } from '@/app/lib/chat/constants';
@@ -128,6 +133,7 @@ export default function CanvasAgentChat({
   const currentFile = useFileStore((s) => s.currentFile);
   const { planningMode, togglePlanningMode } = usePlanModeStore();
   const toolVerbosity = useToolVerbosityStore((s) => s.toolVerbosity);
+  const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
 
   // Container width detection for history layout
   const containerRef = useRef<HTMLDivElement>(null);
@@ -395,10 +401,20 @@ export default function CanvasAgentChat({
     activeFilePath,
     userTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     currentTime: new Date().toISOString(),
+    workspace: activeWorkspace
+      ? {
+        workspaceId: activeWorkspace.id,
+        workspaceType: activeWorkspace.type,
+        workspaceName: activeWorkspace.name,
+        organizationId: activeWorkspace.organizationId,
+        canWrite: activeWorkspace.permissions.canWrite,
+        canShare: activeWorkspace.permissions.canCreatePublicLinks,
+      }
+      : undefined,
     planningMode,
     currentPage: typeof window !== 'undefined' ? window.location.pathname : undefined,
     ...requestContext,
-  }), [planningMode, requestContext]);
+  }), [activeWorkspace, planningMode, requestContext]);
 
   const ensureSessionSubscribed = useCallback(async (targetSessionId: string) => {
     if (subscribedSessionAckRef.current === targetSessionId) {
@@ -586,6 +602,15 @@ export default function CanvasAgentChat({
     userStartedNewChatRef,
     wsRequest,
   });
+
+  useEffect(() => {
+    const handleWorkspaceChange = () => {
+      startNewChat();
+    };
+
+    window.addEventListener(WORKSPACE_CHANGED_EVENT, handleWorkspaceChange);
+    return () => window.removeEventListener(WORKSPACE_CHANGED_EVENT, handleWorkspaceChange);
+  }, [startNewChat]);
 
   const { loadOlderMessages, loadSession } = useChatSessionMessages({
     activeModel,

--- a/app/components/canvas-agent-chat/ChatHeader.tsx
+++ b/app/components/canvas-agent-chat/ChatHeader.tsx
@@ -17,6 +17,8 @@ import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { ChatAgentSelector } from '@/app/components/canvas-agent-chat/ChatAgentSelector';
 import { ChatRuntimeActivityBadge } from '@/app/components/canvas-agent-chat/ChatRuntimeActivityBadge';
+import { WorkspaceBadge } from '@/app/components/workspaces/WorkspaceBadge';
+import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 import type { RuntimeStatus } from '@/app/lib/chat/runtime-status';
 import type { AgentProfile } from '@/app/lib/chat/types';
 import type { ToolVerbosity } from '@/app/store/tool-verbosity-store';
@@ -159,11 +161,13 @@ export function ChatHeader({
                     agents={chatAgentOptions}
                     onSelectAgent={onSelectAgent}
                   />
+                  <WorkspaceBadge compact className="hidden lg:inline-flex" />
                 </div>
               )}
             </div>
           </div>
           <div className="ml-auto flex shrink-0 items-center gap-1">
+            <WorkspaceSwitcher source="chat" variant="compact" className="hidden sm:inline-flex" />
             <button
               type="button"
               aria-label={t('newChatTitle')}
@@ -202,6 +206,7 @@ export function ChatHeader({
                   onSelectAgent={onSelectAgent}
                 />
               ) : null}
+              {isMobile ? <WorkspaceSwitcher source="chat" variant="compact" /> : null}
 
               {runtimeStatus && totalQueuedMessages > 0 && (
                 <span className="inline-flex items-center gap-1 border border-border/60 bg-muted/40 px-1.5 py-0.5 text-[10px] text-muted-foreground">
@@ -314,6 +319,7 @@ export function ChatHeader({
                     {t('summary')}
                   </span>
                 )}
+                <WorkspaceBadge compact />
                 {runtimeStatus?.activeTool && toolVerbosity !== 'minimal' && (
                   <span className="inline-flex items-center gap-1 border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-600">
                     <Wrench size={9} />

--- a/app/components/file-browser/FileBrowser.tsx
+++ b/app/components/file-browser/FileBrowser.tsx
@@ -27,10 +27,12 @@ import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { notifyWorkspaceFileOpened } from '@/app/lib/files/workspace-file-events';
 import { PublicShareDialog } from './PublicShareDialog';
 import { useCreateItemDialog } from './useCreateItemDialog';
+import { useWorkspaceStore } from '@/app/store/workspace-store';
 
 
 import { AppLauncher } from '@/app/components/AppLauncher';
 import { NotificationBell } from '@/app/components/notifications/NotificationBell';
+import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 
 interface FileBrowserProps {
   variant?: 'default' | 'mobile-sheet' | 'fullscreen';
@@ -44,6 +46,7 @@ export function FileBrowser({ variant = 'default', onFileSelect }: FileBrowserPr
   const dragCounter = useRef(0);
   const openedPathParamRef = useRef<string | null>(null);
   const pendingPathParamRef = useRef<string | null>(null);
+  const activeWorkspaceIdRef = useRef<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -76,7 +79,10 @@ export function FileBrowser({ variant = 'default', onFileSelect }: FileBrowserPr
     downloadFile,
     revealAndLoadFile,
     setBulkMoveOpen,
+    resetWorkspaceView,
+    loadFileTree,
   } = useFileStore();
+  const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
 
   useEffect(() => {
     const handle = window.setTimeout(() => {
@@ -84,6 +90,26 @@ export function FileBrowser({ variant = 'default', onFileSelect }: FileBrowserPr
     }, 0);
     return () => window.clearTimeout(handle);
   }, [hydrateClientPreferences]);
+
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    const previousWorkspaceId = activeWorkspaceIdRef.current;
+    activeWorkspaceIdRef.current = activeWorkspaceId;
+
+    if (!previousWorkspaceId || previousWorkspaceId === activeWorkspaceId) return;
+
+    openedPathParamRef.current = null;
+    pendingPathParamRef.current = null;
+    setActiveFilePath(null);
+    setPublicShareOpen(false);
+    setPublicSharePaths([]);
+    setUploadOpen(false);
+    setDeleteOpen(false);
+    setDeletePaths([]);
+    setDeleteSkippedCount(0);
+    resetWorkspaceView();
+    void loadFileTree('.', undefined, true);
+  }, [activeWorkspaceId, loadFileTree, resetWorkspaceView]);
 
   const isDirectoryReachableInTree = useCallback(
     (dirPath: string) => {
@@ -413,6 +439,7 @@ export function FileBrowser({ variant = 'default', onFileSelect }: FileBrowserPr
             <h1 className="hidden md:block text-lg md:text-2xl font-bold truncate">{t('filesTitle')}</h1>
           </div>
           <div className="flex items-center gap-1.5 md:gap-4">
+            <WorkspaceSwitcher source="navbar" variant="compact" />
             <NotificationBell />
             <AppLauncher />
             <ThemeToggle />

--- a/app/components/file-browser/FileToolbar.tsx
+++ b/app/components/file-browser/FileToolbar.tsx
@@ -20,6 +20,7 @@ import {
 import { cn } from '@/lib/utils';
 import { useFileStore } from '@/app/store/file-store';
 import type { BrowserMode } from '@/app/lib/files/types';
+import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 
 export interface FileToolbarHandlers {
   onToggleMultiSelect: () => void;
@@ -166,6 +167,7 @@ export function FileToolbar({ variant, isMultiSelectMode, isDeleteDisabled, hand
   if (isMobileSheet) {
     return (
       <div className="flex items-center gap-1 px-3 py-2">
+        <WorkspaceSwitcher source="file-browser" variant="compact" className="mr-1 shrink-0" />
         <Button
           variant="ghost"
           size="sm"
@@ -223,6 +225,8 @@ export function FileToolbar({ variant, isMultiSelectMode, isDeleteDisabled, hand
   if (isFullscreen) {
     return (
       <div className="flex flex-wrap items-center gap-2 px-4 py-2.5">
+        <WorkspaceSwitcher source="file-browser" variant="toolbar" className="shrink-0" />
+        <div className="hidden h-5 w-px bg-border sm:block" />
         <Button
           variant="ghost"
           size="sm"
@@ -272,8 +276,11 @@ export function FileToolbar({ variant, isMultiSelectMode, isDeleteDisabled, hand
 
   // sidebar variant
   return (
-    <div className="flex items-center gap-x-2 px-3 py-2">
-      <h2 className="shrink-0 text-sm font-semibold text-foreground">{t('filesTitle')}</h2>
+    <div className="flex flex-col gap-2 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="shrink-0 text-sm font-semibold text-foreground">{t('filesTitle')}</h2>
+        <WorkspaceSwitcher source="file-browser" variant="compact" className="min-w-0 shrink" />
+      </div>
       <TooltipProvider delayDuration={300}>
         <div className="flex min-w-0 flex-1 items-center justify-start gap-1">
           <Tooltip>

--- a/app/components/workspaces/WorkspaceBadge.tsx
+++ b/app/components/workspaces/WorkspaceBadge.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Building2, Lock, UserRound, UsersRound } from 'lucide-react';
+import { Lock } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 
 import { Badge } from '@/components/ui/badge';
 import {
@@ -11,6 +12,11 @@ import {
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
+import {
+  getWorkspaceKindLabel,
+  renderWorkspaceIcon,
+  type WorkspaceKindLabels,
+} from '@/app/components/workspaces/workspace-utils';
 import { selectActiveWorkspace, useWorkspaceStore } from '@/app/store/workspace-store';
 
 type WorkspaceBadgeProps = {
@@ -19,27 +25,21 @@ type WorkspaceBadgeProps = {
   className?: string;
 };
 
-function getWorkspaceKindLabel(workspace: ClientWorkspaceSummary | null) {
-  if (workspace?.type === 'team') return 'Team';
-  if (workspace?.type === 'project') return 'Project';
-  return 'Personal';
-}
-
-function renderWorkspaceIcon(workspace: ClientWorkspaceSummary | null, className: string) {
-  if (workspace?.type === 'team') return <UsersRound className={className} />;
-  if (workspace?.type === 'project') return <Building2 className={className} />;
-  return <UserRound className={className} />;
-}
-
 export function WorkspaceBadge({ workspace: providedWorkspace, compact = false, className }: WorkspaceBadgeProps) {
+  const t = useTranslations('workspaces');
   const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
   const workspace = providedWorkspace ?? activeWorkspace;
-  const label = workspace?.name || 'Workspace';
-  const kindLabel = getWorkspaceKindLabel(workspace);
+  const kindLabels = {
+    personal: t('types.personal'),
+    team: t('types.team'),
+    project: t('types.project'),
+  } satisfies WorkspaceKindLabels;
+  const label = workspace?.name || t('label');
+  const kindLabel = getWorkspaceKindLabel(workspace, kindLabels);
   const canWrite = Boolean(workspace?.permissions.canWrite);
   const title = workspace
-    ? `${label} · ${canWrite ? 'Write access' : 'Read only'}`
-    : 'Workspace context is loading';
+    ? `${label} · ${canWrite ? t('access.write') : t('access.readOnly')}`
+    : t('loadingContext');
 
   return (
     <TooltipProvider delayDuration={300}>

--- a/app/components/workspaces/WorkspaceBadge.tsx
+++ b/app/components/workspaces/WorkspaceBadge.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Building2, Lock, UserRound, UsersRound } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
+import { selectActiveWorkspace, useWorkspaceStore } from '@/app/store/workspace-store';
+
+type WorkspaceBadgeProps = {
+  workspace?: ClientWorkspaceSummary | null;
+  compact?: boolean;
+  className?: string;
+};
+
+function getWorkspaceKindLabel(workspace: ClientWorkspaceSummary | null) {
+  if (workspace?.type === 'team') return 'Team';
+  if (workspace?.type === 'project') return 'Project';
+  return 'Personal';
+}
+
+function renderWorkspaceIcon(workspace: ClientWorkspaceSummary | null, className: string) {
+  if (workspace?.type === 'team') return <UsersRound className={className} />;
+  if (workspace?.type === 'project') return <Building2 className={className} />;
+  return <UserRound className={className} />;
+}
+
+export function WorkspaceBadge({ workspace: providedWorkspace, compact = false, className }: WorkspaceBadgeProps) {
+  const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
+  const workspace = providedWorkspace ?? activeWorkspace;
+  const label = workspace?.name || 'Workspace';
+  const kindLabel = getWorkspaceKindLabel(workspace);
+  const canWrite = Boolean(workspace?.permissions.canWrite);
+  const title = workspace
+    ? `${label} · ${canWrite ? 'Write access' : 'Read only'}`
+    : 'Workspace context is loading';
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge
+            variant="outline"
+            data-testid="workspace-badge"
+            data-active-workspace-id={workspace?.id ?? ''}
+            data-active-workspace-type={workspace?.type ?? ''}
+            className={cn(
+              'h-7 max-w-full gap-1.5 rounded-md border-border/70 bg-muted/35 px-2 text-[11px] font-medium text-foreground hover:bg-muted/50',
+              className
+            )}
+          >
+            {renderWorkspaceIcon(workspace, 'h-3.5 w-3.5 shrink-0 text-muted-foreground')}
+            {!compact && (
+              <span className="min-w-0 truncate">
+                {label}
+              </span>
+            )}
+            {compact ? (
+              <span className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">{kindLabel}</span>
+            ) : null}
+            {!canWrite && workspace ? <Lock className="h-3 w-3 shrink-0 text-amber-500" /> : null}
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>{title}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/app/components/workspaces/WorkspaceSwitcher.tsx
+++ b/app/components/workspaces/WorkspaceSwitcher.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useCallback, useEffect } from 'react';
-import { Building2, Check, ChevronsUpDown, Loader2, Lock, RefreshCw, UserRound, UsersRound } from 'lucide-react';
+import { Check, ChevronsUpDown, Loader2, Lock, RefreshCw } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -14,6 +15,11 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
+import {
+  getWorkspaceKindLabel,
+  renderWorkspaceIcon,
+  type WorkspaceKindLabels,
+} from '@/app/components/workspaces/workspace-utils';
 import {
   selectActiveWorkspace,
   useWorkspaceStore,
@@ -28,25 +34,20 @@ type WorkspaceSwitcherProps = {
   className?: string;
 };
 
-function getWorkspaceKindLabel(workspace: ClientWorkspaceSummary | null | undefined) {
-  if (workspace?.type === 'team') return 'Team';
-  if (workspace?.type === 'project') return 'Project';
-  return 'Personal';
-}
+type WorkspaceAccessLabels = {
+  readOnly: string;
+  teamWrite: string;
+  write: string;
+};
 
-function renderWorkspaceIcon(workspace: ClientWorkspaceSummary | null | undefined, className: string) {
-  if (workspace?.type === 'team') return <UsersRound className={className} />;
-  if (workspace?.type === 'project') return <Building2 className={className} />;
-  return <UserRound className={className} />;
-}
-
-function getAccessLabel(workspace: ClientWorkspaceSummary) {
-  if (!workspace.permissions.canWrite) return 'Read only';
-  if (workspace.type === 'team') return 'Team write access';
-  return 'Write access';
+function getAccessLabel(workspace: ClientWorkspaceSummary, labels: WorkspaceAccessLabels) {
+  if (!workspace.permissions.canWrite) return labels.readOnly;
+  if (workspace.type === 'team') return labels.teamWrite;
+  return labels.write;
 }
 
 export function WorkspaceSwitcher({ source, variant = 'default', className }: WorkspaceSwitcherProps) {
+  const t = useTranslations('workspaces');
   const workspaces = useWorkspaceStore((state) => state.workspaces);
   const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
   const isLoading = useWorkspaceStore((state) => state.isLoading);
@@ -69,7 +70,17 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
 
   const isCompact = variant === 'compact';
   const isToolbar = variant === 'toolbar';
-  const activeLabel = activeWorkspace?.name || (isLoading && !initialized ? 'Loading workspace' : 'Workspace');
+  const kindLabels = {
+    personal: t('types.personal'),
+    team: t('types.team'),
+    project: t('types.project'),
+  } satisfies WorkspaceKindLabels;
+  const accessLabels = {
+    readOnly: t('access.readOnly'),
+    teamWrite: t('access.teamWrite'),
+    write: t('access.write'),
+  } satisfies WorkspaceAccessLabels;
+  const activeLabel = activeWorkspace?.name || (isLoading && !initialized ? t('loadingWorkspace') : t('label'));
   const canSwitch = workspaces.length > 1;
 
   if (!canSwitch && activeWorkspace && isCompact) {
@@ -83,10 +94,10 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
         data-active-workspace-id={activeWorkspace.id}
         data-active-workspace-type={activeWorkspace.type}
         className={cn('h-8 min-w-0 gap-1.5 px-2 text-[11px] disabled:opacity-100', className)}
-        title={`${activeWorkspace.name} · ${getAccessLabel(activeWorkspace)}`}
+        title={`${activeWorkspace.name} · ${getAccessLabel(activeWorkspace, accessLabels)}`}
       >
         {renderWorkspaceIcon(activeWorkspace, 'h-3.5 w-3.5 shrink-0')}
-        <span className="hidden min-w-0 truncate sm:inline">{getWorkspaceKindLabel(activeWorkspace)}</span>
+        <span className="hidden min-w-0 truncate sm:inline">{getWorkspaceKindLabel(activeWorkspace, kindLabels)}</span>
         {!activeWorkspace.permissions.canWrite ? <Lock className="h-3 w-3 text-amber-500" /> : null}
       </Button>
     );
@@ -109,7 +120,7 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
             isToolbar && 'bg-background/70',
             className
           )}
-          title={activeWorkspace ? `${activeWorkspace.name} · ${getAccessLabel(activeWorkspace)}` : activeLabel}
+          title={activeWorkspace ? `${activeWorkspace.name} · ${getAccessLabel(activeWorkspace, accessLabels)}` : activeLabel}
         >
           {isLoading && !initialized ? (
             <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
@@ -117,7 +128,7 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
             renderWorkspaceIcon(activeWorkspace, 'h-3.5 w-3.5 shrink-0')
           )}
           <span className={cn('min-w-0 truncate', isCompact && 'hidden sm:inline')}>
-            {isCompact && activeWorkspace ? getWorkspaceKindLabel(activeWorkspace) : activeLabel}
+            {isCompact && activeWorkspace ? getWorkspaceKindLabel(activeWorkspace, kindLabels) : activeLabel}
           </span>
           {activeWorkspace && !activeWorkspace.permissions.canWrite ? <Lock className="h-3 w-3 shrink-0 text-amber-500" /> : null}
           <ChevronsUpDown className="h-3 w-3 shrink-0 text-muted-foreground" />
@@ -125,7 +136,7 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" sideOffset={8} className="w-72">
         <DropdownMenuLabel className="flex items-center justify-between gap-2">
-          <span>Workspace</span>
+          <span>{t('label')}</span>
           <button
             type="button"
             className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
@@ -133,8 +144,8 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
               event.preventDefault();
               void refreshWorkspaces();
             }}
-            aria-label="Refresh workspaces"
-            title="Refresh workspaces"
+            aria-label={t('refresh')}
+            title={t('refresh')}
           >
             <RefreshCw className={cn('h-3.5 w-3.5', isLoading && 'animate-spin')} />
           </button>
@@ -145,7 +156,7 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
         ) : null}
         {workspaces.length === 0 && !error ? (
           <div className="px-2 py-1.5 text-xs text-muted-foreground">
-            {isLoading ? 'Loading workspaces...' : 'No workspace available'}
+            {isLoading ? t('loadingWorkspaces') : t('noWorkspaceAvailable')}
           </div>
         ) : null}
         {workspaces.map((workspace) => {
@@ -157,14 +168,14 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
               key={workspace.id}
               disabled={disabled}
               onSelect={() => handleSelect(workspace)}
-              data-testid={`workspace-option-${workspace.type}`}
+              data-testid={`workspace-option-${workspace.id}`}
               className="items-start gap-2"
             >
               {renderWorkspaceIcon(workspace, 'mt-0.5 h-4 w-4')}
               <span className="min-w-0 flex-1">
                 <span className="block truncate text-sm font-medium">{workspace.name}</span>
                 <span className="block truncate text-[11px] text-muted-foreground">
-                  {getWorkspaceKindLabel(workspace)} · {getAccessLabel(workspace)}
+                  {getWorkspaceKindLabel(workspace, kindLabels)} · {getAccessLabel(workspace, accessLabels)}
                 </span>
               </span>
               {isActive ? <Check className="mt-0.5 h-4 w-4 text-primary" /> : null}

--- a/app/components/workspaces/WorkspaceSwitcher.tsx
+++ b/app/components/workspaces/WorkspaceSwitcher.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useCallback, useEffect } from 'react';
+import { Building2, Check, ChevronsUpDown, Loader2, Lock, RefreshCw, UserRound, UsersRound } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
+import {
+  selectActiveWorkspace,
+  useWorkspaceStore,
+  type WorkspaceSwitchSource,
+} from '@/app/store/workspace-store';
+
+type WorkspaceSwitcherVariant = 'default' | 'compact' | 'toolbar';
+
+type WorkspaceSwitcherProps = {
+  source: WorkspaceSwitchSource;
+  variant?: WorkspaceSwitcherVariant;
+  className?: string;
+};
+
+function getWorkspaceKindLabel(workspace: ClientWorkspaceSummary | null | undefined) {
+  if (workspace?.type === 'team') return 'Team';
+  if (workspace?.type === 'project') return 'Project';
+  return 'Personal';
+}
+
+function renderWorkspaceIcon(workspace: ClientWorkspaceSummary | null | undefined, className: string) {
+  if (workspace?.type === 'team') return <UsersRound className={className} />;
+  if (workspace?.type === 'project') return <Building2 className={className} />;
+  return <UserRound className={className} />;
+}
+
+function getAccessLabel(workspace: ClientWorkspaceSummary) {
+  if (!workspace.permissions.canWrite) return 'Read only';
+  if (workspace.type === 'team') return 'Team write access';
+  return 'Write access';
+}
+
+export function WorkspaceSwitcher({ source, variant = 'default', className }: WorkspaceSwitcherProps) {
+  const workspaces = useWorkspaceStore((state) => state.workspaces);
+  const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
+  const isLoading = useWorkspaceStore((state) => state.isLoading);
+  const initialized = useWorkspaceStore((state) => state.initialized);
+  const error = useWorkspaceStore((state) => state.error);
+  const hydrateWorkspaces = useWorkspaceStore((state) => state.hydrateWorkspaces);
+  const refreshWorkspaces = useWorkspaceStore((state) => state.refreshWorkspaces);
+  const setActiveWorkspace = useWorkspaceStore((state) => state.setActiveWorkspace);
+
+  useEffect(() => {
+    void hydrateWorkspaces();
+  }, [hydrateWorkspaces]);
+
+  const handleSelect = useCallback(
+    (workspace: ClientWorkspaceSummary) => {
+      setActiveWorkspace(workspace.id, source);
+    },
+    [setActiveWorkspace, source]
+  );
+
+  const isCompact = variant === 'compact';
+  const isToolbar = variant === 'toolbar';
+  const activeLabel = activeWorkspace?.name || (isLoading && !initialized ? 'Loading workspace' : 'Workspace');
+  const canSwitch = workspaces.length > 1;
+
+  if (!canSwitch && activeWorkspace && isCompact) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled
+        data-testid="workspace-switcher"
+        data-active-workspace-id={activeWorkspace.id}
+        data-active-workspace-type={activeWorkspace.type}
+        className={cn('h-8 min-w-0 gap-1.5 px-2 text-[11px] disabled:opacity-100', className)}
+        title={`${activeWorkspace.name} · ${getAccessLabel(activeWorkspace)}`}
+      >
+        {renderWorkspaceIcon(activeWorkspace, 'h-3.5 w-3.5 shrink-0')}
+        <span className="hidden min-w-0 truncate sm:inline">{getWorkspaceKindLabel(activeWorkspace)}</span>
+        {!activeWorkspace.permissions.canWrite ? <Lock className="h-3 w-3 text-amber-500" /> : null}
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant={isToolbar ? 'ghost' : 'outline'}
+          size="sm"
+          disabled={isLoading && !initialized}
+          data-testid="workspace-switcher"
+          data-active-workspace-id={activeWorkspace?.id ?? ''}
+          data-active-workspace-type={activeWorkspace?.type ?? ''}
+          className={cn(
+            'h-8 min-w-0 gap-1.5 px-2 text-xs',
+            isCompact ? 'max-w-[9.5rem]' : 'max-w-[14rem]',
+            isToolbar && 'bg-background/70',
+            className
+          )}
+          title={activeWorkspace ? `${activeWorkspace.name} · ${getAccessLabel(activeWorkspace)}` : activeLabel}
+        >
+          {isLoading && !initialized ? (
+            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
+          ) : (
+            renderWorkspaceIcon(activeWorkspace, 'h-3.5 w-3.5 shrink-0')
+          )}
+          <span className={cn('min-w-0 truncate', isCompact && 'hidden sm:inline')}>
+            {isCompact && activeWorkspace ? getWorkspaceKindLabel(activeWorkspace) : activeLabel}
+          </span>
+          {activeWorkspace && !activeWorkspace.permissions.canWrite ? <Lock className="h-3 w-3 shrink-0 text-amber-500" /> : null}
+          <ChevronsUpDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={8} className="w-72">
+        <DropdownMenuLabel className="flex items-center justify-between gap-2">
+          <span>Workspace</span>
+          <button
+            type="button"
+            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            onClick={(event) => {
+              event.preventDefault();
+              void refreshWorkspaces();
+            }}
+            aria-label="Refresh workspaces"
+            title="Refresh workspaces"
+          >
+            <RefreshCw className={cn('h-3.5 w-3.5', isLoading && 'animate-spin')} />
+          </button>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {error ? (
+          <div className="px-2 py-1.5 text-xs text-destructive">{error}</div>
+        ) : null}
+        {workspaces.length === 0 && !error ? (
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">
+            {isLoading ? 'Loading workspaces...' : 'No workspace available'}
+          </div>
+        ) : null}
+        {workspaces.map((workspace) => {
+          const isActive = workspace.id === activeWorkspace?.id;
+          const disabled = workspace.status !== 'active' || !workspace.permissions.canRead;
+
+          return (
+            <DropdownMenuItem
+              key={workspace.id}
+              disabled={disabled}
+              onSelect={() => handleSelect(workspace)}
+              data-testid={`workspace-option-${workspace.type}`}
+              className="items-start gap-2"
+            >
+              {renderWorkspaceIcon(workspace, 'mt-0.5 h-4 w-4')}
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium">{workspace.name}</span>
+                <span className="block truncate text-[11px] text-muted-foreground">
+                  {getWorkspaceKindLabel(workspace)} · {getAccessLabel(workspace)}
+                </span>
+              </span>
+              {isActive ? <Check className="mt-0.5 h-4 w-4 text-primary" /> : null}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/app/components/workspaces/workspace-utils.tsx
+++ b/app/components/workspaces/workspace-utils.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Building2, UserRound, UsersRound } from 'lucide-react';
+
+import type { ClientWorkspaceSummary, ClientWorkspaceType } from '@/app/lib/workspaces/client-types';
+
+export type WorkspaceKindLabels = Record<ClientWorkspaceType, string>;
+
+export function getWorkspaceKindLabel(
+  workspace: ClientWorkspaceSummary | null | undefined,
+  labels: WorkspaceKindLabels
+) {
+  const type = workspace?.type ?? 'personal';
+  return labels[type] ?? labels.personal;
+}
+
+export function renderWorkspaceIcon(workspace: ClientWorkspaceSummary | null | undefined, className: string) {
+  if (workspace?.type === 'team') return <UsersRound className={className} />;
+  if (workspace?.type === 'project') return <Building2 className={className} />;
+  return <UserRound className={className} />;
+}

--- a/app/lib/chat/types.ts
+++ b/app/lib/chat/types.ts
@@ -12,6 +12,14 @@ export interface ChatRequestContext {
   currentTime?: string;
   activeFilePath?: string | null;
   workingDirectory?: string;
+  workspace?: {
+    workspaceId: string;
+    workspaceType: 'personal' | 'team' | 'project';
+    workspaceName: string;
+    organizationId?: string | null;
+    canWrite: boolean;
+    canShare: boolean;
+  };
   planningMode?: boolean;
   currentPage?: string;
   studioContext?: {

--- a/app/lib/workspaces/client-types.ts
+++ b/app/lib/workspaces/client-types.ts
@@ -1,0 +1,36 @@
+export type ClientWorkspaceType = 'personal' | 'team' | 'project';
+
+export type ClientWorkspaceStatus = 'active' | 'archived' | 'disabled';
+
+export interface ClientWorkspacePermissions {
+  canRead: boolean;
+  canWrite: boolean;
+  canDelete: boolean;
+  canCreatePublicLinks: boolean;
+  canManageWorkspace: boolean;
+  canRunAgent: boolean;
+}
+
+export interface ClientWorkspaceSummary {
+  id: string;
+  type: ClientWorkspaceType;
+  name: string;
+  organizationId?: string | null;
+  ownerUserId?: string | null;
+  rootRelativePath?: string;
+  status: ClientWorkspaceStatus;
+  permissions: ClientWorkspacePermissions;
+  legacy?: boolean;
+}
+
+export interface ClientWorkspaceResponse {
+  success: boolean;
+  organizationId?: string | null;
+  teamFeaturesEnabled?: boolean;
+  databaseProvider?: string | null;
+  activeWorkspaceId?: string | null;
+  defaultWorkspace?: ClientWorkspaceSummary | null;
+  workspaces?: ClientWorkspaceSummary[];
+  warnings?: string[];
+  error?: string;
+}

--- a/app/store/file-store.ts
+++ b/app/store/file-store.ts
@@ -219,6 +219,7 @@ interface FileStoreState {
   toggleDirectory: (path: string) => void;
   collapseAllDirectories: () => void;
   clearCurrentFile: () => void;
+  resetWorkspaceView: () => void;
   setSearchQuery: (query: string) => void;
   setCurrentDirectory: (path: string) => void;
   toggleAutoRefresh: () => void;
@@ -904,6 +905,41 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
       fileError: null,
       fileLoadRequestId: state.fileLoadRequestId + 1,
     }));
+  },
+  resetWorkspaceView: () => {
+    const nextExpandedDirs = new Set<string>();
+    set((state) => ({
+      fileTree: [],
+      isLoadingTree: false,
+      treeError: null,
+      selectedNode: null,
+      currentFile: null,
+      isLoadingFile: false,
+      loadingFilePath: null,
+      fileLoadRequestId: state.fileLoadRequestId + 1,
+      fileError: null,
+      expandedDirs: nextExpandedDirs,
+      currentDirectory: '.',
+      uploadProgress: null,
+      searchQuery: '',
+      loadingDirs: new Set<string>(),
+      isMultiSelectMode: false,
+      multiSelectPaths: new Set<string>(),
+      lastSelectedPath: null,
+      contextMenuNode: null,
+      contextMenuPosition: null,
+      isContextMenuOpen: false,
+      backgroundContextMenuPosition: null,
+      backgroundContextMenuDirectory: '.',
+      isBackgroundContextMenuOpen: false,
+      clipboardPaths: new Set<string>(),
+      clipboardMode: null,
+      bulkMoveOpen: false,
+    }));
+    persistExplorerState({
+      currentDirectory: '.',
+      expandedDirs: nextExpandedDirs,
+    });
   },
   setSearchQuery: (query: string) => {
     set({ searchQuery: query });

--- a/app/store/workspace-store.ts
+++ b/app/store/workspace-store.ts
@@ -1,0 +1,217 @@
+import { create } from 'zustand';
+
+import type {
+  ClientWorkspaceResponse,
+  ClientWorkspaceSummary,
+  ClientWorkspaceType,
+} from '@/app/lib/workspaces/client-types';
+
+export const WORKSPACE_CHANGED_EVENT = 'canvas:workspace-changed';
+const ACTIVE_WORKSPACE_STORAGE_KEY = 'canvas.activeWorkspaceId';
+
+export type WorkspaceSwitchSource =
+  | 'home'
+  | 'navbar'
+  | 'chat'
+  | 'file-browser'
+  | 'notebook'
+  | 'system'
+  | 'test';
+
+export interface WorkspaceChangedDetail {
+  previousWorkspaceId: string | null;
+  activeWorkspaceId: string;
+  workspace: ClientWorkspaceSummary;
+  source: WorkspaceSwitchSource;
+}
+
+interface WorkspaceStoreState {
+  workspaces: ClientWorkspaceSummary[];
+  activeWorkspaceId: string | null;
+  organizationId: string | null;
+  teamFeaturesEnabled: boolean;
+  databaseProvider: string | null;
+  warnings: string[];
+  isLoading: boolean;
+  initialized: boolean;
+  error: string | null;
+  lastUpdatedAt: number | null;
+  hydrateWorkspaces: (options?: { force?: boolean }) => Promise<void>;
+  setActiveWorkspace: (workspaceId: string, source?: WorkspaceSwitchSource) => boolean;
+  refreshWorkspaces: () => Promise<void>;
+}
+
+function readCachedActiveWorkspaceId(): string | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const stored = window.localStorage.getItem(ACTIVE_WORKSPACE_STORAGE_KEY);
+    return stored?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedActiveWorkspaceId(workspaceId: string) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(ACTIVE_WORKSPACE_STORAGE_KEY, workspaceId);
+  } catch {
+    // Non-critical: the server remains the source of truth for allowed workspaces.
+  }
+}
+
+function dispatchWorkspaceChanged(detail: WorkspaceChangedDetail) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<WorkspaceChangedDetail>(WORKSPACE_CHANGED_EVENT, { detail }));
+}
+
+function isWorkspaceType(value: unknown): value is ClientWorkspaceType {
+  return value === 'personal' || value === 'team' || value === 'project';
+}
+
+function normalizeWorkspace(candidate: unknown): ClientWorkspaceSummary | null {
+  if (!candidate || typeof candidate !== 'object') return null;
+
+  const record = candidate as Partial<ClientWorkspaceSummary>;
+  if (typeof record.id !== 'string' || !record.id.trim()) return null;
+  if (!isWorkspaceType(record.type)) return null;
+
+  const permissions = record.permissions;
+  if (!permissions || typeof permissions !== 'object' || permissions.canRead !== true) {
+    return null;
+  }
+
+  return {
+    id: record.id,
+    type: record.type,
+    name: typeof record.name === 'string' && record.name.trim() ? record.name : `${record.type} workspace`,
+    organizationId: typeof record.organizationId === 'string' ? record.organizationId : null,
+    ownerUserId: typeof record.ownerUserId === 'string' ? record.ownerUserId : null,
+    rootRelativePath: typeof record.rootRelativePath === 'string' ? record.rootRelativePath : undefined,
+    status: record.status === 'archived' || record.status === 'disabled' ? record.status : 'active',
+    permissions: {
+      canRead: Boolean(permissions.canRead),
+      canWrite: Boolean(permissions.canWrite),
+      canDelete: Boolean(permissions.canDelete),
+      canCreatePublicLinks: Boolean(permissions.canCreatePublicLinks),
+      canManageWorkspace: Boolean(permissions.canManageWorkspace),
+      canRunAgent: Boolean(permissions.canRunAgent),
+    },
+    legacy: Boolean(record.legacy),
+  };
+}
+
+export function normalizeWorkspaceResponse(payload: ClientWorkspaceResponse): {
+  workspaces: ClientWorkspaceSummary[];
+  activeWorkspaceId: string | null;
+  organizationId: string | null;
+  teamFeaturesEnabled: boolean;
+  databaseProvider: string | null;
+  warnings: string[];
+} {
+  const workspaces = Array.isArray(payload.workspaces)
+    ? payload.workspaces.map(normalizeWorkspace).filter((workspace): workspace is ClientWorkspaceSummary => Boolean(workspace))
+    : [];
+  const cachedWorkspaceId = readCachedActiveWorkspaceId();
+  const serverDefaultId = typeof payload.activeWorkspaceId === 'string' ? payload.activeWorkspaceId : null;
+  const preferredWorkspaceId = cachedWorkspaceId || serverDefaultId;
+  const activeWorkspace =
+    workspaces.find((workspace) => workspace.id === preferredWorkspaceId && workspace.status === 'active') ||
+    workspaces.find((workspace) => workspace.id === serverDefaultId && workspace.status === 'active') ||
+    workspaces.find((workspace) => workspace.status === 'active') ||
+    null;
+
+  return {
+    workspaces,
+    activeWorkspaceId: activeWorkspace?.id || null,
+    organizationId: typeof payload.organizationId === 'string' ? payload.organizationId : null,
+    teamFeaturesEnabled: Boolean(payload.teamFeaturesEnabled),
+    databaseProvider: typeof payload.databaseProvider === 'string' ? payload.databaseProvider : null,
+    warnings: Array.isArray(payload.warnings)
+      ? payload.warnings.filter((warning): warning is string => typeof warning === 'string' && warning.trim().length > 0)
+      : [],
+  };
+}
+
+export function selectActiveWorkspace(state: Pick<WorkspaceStoreState, 'workspaces' | 'activeWorkspaceId'>) {
+  return state.workspaces.find((workspace) => workspace.id === state.activeWorkspaceId) || null;
+}
+
+export const useWorkspaceStore = create<WorkspaceStoreState>((set, get) => ({
+  workspaces: [],
+  activeWorkspaceId: readCachedActiveWorkspaceId(),
+  organizationId: null,
+  teamFeaturesEnabled: false,
+  databaseProvider: null,
+  warnings: [],
+  isLoading: false,
+  initialized: false,
+  error: null,
+  lastUpdatedAt: null,
+
+  hydrateWorkspaces: async (options = {}) => {
+    if (get().isLoading) return;
+    if (get().initialized && !options.force) return;
+
+    set({ isLoading: true, error: null });
+
+    try {
+      const response = await fetch('/api/workspaces', {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const payload = (await response.json()) as ClientWorkspaceResponse;
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || 'Could not load workspaces');
+      }
+
+      const normalized = normalizeWorkspaceResponse(payload);
+      if (normalized.activeWorkspaceId) {
+        writeCachedActiveWorkspaceId(normalized.activeWorkspaceId);
+      }
+
+      set({
+        ...normalized,
+        initialized: true,
+        isLoading: false,
+        error: null,
+        lastUpdatedAt: Date.now(),
+      });
+    } catch (error) {
+      set({
+        initialized: true,
+        isLoading: false,
+        error: error instanceof Error ? error.message : 'Could not load workspaces',
+        lastUpdatedAt: Date.now(),
+      });
+    }
+  },
+
+  setActiveWorkspace: (workspaceId, source = 'system') => {
+    const workspace = get().workspaces.find((candidate) => candidate.id === workspaceId);
+    if (!workspace || workspace.status !== 'active' || !workspace.permissions.canRead) return false;
+
+    const previousWorkspaceId = get().activeWorkspaceId;
+    if (previousWorkspaceId === workspace.id) return false;
+
+    writeCachedActiveWorkspaceId(workspace.id);
+    set({
+      activeWorkspaceId: workspace.id,
+      error: null,
+      lastUpdatedAt: Date.now(),
+    });
+    dispatchWorkspaceChanged({
+      previousWorkspaceId,
+      activeWorkspaceId: workspace.id,
+      workspace,
+      source,
+    });
+    return true;
+  },
+
+  refreshWorkspaces: async () => {
+    await get().hydrateWorkspaces({ force: true });
+  },
+}));

--- a/app/store/workspace-store.ts
+++ b/app/store/workspace-store.ts
@@ -139,6 +139,8 @@ export function selectActiveWorkspace(state: Pick<WorkspaceStoreState, 'workspac
   return state.workspaces.find((workspace) => workspace.id === state.activeWorkspaceId) || null;
 }
 
+let workspaceHydrationPromise: Promise<void> | null = null;
+
 export const useWorkspaceStore = create<WorkspaceStoreState>((set, get) => ({
   workspaces: [],
   activeWorkspaceId: readCachedActiveWorkspaceId(),
@@ -152,40 +154,55 @@ export const useWorkspaceStore = create<WorkspaceStoreState>((set, get) => ({
   lastUpdatedAt: null,
 
   hydrateWorkspaces: async (options = {}) => {
-    if (get().isLoading) return;
-    if (get().initialized && !options.force) return;
+    const force = Boolean(options.force);
+    if (get().initialized && !force) return;
+    if (workspaceHydrationPromise) {
+      await workspaceHydrationPromise;
+      if (!force) return;
+    }
 
-    set({ isLoading: true, error: null });
+    const request = (async () => {
+      set({ isLoading: true, error: null });
 
+      try {
+        const response = await fetch('/api/workspaces', {
+          credentials: 'include',
+          cache: 'no-store',
+        });
+        const payload = (await response.json()) as ClientWorkspaceResponse;
+        if (!response.ok || !payload.success) {
+          throw new Error(payload.error || 'Could not load workspaces');
+        }
+
+        const normalized = normalizeWorkspaceResponse(payload);
+        if (normalized.activeWorkspaceId) {
+          writeCachedActiveWorkspaceId(normalized.activeWorkspaceId);
+        }
+
+        set({
+          ...normalized,
+          initialized: true,
+          isLoading: false,
+          error: null,
+          lastUpdatedAt: Date.now(),
+        });
+      } catch (error) {
+        set({
+          initialized: true,
+          isLoading: false,
+          error: error instanceof Error ? error.message : 'Could not load workspaces',
+          lastUpdatedAt: Date.now(),
+        });
+      }
+    })();
+
+    workspaceHydrationPromise = request;
     try {
-      const response = await fetch('/api/workspaces', {
-        credentials: 'include',
-        cache: 'no-store',
-      });
-      const payload = (await response.json()) as ClientWorkspaceResponse;
-      if (!response.ok || !payload.success) {
-        throw new Error(payload.error || 'Could not load workspaces');
+      await request;
+    } finally {
+      if (workspaceHydrationPromise === request) {
+        workspaceHydrationPromise = null;
       }
-
-      const normalized = normalizeWorkspaceResponse(payload);
-      if (normalized.activeWorkspaceId) {
-        writeCachedActiveWorkspaceId(normalized.activeWorkspaceId);
-      }
-
-      set({
-        ...normalized,
-        initialized: true,
-        isLoading: false,
-        error: null,
-        lastUpdatedAt: Date.now(),
-      });
-    } catch (error) {
-      set({
-        initialized: true,
-        isLoading: false,
-        error: error instanceof Error ? error.message : 'Could not load workspaces',
-        lastUpdatedAt: Date.now(),
-      });
     }
   },
 

--- a/docs/architecture/canvas-notebook/team-workspace/README.md
+++ b/docs/architecture/canvas-notebook/team-workspace/README.md
@@ -61,4 +61,5 @@ Dieses Verzeichnis ist der zentrale Arbeitsbereich fuer den Team-Workspace-Umbau
 - Workspace-Modell, Workspace-Service, Bootstrap-Erzeugung und `/api/workspaces` in Canvas Notebook sind eingefuehrt.
 - Community-/Single-User-Installationen bleiben auch bei gesetztem Team-Flag auf Personal Workspace begrenzt.
 - Personal Workspaces werden pro User angelegt; Team Workspace wird nur in teamfaehigen Deployment Modes angelegt.
-- Naechster Schritt: Globalen Workspace-Switcher fuer Startseite, Chat Header und File Browser bauen.
+- Globaler Workspace-Switcher, Workspace-Badge, clientseitiger Workspace-Store und Chat-Neustart bei Workspace-Wechsel sind eingefuehrt.
+- Naechster Schritt: Kopieraktionen zwischen Personal und Team Workspace implementieren.

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -180,9 +180,24 @@
     {
       "id": 14,
       "title": "Globalen Workspace-Switcher fuer Startseite, Chat Header und File Browser bauen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
-      "planningArtifact": "docs/architecture/canvas-notebook/team-workspace/06-workspace-switching-ux.md"
+      "planningArtifact": "docs/architecture/canvas-notebook/team-workspace/06-workspace-switching-ux.md",
+      "implementationArtifacts": [
+        "app/store/workspace-store.ts",
+        "app/lib/workspaces/client-types.ts",
+        "app/components/workspaces/WorkspaceSwitcher.tsx",
+        "app/components/workspaces/WorkspaceBadge.tsx",
+        "app/[locale]/(routes)/page.tsx",
+        "app/[locale]/(routes)/chat/chat-shell.tsx",
+        "app/components/SuitePageLayout.tsx",
+        "app/components/DashboardShell.tsx",
+        "app/components/canvas-agent-chat/ChatHeader.tsx",
+        "app/components/canvas-agent-chat/CanvasAgentChat.tsx",
+        "app/components/file-browser/FileBrowser.tsx",
+        "app/components/file-browser/FileToolbar.tsx",
+        "scripts/workspace-switcher-ui-test.ts"
+      ]
     },
     {
       "id": 15,

--- a/messages/de.json
+++ b/messages/de.json
@@ -47,6 +47,24 @@
     },
     "studio": "Studio"
   },
+  "workspaces": {
+    "label": "Workspace",
+    "loadingWorkspace": "Workspace wird geladen",
+    "loadingWorkspaces": "Workspaces werden geladen...",
+    "loadingContext": "Workspace-Kontext wird geladen",
+    "noWorkspaceAvailable": "Kein Workspace verfügbar",
+    "refresh": "Workspaces aktualisieren",
+    "types": {
+      "personal": "Persönlich",
+      "team": "Team",
+      "project": "Projekt"
+    },
+    "access": {
+      "readOnly": "Nur lesen",
+      "write": "Schreibzugriff",
+      "teamWrite": "Team-Schreibzugriff"
+    }
+  },
   "navigation": {
     "hideSidebar": "Sidebar ausblenden",
     "showSidebar": "Sidebar einblenden",

--- a/messages/en.json
+++ b/messages/en.json
@@ -47,6 +47,24 @@
     },
     "studio": "Studio"
   },
+  "workspaces": {
+    "label": "Workspace",
+    "loadingWorkspace": "Loading workspace",
+    "loadingWorkspaces": "Loading workspaces...",
+    "loadingContext": "Workspace context is loading",
+    "noWorkspaceAvailable": "No workspace available",
+    "refresh": "Refresh workspaces",
+    "types": {
+      "personal": "Personal",
+      "team": "Team",
+      "project": "Project"
+    },
+    "access": {
+      "readOnly": "Read only",
+      "write": "Write access",
+      "teamWrite": "Team write access"
+    }
+  },
   "navigation": {
     "hideSidebar": "Hide sidebar",
     "showSidebar": "Show sidebar",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test:onboarding:profile": "tsx --conditions react-server scripts/onboarding-profile-test.ts",
     "test:workspace:foundation": "tsx --conditions react-server scripts/workspace-context-foundation-test.ts",
     "test:workspace:model": "tsx --conditions react-server scripts/workspace-model-service-test.ts",
+    "test:workspace:switcher-ui": "tsx scripts/workspace-switcher-ui-test.ts",
     "test:e2e": "playwright test --pass-with-no-tests",
     "test:all": "node scripts/test-all.mjs",
     "test:websocket:connection": "node scripts/test-websocket-connection.js",

--- a/scripts/workspace-switcher-ui-test.ts
+++ b/scripts/workspace-switcher-ui-test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+
+type Listener = (event: Event) => void;
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  clear() {
+    this.values.clear();
+  }
+}
+
+class TestCustomEvent<T = unknown> extends Event {
+  readonly detail: T;
+
+  constructor(type: string, init: CustomEventInit<T> = {}) {
+    super(type);
+    this.detail = init.detail as T;
+  }
+}
+
+const localStorage = new MemoryStorage();
+const listeners = new Map<string, Set<Listener>>();
+
+(globalThis as unknown as { CustomEvent: typeof CustomEvent }).CustomEvent = TestCustomEvent as unknown as typeof CustomEvent;
+(globalThis as unknown as { window: unknown }).window = {
+  localStorage,
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    const set = listeners.get(type) ?? new Set<Listener>();
+    const normalizedListener: Listener =
+      typeof listener === 'function' ? listener : (event) => listener.handleEvent(event);
+    set.add(normalizedListener);
+    listeners.set(type, set);
+  },
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    const set = listeners.get(type);
+    if (!set) return;
+    if (typeof listener === 'function') {
+      set.delete(listener);
+    }
+  },
+  dispatchEvent(event: Event) {
+    for (const listener of listeners.get(event.type) ?? []) {
+      listener(event);
+    }
+    return true;
+  },
+};
+
+const personalWorkspace = {
+  id: 'ws_personal',
+  type: 'personal',
+  name: 'Personal Workspace',
+  organizationId: 'org_1',
+  ownerUserId: 'user_1',
+  rootRelativePath: 'workspaces/personal/user_1/files',
+  status: 'active',
+  legacy: false,
+  permissions: {
+    canRead: true,
+    canWrite: true,
+    canDelete: true,
+    canCreatePublicLinks: true,
+    canManageWorkspace: true,
+    canRunAgent: true,
+  },
+};
+
+const teamWorkspace = {
+  id: 'ws_team',
+  type: 'team',
+  name: 'Team Workspace',
+  organizationId: 'org_1',
+  ownerUserId: null,
+  rootRelativePath: 'workspaces/team/org_1/files',
+  status: 'active',
+  legacy: false,
+  permissions: {
+    canRead: true,
+    canWrite: true,
+    canDelete: true,
+    canCreatePublicLinks: true,
+    canManageWorkspace: false,
+    canRunAgent: true,
+  },
+};
+
+(globalThis as unknown as { fetch: typeof fetch }).fetch = async () => (
+  new Response(
+    JSON.stringify({
+      success: true,
+      organizationId: 'org_1',
+      teamFeaturesEnabled: true,
+      databaseProvider: 'sqlite',
+      activeWorkspaceId: personalWorkspace.id,
+      defaultWorkspace: personalWorkspace,
+      workspaces: [personalWorkspace, teamWorkspace],
+      warnings: [],
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  )
+);
+
+async function main() {
+  const {
+    WORKSPACE_CHANGED_EVENT,
+    selectActiveWorkspace,
+    useWorkspaceStore,
+  } = await import('../app/store/workspace-store');
+
+  await useWorkspaceStore.getState().hydrateWorkspaces({ force: true });
+  assert.equal(useWorkspaceStore.getState().activeWorkspaceId, personalWorkspace.id);
+  assert.equal(selectActiveWorkspace(useWorkspaceStore.getState())?.type, 'personal');
+
+  localStorage.setItem('canvas.activeWorkspaceId', teamWorkspace.id);
+  await useWorkspaceStore.getState().hydrateWorkspaces({ force: true });
+  assert.equal(useWorkspaceStore.getState().activeWorkspaceId, teamWorkspace.id);
+  assert.equal(selectActiveWorkspace(useWorkspaceStore.getState())?.type, 'team');
+
+  const receivedDetails: Array<{
+    previousWorkspaceId: string | null;
+    activeWorkspaceId: string;
+    source: string;
+  }> = [];
+  window.addEventListener(WORKSPACE_CHANGED_EVENT, (event) => {
+    receivedDetails.push((event as CustomEvent).detail);
+  });
+
+  const changed = useWorkspaceStore.getState().setActiveWorkspace(personalWorkspace.id, 'test');
+  assert.equal(changed, true);
+  assert.equal(useWorkspaceStore.getState().activeWorkspaceId, personalWorkspace.id);
+  const [receivedDetail] = receivedDetails;
+  assert.equal(receivedDetail.previousWorkspaceId, teamWorkspace.id);
+  assert.equal(receivedDetail.activeWorkspaceId, personalWorkspace.id);
+  assert.equal(receivedDetail.source, 'test');
+
+  const unchanged = useWorkspaceStore.getState().setActiveWorkspace(personalWorkspace.id, 'test');
+  assert.equal(unchanged, false);
+
+  console.log('workspace-switcher-ui-test passed');
+}
+
+void main();


### PR DESCRIPTION
## Summary
- Adds a global client-side workspace store backed by `/api/workspaces`, with localStorage used only as an active-workspace UI cache.
- Adds shared `WorkspaceSwitcher` and `WorkspaceBadge` UI and wires them into Home, Suite headers, Notebook/File Browser, and Chat.
- Resets File Browser UI state on workspace changes and starts a new chat surface when the active workspace changes.
- Marks task 14 complete in the team-workspace todo plan.
- Addresses Greptile feedback by sharing workspace UI helpers, using unique workspace option test IDs, localizing workspace UI strings, and making forced workspace refreshes wait for in-flight hydration before refetching.

## Verification
- `npm run test:workspace:switcher-ui`
- `npm run lint`
- `npm run build`
- Browser validation on `localhost:3000` using Playwright with system Chrome because the in-app `iab` browser was unavailable:
  - Home switcher loads Personal workspace.
  - Switching to Team updates the global active workspace state.
  - Notebook renders global/File Browser/Chat workspace switchers.
  - Chat renders header switchers and remains on a new/empty session after switching.
  - Screenshot: `test-results/workspace-switcher-chat.png`

## Greploop
- Greptile reviewed PR #15 at commit `2582fa460d5d7fe04a734839ec3260d2200020a2` with confidence score `4/5`.
- All four reported P2 findings were reviewed and fixed in commit `67d6bec5dea44f63422c57ea722e065dce54a6e6`.
- All Greptile inline review threads are resolved.
- No second Greptile review was triggered for the same reviewed head SHA.