### PR TITLE
Bind agent sessions to workspace context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,9 @@ eröffne ausschließlich auf localhost 3000 einen dev server. starte keine neuen
 - Git history has a single initial commit; no enforced convention.
 - Use short, descriptive commit messages (e.g., `Fix terminal copy on iPad`).
 - PRs should include: summary, screenshots for UI changes, and steps to verify.
-- Before any PR is merged into `main`, run a `greploop` review for that PR and document the resulting score in the PR.
+- After opening a PR, stop the tool loop and do not manually trigger Greptile/greploop. Greptile performs the first review automatically after PR creation. Wait for the user to say that the first Greptile review has completed or explicitly trigger `/greploop`.
+- Use the `greploop` skill only after the user confirms the automatic Greptile review is available or explicitly asks for it.
+- Before any PR is merged into `main`, review the Greptile/greploop result for that PR and document the resulting score in the PR.
 - Trigger Greptile/greploop at most once per PR head SHA. If Greptile accepts the trigger but does not publish an updated score, wait and treat the PR as blocked; do not post another `@greptile review` for the same head.
 - After addressing review feedback and pushing a new commit, the new head SHA may be reviewed once.
 - A `greploop` score of 4 out of 5 is sufficient for merge; a perfect 5 out of 5 is not required.

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -14,6 +14,7 @@ import { getActiveAiAgentEngine } from '@/app/lib/agents/runtime';
 import { DEFAULT_SESSION_TITLE } from '@/app/lib/pi/session-titles';
 import { CANVAS_CONTROL_PLANE_PROVIDER_ID, getCanvasControlPlaneModels, getPiModels, OLLAMA_PROVIDER_ID, OPENAI_COMPATIBLE_PROVIDER_ID } from '@/app/lib/pi/model-resolver';
 import type { PiThinkingLevel } from '@/app/lib/pi/config';
+import type { ChatRequestContext } from '@/app/lib/chat/types';
 import { getActiveRuntimeStatusSummaries, getStatus, invalidateRuntime } from '@/app/lib/pi/runtime-service';
 import { DEFAULT_AGENT_ID, WEB_CHANNEL_ID, normalizeStoredChannelId, webChannelSessionKey } from '@/app/lib/channels/constants';
 import { ensureDefaultAgent } from '@/app/lib/channels/agents';
@@ -23,6 +24,11 @@ import { getAgentProfile, normalizeManagedAgentId } from '@/app/lib/agents/regis
 import { deletePiSessionsByDbIds } from '@/app/lib/pi/session-deletion';
 import { createPiSystemPromptSnapshot, piSystemPromptSnapshotDbFields } from '@/app/lib/pi/system-prompt-snapshot';
 import { markPiSessionAsReadForUser, markPiSessionAsUnreadForUser } from '@/app/lib/chat/session-read-state';
