### PR TITLE
Implement workspace copy actions

### DIFF
--- a/app/api/files/copy/route.ts
+++ b/app/api/files/copy/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
-import { batchCopy } from '@/app/lib/filesystem/workspace-files';
+import { auth } from '@/app/lib/auth';
+import { batchCopyBetweenWorkspaces } from '@/app/lib/filesystem/workspace-files';
 import { isProtectedAppOutputFolder } from '@/app/lib/filesystem/app-output-folders';
 import {
   applyRateLimit,
@@ -9,12 +10,17 @@ import {
   jsonSuccess,
   readJsonBody,
 } from '@/app/lib/api/route-helpers';
-import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
+import {
+  requireSessionWorkspace,
+  workspaceFileOptions,
+} from '@/app/lib/workspaces/request';
+import { WORKSPACE_ID_HEADER } from '@/app/lib/workspaces/constants';
 
 export async function POST(request: NextRequest) {
-  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canWrite' });
-  if (workspaceResult.response) return workspaceResult.response;
-  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return jsonError('Unauthorized', 401);
+  }
 
   try {
     const rateLimitResponse = applyRateLimit(request, {
@@ -29,8 +35,17 @@ export async function POST(request: NextRequest) {
       destDir?: string;
       overwrite?: boolean;
       renameOnCollision?: boolean;
+      sourceWorkspaceId?: string | null;
+      targetWorkspaceId?: string | null;
     }>(request);
-    const { sources, destDir, overwrite = false, renameOnCollision = false } = body;
+    const {
+      sources,
+      destDir,
+      overwrite = false,
+      renameOnCollision = false,
+      sourceWorkspaceId,
+      targetWorkspaceId,
+    } = body;
 
     if (!sources || !Array.isArray(sources) || sources.length === 0) {
       return jsonError('Sources array is required and must not be empty', 400);
@@ -40,19 +55,47 @@ export async function POST(request: NextRequest) {
       return jsonError('destDir is required', 400);
     }
 
+    const requestWorkspaceId = request.headers.get(WORKSPACE_ID_HEADER)?.trim() || null;
+    const resolvedSourceWorkspaceId = typeof sourceWorkspaceId === 'string' && sourceWorkspaceId.trim()
+      ? sourceWorkspaceId.trim()
+      : requestWorkspaceId;
+    const resolvedTargetWorkspaceId = typeof targetWorkspaceId === 'string' && targetWorkspaceId.trim()
+      ? targetWorkspaceId.trim()
+      : resolvedSourceWorkspaceId;
+
+    const sourceWorkspaceResult = await requireSessionWorkspace(session, {
+      workspaceId: resolvedSourceWorkspaceId,
+      permissions: 'canRead',
+    });
+    if (sourceWorkspaceResult.response) return sourceWorkspaceResult.response;
+
+    const targetWorkspaceResult = await requireSessionWorkspace(session, {
+      workspaceId: resolvedTargetWorkspaceId,
+      permissions: 'canWrite',
+    });
+    if (targetWorkspaceResult.response) return targetWorkspaceResult.response;
+
+    const sourceFileOptions = workspaceFileOptions(sourceWorkspaceResult.workspace);
+    const targetFileOptions = workspaceFileOptions(targetWorkspaceResult.workspace);
+
     const protectedPaths = sources.filter((p) => isProtectedAppOutputFolder(p));
     if (protectedPaths.length > 0) {
       return jsonError(`Protected app output folder(s) cannot be copied: ${protectedPaths.join(', ')}`, 403);
     }
 
-    const result = await batchCopy(sources, destDir, overwrite, renameOnCollision, fileOptions);
+    const result = await batchCopyBetweenWorkspaces(sources, destDir, overwrite, renameOnCollision, {
+      source: sourceFileOptions,
+      target: targetFileOptions,
+    });
 
-    invalidateWorkspaceFileViews({ fileOptions, subtreeDirs: [destDir] });
+    invalidateWorkspaceFileViews({ fileOptions: targetFileOptions, subtreeDirs: [destDir] });
 
     return jsonSuccess({
       copied: result.copied,
       failed: result.failed,
       skipped: result.skipped,
+      sourceWorkspaceId: sourceWorkspaceResult.workspace.workspaceId,
+      targetWorkspaceId: targetWorkspaceResult.workspace.workspaceId,
     });
   } catch (error) {
     return jsonServerError('[API] File copy error:', error, 'Failed to copy files');

--- a/app/api/studio/aspect-ratio/save/route.ts
+++ b/app/api/studio/aspect-ratio/save/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/app/lib/auth';
 import { saveAspectRatioEdit, type AspectRatioSaveRequest } from '@/app/lib/integrations/studio-aspect-ratio-service';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
+import { requireSessionWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export async function POST(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
@@ -25,7 +26,19 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await saveAspectRatioEdit(body, session.user.id);
+    const workspaceOptions = body.action === 'copy_workspace'
+      ? await requireSessionWorkspace(session, {
+          workspaceId: typeof body.targetWorkspaceId === 'string' ? body.targetWorkspaceId : null,
+          permissions: 'canWrite',
+        })
+      : null;
+    if (workspaceOptions?.response) return workspaceOptions.response;
+
+    const result = await saveAspectRatioEdit(
+      body,
+      session.user.id,
+      workspaceOptions?.workspace ? workspaceFileOptions(workspaceOptions.workspace) : undefined
+    );
     return NextResponse.json({ success: true, ...result });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Save failed';

--- a/app/api/studio/outputs/save-to-workspace/route.ts
+++ b/app/api/studio/outputs/save-to-workspace/route.ts
@@ -4,6 +4,8 @@ import { auth } from '@/app/lib/auth';
 import { readOutputFile } from '@/app/lib/integrations/studio-workspace';
 import { getFileStats, writeFile } from '@/app/lib/filesystem/workspace-files';
 import { getStudioOutputForUser } from '@/app/lib/integrations/studio-generation-service';
+import { requireSessionWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
+import type { WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 
 function stripTrailingSlashes(value: string): string {
   let end = value.length;
@@ -21,16 +23,21 @@ function joinWorkspacePath(dirPath: string, fileName: string) {
   return `${stripTrailingSlashes(dirPath)}/${fileName}`;
 }
 
-async function workspacePathExists(filePath: string) {
+async function workspacePathExists(filePath: string, options: WorkspaceFileOperationOptions) {
   try {
-    await getFileStats(filePath);
+    await getFileStats(filePath, options);
     return true;
   } catch {
     return false;
   }
 }
 
-async function getAvailableWorkspacePath(targetPath: string, fileName: string, reservedPaths: Set<string>) {
+async function getAvailableWorkspacePath(
+  targetPath: string,
+  fileName: string,
+  reservedPaths: Set<string>,
+  options: WorkspaceFileOperationOptions
+) {
   const parsed = path.posix.parse(fileName);
   const extension = parsed.ext;
   const baseName = parsed.name || 'studio-output';
@@ -39,7 +46,7 @@ async function getAvailableWorkspacePath(targetPath: string, fileName: string, r
 
   while (true) {
     const candidatePath = joinWorkspacePath(targetPath, candidateName);
-    if (!reservedPaths.has(candidatePath) && !(await workspacePathExists(candidatePath))) {
+    if (!reservedPaths.has(candidatePath) && !(await workspacePathExists(candidatePath, options))) {
       reservedPaths.add(candidatePath);
       return candidatePath;
     }
@@ -57,7 +64,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { outputId, outputIds, targetPath } = body;
+    const { outputId, outputIds, targetPath, targetWorkspaceId } = body;
     const requestedOutputIds = Array.isArray(outputIds)
       ? outputIds
       : outputId
@@ -70,6 +77,13 @@ export async function POST(request: NextRequest) {
     if (!targetPath || typeof targetPath !== 'string') {
       return NextResponse.json({ success: false, error: 'targetPath is required' }, { status: 400 });
     }
+
+    const targetWorkspaceResult = await requireSessionWorkspace(session, {
+      workspaceId: typeof targetWorkspaceId === 'string' ? targetWorkspaceId : null,
+      permissions: 'canWrite',
+    });
+    if (targetWorkspaceResult.response) return targetWorkspaceResult.response;
+    const targetFileOptions = workspaceFileOptions(targetWorkspaceResult.workspace);
 
     const uniqueOutputIds = [...new Set(requestedOutputIds.map((id: string) => id.trim()))];
     const savedPaths: string[] = [];
@@ -85,12 +99,17 @@ export async function POST(request: NextRequest) {
 
       const buffer = await readOutputFile(output.filePath);
       const fileName = output.filePath.split('/').pop() || `studio-output-${id}`;
-      const destinationPath = await getAvailableWorkspacePath(targetPath, fileName, reservedPaths);
-      await writeFile(destinationPath, buffer);
+      const destinationPath = await getAvailableWorkspacePath(targetPath, fileName, reservedPaths, targetFileOptions);
+      await writeFile(destinationPath, buffer, targetFileOptions);
       savedPaths.push(destinationPath);
     }
 
-    return NextResponse.json({ success: true, paths: savedPaths, savedCount: savedPaths.length });
+    return NextResponse.json({
+      success: true,
+      paths: savedPaths,
+      savedCount: savedPaths.length,
+      targetWorkspaceId: targetWorkspaceResult.workspace.workspaceId,
+    });
   } catch (error) {
     console.error('[Studio Save to Workspace] Error:', error);
     return NextResponse.json({ success: false, error: 'Failed to save output to workspace' }, { status: 500 });

--- a/app/apps/studio/components/aspect-ratio/AspectRatioEditorView.tsx
+++ b/app/apps/studio/components/aspect-ratio/AspectRatioEditorView.tsx
@@ -8,8 +8,9 @@ import { toast } from 'sonner';
 
 import { ReferencePickerDialog } from '@/app/apps/studio/components/create/ReferencePickerDialog';
 import { useSetStudioChatContext } from '@/app/apps/studio/context/studio-chat-context';
-import { DirectoryBrowser } from '@/app/components/file-browser/DirectoryBrowser';
 import { useFileStore } from '@/app/store/file-store';
+import { WorkspaceDestinationPicker } from '@/app/components/workspaces/WorkspaceDestinationPicker';
+import { selectActiveWorkspace, useWorkspaceStore } from '@/app/store/workspace-store';
 import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
@@ -368,9 +369,10 @@ function WorkspaceCopyDialog({
   onCopied: (path: string) => void;
 }) {
   const t = useTranslations('studio.aspectRatioEditor');
-  const { fileTree, loadFileTree, refreshDirectory } = useFileStore();
+  const { refreshDirectory } = useFileStore();
+  const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
   const [selectedDir, setSelectedDir] = useState('.');
-  const [expandedDirs, setExpandedDirs] = useState(new Set<string>());
+  const [targetWorkspaceId, setTargetWorkspaceId] = useState<string | null>(activeWorkspace?.id ?? null);
   const [fileName, setFileName] = useState(buildDefaultFileName(preview));
   const [isSaving, setIsSaving] = useState(false);
 
@@ -378,21 +380,12 @@ function WorkspaceCopyDialog({
     if (!open) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setFileName(buildDefaultFileName(preview));
-    void loadFileTree('.', 6, true);
-  }, [loadFileTree, open, preview]);
-
-  const handleToggleDir = (dirPath: string) => {
-    setExpandedDirs((prev) => {
-      const next = new Set(prev);
-      if (next.has(dirPath)) next.delete(dirPath);
-      else next.add(dirPath);
-      return next;
-    });
-    void refreshDirectory(dirPath, true);
-  };
+    setTargetWorkspaceId(activeWorkspace?.id ?? null);
+    setSelectedDir('.');
+  }, [activeWorkspace?.id, open, preview]);
 
   const handleSave = async () => {
-    if (!preview) return;
+    if (!preview || !targetWorkspaceId) return;
     setIsSaving(true);
     try {
       const response = await fetch('/api/studio/aspect-ratio/save', {
@@ -403,12 +396,15 @@ function WorkspaceCopyDialog({
           action: 'copy_workspace',
           previewPath: preview.path,
           targetDirectory: selectedDir,
+          targetWorkspaceId,
           fileName,
         }),
       });
       const payload = await response.json();
       if (!response.ok || !payload.success) throw new Error(payload.error || t('errors.copyFailed'));
-      await refreshDirectory(selectedDir, true);
+      if (targetWorkspaceId === activeWorkspace?.id) {
+        await refreshDirectory(selectedDir, true);
+      }
       onCopied(payload.path);
       onOpenChange(false);
     } catch (error) {
@@ -430,15 +426,16 @@ function WorkspaceCopyDialog({
             <span className="text-xs font-medium text-muted-foreground">{t('workspaceDialog.fileName')}</span>
             <Input value={fileName} onChange={(event) => setFileName(event.target.value)} />
           </label>
-          <div className="min-w-0 overflow-hidden rounded-md border border-border bg-muted/40 px-3 py-2">
-            <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">{t('workspaceDialog.targetFolder')}</p>
-            <p className="mt-1 truncate font-mono text-sm">{selectedDir === '.' ? t('workspaceDialog.workspaceRoot') : selectedDir}</p>
-          </div>
-          <DirectoryBrowser tree={fileTree} selectedPath={selectedDir} onSelect={setSelectedDir} expandedDirs={expandedDirs} onToggleDir={handleToggleDir} />
+          <WorkspaceDestinationPicker
+            selectedWorkspaceId={targetWorkspaceId}
+            selectedDir={selectedDir}
+            onWorkspaceChange={setTargetWorkspaceId}
+            onDirChange={setSelectedDir}
+          />
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>{t('cancel')}</Button>
-          <Button onClick={handleSave} disabled={!preview || isSaving || !fileName.trim()}>
+          <Button onClick={handleSave} disabled={!preview || isSaving || !fileName.trim() || !targetWorkspaceId}>
             {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <FolderInput className="h-4 w-4" />}
             {t('copy')}
           </Button>

--- a/app/apps/studio/components/create/SaveToWorkspaceDialog.tsx
+++ b/app/apps/studio/components/create/SaveToWorkspaceDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -11,7 +12,8 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useFileStore } from '@/app/store/file-store';
-import { DirectoryBrowser } from '@/app/components/file-browser/DirectoryBrowser';
+import { WorkspaceDestinationPicker } from '@/app/components/workspaces/WorkspaceDestinationPicker';
+import { selectActiveWorkspace, useWorkspaceStore } from '@/app/store/workspace-store';
 import { toast } from 'sonner';
 
 interface SaveToWorkspaceDialogProps {
@@ -22,52 +24,44 @@ interface SaveToWorkspaceDialogProps {
 }
 
 export function SaveToWorkspaceDialog({ open, onOpenChange, outputIds, onImported }: SaveToWorkspaceDialogProps) {
-  const { fileTree, loadFileTree, refreshDirectory } = useFileStore();
+  const t = useTranslations('studio.saveToWorkspace');
+  const { refreshDirectory } = useFileStore();
+  const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
   const [selectedDir, setSelectedDir] = useState('.');
-  const [expandedDirs, setExpandedDirs] = useState(new Set<string>());
+  const [targetWorkspaceId, setTargetWorkspaceId] = useState<string | null>(activeWorkspace?.id ?? null);
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (open) {
-      void loadFileTree('.', 6, true);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSelectedDir('.');
+      setTargetWorkspaceId(activeWorkspace?.id ?? null);
     }
-  }, [loadFileTree, open]);
-
-  const handleToggleDir = (dirPath: string) => {
-    setExpandedDirs((prev) => {
-      const next = new Set(prev);
-      if (next.has(dirPath)) {
-        next.delete(dirPath);
-      } else {
-        next.add(dirPath);
-      }
-      return next;
-    });
-
-    void refreshDirectory(dirPath, true);
-  };
+  }, [activeWorkspace?.id, open]);
 
   const handleSave = async () => {
-    if (outputIds.length === 0) return;
+    if (outputIds.length === 0 || !targetWorkspaceId) return;
     setIsSaving(true);
     try {
       const res = await fetch('/api/studio/outputs/save-to-workspace', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ outputIds, targetPath: selectedDir }),
+        body: JSON.stringify({ outputIds, targetPath: selectedDir, targetWorkspaceId }),
       });
       const data = await res.json();
       if (!data.success) {
-        throw new Error(data.error || 'Import fehlgeschlagen');
+        throw new Error(data.error || t('failed'));
       }
 
       const savedCount = typeof data.savedCount === 'number' ? data.savedCount : outputIds.length;
-      await refreshDirectory(selectedDir, true);
-      toast.success(`${savedCount} Datei${savedCount === 1 ? '' : 'en'} in den Workspace importiert`);
+      if (targetWorkspaceId === activeWorkspace?.id) {
+        await refreshDirectory(selectedDir, true);
+      }
+      toast.success(t('success', { count: savedCount }));
       onImported?.();
       onOpenChange(false);
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Import fehlgeschlagen');
+      toast.error(error instanceof Error ? error.message : t('failed'));
     } finally {
       setIsSaving(false);
     }
@@ -77,28 +71,23 @@ export function SaveToWorkspaceDialog({ open, onOpenChange, outputIds, onImporte
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg overflow-hidden">
         <DialogHeader>
-          <DialogTitle>In Workspace importieren</DialogTitle>
+          <DialogTitle>{t('title')}</DialogTitle>
           <DialogDescription>
-            Kopiert {outputIds.length} ausgewählte Datei{outputIds.length === 1 ? '' : 'en'} aus Studio in einen Workspace-Ordner.
+            {t('description', { count: outputIds.length })}
           </DialogDescription>
         </DialogHeader>
         <div className="min-w-0 py-4">
-          <div className="mb-4 min-w-0 overflow-hidden rounded-md border border-border bg-muted/40 px-3 py-2">
-            <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">Zielordner</p>
-            <p className="mt-1 truncate font-mono text-sm">{selectedDir === '.' ? 'Workspace root' : selectedDir}</p>
-          </div>
-          <DirectoryBrowser
-            tree={fileTree}
-            selectedPath={selectedDir}
-            onSelect={setSelectedDir}
-            expandedDirs={expandedDirs}
-            onToggleDir={handleToggleDir}
+          <WorkspaceDestinationPicker
+            selectedWorkspaceId={targetWorkspaceId}
+            selectedDir={selectedDir}
+            onWorkspaceChange={setTargetWorkspaceId}
+            onDirChange={setSelectedDir}
           />
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>Abbrechen</Button>
-          <Button onClick={handleSave} disabled={isSaving || outputIds.length === 0}>
-            {isSaving ? 'Importiere...' : `${outputIds.length} Datei${outputIds.length === 1 ? '' : 'en'} importieren`}
+          <Button variant="outline" onClick={() => onOpenChange(false)}>{t('cancel')}</Button>
+          <Button onClick={handleSave} disabled={isSaving || outputIds.length === 0 || !targetWorkspaceId}>
+            {isSaving ? t('saving') : t('submit', { count: outputIds.length })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/app/components/file-browser/DirectoryBrowser.tsx
+++ b/app/components/file-browser/DirectoryBrowser.tsx
@@ -12,16 +12,27 @@ interface DirectoryBrowserProps {
   onSelect: (path: string) => void;
   expandedDirs: Set<string>;
   onToggleDir: (path: string) => void;
+  loadingDirs?: Set<string>;
+  onLoadSubdirectory?: (path: string) => Promise<void>;
 }
 
-export function DirectoryBrowser({ tree, selectedPath, onSelect, expandedDirs, onToggleDir }: DirectoryBrowserProps) {
+export function DirectoryBrowser({
+  tree,
+  selectedPath,
+  onSelect,
+  expandedDirs,
+  onToggleDir,
+  loadingDirs: providedLoadingDirs,
+  onLoadSubdirectory,
+}: DirectoryBrowserProps) {
   const t = useTranslations('notebook');
-  const { loadSubdirectory, loadingDirs } = useFileStore();
+  const { loadSubdirectory, loadingDirs: storeLoadingDirs } = useFileStore();
+  const loadingDirs = providedLoadingDirs ?? storeLoadingDirs;
 
   const handleToggleDir = async (path: string, isExpanded: boolean) => {
     onToggleDir(path);
     if (!isExpanded) {
-      await loadSubdirectory(path, true);
+      await (onLoadSubdirectory ?? ((dirPath: string) => loadSubdirectory(dirPath, true)))(path);
     }
   };
 

--- a/app/components/file-browser/FileActionsDropdown.tsx
+++ b/app/components/file-browser/FileActionsDropdown.tsx
@@ -10,9 +10,11 @@ import {
   Download,
   FilePlus,
   FolderPlus,
+  FolderInput,
   Globe2,
   ImagePlus,
   Images,
+  Loader2,
   Maximize2,
   Move,
   Pencil,
@@ -42,6 +44,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { hasMarpFileName } from '@/app/lib/marp/detect';
 import { useFileStore } from '@/app/store/file-store';
+import { copyWorkspacePaths } from '@/app/lib/files/client';
 import type { FileNode } from '@/app/lib/files/types';
 import { getParentDirectory, joinWorkspacePath } from '@/app/lib/files/path-utils';
 import { isWorkspaceImageFileName, shareWorkspaceImageFile } from '@/app/lib/files/workspace-image-share';
@@ -59,6 +62,8 @@ import { ShareMarkdownDialog } from './ShareMarkdownDialog';
 import { PublicShareDialog } from './PublicShareDialog';
 import { MarpExportDialog } from './MarpExportDialog';
 import { useCreateItemDialog } from './useCreateItemDialog';
+import { WorkspaceDestinationPicker } from '@/app/components/workspaces/WorkspaceDestinationPicker';
+import { selectActiveWorkspace, useWorkspaceStore } from '@/app/store/workspace-store';
 
 type DropdownMenuContentProps = ComponentProps<typeof DropdownMenuContent>;
 
@@ -103,6 +108,11 @@ export function FileActionsDropdown({
   const [marpExportOpen, setMarpExportOpen] = useState(false);
   const [marpDetection, setMarpDetection] = useState<{ path: string; isMarp: boolean } | null>(null);
   const [publicShareOpen, setPublicShareOpen] = useState(false);
+  const [copyToWorkspaceOpen, setCopyToWorkspaceOpen] = useState(false);
+  const [copyTargetWorkspaceId, setCopyTargetWorkspaceId] = useState<string | null>(null);
+  const [copyTargetDir, setCopyTargetDir] = useState('.');
+  const [isCopyingToWorkspace, setIsCopyingToWorkspace] = useState(false);
+  const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
 
   const {
     deletePath,
@@ -144,6 +154,10 @@ export function FileActionsDropdown({
     : false;
 
   const showMultiSelectOptions = showMultiSelectActions && multiSelectPaths.size > 0;
+  const selectedCopyPaths = useMemo(() => {
+    if (showMultiSelectOptions) return Array.from(multiSelectPaths);
+    return node ? [node.path] : [];
+  }, [multiSelectPaths, node, showMultiSelectOptions]);
 
   useEffect(() => {
     if (!nodePath || !isMarkdown || hasMarpName) {
@@ -318,6 +332,52 @@ export function FileActionsDropdown({
     closeMenu();
   };
 
+  const handleCopyToWorkspace = () => {
+    if (selectedCopyPaths.length === 0) return;
+
+    const selectedProtection = splitProtectedWorkspacePaths(selectedCopyPaths);
+    if (selectedProtection.hasProtected) {
+      toast.error(t('protectedFolderCopy'));
+      return;
+    }
+
+    setCopyTargetWorkspaceId(activeWorkspace?.id ?? null);
+    setCopyTargetDir('.');
+    setCopyToWorkspaceOpen(true);
+    closeMenu();
+  };
+
+  const handleConfirmCopyToWorkspace = async () => {
+    if (selectedCopyPaths.length === 0 || !activeWorkspace?.id || !copyTargetWorkspaceId) return;
+    setIsCopyingToWorkspace(true);
+
+    try {
+      const result = await copyWorkspacePaths({
+        sources: selectedCopyPaths,
+        destDir: copyTargetDir,
+        overwrite: false,
+        renameOnCollision: true,
+        sourceWorkspaceId: activeWorkspace.id,
+        targetWorkspaceId: copyTargetWorkspaceId,
+      }, t('copyToWorkspaceFailed'));
+
+      if (copyTargetWorkspaceId === activeWorkspace.id) {
+        await refreshDirectory(copyTargetDir, true);
+      }
+
+      if (showMultiSelectOptions) {
+        clearMultiSelect();
+      }
+
+      toast.success(t('copyToWorkspaceSuccess', { count: result.copied.length }));
+      setCopyToWorkspaceOpen(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('copyToWorkspaceFailed'));
+    } finally {
+      setIsCopyingToWorkspace(false);
+    }
+  };
+
   const handlePaste = async () => {
     if (!node) return;
     const destDir = node.type === 'directory' ? node.path : getParentDirectory(node.path);
@@ -448,6 +508,10 @@ export function FileActionsDropdown({
           <DropdownMenuItem onSelect={handleCopy} disabled={!node}>
             <ClipboardCopy className="h-4 w-4" />
             {t('copy')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleCopyToWorkspace} disabled={selectedCopyPaths.length === 0}>
+            <FolderInput className="h-4 w-4" />
+            {t('copyToWorkspace')}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handlePaste} disabled={clipboardMode !== 'copy' || clipboardPaths.size === 0}>
             <ClipboardPaste className="h-4 w-4" />
@@ -590,6 +654,34 @@ export function FileActionsDropdown({
             </Button>
             <Button variant="secondary" onClick={handleConfirmMove}>
               {t('move')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={copyToWorkspaceOpen} onOpenChange={setCopyToWorkspaceOpen}>
+        <DialogContent className="max-w-xl overflow-hidden">
+          <DialogHeader>
+            <DialogTitle>{t('copyToWorkspaceTitle')}</DialogTitle>
+            <DialogDescription>{t('copyToWorkspaceDescription', { count: selectedCopyPaths.length })}</DialogDescription>
+          </DialogHeader>
+          <WorkspaceDestinationPicker
+            selectedWorkspaceId={copyTargetWorkspaceId}
+            selectedDir={copyTargetDir}
+            onWorkspaceChange={setCopyTargetWorkspaceId}
+            onDirChange={setCopyTargetDir}
+          />
+          <DialogFooter className="gap-2">
+            <Button variant="ghost" onClick={() => setCopyToWorkspaceOpen(false)}>
+              {t('cancel')}
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => void handleConfirmCopyToWorkspace()}
+              disabled={isCopyingToWorkspace || !copyTargetWorkspaceId || selectedCopyPaths.length === 0}
+            >
+              {isCopyingToWorkspace ? <Loader2 className="h-4 w-4 animate-spin" /> : <FolderInput className="h-4 w-4" />}
+              {t('copyToWorkspaceConfirm')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/components/file-browser/FileActionsDropdown.tsx
+++ b/app/components/file-browser/FileActionsDropdown.tsx
@@ -369,7 +369,23 @@ export function FileActionsDropdown({
         clearMultiSelect();
       }
 
-      toast.success(t('copyToWorkspaceSuccess', { count: result.copied.length }));
+      const unresolvedCount = result.failed.length + result.skipped.length;
+      if (unresolvedCount > 0) {
+        console.warn('[FileActionsDropdown] Cross-workspace copy completed with unresolved paths', {
+          failed: result.failed,
+          skipped: result.skipped,
+        });
+        if (result.copied.length === 0) {
+          toast.error(t('copyToWorkspaceNoFilesCopied', { count: unresolvedCount }));
+          return;
+        }
+        toast.warning(t('copyToWorkspacePartialSuccess', {
+          copied: result.copied.length,
+          failed: unresolvedCount,
+        }));
+      } else {
+        toast.success(t('copyToWorkspaceSuccess', { count: result.copied.length }));
+      }
       setCopyToWorkspaceOpen(false);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : t('copyToWorkspaceFailed'));

--- a/app/components/workspaces/WorkspaceDestinationPicker.tsx
+++ b/app/components/workspaces/WorkspaceDestinationPicker.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { DirectoryBrowser } from '@/app/components/file-browser/DirectoryBrowser';
+import type { FileNode } from '@/app/lib/files/types';
+import { loadWorkspaceTree } from '@/app/lib/files/client';
+import { cn } from '@/lib/utils';
+import {
+  getWorkspaceKindLabel,
+  type WorkspaceKindLabels,
+} from '@/app/components/workspaces/workspace-utils';
+import {
+  selectActiveWorkspace,
+  useWorkspaceStore,
+} from '@/app/store/workspace-store';
+
+interface WorkspaceDestinationPickerProps {
+  selectedWorkspaceId: string | null;
+  selectedDir: string;
+  onWorkspaceChange: (workspaceId: string) => void;
+  onDirChange: (dirPath: string) => void;
+  className?: string;
+}
+
+function mergeDirectoryChildren(nodes: FileNode[], dirPath: string, children: FileNode[]): FileNode[] {
+  return nodes.map((node) => {
+    if (node.path === dirPath && node.type === 'directory') {
+      return { ...node, children };
+    }
+    if (node.children) {
+      return { ...node, children: mergeDirectoryChildren(node.children, dirPath, children) };
+    }
+    return node;
+  });
+}
+
+export function WorkspaceDestinationPicker({
+  selectedWorkspaceId,
+  selectedDir,
+  onWorkspaceChange,
+  onDirChange,
+  className,
+}: WorkspaceDestinationPickerProps) {
+  const t = useTranslations('workspaces');
+  const notebookT = useTranslations('notebook');
+  const workspaces = useWorkspaceStore((state) => state.workspaces);
+  const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
+  const hydrateWorkspaces = useWorkspaceStore((state) => state.hydrateWorkspaces);
+  const [tree, setTree] = useState<FileNode[]>([]);
+  const [expandedDirs, setExpandedDirs] = useState(new Set<string>());
+  const [loadingDirs, setLoadingDirs] = useState(new Set<string>());
+  const [isLoadingTree, setIsLoadingTree] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void hydrateWorkspaces();
+  }, [hydrateWorkspaces]);
+
+  const writableWorkspaces = useMemo(
+    () => workspaces.filter((workspace) => workspace.status === 'active' && workspace.permissions.canWrite),
+    [workspaces]
+  );
+
+  const effectiveWorkspaceId = useMemo(() => {
+    if (selectedWorkspaceId && writableWorkspaces.some((workspace) => workspace.id === selectedWorkspaceId)) {
+      return selectedWorkspaceId;
+    }
+    if (activeWorkspace?.permissions.canWrite) return activeWorkspace.id;
+    return writableWorkspaces[0]?.id ?? null;
+  }, [activeWorkspace, selectedWorkspaceId, writableWorkspaces]);
+
+  const kindLabels = {
+    personal: t('types.personal'),
+    team: t('types.team'),
+    project: t('types.project'),
+  } satisfies WorkspaceKindLabels;
+
+  useEffect(() => {
+    if (effectiveWorkspaceId && effectiveWorkspaceId !== selectedWorkspaceId) {
+      onWorkspaceChange(effectiveWorkspaceId);
+    }
+  }, [effectiveWorkspaceId, onWorkspaceChange, selectedWorkspaceId]);
+
+  useEffect(() => {
+    if (!effectiveWorkspaceId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setTree([]);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingTree(true);
+    setError(null);
+    setExpandedDirs(new Set<string>());
+
+    loadWorkspaceTree('.', 6, true, t('folderLoadFailed'), effectiveWorkspaceId)
+      .then((nextTree) => {
+        if (!cancelled) {
+          setTree(nextTree);
+        }
+      })
+      .catch((loadError) => {
+        if (!cancelled) {
+          setTree([]);
+          setError(loadError instanceof Error ? loadError.message : t('folderLoadFailed'));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoadingTree(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [effectiveWorkspaceId, t]);
+
+  const handleWorkspaceSelect = (workspaceId: string) => {
+    onWorkspaceChange(workspaceId);
+    onDirChange('.');
+  };
+
+  const handleToggleDir = (dirPath: string) => {
+    setExpandedDirs((prev) => {
+      const next = new Set(prev);
+      if (next.has(dirPath)) {
+        next.delete(dirPath);
+      } else {
+        next.add(dirPath);
+      }
+      return next;
+    });
+  };
+
+  const handleLoadSubdirectory = async (dirPath: string) => {
+    if (!effectiveWorkspaceId) return;
+    setLoadingDirs((prev) => new Set(prev).add(dirPath));
+    try {
+      const children = await loadWorkspaceTree(dirPath, 1, true, t('folderLoadFailed'), effectiveWorkspaceId);
+      setTree((prev) => mergeDirectoryChildren(prev, dirPath, children));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : t('folderLoadFailed'));
+    } finally {
+      setLoadingDirs((prev) => {
+        const next = new Set(prev);
+        next.delete(dirPath);
+        return next;
+      });
+    }
+  };
+
+  if (writableWorkspaces.length === 0) {
+    return (
+      <div className={cn('rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground', className)}>
+        {t('noWritableWorkspace')}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('min-w-0 space-y-3', className)}>
+      <label className="flex min-w-0 flex-col gap-1 text-sm">
+        <span className="text-xs font-medium text-muted-foreground">{t('targetWorkspace')}</span>
+        <select
+          className="h-9 min-w-0 rounded-md border border-input bg-background px-2 text-sm"
+          value={effectiveWorkspaceId ?? ''}
+          onChange={(event) => handleWorkspaceSelect(event.target.value)}
+        >
+          {writableWorkspaces.map((workspace) => (
+            <option key={workspace.id} value={workspace.id}>
+              {workspace.name} - {getWorkspaceKindLabel(workspace, kindLabels)}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="min-w-0 overflow-hidden rounded-md border border-border bg-muted/40 px-3 py-2">
+        <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">{t('targetFolder')}</p>
+        <p className="mt-1 truncate font-mono text-sm">{selectedDir === '.' ? notebookT('rootDirectory') : selectedDir}</p>
+      </div>
+
+      {error ? <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</div> : null}
+
+      <div className="relative">
+        {isLoadingTree ? (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded border border-border bg-background/70">
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          </div>
+        ) : null}
+        <DirectoryBrowser
+          tree={tree}
+          selectedPath={selectedDir}
+          onSelect={onDirChange}
+          expandedDirs={expandedDirs}
+          onToggleDir={handleToggleDir}
+          loadingDirs={loadingDirs}
+          onLoadSubdirectory={handleLoadSubdirectory}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/components/workspaces/WorkspaceDestinationPicker.tsx
+++ b/app/components/workspaces/WorkspaceDestinationPicker.tsx
@@ -1,13 +1,26 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { Loader2 } from 'lucide-react';
+import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { DirectoryBrowser } from '@/app/components/file-browser/DirectoryBrowser';
 import type { FileNode } from '@/app/lib/files/types';
 import { loadWorkspaceTree } from '@/app/lib/files/client';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 import {
   getWorkspaceKindLabel,
   type WorkspaceKindLabels,
@@ -54,6 +67,7 @@ export function WorkspaceDestinationPicker({
   const [loadingDirs, setLoadingDirs] = useState(new Set<string>());
   const [isLoadingTree, setIsLoadingTree] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
 
   useEffect(() => {
     void hydrateWorkspaces();
@@ -81,8 +95,9 @@ export function WorkspaceDestinationPicker({
   useEffect(() => {
     if (effectiveWorkspaceId && effectiveWorkspaceId !== selectedWorkspaceId) {
       onWorkspaceChange(effectiveWorkspaceId);
+      onDirChange('.');
     }
-  }, [effectiveWorkspaceId, onWorkspaceChange, selectedWorkspaceId]);
+  }, [effectiveWorkspaceId, onDirChange, onWorkspaceChange, selectedWorkspaceId]);
 
   useEffect(() => {
     if (!effectiveWorkspaceId) {
@@ -122,6 +137,7 @@ export function WorkspaceDestinationPicker({
   const handleWorkspaceSelect = (workspaceId: string) => {
     onWorkspaceChange(workspaceId);
     onDirChange('.');
+    setWorkspaceMenuOpen(false);
   };
 
   const handleToggleDir = (dirPath: string) => {
@@ -161,21 +177,55 @@ export function WorkspaceDestinationPicker({
     );
   }
 
+  const selectedWorkspace = writableWorkspaces.find((workspace) => workspace.id === effectiveWorkspaceId);
+
   return (
     <div className={cn('min-w-0 space-y-3', className)}>
       <label className="flex min-w-0 flex-col gap-1 text-sm">
         <span className="text-xs font-medium text-muted-foreground">{t('targetWorkspace')}</span>
-        <select
-          className="h-9 min-w-0 rounded-md border border-input bg-background px-2 text-sm"
-          value={effectiveWorkspaceId ?? ''}
-          onChange={(event) => handleWorkspaceSelect(event.target.value)}
-        >
-          {writableWorkspaces.map((workspace) => (
-            <option key={workspace.id} value={workspace.id}>
-              {workspace.name} - {getWorkspaceKindLabel(workspace, kindLabels)}
-            </option>
-          ))}
-        </select>
+        <Popover open={workspaceMenuOpen} onOpenChange={setWorkspaceMenuOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              role="combobox"
+              aria-expanded={workspaceMenuOpen}
+              className="h-9 min-w-0 justify-between px-2 text-left font-normal"
+            >
+              <span className="min-w-0 truncate">
+                {selectedWorkspace
+                  ? `${selectedWorkspace.name} - ${getWorkspaceKindLabel(selectedWorkspace, kindLabels)}`
+                  : t('targetWorkspace')}
+              </span>
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-1">
+            <Command>
+              <CommandList>
+                <CommandEmpty>{t('noWritableWorkspace')}</CommandEmpty>
+                <CommandGroup>
+                  {writableWorkspaces.map((workspace) => {
+                    const selected = workspace.id === effectiveWorkspaceId;
+                    return (
+                      <CommandItem
+                        key={workspace.id}
+                        value={`${workspace.name} ${workspace.id}`}
+                        onSelect={() => handleWorkspaceSelect(workspace.id)}
+                      >
+                        <Check className={cn('h-4 w-4', selected ? 'opacity-100' : 'opacity-0')} />
+                        <span className="min-w-0 flex-1 truncate">{workspace.name}</span>
+                        <span className="shrink-0 text-xs text-muted-foreground">
+                          {getWorkspaceKindLabel(workspace, kindLabels)}
+                        </span>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
       </label>
 
       <div className="min-w-0 overflow-hidden rounded-md border border-border bg-muted/40 px-3 py-2">

--- a/app/components/workspaces/WorkspaceDestinationPicker.tsx
+++ b/app/components/workspaces/WorkspaceDestinationPicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
@@ -68,6 +68,7 @@ export function WorkspaceDestinationPicker({
   const [isLoadingTree, setIsLoadingTree] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
+  const latestWorkspaceIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     void hydrateWorkspaces();
@@ -100,9 +101,11 @@ export function WorkspaceDestinationPicker({
   }, [effectiveWorkspaceId, onDirChange, onWorkspaceChange, selectedWorkspaceId]);
 
   useEffect(() => {
+    latestWorkspaceIdRef.current = effectiveWorkspaceId;
     if (!effectiveWorkspaceId) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setTree([]);
+      setLoadingDirs(new Set<string>());
       return;
     }
 
@@ -110,6 +113,7 @@ export function WorkspaceDestinationPicker({
     setIsLoadingTree(true);
     setError(null);
     setExpandedDirs(new Set<string>());
+    setLoadingDirs(new Set<string>());
 
     loadWorkspaceTree('.', 6, true, t('folderLoadFailed'), effectiveWorkspaceId)
       .then((nextTree) => {
@@ -153,14 +157,18 @@ export function WorkspaceDestinationPicker({
   };
 
   const handleLoadSubdirectory = async (dirPath: string) => {
-    if (!effectiveWorkspaceId) return;
+    const requestWorkspaceId = effectiveWorkspaceId;
+    if (!requestWorkspaceId) return;
     setLoadingDirs((prev) => new Set(prev).add(dirPath));
     try {
-      const children = await loadWorkspaceTree(dirPath, 1, true, t('folderLoadFailed'), effectiveWorkspaceId);
+      const children = await loadWorkspaceTree(dirPath, 1, true, t('folderLoadFailed'), requestWorkspaceId);
+      if (latestWorkspaceIdRef.current !== requestWorkspaceId) return;
       setTree((prev) => mergeDirectoryChildren(prev, dirPath, children));
     } catch (loadError) {
+      if (latestWorkspaceIdRef.current !== requestWorkspaceId) return;
       setError(loadError instanceof Error ? loadError.message : t('folderLoadFailed'));
     } finally {
+      if (latestWorkspaceIdRef.current !== requestWorkspaceId) return;
       setLoadingDirs((prev) => {
         const next = new Set(prev);
         next.delete(dirPath);

--- a/app/lib/files/client.ts
+++ b/app/lib/files/client.ts
@@ -1,4 +1,6 @@
 import type { ConvertParams } from '@/app/components/shared/ImagePreprocessDialog';
+import { WORKSPACE_ID_HEADER } from '@/app/lib/workspaces/constants';
+import { useWorkspaceStore } from '@/app/store/workspace-store';
 import type { CurrentFile, FileNode } from './types';
 
 interface ApiErrorPayload {
@@ -15,6 +17,8 @@ export interface CopyWorkspacePathsResult {
   copied: string[];
   failed: Array<{ path: string; error: string }>;
   skipped: string[];
+  sourceWorkspaceId?: string;
+  targetWorkspaceId?: string;
 }
 
 export interface WorkspacePathConflictError extends Error {
@@ -43,6 +47,22 @@ function describeNonJsonResponse(response: Response, fallbackMessage: string, bo
     ? 'HTML'
     : 'a non-JSON response';
   return `${fallbackMessage}${formatResponseStatus(response)}: server returned ${responseKind} instead of JSON. Please retry when the server is responsive.`;
+}
+
+function getActiveWorkspaceId(): string | null {
+  return useWorkspaceStore.getState().activeWorkspaceId;
+}
+
+function workspaceHeaders(workspaceId?: string | null): HeadersInit {
+  const resolvedWorkspaceId = workspaceId ?? getActiveWorkspaceId();
+  return resolvedWorkspaceId ? { [WORKSPACE_ID_HEADER]: resolvedWorkspaceId } : {};
+}
+
+function withWorkspaceQuery(url: string, workspaceId?: string | null) {
+  const resolvedWorkspaceId = workspaceId ?? getActiveWorkspaceId();
+  if (!resolvedWorkspaceId) return url;
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}workspaceId=${encodeURIComponent(resolvedWorkspaceId)}`;
 }
 
 export async function readApiJson<T>(response: Response, fallbackMessage: string): Promise<T> {
@@ -78,12 +98,15 @@ export async function loadWorkspaceTree(
   path = '.',
   depth = 4,
   noCache = false,
-  fallbackMessage = 'Failed to load file tree'
+  fallbackMessage = 'Failed to load file tree',
+  workspaceId?: string | null
 ): Promise<FileNode[]> {
-  const url = `/api/files/tree?path=${encodeURIComponent(path)}&depth=${depth}${noCache ? `&noCache=${Date.now()}` : ''}`;
+  const baseUrl = `/api/files/tree?path=${encodeURIComponent(path)}&depth=${depth}${noCache ? `&noCache=${Date.now()}` : ''}`;
+  const url = withWorkspaceQuery(baseUrl, workspaceId);
   const response = await fetch(url, {
     credentials: 'include',
     cache: noCache ? 'no-store' : 'default',
+    headers: workspaceHeaders(workspaceId),
   });
 
   if (!response.ok) {
@@ -107,6 +130,7 @@ export async function readWorkspaceFile(
   const response = await fetch(url, {
     credentials: 'include',
     cache: 'no-store',
+    headers: workspaceHeaders(),
   });
 
   if (!response.ok) {
@@ -120,7 +144,7 @@ export async function readWorkspaceFile(
 export async function writeWorkspaceFile(path: string, content: string): Promise<void> {
   const response = await fetch('/api/files/write', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...workspaceHeaders() },
     credentials: 'include',
     body: JSON.stringify({ path, content }),
   });
@@ -137,7 +161,7 @@ export async function createWorkspacePath(
 ): Promise<void> {
   const response = await fetch('/api/files/create', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...workspaceHeaders() },
     credentials: 'include',
     body: JSON.stringify({ path, type, ...options }),
   });
@@ -150,7 +174,7 @@ export async function createWorkspacePath(
 export async function deleteWorkspacePaths(paths: string[]): Promise<DeleteWorkspacePathsResult> {
   const response = await fetch('/api/files/delete', {
     method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...workspaceHeaders() },
     credentials: 'include',
     body: JSON.stringify({ path: paths }),
   });
@@ -165,7 +189,7 @@ export async function deleteWorkspacePaths(paths: string[]): Promise<DeleteWorks
 export async function renameWorkspacePath(oldPath: string, newPath: string, overwrite = false): Promise<void> {
   const response = await fetch('/api/files/rename', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...workspaceHeaders() },
     credentials: 'include',
     body: JSON.stringify({ oldPath, newPath, overwrite }),
   });
@@ -194,10 +218,12 @@ export async function copyWorkspacePaths(params: {
   destDir: string;
   overwrite?: boolean;
   renameOnCollision?: boolean;
+  sourceWorkspaceId?: string | null;
+  targetWorkspaceId?: string | null;
 }, fallbackMessage = 'Failed to copy files'): Promise<CopyWorkspacePathsResult> {
   const response = await fetch('/api/files/copy', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...workspaceHeaders(params.sourceWorkspaceId) },
     credentials: 'include',
     body: JSON.stringify(params),
   });
@@ -236,6 +262,10 @@ export async function uploadWorkspaceFiles({
     const xhr = new XMLHttpRequest();
     xhr.open('POST', '/api/files/upload', true);
     xhr.withCredentials = true;
+    const workspaceId = getActiveWorkspaceId();
+    if (workspaceId) {
+      xhr.setRequestHeader(WORKSPACE_ID_HEADER, workspaceId);
+    }
 
     xhr.upload.onprogress = (event) => {
       if (event.lengthComputable) {
@@ -273,7 +303,7 @@ export async function uploadWorkspaceFiles({
 }
 
 export function triggerWorkspaceDownload(path: string): void {
-  const url = `/api/files/download?path=${encodeURIComponent(path)}&download=1`;
+  const url = withWorkspaceQuery(`/api/files/download?path=${encodeURIComponent(path)}&download=1`);
   const anchor = document.createElement('a');
   const name = path.split('/').pop() || 'download';
   anchor.href = url;

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -411,6 +411,48 @@ export async function copyFile(
   return {copied: destRelative, skipped: false};
 }
 
+export async function copyFileBetweenWorkspaces(
+  sourcePath: string,
+  destDir: string,
+  overwrite = false,
+  renameOnCollision = false,
+  options: {
+    source: WorkspaceFileOperationOptions;
+    target: WorkspaceFileOperationOptions;
+  }
+): Promise<{copied: string; skipped: boolean}> {
+  const fullSource = await resolveExistingWorkspacePath(sourcePath, options.source);
+  const fullDestDir = await resolveExistingWorkspacePath(destDir, options.target);
+  const fileName = path.basename(fullSource);
+  let destFileName = fileName;
+
+  if (renameOnCollision) {
+    const fullDest = path.join(fullDestDir, destFileName);
+    try {
+      await fs.access(fullDest);
+      destFileName = findAvailableDestName(fileName, fullDestDir);
+    } catch {
+      // Destination doesn't exist - use original name
+    }
+  } else {
+    const fullDest = path.join(fullDestDir, destFileName);
+    try {
+      await fs.access(fullDest);
+      if (!overwrite) {
+        return {copied: '', skipped: true};
+      }
+      await fs.rm(fullDest, {recursive: true, force: true});
+    } catch {
+      // Destination doesn't exist - good
+    }
+  }
+
+  const fullDest = path.join(fullDestDir, destFileName);
+  const destRelative = destDir === '.' ? destFileName : `${destDir}/${destFileName}`;
+  await fs.cp(fullSource, fullDest, {recursive: true});
+  return {copied: destRelative, skipped: false};
+}
+
 export async function batchCopy(
   sources: string[],
   destDir: string,
@@ -424,6 +466,45 @@ export async function batchCopy(
     sources.map(async (sourcePath) => {
       try {
         const result = await copyFile(sourcePath, destDir, overwrite, renameOnCollision, options);
+        if (result.skipped) {
+          results.skipped.push(sourcePath);
+        } else {
+          results.copied.push(result.copied);
+        }
+      } catch (error) {
+        results.failed.push({
+          path: sourcePath,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    })
+  );
+
+  return results;
+}
+
+export async function batchCopyBetweenWorkspaces(
+  sources: string[],
+  destDir: string,
+  overwrite = false,
+  renameOnCollision = false,
+  options: {
+    source: WorkspaceFileOperationOptions;
+    target: WorkspaceFileOperationOptions;
+  }
+): Promise<CopyResult> {
+  const results: CopyResult = {copied: [], failed: [], skipped: []};
+
+  await Promise.allSettled(
+    sources.map(async (sourcePath) => {
+      try {
+        const result = await copyFileBetweenWorkspaces(
+          sourcePath,
+          destDir,
+          overwrite,
+          renameOnCollision,
+          options
+        );
         if (result.skipped) {
           results.skipped.push(sourcePath);
         } else {

--- a/app/lib/integrations/studio-aspect-ratio-service.ts
+++ b/app/lib/integrations/studio-aspect-ratio-service.ts
@@ -7,7 +7,7 @@ import sharp from 'sharp';
 
 import { db } from '@/app/lib/db';
 import { studioGenerationOutputs, studioGenerations } from '@/app/lib/db/schema';
-import { writeFile } from '@/app/lib/filesystem/workspace-files';
+import { writeFile, type WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 import { getImageGenerationProvider } from '@/app/lib/integrations/image-generation-providers';
 import { classifyMediaReference, loadMediaReference } from '@/app/lib/integrations/media-reference-resolver';
 import {
@@ -67,6 +67,7 @@ export interface AspectRatioSaveRequest {
   provider?: AspectRatioProvider;
   model?: string;
   targetDirectory?: string;
+  targetWorkspaceId?: string;
   fileName?: string;
   confirmOverwrite?: boolean;
 }
@@ -520,7 +521,11 @@ async function keepEditAsStudioOutput(
   };
 }
 
-export async function saveAspectRatioEdit(input: AspectRatioSaveRequest, userId: string): Promise<{ path: string; generationId?: string; outputId?: string }> {
+export async function saveAspectRatioEdit(
+  input: AspectRatioSaveRequest,
+  userId: string,
+  workspaceOptions?: WorkspaceFileOperationOptions
+): Promise<{ path: string; generationId?: string; outputId?: string }> {
   const editRelativePath = getEditRelativePath(input.previewPath);
   const buffer = await readEditFile(editRelativePath);
 
@@ -534,7 +539,7 @@ export async function saveAspectRatioEdit(input: AspectRatioSaveRequest, userId:
       : '.';
     const fileName = sanitizeFileName(input.fileName, path.posix.basename(editRelativePath));
     const targetPath = joinWorkspacePath(targetDirectory, fileName);
-    await writeFile(targetPath, buffer);
+    await writeFile(targetPath, buffer, workspaceOptions);
     return { path: targetPath };
   }
 

--- a/app/lib/workspaces/constants.ts
+++ b/app/lib/workspaces/constants.ts
@@ -1,0 +1,1 @@
+export const WORKSPACE_ID_HEADER = 'x-canvas-workspace-id';

--- a/app/lib/workspaces/request.ts
+++ b/app/lib/workspaces/request.ts
@@ -5,7 +5,13 @@ import { NextResponse } from 'next/server';
 
 import { auth } from '@/app/lib/auth';
 import { createLegacyPersonalWorkspaceContext, resolveWorkspaceActor } from './context';
+import { WORKSPACE_ID_HEADER } from './constants';
+import {
+  ensureOrganizationBootstrapForUser,
+  openOrganizationBootstrapDatabase,
+} from '@/app/lib/organization/bootstrap';
 import { assertWorkspacePermission } from './permissions';
+import { resolveWorkspaceContextById } from './service';
 import type { WorkspaceContext, WorkspacePermissions } from './types';
 
 export type RequestWorkspaceSession = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>;
@@ -20,6 +26,10 @@ type RequestWorkspaceResult =
   | (RequestWorkspace & { response: null })
   | { session: null; workspace: null; response: NextResponse };
 
+type SessionWorkspaceResult =
+  | (RequestWorkspace & { response: null })
+  | { session: RequestWorkspaceSession; workspace: null; response: NextResponse };
+
 function normalizePermissions(
   permissions?: RequestWorkspacePermission | RequestWorkspacePermission[]
 ): RequestWorkspacePermission[] {
@@ -27,9 +37,110 @@ function normalizePermissions(
   return Array.isArray(permissions) ? permissions : [permissions];
 }
 
+function requestedWorkspaceIdFromRequest(request: NextRequest): string | null {
+  const headerValue = request.headers.get(WORKSPACE_ID_HEADER)?.trim();
+  if (headerValue) return headerValue;
+
+  const queryValue = request.nextUrl.searchParams.get('workspaceId')?.trim();
+  return queryValue || null;
+}
+
+function assertWorkspacePermissions(
+  workspace: WorkspaceContext,
+  permissions?: RequestWorkspacePermission | RequestWorkspacePermission[]
+): NextResponse | null {
+  try {
+    for (const permission of normalizePermissions(permissions)) {
+      assertWorkspacePermission(workspace.permissions, permission);
+    }
+    return null;
+  } catch (error) {
+    const status = error && typeof error === 'object' && 'status' in error
+      ? Number(error.status)
+      : 403;
+    const message = error instanceof Error ? error.message : 'Workspace permission denied';
+    return NextResponse.json({ success: false, error: message }, { status });
+  }
+}
+
+export async function requireSessionWorkspace(
+  session: RequestWorkspaceSession,
+  options: {
+    workspaceId?: string | null;
+    permissions?: RequestWorkspacePermission | RequestWorkspacePermission[];
+  } = {}
+): Promise<SessionWorkspaceResult> {
+  const actor = resolveWorkspaceActor({
+    id: session.user.id,
+    email: session.user.email,
+    role: session.user.role,
+  });
+
+  const requestedWorkspaceId = options.workspaceId?.trim() || null;
+  let workspace: WorkspaceContext | null = null;
+
+  if (!requestedWorkspaceId) {
+    workspace = createLegacyPersonalWorkspaceContext(actor);
+  } else {
+    const sqlite = openOrganizationBootstrapDatabase();
+    try {
+      sqlite.exec('BEGIN IMMEDIATE');
+      const status = ensureOrganizationBootstrapForUser(sqlite, session.user.id);
+      if (!status.organizationId) {
+        sqlite.exec('ROLLBACK');
+        return {
+          session,
+          workspace: null,
+          response: NextResponse.json({ success: false, error: 'Organization is not configured' }, { status: 409 }),
+        };
+      }
+
+      workspace = resolveWorkspaceContextById(sqlite, {
+        actor,
+        workspaceId: requestedWorkspaceId,
+      });
+      sqlite.exec('COMMIT');
+    } catch (error) {
+      if (sqlite.inTransaction) {
+        sqlite.exec('ROLLBACK');
+      }
+      const message = error instanceof Error ? error.message : 'Could not resolve workspace';
+      return {
+        session,
+        workspace: null,
+        response: NextResponse.json({ success: false, error: message }, { status: 500 }),
+      };
+    } finally {
+      sqlite.close();
+    }
+
+    if (!workspace) {
+      return {
+        session,
+        workspace: null,
+        response: NextResponse.json({ success: false, error: 'Workspace not found or inaccessible' }, { status: 404 }),
+      };
+    }
+  }
+
+  const permissionResponse = assertWorkspacePermissions(workspace, options.permissions);
+  if (permissionResponse) {
+    return {
+      session,
+      workspace: null,
+      response: permissionResponse,
+    };
+  }
+
+  return { session, workspace, response: null };
+}
+
 export async function requireRequestWorkspace(
   request: NextRequest,
-  options: { permissions?: RequestWorkspacePermission | RequestWorkspacePermission[] } = {}
+  options: {
+    workspaceId?: string | null;
+    permissions?: RequestWorkspacePermission | RequestWorkspacePermission[];
+  } = {}
 ): Promise<RequestWorkspaceResult> {
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session) {
@@ -40,30 +151,19 @@ export async function requireRequestWorkspace(
     };
   }
 
-  const actor = resolveWorkspaceActor({
-    id: session.user.id,
-    email: session.user.email,
-    role: session.user.role,
+  const result = await requireSessionWorkspace(session, {
+    workspaceId: options.workspaceId ?? requestedWorkspaceIdFromRequest(request),
+    permissions: options.permissions,
   });
-  const workspace = createLegacyPersonalWorkspaceContext(actor);
-
-  try {
-    for (const permission of normalizePermissions(options.permissions)) {
-      assertWorkspacePermission(workspace.permissions, permission);
-    }
-  } catch (error) {
-    const status = error && typeof error === 'object' && 'status' in error
-      ? Number(error.status)
-      : 403;
-    const message = error instanceof Error ? error.message : 'Workspace permission denied';
+  if (result.response) {
     return {
       session: null,
       workspace: null,
-      response: NextResponse.json({ success: false, error: message }, { status }),
+      response: result.response,
     };
   }
 
-  return { session, workspace, response: null };
+  return result;
 }
 
 export function workspaceFileOptions(workspace: WorkspaceContext) {

--- a/docs/architecture/canvas-notebook/team-workspace/README.md
+++ b/docs/architecture/canvas-notebook/team-workspace/README.md
@@ -62,4 +62,5 @@ Dieses Verzeichnis ist der zentrale Arbeitsbereich fuer den Team-Workspace-Umbau
 - Community-/Single-User-Installationen bleiben auch bei gesetztem Team-Flag auf Personal Workspace begrenzt.
 - Personal Workspaces werden pro User angelegt; Team Workspace wird nur in teamfaehigen Deployment Modes angelegt.
 - Globaler Workspace-Switcher, Workspace-Badge, clientseitiger Workspace-Store und Chat-Neustart bei Workspace-Wechsel sind eingefuehrt.
-- Naechster Schritt: Kopieraktionen zwischen Personal und Team Workspace implementieren.
+- Kopieraktionen zwischen Personal und Team Workspace sind fuer File Browser und Studio-Importe umgesetzt.
+- Naechster Schritt: Agent-Runtime-Einstellungen und Agent-Sessions an User-/Workspace-Kontext binden.

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -202,11 +202,20 @@
     {
       "id": 15,
       "title": "Kopieraktionen zwischen Personal und Team Workspace implementieren",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/06-workspace-switching-ux.md",
         "docs/architecture/canvas-notebook/team-workspace/07-filesystem-migration-and-write-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/api/files/copy/route.ts",
+        "app/api/studio/outputs/save-to-workspace/route.ts",
+        "app/api/studio/aspect-ratio/save/route.ts",
+        "app/components/workspaces/WorkspaceDestinationPicker.tsx",
+        "app/components/file-browser/FileActionsDropdown.tsx",
+        "app/lib/filesystem/workspace-files.ts",
+        "scripts/workspace-cross-copy-test.ts"
       ]
     },
     {

--- a/messages/de.json
+++ b/messages/de.json
@@ -54,6 +54,10 @@
     "loadingContext": "Workspace-Kontext wird geladen",
     "noWorkspaceAvailable": "Kein Workspace verfügbar",
     "refresh": "Workspaces aktualisieren",
+    "targetWorkspace": "Ziel-Workspace",
+    "targetFolder": "Zielordner",
+    "folderLoadFailed": "Workspace-Ordner konnten nicht geladen werden",
+    "noWritableWorkspace": "Kein beschreibbarer Workspace verfügbar.",
     "types": {
       "personal": "Persönlich",
       "team": "Team",
@@ -392,6 +396,12 @@
     "fileActions": "Dateiaktionen",
     "copyPath": "Pfad kopieren",
     "copy": "Kopieren",
+    "copyToWorkspace": "In Workspace kopieren",
+    "copyToWorkspaceTitle": "In Workspace kopieren",
+    "copyToWorkspaceDescription": "Wähle Ziel-Workspace und Zielordner für {count} ausgewählte Elemente.",
+    "copyToWorkspaceConfirm": "Kopieren",
+    "copyToWorkspaceSuccess": "{count} Elemente kopiert.",
+    "copyToWorkspaceFailed": "Kopieren in Workspace fehlgeschlagen",
     "paste": "Einfügen",
     "duplicate": "Duplizieren",
     "rename": "Umbenennen",
@@ -403,6 +413,7 @@
     "resizeInStudio": "Bild im AR Editor öffnen",
     "protectedFolderRename": "Dieser App-Output-Ordner kann nicht umbenannt werden.",
     "protectedFolderMove": "Dieser App-Output-Ordner kann nicht verschoben werden.",
+    "protectedFolderCopy": "Dieser App-Output-Ordner kann nicht kopiert werden.",
     "renameTitle": "\"{name}\" umbenennen",
     "renameDescription": "Gib einen neuen Namen ein. Der Eintrag bleibt im gleichen Verzeichnis.",
     "newName": "Neuer Name",
@@ -3448,6 +3459,15 @@
     "comingSoon": "Coming Soon — Diese Funktion ist bald verfügbar.",
     "common": {
       "loading": "Lade..."
+    },
+    "saveToWorkspace": {
+      "title": "In Workspace importieren",
+      "description": "Kopiert {count} ausgewählte Studio-Datei(en) in einen Workspace-Ordner.",
+      "cancel": "Abbrechen",
+      "submit": "{count} Datei(en) importieren",
+      "saving": "Importiere...",
+      "success": "{count} Datei(en) in den Workspace importiert.",
+      "failed": "Import fehlgeschlagen"
     },
     "providerRequirements": {
       "openIntegrations": "Integrationen öffnen",

--- a/messages/de.json
+++ b/messages/de.json
@@ -401,6 +401,8 @@
     "copyToWorkspaceDescription": "Wähle Ziel-Workspace und Zielordner für {count} ausgewählte Elemente.",
     "copyToWorkspaceConfirm": "Kopieren",
     "copyToWorkspaceSuccess": "{count} Elemente kopiert.",
+    "copyToWorkspacePartialSuccess": "{copied} Elemente kopiert. {failed} Elemente sind fehlgeschlagen oder wurden übersprungen.",
+    "copyToWorkspaceNoFilesCopied": "Keine Elemente wurden kopiert. {count} Elemente sind fehlgeschlagen oder wurden übersprungen.",
     "copyToWorkspaceFailed": "Kopieren in Workspace fehlgeschlagen",
     "paste": "Einfügen",
     "duplicate": "Duplizieren",

--- a/messages/en.json
+++ b/messages/en.json
@@ -54,6 +54,10 @@
     "loadingContext": "Workspace context is loading",
     "noWorkspaceAvailable": "No workspace available",
     "refresh": "Refresh workspaces",
+    "targetWorkspace": "Target workspace",
+    "targetFolder": "Target folder",
+    "folderLoadFailed": "Could not load workspace folders",
+    "noWritableWorkspace": "No writable workspace available.",
     "types": {
       "personal": "Personal",
       "team": "Team",
@@ -393,6 +397,12 @@
     "fileActions": "File actions",
     "copyPath": "Copy path",
     "copy": "Copy",
+    "copyToWorkspace": "Copy to workspace",
+    "copyToWorkspaceTitle": "Copy to workspace",
+    "copyToWorkspaceDescription": "Choose a target workspace and folder for {count} selected item(s).",
+    "copyToWorkspaceConfirm": "Copy",
+    "copyToWorkspaceSuccess": "{count} item(s) copied.",
+    "copyToWorkspaceFailed": "Failed to copy to workspace",
     "paste": "Paste",
     "duplicate": "Duplicate",
     "rename": "Rename",
@@ -404,6 +414,7 @@
     "resizeInStudio": "Open image in AR Editor",
     "protectedFolderRename": "This app output folder cannot be renamed.",
     "protectedFolderMove": "This app output folder cannot be moved.",
+    "protectedFolderCopy": "This app output folder cannot be copied.",
     "renameTitle": "Rename \"{name}\"",
     "renameDescription": "Enter a new name for the item. The new name will be saved in the same directory.",
     "newName": "New name",
@@ -3449,6 +3460,15 @@
     "comingSoon": "Coming Soon — This feature will be available soon.",
     "common": {
       "loading": "Loading..."
+    },
+    "saveToWorkspace": {
+      "title": "Import to workspace",
+      "description": "Copy {count} selected Studio file(s) into a workspace folder.",
+      "cancel": "Cancel",
+      "submit": "Import {count} file(s)",
+      "saving": "Importing...",
+      "success": "{count} file(s) imported into the workspace.",
+      "failed": "Import failed"
     },
     "providerRequirements": {
       "openIntegrations": "Open integrations",

--- a/messages/en.json
+++ b/messages/en.json
@@ -402,6 +402,8 @@
     "copyToWorkspaceDescription": "Choose a target workspace and folder for {count} selected item(s).",
     "copyToWorkspaceConfirm": "Copy",
     "copyToWorkspaceSuccess": "{count} item(s) copied.",
+    "copyToWorkspacePartialSuccess": "{copied} item(s) copied. {failed} item(s) failed or were skipped.",
+    "copyToWorkspaceNoFilesCopied": "No items were copied. {count} item(s) failed or were skipped.",
     "copyToWorkspaceFailed": "Failed to copy to workspace",
     "paste": "Paste",
     "duplicate": "Duplicate",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "test:workspace:foundation": "tsx --conditions react-server scripts/workspace-context-foundation-test.ts",
     "test:workspace:model": "tsx --conditions react-server scripts/workspace-model-service-test.ts",
     "test:workspace:switcher-ui": "tsx scripts/workspace-switcher-ui-test.ts",
+    "test:workspace:cross-copy": "tsx --conditions react-server scripts/workspace-cross-copy-test.ts",
     "test:e2e": "playwright test --pass-with-no-tests",
     "test:all": "node scripts/test-all.mjs",
     "test:websocket:connection": "node scripts/test-websocket-connection.js",

--- a/scripts/workspace-cross-copy-test.ts
+++ b/scripts/workspace-cross-copy-test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { batchCopyBetweenWorkspaces } from '@/app/lib/filesystem/workspace-files';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
+
+function createWorkspaceContext(rootPath: string, workspaceId: string, type: WorkspaceContext['workspaceType']): WorkspaceContext {
+  return {
+    workspaceId,
+    workspaceType: type,
+    rootPath,
+    rootRelativePath: path.basename(rootPath),
+    displayName: workspaceId,
+    status: 'active',
+    organizationId: 'org_test',
+    ownerUserId: type === 'personal' ? 'user_test' : null,
+    permissions: {
+      canRead: true,
+      canWrite: true,
+      canDelete: true,
+      canCreatePublicLinks: true,
+      canManageWorkspace: true,
+      canRunAgent: true,
+    },
+    legacy: false,
+  };
+}
+
+async function main() {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'canvas-workspace-cross-copy-'));
+  try {
+    const sourceRoot = path.join(tempRoot, 'personal');
+    const targetRoot = path.join(tempRoot, 'team');
+    await mkdir(path.join(sourceRoot, 'docs', 'nested'), { recursive: true });
+    await mkdir(path.join(targetRoot, 'imports'), { recursive: true });
+    await writeFile(path.join(sourceRoot, 'docs', 'nested', 'a.txt'), 'alpha\n');
+    await writeFile(path.join(sourceRoot, 'docs', 'b.txt'), 'beta\n');
+    await writeFile(path.join(targetRoot, 'imports', 'b.txt'), 'existing\n');
+
+    const source = createWorkspaceContext(sourceRoot, 'ws_personal', 'personal');
+    const target = createWorkspaceContext(targetRoot, 'ws_team', 'team');
+
+    const result = await batchCopyBetweenWorkspaces(
+      ['docs/b.txt', 'docs/nested'],
+      'imports',
+      false,
+      true,
+      { source: { workspace: source }, target: { workspace: target } }
+    );
+
+    assert.deepEqual(result.failed, []);
+    assert.equal(result.skipped.length, 0);
+    assert.ok(result.copied.includes('imports/b (1).txt'));
+    assert.ok(result.copied.includes('imports/nested'));
+    assert.equal(await readFile(path.join(targetRoot, 'imports', 'b (1).txt'), 'utf8'), 'beta\n');
+    assert.equal(await readFile(path.join(targetRoot, 'imports', 'nested', 'a.txt'), 'utf8'), 'alpha\n');
+    assert.equal(await readFile(path.join(sourceRoot, 'docs', 'b.txt'), 'utf8'), 'beta\n');
+
+    const traversalResult = await batchCopyBetweenWorkspaces(
+      ['../outside.txt'],
+      'imports',
+      false,
+      true,
+      { source: { workspace: source }, target: { workspace: target } }
+    );
+    assert.equal(traversalResult.copied.length, 0);
+    assert.equal(traversalResult.failed.length, 1);
+
+    console.log('workspace-cross-copy-test passed');
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add cross-workspace copy support with source/target workspace permission checks
- add reusable workspace destination picker for File Browser and Studio save/copy flows
- update the team-workspace todo source of truth and add a focused cross-workspace copy regression test

## Verification
- npm run test:workspace:cross-copy
- npm run test:workspace:switcher-ui
- npm run test:workspace:model
- npm run test:workspace:foundation
- npm run lint
- npm run build

## Greptile / greploop
- Initial Greptile review found 3 actionable threads; all were fixed and resolved.
- Follow-up Greptile summary reported 4/5 and one additional issue; the stale subdirectory-load race was fixed.
- Final Greptile summary for head `33d1addbc261727ecfd6f60b1e4543cf06ad39f7`: 5/5, safe to merge.
- Current status: zero unresolved review threads; CodeQL checks passing.
- Non-blocking Greptile notes reviewed: aspect-ratio missing target fallback and duplicate SQLite connection are follow-up optimization/polish items, not merge blockers.

## Notes
- Browser/Playwright UI automation was not run because this repo AGENTS.md requires explicit approval before using it.