+import {
+  resolveAgentSessionWorkspaceForUser,
+  storedPiSessionWorkspaceToSummary,
+  workspaceToPiSessionFields,
+} from '@/app/lib/pi/session-workspace-context';
 
 type CreateSessionPayload = {
   title?: string;
@@ -31,6 +37,8 @@ type CreateSessionPayload = {
   agentId?: string;
   channelId?: string;
   channelSessionKey?: string;
+  workspaceId?: string;
+  workspace?: ChatRequestContext['workspace'];
 };
 
 type RenameSessionPayload = {
@@ -84,6 +92,10 @@ function normalizeOptionalString(value: unknown): string | null {
 
 function normalizeSessionAgentId(value: unknown): string {
   return normalizeManagedAgentId(normalizeOptionalString(value));
+}
+
+function resolveCreateSessionWorkspaceId(payload: CreateSessionPayload): string | null {
+  return normalizeOptionalString(payload.workspaceId) ?? normalizeOptionalString(payload.workspace?.workspaceId);
 }
 
 function normalizeThinkingLevel(value: unknown): PiThinkingLevel | null {
@@ -259,6 +271,11 @@ export async function GET(request: NextRequest) {
           createdAt: piSessions.createdAt,
           lastMessageAt: piSessions.lastMessageAt,
           lastViewedAt: piSessions.lastViewedAt,
+          organizationId: piSessions.organizationId,
+          workspaceId: piSessions.workspaceId,
+          workspaceType: piSessions.workspaceType,
+          workspaceName: piSessions.workspaceName,
+          workspaceRootRelativePath: piSessions.workspaceRootRelativePath,
           creatorName: user.name,
           creatorEmail: user.email,
         })
@@ -316,6 +333,15 @@ export async function GET(request: NextRequest) {
         runtimeActiveToolName: runtimeStatus?.activeToolName ?? null,
         channelId: item.channelId,
         hasUnread,
+        workspace: item.engine === 'pi'
+          ? storedPiSessionWorkspaceToSummary({
+            workspaceId: 'workspaceId' in item ? item.workspaceId : null,
+            workspaceType: 'workspaceType' in item ? item.workspaceType : null,
+            workspaceName: 'workspaceName' in item ? item.workspaceName : null,
+            workspaceRootRelativePath: 'workspaceRootRelativePath' in item ? item.workspaceRootRelativePath : null,
+            organizationId: 'organizationId' in item ? item.organizationId : null,
+          })
+          : null,
         creator: {
           name: item.creatorName || null,
           email: item.creatorEmail || null,
@@ -402,6 +428,11 @@ export async function POST(request: NextRequest) {
         : normalizedChannelId === WEB_CHANNEL_ID
           ? webChannelSessionKey(session.user.id)
           : null;
+      const workspace = await resolveAgentSessionWorkspaceForUser({
+        userId: session.user.id,
+        workspaceId: resolveCreateSessionWorkspaceId(payload),
+      });
+      const workspaceFields = workspaceToPiSessionFields(workspace);
 
       const inserted = await db
         .insert(piSessions)
@@ -415,6 +446,7 @@ export async function POST(request: NextRequest) {
           title,
           channelId: 'app',
           channelSessionKey: null,
+          ...workspaceFields,
           ...piSystemPromptSnapshotDbFields(promptSnapshot),
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -435,6 +467,7 @@ export async function POST(request: NextRequest) {
         session: {
           ...inserted[0],
           engine: 'pi',
+          workspace: storedPiSessionWorkspaceToSummary(inserted[0]),
           creator: {
             name: session.user.name || null,
             email: session.user.email || null,

--- a/app/components/canvas-agent-chat/useChatControlActions.ts
+++ b/app/components/canvas-agent-chat/useChatControlActions.ts
@@ -270,12 +270,17 @@ export function useChatControlActions({
       : configuredModelState?.thinkingLevel || activeThinkingLevel;
     const optimisticTitle = getOptimisticSessionTitle(preferredTitle ?? input, t('newChatTitle'));
     const requestedTitle = isAutomaticSessionTitle(optimisticTitle) ? undefined : optimisticTitle;
+    const requestContext = buildRequestContext(currentFilePath);
 
     const createSessionPayload = await createChatSession({
       agentId,
       ...(requestedTitle ? { title: requestedTitle } : {}),
       ...(requestedModel ? { model: requestedModel } : {}),
       ...(requestedThinkingLevel ? { thinkingLevel: requestedThinkingLevel } : {}),
+      ...(requestContext.workspace ? {
+        workspaceId: requestContext.workspace.workspaceId,
+        workspace: requestContext.workspace,
+      } : {}),
     });
 
     if (!createSessionPayload?.success || !createSessionPayload.session?.sessionId) {
@@ -314,13 +319,14 @@ export function useChatControlActions({
       engine: createSessionPayload.session.engine || 'pi',
       lastMessageAt: new Date().toISOString(),
       hasUnread: false,
+      workspace: createSessionPayload.session.workspace ?? null,
       creator: createSessionPayload.session.creator,
     };
 
     addSessionToHistory(newSession);
 
     return nextSessionId;
-  }, [activeModel, activeProvider, activeThinkingLevel, addSessionToHistory, agentConfig, input, optimisticSessionTitlesRef, selectedAgentId, sessionAgentIdRef, sessionIdRef, setActiveModel, setActiveProvider, setActiveThinkingLevel, setSessionId, setSessionTitle, skipNextSessionStatusRefreshRef, t]);
+  }, [activeModel, activeProvider, activeThinkingLevel, addSessionToHistory, agentConfig, buildRequestContext, currentFilePath, input, optimisticSessionTitlesRef, selectedAgentId, sessionAgentIdRef, sessionIdRef, setActiveModel, setActiveProvider, setActiveThinkingLevel, setSessionId, setSessionTitle, skipNextSessionStatusRefreshRef, t]);
 
   const postControl = useCallback(async (
     targetSessionId: string,

--- a/app/lib/channels/router.ts
+++ b/app/lib/channels/router.ts
@@ -4,6 +4,7 @@ import type { InboundMessage } from './types';
 import { resolveChannelSession } from './session-resolver';
 import { buildUserAgentMessageFromInbound } from './message-normalization';
 import { buildChannelChatContext } from './chat-context';
+import { requestedWorkspaceIdFromChatContext } from '@/app/lib/pi/session-workspace-context';
 
 export type RoutedChannelMessageResult = {
   sessionId: string;
@@ -21,6 +22,7 @@ export async function handleInboundChannelMessage(
     channelThreadKey: message.channelThreadKey,
     requestedSessionId: message.requestedSessionId,
     displayName: typeof message.metadata?.displayName === 'string' ? message.metadata.displayName : null,
+    workspaceId: requestedWorkspaceIdFromChatContext(context),
   });
 
   const status = await sendMessage(

--- a/app/lib/channels/session-resolver.ts
+++ b/app/lib/channels/session-resolver.ts
@@ -9,6 +9,10 @@ import { DEFAULT_AGENT_ID, normalizeChannelThreadKey, WEB_CHANNEL_ID, webChannel
 import { ensureDefaultAgent } from './agents';
 import { getActiveChannelSession, setActiveChannelSession } from './active-sessions';
 import { ensureSessionChannelLink } from './channel-links';
+import {
+  resolveAgentSessionWorkspaceForUser,
+  workspaceToPiSessionFields,
+} from '@/app/lib/pi/session-workspace-context';
 
 export type ResolveChannelSessionInput = {
   userId: string;
@@ -18,6 +22,7 @@ export type ResolveChannelSessionInput = {
   requestedSessionId?: string | null;
   displayName?: string | null;
   agentId?: string;
+  workspaceId?: string | null;
 };
 
 function resolveAgentId(agentId?: string | null): string {
@@ -43,6 +48,10 @@ export async function createChannelSession(input: ResolveChannelSessionInput): P
   const sessionId = input.requestedSessionId || `sess-${Date.now()}-${randomUUID()}`;
   const effectiveConfig = await resolveAgentRuntimeConfig(agentId);
   const promptSnapshot = await createPiSystemPromptSnapshot(agentId);
+  const workspace = await resolveAgentSessionWorkspaceForUser({
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+  });
   const now = new Date();
 
   await db.insert(piSessions).values({
@@ -60,6 +69,7 @@ export async function createChannelSession(input: ResolveChannelSessionInput): P
     updatedAt: now,
     lastMessageAt: null,
     lastViewedAt: null,
+    ...workspaceToPiSessionFields(workspace),
   }).onConflictDoNothing();
 
   await ensureSessionChannelLink({
@@ -84,6 +94,10 @@ export async function resolveChannelSession(input: ResolveChannelSessionInput): 
     const exists = await userOwnsPiSession(input.requestedSessionId, input.userId, agentId);
     if (!exists && input.channelId !== WEB_CHANNEL_ID) {
       throw new Error('Session not found');
+    }
+    if (!exists) {
+      await createChannelSession({ ...input, agentId, channelThreadKey });
+      return input.requestedSessionId;
     }
 
     await ensureSessionChannelLink({

--- a/app/lib/chat/session-api.ts
+++ b/app/lib/chat/session-api.ts
@@ -1,5 +1,5 @@
 import { safeFetchJson } from '@/app/lib/chat/fetch-json';
-import type { AISession, PersistedChatMessage } from '@/app/lib/chat/types';
+import type { AISession, ChatRequestContext, PersistedChatMessage } from '@/app/lib/chat/types';
 import type { PiThinkingLevel } from '@/app/lib/pi/config';
 
 export type ChatSessionMessagesPayload = {
@@ -16,6 +16,8 @@ export type CreateChatSessionPayload = {
   title?: string;
   model?: string;
   thinkingLevel?: PiThinkingLevel;
+  workspaceId?: string;
+  workspace?: ChatRequestContext['workspace'];
 };
 
 export type CreateChatSessionResponse = {

--- a/app/lib/chat/types.ts
+++ b/app/lib/chat/types.ts
@@ -114,6 +114,14 @@ export interface AISession {
   runtimePhase?: SessionRuntimePhase | null;
   runtimeActiveToolName?: string | null;
   hasUnread?: boolean;
+  workspace?: {
+    workspaceId: string;
+    workspaceType: 'personal' | 'team' | 'project';
+    workspaceName: string;
+    organizationId?: string | null;
+    rootRelativePath?: string | null;
+    legacy?: boolean;
+  } | null;
   creator?: {
     name?: string | null;
     email?: string | null;

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -173,6 +173,11 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       last_viewed_at INTEGER,
       channel_id TEXT NOT NULL DEFAULT 'app',
       channel_session_key TEXT,
+      organization_id TEXT,
+      workspace_id TEXT,
+      workspace_type TEXT,
+      workspace_name TEXT,
+      workspace_root_relative_path TEXT,
       FOREIGN KEY (user_id) REFERENCES user(id)
     );
 
@@ -992,6 +997,11 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     system_prompt_snapshot: 'TEXT',
     system_prompt_snapshot_hash: 'TEXT',
     system_prompt_snapshot_created_at: 'INTEGER',
+    organization_id: 'TEXT',
+    workspace_id: 'TEXT',
+    workspace_type: 'TEXT',
+    workspace_name: 'TEXT',
+    workspace_root_relative_path: 'TEXT',
   });
 
   addColumns(sqlite, 'automation_jobs', {
@@ -1029,6 +1039,8 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_user_channel_created ON pi_sessions (user_id, channel_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_agent ON pi_sessions (agent_id);
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_channel ON pi_sessions (channel_id, channel_session_key);
+    CREATE INDEX IF NOT EXISTS idx_pi_sessions_workspace ON pi_sessions (workspace_id);
+    CREATE INDEX IF NOT EXISTS idx_pi_sessions_user_workspace_created ON pi_sessions (user_id, workspace_id, created_at);
   `);
 
   sqlite.exec(`

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -195,12 +195,19 @@ export const piSessions = sqliteTable("pi_sessions", {
   lastViewedAt: integer("last_viewed_at", { mode: "timestamp" }),
   channelId: text("channel_id").notNull().default('app'),
   channelSessionKey: text("channel_session_key"),
+  organizationId: text("organization_id"),
+  workspaceId: text("workspace_id"),
+  workspaceType: text("workspace_type"),
+  workspaceName: text("workspace_name"),
+  workspaceRootRelativePath: text("workspace_root_relative_path"),
 }, (table) => ({
   channelIdx: index("idx_pi_sessions_channel").on(table.channelId, table.channelSessionKey),
   userCreatedIdx: index("idx_pi_sessions_user_created").on(table.userId, table.createdAt),
   userSessionIdx: index("idx_pi_sessions_user_session").on(table.userId, table.sessionId),
   userChannelIdx: index("idx_pi_sessions_user_channel_created").on(table.userId, table.channelId, table.createdAt),
   agentIdx: index("idx_pi_sessions_agent").on(table.agentId),
+  workspaceIdx: index("idx_pi_sessions_workspace").on(table.workspaceId),
+  userWorkspaceCreatedIdx: index("idx_pi_sessions_user_workspace_created").on(table.userId, table.workspaceId, table.createdAt),
 }));
 
 export const agents = sqliteTable("agents", {

--- a/app/lib/pi/agent-execution-context.ts
+++ b/app/lib/pi/agent-execution-context.ts
@@ -1,0 +1,32 @@
+import 'server-only';
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { WorkspaceType } from '@/app/lib/workspaces/types';
+
+export type AgentExecutionContext = {
+  userId: string;
+  sessionId: string;
+  workspaceId: string;
+  workspaceType: WorkspaceType;
+  workspaceName: string | null;
+  organizationId: string | null;
+  workspaceRoot: string;
+  workspaceRootRelativePath: string | null;
+  canWrite: boolean;
+  canShare: boolean;
+  legacy: boolean;
+};
+
+const agentExecutionContextStorage = new AsyncLocalStorage<AgentExecutionContext>();
+
+export function getAgentExecutionContext(): AgentExecutionContext | null {
+  return agentExecutionContextStorage.getStore() ?? null;
+}
+
+export function runWithAgentExecutionContext<T>(
+  context: AgentExecutionContext,
+  callback: () => T,
+): T {
+  return agentExecutionContextStorage.run(context, callback);
+}

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -169,17 +169,35 @@ function assertContextWorkspaceReadAllowed(candidatePath: string): void {
   }
 }
 
-function assertContextWorkspaceWriteAllowed(candidatePath: string): void {
+async function assertContextWorkspaceWriteAllowed(candidatePath: string): Promise<void> {
   const executionContext = getAgentExecutionContext();
   if (!executionContext) return;
 
+  const workspaceRoot = path.resolve(executionContext.workspaceRoot);
   const resolvedPath = path.resolve(candidatePath);
-  if (!isPathWithin(resolvedPath, executionContext.workspaceRoot)) {
+  if (!isPathWithin(resolvedPath, workspaceRoot)) {
     throw new Error('Agent file writes are limited to the workspace bound to this chat session.');
   }
 
   if (!executionContext.canWrite) {
     throw new Error('Agent file writes are disabled for the active workspace.');
+  }
+
+  const workspaceRootRealPath = await resolveWorkspaceRootRealPath(workspaceRoot);
+  try {
+    const realPath = await fs.realpath(resolvedPath);
+    if (!isPathWithin(realPath, workspaceRootRealPath)) {
+      throw new Error('Agent file writes are limited to the workspace bound to this chat session.');
+    }
+  } catch (error) {
+    if (!isEnoent(error)) {
+      throw error;
+    }
+
+    const realParent = await resolveNearestExistingParentPath(resolvedPath);
+    if (!isPathWithin(realParent, workspaceRootRealPath)) {
+      throw new Error('Agent file writes are limited to the workspace bound to this chat session.');
+    }
   }
 }
 
@@ -221,16 +239,12 @@ export async function assertAgentPathAllowed(candidatePath: string): Promise<voi
   }
 }
 
-async function assertNearestWritableParentAllowed(candidatePath: string): Promise<void> {
+async function resolveNearestExistingParentPath(candidatePath: string): Promise<string> {
   let current = path.dirname(path.resolve(candidatePath));
 
   while (current !== path.dirname(current)) {
     try {
-      const realCurrent = await fs.realpath(current);
-      if (isProtectedAgentPath(realCurrent)) {
-        throw new Error('Access to this path is restricted for security reasons.');
-      }
-      return;
+      return await fs.realpath(current);
     } catch (error) {
       if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
         current = path.dirname(current);
@@ -243,8 +257,26 @@ async function assertNearestWritableParentAllowed(candidatePath: string): Promis
   throw new Error('Unable to resolve a writable parent directory.');
 }
 
+async function resolveWorkspaceRootRealPath(workspaceRoot: string): Promise<string> {
+  try {
+    return await fs.realpath(workspaceRoot);
+  } catch (error) {
+    if (isEnoent(error)) {
+      return path.resolve(workspaceRoot);
+    }
+    throw error;
+  }
+}
+
+async function assertNearestWritableParentAllowed(candidatePath: string): Promise<void> {
+  const realParent = await resolveNearestExistingParentPath(candidatePath);
+  if (isProtectedAgentPath(realParent)) {
+    throw new Error('Access to this path is restricted for security reasons.');
+  }
+}
+
 export async function assertAgentWritablePathAllowed(candidatePath: string): Promise<void> {
-  assertContextWorkspaceWriteAllowed(candidatePath);
+  await assertContextWorkspaceWriteAllowed(candidatePath);
   await assertAgentPathAllowed(candidatePath);
   await assertNearestWritableParentAllowed(candidatePath);
 }
@@ -263,10 +295,6 @@ export function sha256Text(content: string): string {
 
 function isEnoent(error: unknown): boolean {
   return Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT');
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function countOccurrences(content: string, needle: string): number {
@@ -1338,12 +1366,11 @@ function findShellWriteRedirectTargets(command: string): string[] {
 function shellRedirectWritesManagedPath(command: string, cdsIntoManagedPath: boolean): boolean {
   const targets = findShellWriteRedirectTargets(command);
   if (targets.length === 0) return false;
-  const executionContext = getAgentExecutionContext();
 
   return targets.some((target) => {
     if (isManagedDataPath(target)) return true;
     if (path.isAbsolute(target)) return false;
-    return cdsIntoManagedPath || Boolean(executionContext);
+    return cdsIntoManagedPath;
   });
 }
 
@@ -1369,8 +1396,7 @@ export function detectUnsafeBashCommand(command: string): string | null {
   const executionContext = getAgentExecutionContext();
   const mentionsManagedPath = /\/data\/(?:workspace|workspaces|agents)(?:\/|$)/.test(normalized) ||
     Boolean(executionContext?.workspaceRoot && normalized.includes(executionContext.workspaceRoot));
-  const cdsIntoManagedPath = /\bcd\s+\/data\/(?:workspace|workspaces|agents)(?:\/|$|\s)/.test(normalized) ||
-    Boolean(executionContext?.workspaceRoot && new RegExp(`\\bcd\\s+${escapeRegExp(executionContext.workspaceRoot)}(?:$|\\s)`).test(normalized));
+  const cdsIntoManagedPath = /\bcd\s+\/data\/(?:workspace|workspaces|agents)(?:\/|$|\s)/.test(normalized);
 
   if (/\bsed\b(?=[^;&|]*\s-[A-Za-z]*i(?:\b|\.|['"]|$))/.test(normalized)) {
     return 'Unsafe in-place file edits with sed are blocked. Use edit_file or apply_patch instead.';
@@ -1380,11 +1406,11 @@ export function detectUnsafeBashCommand(command: string): string | null {
     return 'Unsafe in-place file edits with perl are blocked. Use edit_file or apply_patch instead.';
   }
 
-  if ((mentionsManagedPath || cdsIntoManagedPath || executionContext) && /\btee\b/.test(normalized)) {
+  if ((mentionsManagedPath || cdsIntoManagedPath) && /\btee\b/.test(normalized)) {
     return 'Shell file writes with tee in workspace or agent paths are blocked. Use write, edit_file, or apply_patch instead.';
   }
 
-  if ((mentionsManagedPath || cdsIntoManagedPath || executionContext) && shellRedirectWritesManagedPath(normalized, cdsIntoManagedPath)) {
+  if ((mentionsManagedPath || cdsIntoManagedPath) && shellRedirectWritesManagedPath(normalized, cdsIntoManagedPath)) {
     return 'Shell redirects that write workspace or agent files are blocked. Use write, edit_file, or apply_patch instead.';
   }
 

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -9,6 +9,7 @@ import {
   syncPublicSharesAfterMove,
   syncPublicSharesAfterWrite,
 } from '@/app/lib/public-sharing/public-file-shares';
+import { getAgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
 
 const SNAPSHOT_DIR_NAME = 'agent-file-snapshots';
 const MAX_DIFF_CHARS = 24_000;
@@ -111,6 +112,11 @@ export function getAgentDataRoot(): string {
 }
 
 export function getAgentWorkspaceRoot(): string {
+  const executionContext = getAgentExecutionContext();
+  if (executionContext?.workspaceRoot) {
+    return executionContext.workspaceRoot;
+  }
+
   return path.join(getAgentDataRoot(), 'workspace');
 }
 
@@ -139,6 +145,44 @@ function isPathWithin(candidatePath: string, basePath: string): boolean {
   return normalizedCandidate === normalizedBase || normalizedCandidate.startsWith(`${normalizedBase}${path.sep}`);
 }
 
+function getManagedWorkspaceRoots(): string[] {
+  const dataRoot = getAgentDataRoot();
+  return [
+    path.join(dataRoot, 'workspace'),
+    path.join(dataRoot, 'workspaces'),
+    '/data/workspace',
+    '/data/workspaces',
+  ];
+}
+
+function isManagedWorkspacePath(candidatePath: string): boolean {
+  return getManagedWorkspaceRoots().some((workspaceRoot) => isPathWithin(candidatePath, workspaceRoot));
+}
+
+function assertContextWorkspaceReadAllowed(candidatePath: string): void {
+  const executionContext = getAgentExecutionContext();
+  if (!executionContext) return;
+
+  const resolvedPath = path.resolve(candidatePath);
+  if (isManagedWorkspacePath(resolvedPath) && !isPathWithin(resolvedPath, executionContext.workspaceRoot)) {
+    throw new Error('Agent file access is limited to the workspace bound to this chat session.');
+  }
+}
+
+function assertContextWorkspaceWriteAllowed(candidatePath: string): void {
+  const executionContext = getAgentExecutionContext();
+  if (!executionContext) return;
+
+  const resolvedPath = path.resolve(candidatePath);
+  if (!isPathWithin(resolvedPath, executionContext.workspaceRoot)) {
+    throw new Error('Agent file writes are limited to the workspace bound to this chat session.');
+  }
+
+  if (!executionContext.canWrite) {
+    throw new Error('Agent file writes are disabled for the active workspace.');
+  }
+}
+
 function getProtectedAgentPaths(): string[] {
   const dataRoot = getAgentDataRoot();
   return [
@@ -157,12 +201,15 @@ export function isProtectedAgentPath(candidatePath: string): boolean {
 }
 
 export async function assertAgentPathAllowed(candidatePath: string): Promise<void> {
+  assertContextWorkspaceReadAllowed(candidatePath);
+
   if (isProtectedAgentPath(candidatePath)) {
     throw new Error('Access to this path is restricted for security reasons.');
   }
 
   try {
     const realPath = await fs.realpath(candidatePath);
+    assertContextWorkspaceReadAllowed(realPath);
     if (isProtectedAgentPath(realPath)) {
       throw new Error('Access to this path is restricted for security reasons.');
     }
@@ -197,6 +244,7 @@ async function assertNearestWritableParentAllowed(candidatePath: string): Promis
 }
 
 export async function assertAgentWritablePathAllowed(candidatePath: string): Promise<void> {
+  assertContextWorkspaceWriteAllowed(candidatePath);
   await assertAgentPathAllowed(candidatePath);
   await assertNearestWritableParentAllowed(candidatePath);
 }
@@ -215,6 +263,10 @@ export function sha256Text(content: string): string {
 
 function isEnoent(error: unknown): boolean {
   return Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function countOccurrences(content: string, needle: string): number {
@@ -1243,7 +1295,21 @@ export async function deleteAgentPaths(params: {
 }
 
 function isManagedDataPath(target: string): boolean {
-  return /^\/data\/(?:workspace|agents)(?:\/|$)/.test(target);
+  const normalized = path.isAbsolute(target) ? path.resolve(target) : target;
+  if (/^\/data\/(?:workspace|workspaces|agents)(?:\/|$)/.test(normalized)) {
+    return true;
+  }
+  if (!path.isAbsolute(normalized)) {
+    return false;
+  }
+
+  const dataRoot = getAgentDataRoot();
+  const candidateRoots = [
+    getAgentWorkspaceRoot(),
+    path.join(dataRoot, 'workspaces'),
+    path.join(dataRoot, 'agents'),
+  ];
+  return candidateRoots.some((candidateRoot) => isPathWithin(normalized, candidateRoot));
 }
 
 function stripShellTokenQuotes(token: string): string {
@@ -1272,11 +1338,12 @@ function findShellWriteRedirectTargets(command: string): string[] {
 function shellRedirectWritesManagedPath(command: string, cdsIntoManagedPath: boolean): boolean {
   const targets = findShellWriteRedirectTargets(command);
   if (targets.length === 0) return false;
+  const executionContext = getAgentExecutionContext();
 
   return targets.some((target) => {
     if (isManagedDataPath(target)) return true;
     if (path.isAbsolute(target)) return false;
-    return cdsIntoManagedPath;
+    return cdsIntoManagedPath || Boolean(executionContext);
   });
 }
 
@@ -1299,8 +1366,11 @@ export function detectUnsafeBashCommand(command: string): string | null {
   }
 
   const normalized = command.replace(/\s+/g, ' ').trim();
-  const mentionsManagedPath = /\/data\/(?:workspace|agents)(?:\/|$)/.test(normalized);
-  const cdsIntoManagedPath = /\bcd\s+\/data\/(?:workspace|agents)(?:\/|$|\s)/.test(normalized);
+  const executionContext = getAgentExecutionContext();
+  const mentionsManagedPath = /\/data\/(?:workspace|workspaces|agents)(?:\/|$)/.test(normalized) ||
+    Boolean(executionContext?.workspaceRoot && normalized.includes(executionContext.workspaceRoot));
+  const cdsIntoManagedPath = /\bcd\s+\/data\/(?:workspace|workspaces|agents)(?:\/|$|\s)/.test(normalized) ||
+    Boolean(executionContext?.workspaceRoot && new RegExp(`\\bcd\\s+${escapeRegExp(executionContext.workspaceRoot)}(?:$|\\s)`).test(normalized));
 
   if (/\bsed\b(?=[^;&|]*\s-[A-Za-z]*i(?:\b|\.|['"]|$))/.test(normalized)) {
     return 'Unsafe in-place file edits with sed are blocked. Use edit_file or apply_patch instead.';
@@ -1310,11 +1380,11 @@ export function detectUnsafeBashCommand(command: string): string | null {
     return 'Unsafe in-place file edits with perl are blocked. Use edit_file or apply_patch instead.';
   }
 
-  if ((mentionsManagedPath || cdsIntoManagedPath) && /\btee\b/.test(normalized)) {
-    return 'Shell file writes with tee in /data/workspace or /data/agents are blocked. Use write, edit_file, or apply_patch instead.';
+  if ((mentionsManagedPath || cdsIntoManagedPath || executionContext) && /\btee\b/.test(normalized)) {
+    return 'Shell file writes with tee in workspace or agent paths are blocked. Use write, edit_file, or apply_patch instead.';
   }
 
-  if ((mentionsManagedPath || cdsIntoManagedPath) && shellRedirectWritesManagedPath(normalized, cdsIntoManagedPath)) {
+  if ((mentionsManagedPath || cdsIntoManagedPath || executionContext) && shellRedirectWritesManagedPath(normalized, cdsIntoManagedPath)) {
     return 'Shell redirects that write workspace or agent files are blocked. Use write, edit_file, or apply_patch instead.';
   }
 

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -135,6 +135,14 @@ export type PiRuntimePromptContext = {
   activeFilePath?: string | null;
   userTimeZone?: string;
   currentTime?: string;
+  workspace?: {
+    workspaceId: string;
+    workspaceType: 'personal' | 'team' | 'project';
+    workspaceName: string;
+    organizationId?: string | null;
+    canWrite: boolean;
+    canShare: boolean;
+  };
   planningMode?: boolean;
   currentPage?: string;
   studioContext?: {
@@ -351,6 +359,7 @@ type PiRuntimePromptDispatchTarget = {
   setPageContext: (page: string | undefined) => void;
   setStudioContext: (context: PiRuntimePromptContext['studioContext']) => void;
   setEmailContext: (context: PiRuntimePromptContext['emailContext']) => void;
+  setWorkspaceContext: (context: PiRuntimePromptContext['workspace']) => void;
   reloadTools: () => Promise<void>;
   startPrompt: (message: Extract<AgentMessage, { role: 'user' }>) => void;
 };
@@ -370,6 +379,7 @@ function applyPiRuntimePromptContext(
   runtime.setPageContext(context?.currentPage);
   runtime.setStudioContext(context?.studioContext);
   runtime.setEmailContext(context?.emailContext);
+  runtime.setWorkspaceContext(context?.workspace);
 }
 
 class LivePiRuntime {
@@ -403,6 +413,7 @@ class LivePiRuntime {
   private pageContext: string | null = null;
   private studioContext: PiRuntimePromptContext['studioContext'] | null = null;
   private emailContext: PiRuntimePromptContext['emailContext'] | null = null;
+  private workspaceContext: PiRuntimePromptContext['workspace'] | null = null;
   private persistLock = false;
   private persistPending: 'turn_end' | 'agent_end' | 'error' | null = null;
   private lastBroadcastStatusSignature: string | null = null;
@@ -705,6 +716,10 @@ class LivePiRuntime {
     this.emailContext = context ?? null;
   }
 
+  setWorkspaceContext(context: PiRuntimePromptContext['workspace']) {
+    this.workspaceContext = context ?? null;
+  }
+
   async reloadTools() {
     this.tools = await getPiTools(this.userId, this.agentId, this.sessionId);
     this.lastComposition = null;
@@ -712,12 +727,43 @@ class LivePiRuntime {
   }
 
   private getEffectiveSystemPrompt(): string {
+    const blocks: string[] = [];
     const channelBlock = getChannelSystemPromptBlock(this.channelId);
-    if (!channelBlock || this.systemPrompt.includes(channelBlock)) {
-      return this.systemPrompt;
+    if (channelBlock && !this.systemPrompt.includes(channelBlock)) {
+      blocks.push(channelBlock);
     }
 
-    return `${this.systemPrompt}\n\n${channelBlock}`;
+    const workspaceBlock = this.getWorkspaceContextBlock();
+    if (workspaceBlock) {
+      blocks.push(workspaceBlock);
+    }
+
+    return blocks.length > 0 ? `${this.systemPrompt}\n\n${blocks.join('\n\n')}` : this.systemPrompt;
+  }
+
+  private getWorkspaceContextBlock(): string | null {
+    if (!this.workspaceContext) {
+      return null;
+    }
+
+    const lines = [
+      '## Active Workspace Context',
+      `This chat session is bound to the ${this.workspaceContext.workspaceType} workspace "${this.workspaceContext.workspaceName}".`,
+      `Workspace ID: ${this.workspaceContext.workspaceId}`,
+      'All workspace-relative file paths resolve inside this workspace. Do not switch workspace inside this session; a workspace switch requires a new chat session.',
+    ];
+
+    if (this.workspaceContext.organizationId) {
+      lines.push(`Organization ID: ${this.workspaceContext.organizationId}`);
+    }
+    if (!this.workspaceContext.canWrite) {
+      lines.push('Workspace writes are disabled for this session. Read files only unless the user switches to a workspace with write permission.');
+    }
+    if (!this.workspaceContext.canShare) {
+      lines.push('Public sharing is disabled for this session.');
+    }
+
+    return lines.join('\n');
   }
 
   private getStudioContextBlock(): string | null {

--- a/app/lib/pi/runtime-service.ts
+++ b/app/lib/pi/runtime-service.ts
@@ -16,6 +16,11 @@ import {
 import { getStudioOutputsRoot } from '@/app/lib/integrations/studio-workspace';
 import { normalizeTimeZone } from '@/app/lib/time-zones';
 import { getUserPreferredTimeZone } from '@/app/lib/user-preferences';
+import {
+  ensurePiSessionWorkspaceSnapshot,
+  requestedWorkspaceIdFromChatContext,
+  workspaceToChatRequestWorkspace,
+} from '@/app/lib/pi/session-workspace-context';
 
 export type UserAgentMessage = Extract<AgentMessage, { role: 'user' }>;
 
@@ -95,7 +100,11 @@ export function resolveChatRequestContext(payload: unknown): ChatRequestContext 
     : record as ChatRequestContext;
 }
 
-async function normalizeContext(context: ChatRequestContext | undefined, userId: string): Promise<ChatRequestContext> {
+async function normalizeContext(
+  context: ChatRequestContext | undefined,
+  userId: string,
+  sessionId: string,
+): Promise<ChatRequestContext> {
   let userTimeZone: string;
   try {
     userTimeZone = await getUserPreferredTimeZone(userId);
@@ -104,12 +113,19 @@ async function normalizeContext(context: ChatRequestContext | undefined, userId:
     userTimeZone = normalizeTimeZone(context?.userTimeZone);
   }
 
+  const workspace = await ensurePiSessionWorkspaceSnapshot({
+    sessionId,
+    userId,
+    requestedWorkspaceId: requestedWorkspaceIdFromChatContext(context),
+  });
+
   return {
     channelId: typeof context?.channelId === 'string' ? context.channelId : undefined,
     userTimeZone,
     currentTime: typeof context?.currentTime === 'string' ? context.currentTime : new Date().toISOString(),
     activeFilePath: typeof context?.activeFilePath === 'string' ? context.activeFilePath : null,
     workingDirectory: typeof context?.workingDirectory === 'string' ? context.workingDirectory : undefined,
+    workspace: workspaceToChatRequestWorkspace(workspace),
     planningMode: context?.planningMode === true,
     currentPage: typeof context?.currentPage === 'string' ? context.currentPage : undefined,
     studioContext: context?.studioContext,
@@ -201,6 +217,7 @@ function applyPromptContext(runtimeInstance: RuntimeInstance, context: ChatReque
   runtimeInstance.setPlanningMode(context.planningMode === true);
   runtimeInstance.setPageContext(context.currentPage);
   runtimeInstance.setStudioContext(context.studioContext);
+  runtimeInstance.setWorkspaceContext(context.workspace);
 }
 
 export async function prepareRuntimePrompt(
@@ -213,7 +230,7 @@ export async function prepareRuntimePrompt(
   status: PiRuntimeStatus;
   context: ChatRequestContext;
 }> {
-  const context = await normalizeContext(resolveChatRequestContext(payload), userId);
+  const context = await normalizeContext(resolveChatRequestContext(payload), userId, sessionId);
   const runtimeInstance = await getOrCreatePiRuntime(sessionId, userId);
   const promptMessage = await injectStudioImage(resolvePromptMessage(payload), context);
   const status = runtimeInstance.getStatus();
@@ -230,6 +247,8 @@ export async function prepareRuntimePrompt(
     contextWindow: status.contextWindow,
     hasStudioContext: !!context.studioContext,
     hasEmailContext: !!context.emailContext,
+    workspaceId: context.workspace?.workspaceId,
+    workspaceType: context.workspace?.workspaceType,
     studioOutputPath: context.studioContext?.outputFilePath,
   });
 

--- a/app/lib/pi/runtime-service.ts
+++ b/app/lib/pi/runtime-service.ts
@@ -113,11 +113,21 @@ async function normalizeContext(
     userTimeZone = normalizeTimeZone(context?.userTimeZone);
   }
 
-  const workspace = await ensurePiSessionWorkspaceSnapshot({
-    sessionId,
-    userId,
-    requestedWorkspaceId: requestedWorkspaceIdFromChatContext(context),
-  });
+  let workspace: ChatRequestContext['workspace'] | undefined;
+  try {
+    const resolvedWorkspace = await ensurePiSessionWorkspaceSnapshot({
+      sessionId,
+      userId,
+      requestedWorkspaceId: requestedWorkspaceIdFromChatContext(context),
+    });
+    workspace = workspaceToChatRequestWorkspace(resolvedWorkspace);
+  } catch (error) {
+    console.warn('[RuntimeService] Failed to resolve session workspace context:', {
+      sessionId,
+      userId,
+      error: getErrorMessage(error),
+    });
+  }
 
   return {
     channelId: typeof context?.channelId === 'string' ? context.channelId : undefined,
@@ -125,7 +135,7 @@ async function normalizeContext(
     currentTime: typeof context?.currentTime === 'string' ? context.currentTime : new Date().toISOString(),
     activeFilePath: typeof context?.activeFilePath === 'string' ? context.activeFilePath : null,
     workingDirectory: typeof context?.workingDirectory === 'string' ? context.workingDirectory : undefined,
-    workspace: workspaceToChatRequestWorkspace(workspace),
+    workspace,
     planningMode: context?.planningMode === true,
     currentPage: typeof context?.currentPage === 'string' ? context.currentPage : undefined,
     studioContext: context?.studioContext,

--- a/app/lib/pi/runtime-service.ts
+++ b/app/lib/pi/runtime-service.ts
@@ -250,6 +250,9 @@ export async function prepareRuntimePrompt(
   }
 
   applyPromptContext(runtimeInstance, context);
+  if (!status.canAbort) {
+    await runtimeInstance.reloadTools();
+  }
 
   console.log('[RuntimeService] Runtime status:', {
     sessionId,

--- a/app/lib/pi/session-store.ts
+++ b/app/lib/pi/session-store.ts
@@ -13,6 +13,10 @@ import {
 import { parsePersistedPiMessage, type PiMessageProjectionMode } from './message-projection';
 import { ensureSessionChannelLink } from '@/app/lib/channels/channel-links';
 import { DEFAULT_AGENT_ID, normalizeChannelThreadKey, normalizeStoredChannelId, WEB_CHANNEL_ID, webChannelSessionKey } from '@/app/lib/channels/constants';
+import {
+  resolveAgentSessionWorkspaceForUser,
+  workspaceToPiSessionFields,
+} from '@/app/lib/pi/session-workspace-context';
 
 /**
  * Handles persistence for PI session snapshots (AgentMessage context).
@@ -131,6 +135,7 @@ export async function savePiSession(
 
   if (!session) {
     const promptSnapshot = options?.systemPromptSnapshot ?? await createPiSystemPromptSnapshot(agentId);
+    const workspace = await resolveAgentSessionWorkspaceForUser({ userId });
     const [inserted] = await db.insert(piSessions).values({
       sessionId,
       userId,
@@ -144,6 +149,7 @@ export async function savePiSession(
       updatedAt: new Date(),
       lastMessageAt: lastMessageAt,
       lastViewedAt: null,
+      ...workspaceToPiSessionFields(workspace),
       ...piSystemPromptSnapshotDbFields(promptSnapshot),
       ...summaryFields,
     }).returning({ id: piSessions.id });
@@ -154,6 +160,9 @@ export async function savePiSession(
     const promptSnapshotFields = session.systemPromptSnapshot
       ? {}
       : piSystemPromptSnapshotDbFields(options?.systemPromptSnapshot ?? await createPiSystemPromptSnapshot(agentId));
+    const workspaceFields = session.workspaceId
+      ? {}
+      : workspaceToPiSessionFields(await resolveAgentSessionWorkspaceForUser({ userId }));
 
     await db.update(piSessions)
       .set({ 
@@ -162,6 +171,7 @@ export async function savePiSession(
         provider,
         model,
         lastMessageAt: lastMessageAt,
+        ...workspaceFields,
         ...promptSnapshotFields,
         ...summaryFields 
       })

--- a/app/lib/pi/session-workspace-context.ts
+++ b/app/lib/pi/session-workspace-context.ts
@@ -1,0 +1,274 @@
+import 'server-only';
+
+import Database from 'better-sqlite3';
+import { and, eq } from 'drizzle-orm';
+import path from 'node:path';
+
+import type { ChatRequestContext } from '@/app/lib/chat/types';
+import { db } from '@/app/lib/db';
+import { piSessions } from '@/app/lib/db/schema';
+import {
+  ensureOrganizationBootstrapForUser,
+} from '@/app/lib/organization/bootstrap';
+import {
+  LEGACY_PERSONAL_WORKSPACE_ID,
+  createLegacyPersonalWorkspaceContext,
+  resolveWorkspaceActor,
+  resolveWorkspaceDataRoot,
+} from '@/app/lib/workspaces/context';
+import { assertWorkspacePermission } from '@/app/lib/workspaces/permissions';
+import {
+  ensureDefaultWorkspaceRecords,
+  resolveDefaultWorkspaceContext,
+  resolveWorkspaceContextById,
+} from '@/app/lib/workspaces/service';
+import type { WorkspaceContext, WorkspacePermissions, WorkspaceType } from '@/app/lib/workspaces/types';
+import type { AgentExecutionContext } from './agent-execution-context';
+
+export type WorkspacePermissionRequirement = keyof WorkspacePermissions;
+
+export type PiSessionWorkspaceFields = {
+  organizationId: string | null;
+  workspaceId: string;
+  workspaceType: WorkspaceType;
+  workspaceName: string | null;
+  workspaceRootRelativePath: string | null;
+};
+
+type UserRow = {
+  id: string;
+  email: string | null;
+  role: string | null;
+};
+
+type OrganizationRow = {
+  organization_id: string;
+  team_features_enabled: number;
+};
+
+type StoredPiSessionWorkspace = {
+  workspaceId: string | null;
+  workspaceType: string | null;
+  workspaceName: string | null;
+  workspaceRootRelativePath: string | null;
+  organizationId: string | null;
+};
+
+const DEFAULT_AGENT_SESSION_PERMISSIONS: WorkspacePermissionRequirement[] = ['canRead', 'canRunAgent'];
+
+function openWorkspaceContextDatabase(): Database.Database {
+  const sqlite = new Database(path.join(resolveWorkspaceDataRoot(), 'sqlite.db'));
+  sqlite.pragma('foreign_keys = ON');
+  sqlite.pragma('busy_timeout = 5000');
+  return sqlite;
+}
+
+function getUserRow(sqlite: Database.Database, userId: string): UserRow | null {
+  return sqlite.prepare(`
+    SELECT id, email, role
+    FROM user
+    WHERE id = ?
+    LIMIT 1
+  `).get(userId) as UserRow | undefined || null;
+}
+
+function getPrimaryOrganizationRow(sqlite: Database.Database): OrganizationRow | null {
+  return sqlite.prepare(`
+    SELECT organization_id, team_features_enabled
+    FROM canvas_organization_settings
+    ORDER BY created_at ASC
+    LIMIT 1
+  `).get() as OrganizationRow | undefined || null;
+}
+
+function ensureWorkspaceRecordsForExistingOrganization(
+  sqlite: Database.Database,
+  organization: OrganizationRow,
+  userId: string,
+): void {
+  ensureDefaultWorkspaceRecords(sqlite, {
+    organizationId: organization.organization_id,
+    userId,
+    teamFeaturesEnabled: organization.team_features_enabled === 1,
+  });
+}
+
+function assertPermissions(
+  workspace: WorkspaceContext,
+  requirements: WorkspacePermissionRequirement[] = DEFAULT_AGENT_SESSION_PERMISSIONS,
+): void {
+  for (const requirement of requirements) {
+    assertWorkspacePermission(workspace.permissions, requirement);
+  }
+}
+
+function normalizeWorkspaceType(value: string | null | undefined): WorkspaceType {
+  if (value === 'team' || value === 'project') return value;
+  return 'personal';
+}
+
+function normalizeRequestedWorkspaceId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function requestedWorkspaceIdFromChatContext(context?: ChatRequestContext | null): string | null {
+  return normalizeRequestedWorkspaceId(context?.workspace?.workspaceId);
+}
+
+export function workspaceToPiSessionFields(workspace: WorkspaceContext): PiSessionWorkspaceFields {
+  return {
+    organizationId: workspace.organizationId ?? null,
+    workspaceId: workspace.workspaceId,
+    workspaceType: workspace.workspaceType,
+    workspaceName: workspace.displayName ?? null,
+    workspaceRootRelativePath: workspace.rootRelativePath ?? null,
+  };
+}
+
+export function workspaceToChatRequestWorkspace(workspace: WorkspaceContext): NonNullable<ChatRequestContext['workspace']> {
+  return {
+    workspaceId: workspace.workspaceId,
+    workspaceType: workspace.workspaceType,
+    workspaceName: workspace.displayName || (workspace.workspaceType === 'team' ? 'Team Workspace' : 'Personal Workspace'),
+    organizationId: workspace.organizationId ?? null,
+    canWrite: workspace.permissions.canWrite,
+    canShare: workspace.permissions.canCreatePublicLinks,
+  };
+}
+
+export function storedPiSessionWorkspaceToSummary(row: StoredPiSessionWorkspace | null | undefined) {
+  if (!row?.workspaceId) return null;
+  return {
+    workspaceId: row.workspaceId,
+    workspaceType: normalizeWorkspaceType(row.workspaceType),
+    workspaceName: row.workspaceName || (row.workspaceType === 'team' ? 'Team Workspace' : 'Personal Workspace'),
+    organizationId: row.organizationId ?? null,
+    rootRelativePath: row.workspaceRootRelativePath ?? null,
+    legacy: row.workspaceId === LEGACY_PERSONAL_WORKSPACE_ID,
+  };
+}
+
+export async function resolveAgentSessionWorkspaceForUser(input: {
+  userId: string;
+  workspaceId?: string | null;
+  permissions?: WorkspacePermissionRequirement[];
+}): Promise<WorkspaceContext> {
+  const requestedWorkspaceId = normalizeRequestedWorkspaceId(input.workspaceId);
+
+  if (requestedWorkspaceId === LEGACY_PERSONAL_WORKSPACE_ID) {
+    const legacyWorkspace = createLegacyPersonalWorkspaceContext(resolveWorkspaceActor({ id: input.userId }));
+    assertPermissions(legacyWorkspace, input.permissions);
+    return legacyWorkspace;
+  }
+
+  const sqlite = openWorkspaceContextDatabase();
+  try {
+    sqlite.exec('BEGIN IMMEDIATE');
+    let organization = getPrimaryOrganizationRow(sqlite);
+    if (organization) {
+      ensureWorkspaceRecordsForExistingOrganization(sqlite, organization, input.userId);
+    } else {
+      const status = ensureOrganizationBootstrapForUser(sqlite, input.userId);
+      organization = status.organizationId
+        ? {
+          organization_id: status.organizationId,
+          team_features_enabled: status.teamFeaturesEnabled ? 1 : 0,
+        }
+        : null;
+    }
+
+    const userRow = getUserRow(sqlite, input.userId);
+    if (!organization || !userRow) {
+      sqlite.exec('ROLLBACK');
+      throw new Error('Organization workspace context is not configured for this user.');
+    }
+
+    const actor = resolveWorkspaceActor({
+      id: userRow.id,
+      email: userRow.email,
+      role: userRow.role,
+    });
+
+    const workspace = requestedWorkspaceId
+      ? resolveWorkspaceContextById(sqlite, { actor, workspaceId: requestedWorkspaceId })
+      : resolveDefaultWorkspaceContext(sqlite, { actor, organizationId: organization.organization_id });
+
+    sqlite.exec('COMMIT');
+
+    if (!workspace) {
+      throw new Error('Workspace not found or inaccessible.');
+    }
+
+    assertPermissions(workspace, input.permissions);
+    return workspace;
+  } catch (error) {
+    if (sqlite.inTransaction) {
+      sqlite.exec('ROLLBACK');
+    }
+    throw error;
+  } finally {
+    sqlite.close();
+  }
+}
+
+export async function ensurePiSessionWorkspaceSnapshot(input: {
+  sessionId: string;
+  userId: string;
+  agentId?: string | null;
+  requestedWorkspaceId?: string | null;
+  permissions?: WorkspacePermissionRequirement[];
+}): Promise<WorkspaceContext> {
+  const session = await db.query.piSessions.findFirst({
+    where: and(
+      eq(piSessions.sessionId, input.sessionId),
+      eq(piSessions.userId, input.userId),
+      ...(input.agentId ? [eq(piSessions.agentId, input.agentId)] : []),
+    ),
+  });
+
+  const workspace = await resolveAgentSessionWorkspaceForUser({
+    userId: input.userId,
+    workspaceId: session?.workspaceId || input.requestedWorkspaceId || null,
+    permissions: input.permissions,
+  });
+
+  if (session) {
+    await db
+      .update(piSessions)
+      .set({
+        ...workspaceToPiSessionFields(workspace),
+        updatedAt: new Date(),
+      })
+      .where(eq(piSessions.id, session.id));
+  }
+
+  return workspace;
+}
+
+export async function resolveAgentExecutionContextForSession(input: {
+  sessionId: string;
+  userId: string;
+  agentId?: string | null;
+}): Promise<AgentExecutionContext> {
+  const workspace = await ensurePiSessionWorkspaceSnapshot({
+    sessionId: input.sessionId,
+    userId: input.userId,
+    agentId: input.agentId,
+  });
+
+  return {
+    userId: input.userId,
+    sessionId: input.sessionId,
+    workspaceId: workspace.workspaceId,
+    workspaceType: workspace.workspaceType,
+    workspaceName: workspace.displayName ?? null,
+    organizationId: workspace.organizationId ?? null,
+    workspaceRoot: workspace.rootPath,
+    workspaceRootRelativePath: workspace.rootRelativePath ?? null,
+    canWrite: workspace.permissions.canWrite,
+    canShare: workspace.permissions.canCreatePublicLinks,
+    legacy: workspace.legacy,
+  };
+}

--- a/app/lib/pi/session-workspace-context.ts
+++ b/app/lib/pi/session-workspace-context.ts
@@ -54,12 +54,32 @@ type StoredPiSessionWorkspace = {
   organizationId: string | null;
 };
 
+type PiSessionWorkspaceSnapshotRow = {
+  organizationId: string | null;
+  workspaceId: string | null;
+  workspaceType: string | null;
+  workspaceName: string | null;
+  workspaceRootRelativePath: string | null;
+};
+
 const DEFAULT_AGENT_SESSION_PERMISSIONS: WorkspacePermissionRequirement[] = ['canRead', 'canRunAgent'];
 
+let workspaceContextDatabase: { sqlitePath: string; sqlite: Database.Database } | null = null;
+
 function openWorkspaceContextDatabase(): Database.Database {
-  const sqlite = new Database(path.join(resolveWorkspaceDataRoot(), 'sqlite.db'));
+  const sqlitePath = path.join(resolveWorkspaceDataRoot(), 'sqlite.db');
+  if (workspaceContextDatabase?.sqlitePath === sqlitePath && workspaceContextDatabase.sqlite.open) {
+    return workspaceContextDatabase.sqlite;
+  }
+
+  if (workspaceContextDatabase?.sqlite.open) {
+    workspaceContextDatabase.sqlite.close();
+  }
+
+  const sqlite = new Database(sqlitePath);
   sqlite.pragma('foreign_keys = ON');
   sqlite.pragma('busy_timeout = 5000');
+  workspaceContextDatabase = { sqlitePath, sqlite };
   return sqlite;
 }
 
@@ -138,6 +158,17 @@ export function workspaceToChatRequestWorkspace(workspace: WorkspaceContext): No
   };
 }
 
+function piSessionWorkspaceFieldsChanged(
+  session: PiSessionWorkspaceSnapshotRow,
+  fields: PiSessionWorkspaceFields,
+): boolean {
+  return session.organizationId !== fields.organizationId ||
+    session.workspaceId !== fields.workspaceId ||
+    session.workspaceType !== fields.workspaceType ||
+    session.workspaceName !== fields.workspaceName ||
+    session.workspaceRootRelativePath !== fields.workspaceRootRelativePath;
+}
+
 export function storedPiSessionWorkspaceToSummary(row: StoredPiSessionWorkspace | null | undefined) {
   if (!row?.workspaceId) return null;
   return {
@@ -208,8 +239,6 @@ export async function resolveAgentSessionWorkspaceForUser(input: {
       sqlite.exec('ROLLBACK');
     }
     throw error;
-  } finally {
-    sqlite.close();
   }
 }
 
@@ -234,11 +263,12 @@ export async function ensurePiSessionWorkspaceSnapshot(input: {
     permissions: input.permissions,
   });
 
-  if (session) {
+  const workspaceFields = workspaceToPiSessionFields(workspace);
+  if (session && piSessionWorkspaceFieldsChanged(session, workspaceFields)) {
     await db
       .update(piSessions)
       .set({
-        ...workspaceToPiSessionFields(workspace),
+        ...workspaceFields,
         updatedAt: new Date(),
       })
       .where(eq(piSessions.id, session.id));

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -125,9 +125,22 @@ import {
   MAX_AUDIO_TRANSCRIPTION_BYTES,
   transcribeAudio,
 } from '@/app/lib/integrations/audio-transcription-service';
+import { runWithAgentExecutionContext, type AgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
+import { resolveAgentExecutionContextForSession } from '@/app/lib/pi/session-workspace-context';
 
 
 const execAsync = promisify(exec);
+
+function wrapToolWithExecutionContext(tool: AgentTool, context: AgentExecutionContext): AgentTool {
+  const execute = tool.execute;
+  return {
+    ...tool,
+    execute: (toolCallId, params, signal) => runWithAgentExecutionContext(
+      context,
+      () => execute(toolCallId, params, signal),
+    ),
+  };
+}
 
 const DEFAULT_READ_TEXT_LIMIT = 40_000;
 const MAX_READ_TEXT_LIMIT = 120_000;
@@ -2390,9 +2403,7 @@ export const piTools: AgentTool[] = [
   {
     name: 'bash',
     label: 'Executing command',
-    // NOTE: cwd is intentionally '/' (not restricted to workspace) so the agent
-    // can run commands in /data/agents/canvas-agent or any other path it needs.
-    description: 'Executes a bash command. Not restricted to workspace — use cd or absolute paths as needed.',
+    description: 'Executes a bash command from the workspace bound to the current chat session. Prefer file tools for writes.',
     parameters: Type.Object({
       command: Type.String({ description: 'The command to execute.' }),
     }),
@@ -2402,7 +2413,7 @@ export const piTools: AgentTool[] = [
         throwIfAborted(signal);
         assertBashCommandAllowed(command);
         const { stdout, stderr } = await execAsync(command, {
-          cwd: '/',
+          cwd: getAgentWorkspaceRoot(),
           env: filterSafeEnv(process.env) as NodeJS.ProcessEnv,
           signal,
         });
@@ -3351,6 +3362,15 @@ export async function getPiTools(userId?: string, agentId?: string | null, sessi
     if (onboardingProfileToolAvailable && !allTools.some((tool) => tool.name === ONBOARDING_PROFILE_TOOL_NAME)) {
       allTools.push(createOnboardingProfileTool(userId, agentId, sessionId));
     }
+  }
+
+  if (userId && sessionId) {
+    const executionContext = await resolveAgentExecutionContextForSession({
+      userId,
+      sessionId,
+      agentId,
+    });
+    return allTools.map((tool) => wrapToolWithExecutionContext(tool, executionContext));
   }
 
   return allTools;

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -3365,11 +3365,18 @@ export async function getPiTools(userId?: string, agentId?: string | null, sessi
   }
 
   if (userId && sessionId) {
-    const executionContext = await resolveAgentExecutionContextForSession({
-      userId,
-      sessionId,
-      agentId,
-    });
+    let executionContext: AgentExecutionContext;
+    try {
+      executionContext = await resolveAgentExecutionContextForSession({
+        userId,
+        sessionId,
+        agentId,
+      });
+    } catch (error) {
+      console.error('[ToolRegistry] Failed to resolve workspace execution context; disabling tools for this session:', error);
+      return [];
+    }
+
     return allTools.map((tool) => wrapToolWithExecutionContext(tool, executionContext));
   }
 

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -3373,7 +3373,7 @@ export async function getPiTools(userId?: string, agentId?: string | null, sessi
         agentId,
       });
     } catch (error) {
-      console.error('[ToolRegistry] Failed to resolve workspace execution context; disabling tools for this session:', error);
+      console.error('[ToolRegistry] Failed to resolve workspace execution context; disabling tools until the next reload:', error);
       return [];
     }
 

--- a/docs/architecture/canvas-notebook/team-workspace/README.md
+++ b/docs/architecture/canvas-notebook/team-workspace/README.md
@@ -63,4 +63,5 @@ Dieses Verzeichnis ist der zentrale Arbeitsbereich fuer den Team-Workspace-Umbau
 - Personal Workspaces werden pro User angelegt; Team Workspace wird nur in teamfaehigen Deployment Modes angelegt.
 - Globaler Workspace-Switcher, Workspace-Badge, clientseitiger Workspace-Store und Chat-Neustart bei Workspace-Wechsel sind eingefuehrt.
 - Kopieraktionen zwischen Personal und Team Workspace sind fuer File Browser und Studio-Importe umgesetzt.
-- Naechster Schritt: Agent-Runtime-Einstellungen und Agent-Sessions an User-/Workspace-Kontext binden.
+- Agent-Runtime-Einstellungen und Agent-Sessions sind an User-/Workspace-Kontext gebunden.
+- Naechster Schritt: Plugins, Skills und Agent-Definitionen auf User-Scope mit optionaler Organization-Teilung migrieren.

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -221,7 +221,7 @@
     {
       "id": 16,
       "title": "Agent-Runtime-Einstellungen und Agent-Sessions an User-/Workspace-Kontext binden",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/05-actor-audit-retention.md",
@@ -230,6 +230,17 @@
         "docs/architecture/canvas-notebook/team-workspace/08-user-scoped-secrets-runtime.md",
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md",
         "docs/architecture/canvas-notebook/team-workspace/10-agent-tool-execution-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/pi/session-workspace-context.ts",
+        "app/lib/pi/agent-execution-context.ts",
+        "app/lib/pi/agent-file-operations.ts",
+        "app/lib/pi/runtime-service.ts",
+        "app/lib/pi/live-runtime.ts",
+        "app/lib/pi/tool-registry.ts",
+        "app/lib/channels/session-resolver.ts",
+        "app/api/sessions/route.ts",
+        "scripts/agent-session-workspace-context-test.ts"
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:workspace:model": "tsx --conditions react-server scripts/workspace-model-service-test.ts",
     "test:workspace:switcher-ui": "tsx scripts/workspace-switcher-ui-test.ts",
     "test:workspace:cross-copy": "tsx --conditions react-server scripts/workspace-cross-copy-test.ts",
+    "test:agent:session-workspace": "tsx --conditions react-server scripts/agent-session-workspace-context-test.ts",
     "test:e2e": "playwright test --pass-with-no-tests",
     "test:all": "node scripts/test-all.mjs",
     "test:websocket:connection": "node scripts/test-websocket-connection.js",

--- a/scripts/agent-session-workspace-context-test.ts
+++ b/scripts/agent-session-workspace-context-test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+async function main() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-agent-session-workspace-'));
+  const dataRoot = path.join(tempRoot, 'data');
+  process.env.DATA = dataRoot;
+  process.env.CANVAS_DEPLOYMENT_MODE = 'managed-team';
+  process.env.CANVAS_DATABASE_PROVIDER = 'postgres';
+
+  try {
+    await fs.mkdir(dataRoot, { recursive: true });
+
+    const { db } = await import('../app/lib/db');
+    const { user, piSessions } = await import('../app/lib/db/schema');
+    const {
+      resolveAgentExecutionContextForSession,
+      resolveAgentSessionWorkspaceForUser,
+      workspaceToPiSessionFields,
+    } = await import('../app/lib/pi/session-workspace-context');
+    const {
+      getAgentWorkspaceRoot,
+      writeAgentTextFile,
+      assertAgentPathAllowed,
+    } = await import('../app/lib/pi/agent-file-operations');
+    const { runWithAgentExecutionContext } = await import('../app/lib/pi/agent-execution-context');
+
+    const now = new Date();
+    const userId = 'user-agent-workspace';
+    await db.insert(user).values({
+      id: userId,
+      name: 'Agent Workspace Tester',
+      email: 'agent-workspace@example.test',
+      emailVerified: true,
+      image: null,
+      role: 'admin',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const workspace = await resolveAgentSessionWorkspaceForUser({ userId });
+    assert.equal(workspace.workspaceType, 'personal');
+    assert.equal(workspace.permissions.canRead, true);
+    assert.equal(workspace.permissions.canWrite, true);
+    assert.equal(workspace.rootPath, path.join(dataRoot, 'workspaces', 'personal', userId, 'files'));
+    await fs.access(workspace.rootPath);
+
+    const sessionId = 'sess-agent-workspace';
+    await db.insert(piSessions).values({
+      sessionId,
+      userId,
+      agentId: 'canvas-agent',
+      provider: 'test-provider',
+      model: 'test-model',
+      thinkingLevel: 'off',
+      title: 'Workspace-bound session',
+      channelId: 'app',
+      channelSessionKey: null,
+      createdAt: now,
+      updatedAt: now,
+      ...workspaceToPiSessionFields(workspace),
+    });
+
+    const executionContext = await resolveAgentExecutionContextForSession({
+      sessionId,
+      userId,
+      agentId: 'canvas-agent',
+    });
+    assert.equal(executionContext.workspaceId, workspace.workspaceId);
+    assert.equal(executionContext.workspaceRoot, workspace.rootPath);
+
+    await runWithAgentExecutionContext(executionContext, async () => {
+      assert.equal(getAgentWorkspaceRoot(), workspace.rootPath);
+
+      const result = await writeAgentTextFile({
+        path: 'notes/context.md',
+        content: '# Session Workspace\n',
+      });
+      assert.equal(result.resolvedPath, path.join(workspace.rootPath, 'notes', 'context.md'));
+      assert.equal(await fs.readFile(result.resolvedPath, 'utf8'), '# Session Workspace\n');
+
+      await assert.rejects(
+        () => assertAgentPathAllowed(path.join(dataRoot, 'workspaces', 'personal', 'other-user', 'files', 'secret.md')),
+        /limited to the workspace bound to this chat session/,
+      );
+
+      await assert.rejects(
+        () => writeAgentTextFile({
+          path: path.join(dataRoot, 'workspaces', 'personal', 'other-user', 'files', 'secret.md'),
+          content: 'blocked',
+        }),
+        /limited to the workspace bound to this chat session/,
+      );
+    });
+
+    console.log('agent-session-workspace-context-test: ok');
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+void main();

--- a/scripts/agent-session-workspace-context-test.ts
+++ b/scripts/agent-session-workspace-context-test.ts
@@ -21,6 +21,7 @@ async function main() {
       workspaceToPiSessionFields,
     } = await import('../app/lib/pi/session-workspace-context');
     const {
+      detectUnsafeBashCommand,
       getAgentWorkspaceRoot,
       writeAgentTextFile,
       assertAgentPathAllowed,
@@ -73,6 +74,8 @@ async function main() {
 
     await runWithAgentExecutionContext(executionContext, async () => {
       assert.equal(getAgentWorkspaceRoot(), workspace.rootPath);
+      assert.equal(detectUnsafeBashCommand('./run-tests.sh > results.txt'), null);
+      assert.equal(detectUnsafeBashCommand('npm run build 2>&1 | tee build.log'), null);
 
       const result = await writeAgentTextFile({
         path: 'notes/context.md',
@@ -89,6 +92,17 @@ async function main() {
       await assert.rejects(
         () => writeAgentTextFile({
           path: path.join(dataRoot, 'workspaces', 'personal', 'other-user', 'files', 'secret.md'),
+          content: 'blocked',
+        }),
+        /limited to the workspace bound to this chat session/,
+      );
+
+      const outsideRoot = path.join(tempRoot, 'outside');
+      await fs.mkdir(outsideRoot, { recursive: true });
+      await fs.symlink(outsideRoot, path.join(workspace.rootPath, 'evil-link'));
+      await assert.rejects(
+        () => writeAgentTextFile({
+          path: 'evil-link/secret.txt',
           content: 'blocked',
         }),
         /limited to the workspace bound to this chat session/,


### PR DESCRIPTION
## Summary
- persist organization/workspace context on PI sessions and return it in session history
- bind runtime prompts and tool execution to the stored session workspace
- enforce workspace-scoped file reads/writes for agent file tools and run bash from the session workspace
- mark Task 16 complete in the architecture todo source
- address Greptile feedback on bash write guards, SQLite connection reuse, redundant session updates, symlink-safe write validation, and workspace-resolution fallback behavior

## Verification
- npm run test:agent:session-workspace
- npm run test:workspace:model
- npm run test:channels:db (passes; logs existing missing local plugin skill under /data/plugins/...)
- npm run lint
- npm run build
- GitHub CodeQL / Analyze checks passed on head 5c107656

## Greptile / greploop
- Initial Greptile review: 3/5 with four actionable issues
- Fixed initial issues in 395feb7c and resolved Greptile review threads
- Follow-up Greptile review reached 5/5 on 395feb7c, then opened one additional P1 thread
- Fixed the additional P1 in 5c107656 and resolved its review thread
- Triggered Greptile once for head 5c107656; awaiting an updated 4/5+ score before merge