### PR TITLE
Add user-scoped agent storage foundation

### DIFF
--- a/app/api/agents/doctor/route.ts
+++ b/app/api/agents/doctor/route.ts
@@ -30,9 +30,12 @@ async function requireSession(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const { response } = await requireSession(request);
+  const { session, response } = await requireSession(request);
   if (response) {
     return response;
+  }
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
   }
 
   const limited = rateLimit(request, {
@@ -50,7 +53,7 @@ export async function POST(request: NextRequest) {
     // buildAgentConfigReadiness no longer requires a config parameter
     const [readiness, promptResult, qmd] = await Promise.all([
       buildAgentConfigReadiness(),
-      loadManagedAgentSystemPrompt(agentId),
+      loadManagedAgentSystemPrompt(agentId, { userId: session.user.id }),
       getQmdDoctorStatus(),
     ]);
     const { diagnostics } = promptResult;

--- a/app/api/agents/files/route.ts
+++ b/app/api/agents/files/route.ts
@@ -45,9 +45,12 @@ function isInheritedFileForAgent(fileName: AgentManagedFileName, agentId?: strin
 }
 
 export async function GET(request: NextRequest) {
-  const { response } = await requireSession(request);
+  const { session, response } = await requireSession(request);
   if (response) {
     return response;
+  }
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
   }
 
   const limited = rateLimit(request, {
@@ -61,7 +64,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const agentId = request.nextUrl.searchParams.get('agentId');
-    const files = await readManagedAgentFiles(agentId);
+    const files = await readManagedAgentFiles(agentId, { userId: session.user.id });
     return NextResponse.json({
       success: true,
       data: { files },
@@ -74,9 +77,12 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
-  const { response } = await requireSession(request);
+  const { session, response } = await requireSession(request);
   if (response) {
     return response;
+  }
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
   }
 
   const limited = rateLimit(request, {
@@ -110,7 +116,7 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ success: false, error: `${fileName} is inherited from the Canvas Agent and cannot be edited for specialized agents.` }, { status: 400 });
     }
 
-    const content = await writeManagedAgentFile(fileName, payload.content, agentId);
+    const content = await writeManagedAgentFile(fileName, payload.content, agentId, { userId: session.user.id });
     return NextResponse.json({
       success: true,
       data: {
@@ -127,9 +133,12 @@ export async function PUT(request: NextRequest) {
 
 // POST /api/agents/files - Reset to seed
 export async function POST(request: NextRequest) {
-  const { response } = await requireSession(request);
+  const { session, response } = await requireSession(request);
   if (response) {
     return response;
+  }
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
   }
 
   const limited = rateLimit(request, {
@@ -169,7 +178,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ success: false, error: `${fileName} is inherited from the Canvas Agent and cannot be reset for specialized agents.` }, { status: 400 });
       }
 
-      const content = await resetManagedAgentFile(fileName, agentId);
+      const content = await resetManagedAgentFile(fileName, agentId, { userId: session.user.id });
 
       return NextResponse.json({
         success: true,
@@ -187,7 +196,7 @@ export async function POST(request: NextRequest) {
         : SPECIAL_AGENT_MANAGED_FILE_NAMES;
 
       for (const fileName of fileNames) {
-        const content = await resetManagedAgentFile(fileName, agentId);
+        const content = await resetManagedAgentFile(fileName, agentId, { userId: session.user.id });
         results.push({ fileName, content });
       }
 

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -77,12 +77,13 @@ function managedFilesValue(value: unknown): Partial<Record<AgentManagedFileName,
 async function writeInitialAgentFiles(
   agentId: string,
   files: Partial<Record<AgentManagedFileName, string>>,
+  userId: string,
 ): Promise<void> {
   for (const [fileName, content] of Object.entries(files)) {
     if (!isManagedAgentFileName(fileName) || !isWritableManagedAgentFileName(fileName, agentId)) {
       continue;
     }
-    await writeManagedAgentFile(fileName, content ?? '', agentId);
+    await writeManagedAgentFile(fileName, content ?? '', agentId, { userId });
   }
 }
 
@@ -114,7 +115,7 @@ export async function POST(request: NextRequest) {
       relevantSkills: stringArrayValue(payload.relevantSkills),
       relevantConnections: stringArrayValue(payload.relevantConnections),
     });
-    await writeInitialAgentFiles(agent.agentId, managedFilesValue(payload.files));
+    await writeInitialAgentFiles(agent.agentId, managedFilesValue(payload.files), session.user.id);
     return NextResponse.json({ success: true, data: { agent } });
   } catch (error) {
     return NextResponse.json(

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -420,7 +420,7 @@ export async function POST(request: NextRequest) {
 
       const model = requestedModel || providerConfig?.model || 'unknown';
       const thinkingLevel = requestedThinkingLevel || providerConfig?.thinking || 'off';
-      const promptSnapshot = await createPiSystemPromptSnapshot(requestedAgentId);
+      const promptSnapshot = await createPiSystemPromptSnapshot(requestedAgentId, { userId: session.user.id });
       const channelId = typeof payload.channelId === 'string' ? payload.channelId : 'app';
       const normalizedChannelId = normalizeStoredChannelId(channelId);
       const channelSessionKey = typeof payload.channelSessionKey === 'string'

--- a/app/lib/agents/memory-store.ts
+++ b/app/lib/agents/memory-store.ts
@@ -5,6 +5,7 @@ import {
   readManagedAgentFile,
   writeManagedAgentFile,
   type AgentManagedFileName,
+  type AgentStorageScope,
 } from './storage';
 
 export type MemoryTarget = 'agent' | 'user';
@@ -28,6 +29,10 @@ export type MemoryMutationResult = MemoryReadResult & {
   changed: boolean;
   entry?: MemoryEntry;
   deletedEntry?: MemoryEntry;
+};
+
+type MemoryScopeParams = {
+  userId?: string | null;
 };
 
 type ParsedMemoryFile = {
@@ -153,10 +158,18 @@ function createMemoryId(content: string, existingIds: Set<string>): string {
   throw new Error('Could not create a unique memory id.');
 }
 
-async function readParsedMemory(target: MemoryTarget, agentId?: string | null) {
+function resolveMemoryStorageScope(params?: MemoryScopeParams | null): AgentStorageScope | null {
+  return params?.userId ? { userId: params.userId } : null;
+}
+
+async function readParsedMemory(
+  target: MemoryTarget,
+  agentId?: string | null,
+  scope?: AgentStorageScope | null,
+) {
   const { fileName, limit } = resolveMemoryFile(target);
   const storageAgentId = resolveStorageAgentId(target, agentId);
-  const rawContent = await readManagedAgentFile(fileName as AgentManagedFileName, storageAgentId);
+  const rawContent = await readManagedAgentFile(fileName as AgentManagedFileName, storageAgentId, scope);
   const parsed = parseMemoryFile(rawContent);
   return { fileName, limit, storageAgentId, parsed };
 }
@@ -166,10 +179,11 @@ async function writeParsedMemory(
   fileName: 'MEMORY.md' | 'USER.md',
   limit: number,
   parsed: ParsedMemoryFile,
+  scope?: AgentStorageScope | null,
 ): Promise<string> {
   const content = serializeMemoryFile(parsed);
   assertWithinLimit(content, limit);
-  return writeManagedAgentFile(fileName as AgentManagedFileName, content, agentId);
+  return writeManagedAgentFile(fileName as AgentManagedFileName, content, agentId, scope);
 }
 
 function toReadResult(
@@ -190,8 +204,12 @@ function toReadResult(
   };
 }
 
-export async function readMemory(params: { target: MemoryTarget; agentId?: string | null }): Promise<MemoryReadResult> {
-  const { fileName, limit, storageAgentId, parsed } = await readParsedMemory(params.target, params.agentId);
+export async function readMemory(params: {
+  target: MemoryTarget;
+  agentId?: string | null;
+} & MemoryScopeParams): Promise<MemoryReadResult> {
+  const scope = resolveMemoryStorageScope(params);
+  const { fileName, limit, storageAgentId, parsed } = await readParsedMemory(params.target, params.agentId, scope);
   return toReadResult(params.target, storageAgentId, fileName, limit, parsed);
 }
 
@@ -199,9 +217,10 @@ export async function addMemory(params: {
   target: MemoryTarget;
   agentId?: string | null;
   content: string;
-}): Promise<MemoryMutationResult> {
+} & MemoryScopeParams): Promise<MemoryMutationResult> {
   const content = assertValidEntryContent(params.content);
-  const { fileName, limit, storageAgentId, parsed } = await readParsedMemory(params.target, params.agentId);
+  const scope = resolveMemoryStorageScope(params);
+  const { fileName, limit, storageAgentId, parsed } = await readParsedMemory(params.target, params.agentId, scope);
   const normalized = normalizeForDedupe(content);
   const existing = parsed.entries.find((entry) => normalizeForDedupe(entry.content) === normalized);
 
@@ -221,7 +240,7 @@ export async function addMemory(params: {
     ...parsed,
     entries: [...parsed.entries, entry],
   };
-  const writtenContent = await writeParsedMemory(storageAgentId, fileName, limit, next);
+  const writtenContent = await writeParsedMemory(storageAgentId, fileName, limit, next, scope);
 
   return {
     ...toReadResult(params.target, storageAgentId, fileName, limit, next, writtenContent),
@@ -235,14 +254,15 @@ export async function updateMemory(params: {
   agentId?: string | null;
   id: string;
   content: string;
-}): Promise<MemoryMutationResult> {
+} & MemoryScopeParams): Promise<MemoryMutationResult> {
   const id = params.id.trim();
   if (!id) {
     throw new Error('Memory id is required.');
   }
 
   const content = assertValidEntryContent(params.content);
-  const { fileName, limit, storageAgentId, parsed } = await readParsedMemory(params.target, params.agentId);
+  const scope = resolveMemoryStorageScope(params);
+  const { fileName, limit, storageAgentId, parsed } = await readParsedMemory(params.target, params.agentId, scope);
   const index = parsed.entries.findIndex((entry) => entry.id === id);
   if (index < 0) {
     throw new Error(`Memory entry "${id}" was not found.`);
@@ -258,7 +278,7 @@ export async function updateMemory(params: {
   const nextEntries = [...parsed.entries];
   nextEntries[index] = entry;
   const next = { ...parsed, entries: nextEntries };
-  const writtenContent = await writeParsedMemory(storageAgentId, fileName, limit, next);
+  const writtenContent = await writeParsedMemory(storageAgentId, fileName, limit, next, scope);
 
   return {
     ...toReadResult(params.target, storageAgentId, fileName, limit, next, writtenContent),
@@ -271,13 +291,14 @@ export async function deleteMemory(params: {
   target: MemoryTarget;
   agentId?: string | null;
   id: string;
-}): Promise<MemoryMutationResult> {
+} & MemoryScopeParams): Promise<MemoryMutationResult> {
   const id = params.id.trim();
   if (!id) {
     throw new Error('Memory id is required.');
   }
 
-  const { fileName, limit, storageAgentId, parsed } = await readParsedMemory(params.target, params.agentId);
+  const scope = resolveMemoryStorageScope(params);
+  const { fileName, limit, storageAgentId, parsed } = await readParsedMemory(params.target, params.agentId, scope);
   const deletedEntry = parsed.entries.find((entry) => entry.id === id);
   if (!deletedEntry) {
     throw new Error(`Memory entry "${id}" was not found.`);
@@ -287,7 +308,7 @@ export async function deleteMemory(params: {
     ...parsed,
     entries: parsed.entries.filter((entry) => entry.id !== id),
   };
-  const writtenContent = await writeParsedMemory(storageAgentId, fileName, limit, next);
+  const writtenContent = await writeParsedMemory(storageAgentId, fileName, limit, next, scope);
 
   return {
     ...toReadResult(params.target, storageAgentId, fileName, limit, next, writtenContent),

--- a/app/lib/agents/storage.ts
+++ b/app/lib/agents/storage.ts
@@ -6,7 +6,7 @@ import { type AgentId } from './catalog';
 import { DEFAULT_PI_CONFIG, normalizePiRuntimeConfig, type PiRuntimeConfig, validatePiConfig } from '../pi/config';
 import { CANVAS_CONTROL_PLANE_PROVIDER_ID, getCanvasControlPlaneModels } from '../managed/control-plane-models';
 import { getManagedControlPlaneBaseUrl } from '../managed/control-plane-url';
-import { resolveAgentStorageDir, resolveAgentsStorageRoot } from '../runtime-data-paths';
+import { normalizeDataScopeId, resolveAgentStorageDir, resolveAgentsStorageRoot, resolveUserAgentsDir } from '../runtime-data-paths';
 import {
   ensureSettingsStorageDirectory,
   readSettingsTextFileIfExists,
@@ -25,6 +25,9 @@ export const CANVAS_INHERITED_FILE_NAMES = ['USER.md'] as const;
 
 export type AgentManagedFileName = (typeof AGENT_MANAGED_FILE_NAMES)[number];
 export type AgentManagedFiles = Record<AgentManagedFileName, string>;
+export type AgentStorageScope = {
+  userId?: string | null;
+};
 
 // Seed system prompts directory (relative to project root)
 const SEED_SYS_PROMPTS_DIR = path.join(process.cwd(), 'seed_sys_prompts');
@@ -190,12 +193,17 @@ async function writeTextAtomic(filePath: string, content: string): Promise<void>
   await fs.rename(tempPath, filePath);
 }
 
-function resolveAgentScopedStorageDir(agentId?: string | null): string {
-  return path.join(AGENTS_STORAGE_ROOT, normalizeManagedAgentId(agentId));
+function resolveAgentStorageRootForScope(scope?: AgentStorageScope | null): string {
+  const userId = scope?.userId?.trim();
+  return userId ? resolveUserAgentsDir(normalizeDataScopeId(userId, 'userId')) : AGENTS_STORAGE_ROOT;
 }
 
-function resolveManagedFilePath(fileName: AgentManagedFileName, agentId?: string | null): string {
-  return path.join(resolveAgentScopedStorageDir(agentId), fileName);
+function resolveAgentScopedStorageDir(agentId?: string | null, scope?: AgentStorageScope | null): string {
+  return path.join(resolveAgentStorageRootForScope(scope), normalizeManagedAgentId(agentId));
+}
+
+function resolveManagedFilePath(fileName: AgentManagedFileName, agentId?: string | null, scope?: AgentStorageScope | null): string {
+  return path.join(/* turbopackIgnore: true */ resolveAgentScopedStorageDir(agentId, scope), fileName);
 }
 
 function resolveLegacyManagedFilePath(fileName: AgentManagedFileName): string {
@@ -238,14 +246,15 @@ async function migrateLegacyCanvasAgentFileIfMissing(
   return legacyContent;
 }
 
-export async function ensureAgentManagedFilesExist(agentId?: string | null): Promise<void> {
-  await fs.mkdir(resolveAgentScopedStorageDir(agentId), { recursive: true });
-  if (shouldMigrateLegacyCanvasAgentFiles(agentId)) {
+export async function ensureAgentManagedFilesExist(agentId?: string | null, scope?: AgentStorageScope | null): Promise<void> {
+  await fs.mkdir(resolveAgentScopedStorageDir(agentId, scope), { recursive: true });
+  const shouldUseLegacyMigration = !scope?.userId && shouldMigrateLegacyCanvasAgentFiles(agentId);
+  if (shouldUseLegacyMigration) {
     await ensureLegacyAgentStorageDirectory();
   }
 
   for (const fileName of getOwnedManagedFileNames(agentId)) {
-    const filePath = resolveManagedFilePath(fileName, agentId);
+    const filePath = resolveManagedFilePath(fileName, agentId, scope);
     let existing = await readFileIfExists(filePath);
 
     // A present empty file is intentional, for example after resetting USER.md or MEMORY.md.
@@ -253,7 +262,7 @@ export async function ensureAgentManagedFilesExist(agentId?: string | null): Pro
       continue;
     }
 
-    if (shouldMigrateLegacyCanvasAgentFiles(agentId)) {
+    if (shouldUseLegacyMigration) {
       existing = await migrateLegacyCanvasAgentFileIfMissing(fileName, filePath, existing);
       if (existing !== null) {
         continue;
@@ -268,29 +277,37 @@ export async function ensureAgentManagedFilesExist(agentId?: string | null): Pro
   }
 }
 
-export async function readManagedAgentFile(fileName: AgentManagedFileName, agentId?: string | null): Promise<string> {
-  await ensureAgentManagedFilesExist(agentId);
-  const filePath = resolveManagedFilePath(fileName, agentId);
+export async function readManagedAgentFile(
+  fileName: AgentManagedFileName,
+  agentId?: string | null,
+  scope?: AgentStorageScope | null,
+): Promise<string> {
+  await ensureAgentManagedFilesExist(agentId, scope);
+  const filePath = resolveManagedFilePath(fileName, agentId, scope);
   const content = await readFileIfExists(filePath);
 
   return content ?? '';
 }
 
-export async function resetManagedAgentFile(fileName: AgentManagedFileName, agentId?: string | null): Promise<string> {
-  await fs.mkdir(resolveAgentScopedStorageDir(agentId), { recursive: true });
-  const filePath = resolveManagedFilePath(fileName, agentId);
+export async function resetManagedAgentFile(
+  fileName: AgentManagedFileName,
+  agentId?: string | null,
+  scope?: AgentStorageScope | null,
+): Promise<string> {
+  await fs.mkdir(resolveAgentScopedStorageDir(agentId, scope), { recursive: true });
+  const filePath = resolveManagedFilePath(fileName, agentId, scope);
   const seedContent = await readSeedFile(fileName);
 
   await writeTextAtomic(filePath, seedContent ?? '');
   return (await readFileIfExists(filePath)) ?? '';
 }
 
-export async function readManagedAgentFiles(agentId?: string | null): Promise<AgentManagedFiles> {
-  await ensureAgentManagedFilesExist(agentId);
+export async function readManagedAgentFiles(agentId?: string | null, scope?: AgentStorageScope | null): Promise<AgentManagedFiles> {
+  await ensureAgentManagedFilesExist(agentId, scope);
 
   const entries = await Promise.all(
     AGENT_MANAGED_FILE_NAMES.map(async (fileName) => {
-      const content = await readManagedAgentFile(fileName, agentId);
+      const content = await readManagedAgentFile(fileName, agentId, scope);
       return [fileName, content] as const;
     })
   );
@@ -298,17 +315,17 @@ export async function readManagedAgentFiles(agentId?: string | null): Promise<Ag
   return Object.fromEntries(entries) as AgentManagedFiles;
 }
 
-export async function readRuntimeManagedAgentFiles(agentId?: string | null): Promise<AgentManagedFiles> {
+export async function readRuntimeManagedAgentFiles(agentId?: string | null, scope?: AgentStorageScope | null): Promise<AgentManagedFiles> {
   const normalizedAgentId = normalizeManagedAgentId(agentId);
   if (normalizedAgentId === DEFAULT_MANAGED_AGENT_ID) {
-    return readManagedAgentFiles(DEFAULT_MANAGED_AGENT_ID);
+    return readManagedAgentFiles(DEFAULT_MANAGED_AGENT_ID, scope);
   }
 
   const entries = await Promise.all(
     AGENT_MANAGED_FILE_NAMES.map(async (fileName) => {
       const inherited = (CANVAS_INHERITED_FILE_NAMES as readonly string[]).includes(fileName);
       const sourceAgentId = inherited ? DEFAULT_MANAGED_AGENT_ID : normalizedAgentId;
-      const content = await readManagedAgentFile(fileName, sourceAgentId);
+      const content = await readManagedAgentFile(fileName, sourceAgentId, scope);
       return [fileName, content] as const;
     }),
   );
@@ -316,11 +333,16 @@ export async function readRuntimeManagedAgentFiles(agentId?: string | null): Pro
   return Object.fromEntries(entries) as AgentManagedFiles;
 }
 
-export async function writeManagedAgentFile(fileName: AgentManagedFileName, content: string, agentId?: string | null): Promise<string> {
-  await ensureAgentManagedFilesExist(agentId);
-  const filePath = resolveManagedFilePath(fileName, agentId);
+export async function writeManagedAgentFile(
+  fileName: AgentManagedFileName,
+  content: string,
+  agentId?: string | null,
+  scope?: AgentStorageScope | null,
+): Promise<string> {
+  await ensureAgentManagedFilesExist(agentId, scope);
+  const filePath = resolveManagedFilePath(fileName, agentId, scope);
   await writeTextAtomic(filePath, content);
-  return readManagedAgentFile(fileName, agentId);
+  return readManagedAgentFile(fileName, agentId, scope);
 }
 
 /**

--- a/app/lib/agents/storage.ts
+++ b/app/lib/agents/storage.ts
@@ -6,7 +6,7 @@ import { type AgentId } from './catalog';
 import { DEFAULT_PI_CONFIG, normalizePiRuntimeConfig, type PiRuntimeConfig, validatePiConfig } from '../pi/config';
 import { CANVAS_CONTROL_PLANE_PROVIDER_ID, getCanvasControlPlaneModels } from '../managed/control-plane-models';
 import { getManagedControlPlaneBaseUrl } from '../managed/control-plane-url';
-import { normalizeDataScopeId, resolveAgentStorageDir, resolveAgentsStorageRoot, resolveUserAgentsDir } from '../runtime-data-paths';
+import { resolveAgentStorageDir, resolveAgentsStorageRoot, resolveUserAgentsDir } from '../runtime-data-paths';
 import {
   ensureSettingsStorageDirectory,
   readSettingsTextFileIfExists,
@@ -195,15 +195,27 @@ async function writeTextAtomic(filePath: string, content: string): Promise<void>
 
 function resolveAgentStorageRootForScope(scope?: AgentStorageScope | null): string {
   const userId = scope?.userId?.trim();
-  return userId ? resolveUserAgentsDir(normalizeDataScopeId(userId, 'userId')) : AGENTS_STORAGE_ROOT;
+  return userId ? resolveUserAgentsDir(userId) : AGENTS_STORAGE_ROOT;
+}
+
+function resolveScopedChildPath(root: string, childName: string, label: string): string {
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(resolvedRoot, childName);
+  const relativePath = path.relative(resolvedRoot, resolvedPath);
+
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new AgentConfigValidationError(`Invalid ${label}.`);
+  }
+
+  return resolvedPath;
 }
 
 function resolveAgentScopedStorageDir(agentId?: string | null, scope?: AgentStorageScope | null): string {
-  return path.join(resolveAgentStorageRootForScope(scope), normalizeManagedAgentId(agentId));
+  return resolveScopedChildPath(resolveAgentStorageRootForScope(scope), normalizeManagedAgentId(agentId), 'agentId');
 }
 
 function resolveManagedFilePath(fileName: AgentManagedFileName, agentId?: string | null, scope?: AgentStorageScope | null): string {
-  return path.join(/* turbopackIgnore: true */ resolveAgentScopedStorageDir(agentId, scope), fileName);
+  return resolveScopedChildPath(resolveAgentScopedStorageDir(agentId, scope), fileName, 'agent managed file');
 }
 
 function resolveLegacyManagedFilePath(fileName: AgentManagedFileName): string {

--- a/app/lib/agents/system-prompt-shared.ts
+++ b/app/lib/agents/system-prompt-shared.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { normalizeDataScopeId, resolveAgentsStorageRoot, resolveUserAgentsDir } from '../runtime-data-paths';
+import { resolveAgentsStorageRoot, resolveUserAgentsDir } from '../runtime-data-paths';
 import { CANVAS_BASE_SYSTEM_PROMPT, CANVAS_BASE_TOOL_GUIDANCE } from './base-system-prompt';
 import type { AgentStorageScope } from './storage';
 
@@ -90,7 +90,7 @@ function getPromptSourcePath(fileName: ManagedPromptFileName, source?: ManagedPr
   const agentId = normalizePromptAgentId(inherited ? 'canvas-agent' : source?.agentId);
   const userId = source?.scope?.userId?.trim();
   const storageRoot = userId
-    ? resolveUserAgentsDir(normalizeDataScopeId(userId, 'userId'))
+    ? resolveUserAgentsDir(userId)
     : AGENTS_STORAGE_ROOT;
   return path.join(/* turbopackIgnore: true */ storageRoot, agentId, fileName);
 }

--- a/app/lib/agents/system-prompt-shared.ts
+++ b/app/lib/agents/system-prompt-shared.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
 
-import { resolveAgentsStorageRoot } from '../runtime-data-paths';
+import { normalizeDataScopeId, resolveAgentsStorageRoot, resolveUserAgentsDir } from '../runtime-data-paths';
 import { CANVAS_BASE_SYSTEM_PROMPT, CANVAS_BASE_TOOL_GUIDANCE } from './base-system-prompt';
+import type { AgentStorageScope } from './storage';
 
 export const MANAGED_PROMPT_FILE_NAMES = ['AGENTS.md', 'USER.md', 'MEMORY.md', 'SOUL.md', 'TOOLS.md', 'HEARTBEAT.md'] as const;
 
@@ -58,7 +59,7 @@ You are currently operating in **Planning Mode**. This mode restricts you to rea
 Acknowledge the request, outline what you would do, then ask the user to **switch back to Standard Mode** (Shift+Tab) so you can execute the changes.`;
 
 const MANAGED_FILES_INTRO =
-  `The following editable agent-managed files add agent-specific role, memory, tone, and tool preferences. They are stored under ${AGENTS_STORAGE_ROOT}/<agent-id> and can be edited when the user asks.`;
+  `The following editable agent-managed files add agent-specific role, memory, tone, and tool preferences. They are stored under the active agent storage scope and can be edited when the user asks.`;
 
 export type ManagedPromptDiagnostics = {
   loadedFiles: ManagedPromptFileName[];
@@ -76,6 +77,7 @@ export type ManagedSystemPromptResult = {
 export type ManagedPromptSource = {
   agentId?: string | null;
   inheritedFiles?: readonly ManagedPromptFileName[];
+  scope?: AgentStorageScope | null;
 };
 
 function normalizePromptAgentId(agentId?: string | null): string {
@@ -86,7 +88,11 @@ function normalizePromptAgentId(agentId?: string | null): string {
 function getPromptSourcePath(fileName: ManagedPromptFileName, source?: ManagedPromptSource): string {
   const inherited = source?.inheritedFiles?.includes(fileName) ?? false;
   const agentId = normalizePromptAgentId(inherited ? 'canvas-agent' : source?.agentId);
-  return path.join(AGENTS_STORAGE_ROOT, agentId, fileName);
+  const userId = source?.scope?.userId?.trim();
+  const storageRoot = userId
+    ? resolveUserAgentsDir(normalizeDataScopeId(userId, 'userId'))
+    : AGENTS_STORAGE_ROOT;
+  return path.join(/* turbopackIgnore: true */ storageRoot, agentId, fileName);
 }
 
 export function composeManagedAgentSystemPrompt(

--- a/app/lib/agents/system-prompt.ts
+++ b/app/lib/agents/system-prompt.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_MANAGED_AGENT_ID,
   readRuntimeManagedAgentFiles,
   readPiRuntimeConfig,
+  type AgentStorageScope,
 } from './storage';
 import { resolveAgentRuntimeConfig } from './effective-runtime-config';
 import {
@@ -271,10 +272,13 @@ async function buildOnboardingBootstrapContext(normalizedAgentId: string): Promi
   }
 }
 
-export async function loadManagedAgentSystemPrompt(agentId?: string | null): Promise<ManagedSystemPromptResult> {
+export async function loadManagedAgentSystemPrompt(
+  agentId?: string | null,
+  scope?: AgentStorageScope | null,
+): Promise<ManagedSystemPromptResult> {
   try {
     const normalizedAgentId = agentId?.trim().toLowerCase() || DEFAULT_MANAGED_AGENT_ID;
-    const files = await readRuntimeManagedAgentFiles(normalizedAgentId);
+    const files = await readRuntimeManagedAgentFiles(normalizedAgentId, scope);
     const agentProfile = await getAgentProfile(normalizedAgentId);
     
     // Load PI config to get enabled skills and check composio tools
@@ -289,6 +293,7 @@ export async function loadManagedAgentSystemPrompt(agentId?: string | null): Pro
     const result = composeManagedAgentSystemPrompt(files, skillsContext, {
       agentId: normalizedAgentId,
       inheritedFiles: normalizedAgentId === DEFAULT_MANAGED_AGENT_ID ? [] : CANVAS_INHERITED_FILE_NAMES,
+      scope,
     });
     
     let systemPrompt = result.systemPrompt;

--- a/app/lib/channels/session-resolver.ts
+++ b/app/lib/channels/session-resolver.ts
@@ -47,7 +47,7 @@ export async function createChannelSession(input: ResolveChannelSessionInput): P
   const agentId = resolveAgentId(input.agentId);
   const sessionId = input.requestedSessionId || `sess-${Date.now()}-${randomUUID()}`;
   const effectiveConfig = await resolveAgentRuntimeConfig(agentId);
-  const promptSnapshot = await createPiSystemPromptSnapshot(agentId);
+  const promptSnapshot = await createPiSystemPromptSnapshot(agentId, { userId: input.userId });
   const workspace = await resolveAgentSessionWorkspaceForUser({
     userId: input.userId,
     workspaceId: input.workspaceId,

--- a/app/lib/onboarding/profile.ts
+++ b/app/lib/onboarding/profile.ts
@@ -210,8 +210,8 @@ export async function completeOnboardingProfile(params: {
   const userMd = normalizeProfileContent(params.userMd, 'USER.md');
   const soulMd = normalizeProfileContent(params.soulMd, 'SOUL.md');
 
-  await writeManagedAgentFile('USER.md', userMd, DEFAULT_MANAGED_AGENT_ID);
-  await writeManagedAgentFile('SOUL.md', soulMd, DEFAULT_MANAGED_AGENT_ID);
+  await writeManagedAgentFile('USER.md', userMd, DEFAULT_MANAGED_AGENT_ID, { userId: params.userId });
+  await writeManagedAgentFile('SOUL.md', soulMd, DEFAULT_MANAGED_AGENT_ID, { userId: params.userId });
   const deletedBootstrap = await deleteOnboardingBootstrapFile();
 
   await markOnboardingComplete({

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -7,8 +7,27 @@ import path from 'node:path';
 
 import { getBootstrapAdminEmail } from '@/app/lib/bootstrap-admin';
 import { runMigrations } from '@/app/lib/db/migrate';
-import { resolveWorkspaceDataRoot } from '@/app/lib/workspaces/context';
+import {
+  resolveOrganizationAgentTemplatesDir,
+  resolveOrganizationDataRoot,
+  resolveOrganizationMcpTemplatesDir,
+  resolveOrganizationPluginTemplatesDir,
+  resolveOrganizationPoliciesDir,
+  resolveOrganizationSecretsDir,
+  resolveOrganizationSkillTemplatesDir,
+  resolveSystemBackupsDir,
+  resolveSystemLogsDir,
+  resolveSystemMigrationDir,
+  resolveUserAgentsDir,
+  resolveUserMailDir,
+  resolveUserMcpDir,
+  resolveUserPluginsDir,
+  resolveUserSecretsDir,
+  resolveUserSettingsDir,
+  resolveUserSkillsDir,
+} from '@/app/lib/runtime-data-paths';
 import { ensureDefaultWorkspaceRecords } from '@/app/lib/workspaces/service';
+import { resolveWorkspaceDataRoot } from '@/app/lib/workspaces/context';
 
 export const LOCAL_ORGANIZATION_ID_PREFIX = 'org_';
 
@@ -174,26 +193,26 @@ function buildScopedPaths(organizationId: string, userId: string, teamFeaturesEn
   const dataRoot = getDataRoot();
   return {
     personalWorkspace: path.join(dataRoot, 'workspaces', 'personal', userId, 'files'),
-    userSettings: path.join(dataRoot, 'users', userId, 'settings'),
-    userSecrets: path.join(dataRoot, 'users', userId, 'secrets'),
-    userAgents: path.join(dataRoot, 'users', userId, 'agents'),
-    userSkills: path.join(dataRoot, 'users', userId, 'skills'),
-    userPlugins: path.join(dataRoot, 'users', userId, 'plugins'),
-    userMcp: path.join(dataRoot, 'users', userId, 'mcp'),
-    userMail: path.join(dataRoot, 'users', userId, 'mail'),
-    organizationRoot: path.join(dataRoot, 'organizations', organizationId),
-    organizationSecrets: path.join(dataRoot, 'organizations', organizationId, 'secrets'),
-    organizationPolicies: path.join(dataRoot, 'organizations', organizationId, 'policies'),
-    organizationAgentTemplates: path.join(dataRoot, 'organizations', organizationId, 'agent-templates'),
-    organizationMcpTemplates: path.join(dataRoot, 'organizations', organizationId, 'mcp-templates'),
-    organizationSkillTemplates: path.join(dataRoot, 'organizations', organizationId, 'skill-templates'),
-    organizationPluginTemplates: path.join(dataRoot, 'organizations', organizationId, 'plugin-templates'),
+    userSettings: resolveUserSettingsDir(userId),
+    userSecrets: resolveUserSecretsDir(userId),
+    userAgents: resolveUserAgentsDir(userId),
+    userSkills: resolveUserSkillsDir(userId),
+    userPlugins: resolveUserPluginsDir(userId),
+    userMcp: resolveUserMcpDir(userId),
+    userMail: resolveUserMailDir(userId),
+    organizationRoot: resolveOrganizationDataRoot(organizationId),
+    organizationSecrets: resolveOrganizationSecretsDir(organizationId),
+    organizationPolicies: resolveOrganizationPoliciesDir(organizationId),
+    organizationAgentTemplates: resolveOrganizationAgentTemplatesDir(organizationId),
+    organizationMcpTemplates: resolveOrganizationMcpTemplatesDir(organizationId),
+    organizationSkillTemplates: resolveOrganizationSkillTemplatesDir(organizationId),
+    organizationPluginTemplates: resolveOrganizationPluginTemplatesDir(organizationId),
     teamWorkspace: teamFeaturesEnabled
       ? path.join(dataRoot, 'workspaces', 'team', organizationId, 'files')
       : null,
-    systemBackups: path.join(dataRoot, 'system', 'backups'),
-    systemMigration: path.join(dataRoot, 'system', 'migration'),
-    systemLogs: path.join(dataRoot, 'system', 'logs'),
+    systemBackups: resolveSystemBackupsDir(),
+    systemMigration: resolveSystemMigrationDir(),
+    systemLogs: resolveSystemLogsDir(),
   };
 }
 

--- a/app/lib/pi/delegate-task-tool.ts
+++ b/app/lib/pi/delegate-task-tool.ts
@@ -360,7 +360,9 @@ async function startEphemeralDelegatedRun(request: DelegateTaskRequest): Promise
   const model = effectiveConfig.model;
   const sessionId = buildDelegatedSessionId();
   const tools = await resolveEphemeralTools(request, sessionId);
-  const { systemPrompt: baseSystemPrompt } = await loadManagedAgentSystemPrompt(request.sourceAgentId);
+  const { systemPrompt: baseSystemPrompt } = await loadManagedAgentSystemPrompt(request.sourceAgentId, {
+    userId: request.userId,
+  });
   const systemPrompt = buildEphemeralSystemPrompt(baseSystemPrompt, request, tools);
   const promptMessage = buildDelegationPrompt(request);
 
@@ -438,7 +440,7 @@ async function ensureManagedDelegatedSession(request: DelegateTaskRequest): Prom
   const effectiveConfig = await resolveAgentRuntimeConfig(request.targetAgentId);
   const provider = effectiveConfig.activeProvider;
   const providerConfig = effectiveConfig.providerConfig;
-  const promptSnapshot = await createPiSystemPromptSnapshot(request.targetAgentId);
+  const promptSnapshot = await createPiSystemPromptSnapshot(request.targetAgentId, { userId: request.userId });
 
   await db.insert(piSessions).values({
     sessionId,

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -1458,7 +1458,7 @@ async function createRuntime(sessionId: string, userId: string): Promise<LivePiR
   };
   const promptSnapshot = sessionRecord
     ? await ensurePiSessionSystemPromptSnapshot(sessionRecord)
-    : await createPiSystemPromptSnapshot(agentId);
+    : await createPiSystemPromptSnapshot(agentId, { userId });
   const systemPrompt = promptSnapshot.systemPrompt;
   const tools = await getPiTools(userId, agentId, sessionId);
   const toolLoopGuard = createToolLoopGuard();

--- a/app/lib/pi/session-store.ts
+++ b/app/lib/pi/session-store.ts
@@ -134,7 +134,7 @@ export async function savePiSession(
   const lastMessageAt = assistantActivityAt ?? session?.lastMessageAt ?? null;
 
   if (!session) {
-    const promptSnapshot = options?.systemPromptSnapshot ?? await createPiSystemPromptSnapshot(agentId);
+    const promptSnapshot = options?.systemPromptSnapshot ?? await createPiSystemPromptSnapshot(agentId, { userId });
     const workspace = await resolveAgentSessionWorkspaceForUser({ userId });
     const [inserted] = await db.insert(piSessions).values({
       sessionId,
@@ -159,7 +159,7 @@ export async function savePiSession(
     const nextTitle = normalizedTitleOverride || (isAutomaticSessionTitle(session.title) ? derivedTitle : session.title);
     const promptSnapshotFields = session.systemPromptSnapshot
       ? {}
-      : piSystemPromptSnapshotDbFields(options?.systemPromptSnapshot ?? await createPiSystemPromptSnapshot(agentId));
+      : piSystemPromptSnapshotDbFields(options?.systemPromptSnapshot ?? await createPiSystemPromptSnapshot(agentId, { userId }));
     const workspaceFields = session.workspaceId
       ? {}
       : workspaceToPiSessionFields(await resolveAgentSessionWorkspaceForUser({ userId }));

--- a/app/lib/pi/system-prompt-snapshot.ts
+++ b/app/lib/pi/system-prompt-snapshot.ts
@@ -9,7 +9,7 @@ import { piSessions } from '@/app/lib/db/schema';
 
 type PiSessionPromptSnapshotRow = Pick<
   typeof piSessions.$inferSelect,
-  'id' | 'agentId' | 'systemPromptSnapshot' | 'systemPromptSnapshotHash' | 'systemPromptSnapshotCreatedAt'
+  'id' | 'userId' | 'agentId' | 'systemPromptSnapshot' | 'systemPromptSnapshotHash' | 'systemPromptSnapshotCreatedAt'
 >;
 
 export type PiSystemPromptSnapshot = {
@@ -33,8 +33,11 @@ export function buildPiSystemPromptSnapshotFromText(
   };
 }
 
-export async function createPiSystemPromptSnapshot(agentId?: string | null): Promise<PiSystemPromptSnapshot> {
-  const { systemPrompt } = await loadManagedAgentSystemPrompt(agentId);
+export async function createPiSystemPromptSnapshot(
+  agentId?: string | null,
+  scope?: { userId?: string | null } | null,
+): Promise<PiSystemPromptSnapshot> {
+  const { systemPrompt } = await loadManagedAgentSystemPrompt(agentId, scope);
   return buildPiSystemPromptSnapshotFromText(systemPrompt);
 }
 
@@ -69,7 +72,7 @@ export async function ensurePiSessionSystemPromptSnapshot(
     return snapshot;
   }
 
-  const snapshot = await createPiSystemPromptSnapshot(session.agentId);
+  const snapshot = await createPiSystemPromptSnapshot(session.agentId, { userId: session.userId });
   await db
     .update(piSessions)
     .set(piSystemPromptSnapshotDbFields(snapshot))
@@ -95,5 +98,5 @@ export async function loadPiSessionSystemPromptSnapshot(input: {
     return ensurePiSessionSystemPromptSnapshot(session);
   }
 
-  return createPiSystemPromptSnapshot(input.agentId);
+  return createPiSystemPromptSnapshot(input.agentId, { userId: input.userId });
 }

--- a/app/lib/pi/system-prompt-snapshot.ts
+++ b/app/lib/pi/system-prompt-snapshot.ts
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 
 import { loadManagedAgentSystemPrompt } from '@/app/lib/agents/system-prompt';
+import type { AgentStorageScope } from '@/app/lib/agents/storage';
 import { db } from '@/app/lib/db';
 import { piSessions } from '@/app/lib/db/schema';
 
@@ -35,7 +36,7 @@ export function buildPiSystemPromptSnapshotFromText(
 
 export async function createPiSystemPromptSnapshot(
   agentId?: string | null,
-  scope?: { userId?: string | null } | null,
+  scope?: AgentStorageScope | null,
 ): Promise<PiSystemPromptSnapshot> {
   const { systemPrompt } = await loadManagedAgentSystemPrompt(agentId, scope);
   return buildPiSystemPromptSnapshotFromText(systemPrompt);

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -2716,7 +2716,7 @@ function createPublicShareTool(userId?: string, agentId?: string | null, session
   };
 }
 
-function createMemoryTool(agentId?: string | null): AgentTool {
+function createMemoryTool(userId?: string, agentId?: string | null): AgentTool {
   return {
     name: 'memory',
     label: 'Managing memory',
@@ -2753,7 +2753,7 @@ function createMemoryTool(agentId?: string | null): AgentTool {
         }
 
         if (input.action === 'read') {
-          const result = await readMemory({ target, agentId });
+          const result = await readMemory({ target, agentId, userId });
           return { content: [{ type: 'text', text: formatMemoryResult(result) }], details: result };
         }
 
@@ -2761,7 +2761,7 @@ function createMemoryTool(agentId?: string | null): AgentTool {
           if (typeof input.content !== 'string') {
             throw new Error('content is required for add.');
           }
-          const result = await addMemory({ target, agentId, content: input.content });
+          const result = await addMemory({ target, agentId, userId, content: input.content });
           const prefix = result.changed ? 'Memory entry added.' : 'Memory entry already existed.';
           return { content: [{ type: 'text', text: `${prefix}\n${formatMemoryResult(result)}` }], details: result };
         }
@@ -2773,7 +2773,7 @@ function createMemoryTool(agentId?: string | null): AgentTool {
           if (typeof input.content !== 'string') {
             throw new Error('content is required for update.');
           }
-          const result = await updateMemory({ target, agentId, id: input.id, content: input.content });
+          const result = await updateMemory({ target, agentId, userId, id: input.id, content: input.content });
           return { content: [{ type: 'text', text: `Memory entry updated.\n${formatMemoryResult(result)}` }], details: result };
         }
 
@@ -2781,7 +2781,7 @@ function createMemoryTool(agentId?: string | null): AgentTool {
           if (!input.id) {
             throw new Error('id is required for delete.');
           }
-          const result = await deleteMemory({ target, agentId, id: input.id });
+          const result = await deleteMemory({ target, agentId, userId, id: input.id });
           return { content: [{ type: 'text', text: `Memory entry deleted.\n${formatMemoryResult(result)}` }], details: result };
         }
 
@@ -2860,7 +2860,7 @@ function createOnboardingProfileTool(userId?: string, agentId?: string | null, s
 function createUserScopedTools(userId?: string, agentId?: string | null, sessionId?: string | null): AgentTool[] {
   const sourceAgentId = normalizeManagedAgentId(agentId);
   const tools: AgentTool[] = [
-    createMemoryTool(agentId),
+    createMemoryTool(userId, agentId),
     createSessionSearchTool({ userId, agentId }),
     createHumanTodoTool({ userId, agentId, sessionId }),
     createPublicShareTool(userId, agentId, sessionId),

--- a/app/lib/runtime-data-paths.ts
+++ b/app/lib/runtime-data-paths.ts
@@ -22,6 +22,13 @@ export function resolveCanvasDataRoot(cwd?: string): string {
     return path.resolve(configured);
   }
 
+  const data = process.env.DATA?.trim();
+  if (data && data !== './data' && data !== 'data') {
+    return path.isAbsolute(data)
+      ? data
+      : path.resolve(cwd ?? process.cwd(), data);
+  }
+
   if (directoryExists(CONTAINER_DATA_ROOT)) {
     return CONTAINER_DATA_ROOT;
   }
@@ -35,6 +42,124 @@ export function resolveAgentStorageDir(cwd?: string): string {
 
 export function resolveAgentsStorageRoot(cwd?: string): string {
   return path.join(/* turbopackIgnore: true */ resolveCanvasDataRoot(cwd), 'agents');
+}
+
+export function normalizeDataScopeId(id: string, label = 'scope id'): string {
+  const normalized = id.trim();
+  if (
+    !normalized ||
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.includes('/') ||
+    normalized.includes('\\') ||
+    normalized.includes('\0')
+  ) {
+    throw new Error(`Invalid ${label}.`);
+  }
+  return normalized;
+}
+
+export function resolveUsersDataRoot(cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveCanvasDataRoot(cwd), 'users');
+}
+
+export function resolveUserDataRoot(userId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveUsersDataRoot(cwd), normalizeDataScopeId(userId, 'userId'));
+}
+
+export function resolveUserSettingsDir(userId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveUserDataRoot(userId, cwd), 'settings');
+}
+
+export function resolveUserSecretsDir(userId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveUserDataRoot(userId, cwd), 'secrets');
+}
+
+export function resolveUserAgentsDir(userId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveUserDataRoot(userId, cwd), 'agents');
+}
+
+export function resolveUserSkillsDir(userId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveUserDataRoot(userId, cwd), 'skills');
+}
+
+export function resolveUserPluginsDir(userId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveUserDataRoot(userId, cwd), 'plugins');
+}
+
+export function resolveUserMcpDir(userId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveUserDataRoot(userId, cwd), 'mcp');
+}
+
+export function resolveUserMailDir(userId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveUserDataRoot(userId, cwd), 'mail');
+}
+
+export function resolveOrganizationsDataRoot(cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveCanvasDataRoot(cwd), 'organizations');
+}
+
+export function resolveOrganizationDataRoot(organizationId: string, cwd?: string): string {
+  return path.join(
+    /* turbopackIgnore: true */ resolveOrganizationsDataRoot(cwd),
+    normalizeDataScopeId(organizationId, 'organizationId'),
+  );
+}
+
+export function resolveOrganizationSettingsDir(organizationId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveOrganizationDataRoot(organizationId, cwd), 'settings');
+}
+
+export function resolveOrganizationSecretsDir(organizationId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveOrganizationDataRoot(organizationId, cwd), 'secrets');
+}
+
+export function resolveOrganizationPoliciesDir(organizationId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveOrganizationDataRoot(organizationId, cwd), 'policies');
+}
+
+export function resolveOrganizationAgentTemplatesDir(organizationId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveOrganizationDataRoot(organizationId, cwd), 'agent-templates');
+}
+
+export function resolveOrganizationSkillTemplatesDir(organizationId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveOrganizationDataRoot(organizationId, cwd), 'skill-templates');
+}
+
+export function resolveOrganizationPluginTemplatesDir(organizationId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveOrganizationDataRoot(organizationId, cwd), 'plugin-templates');
+}
+
+export function resolveOrganizationMcpTemplatesDir(organizationId: string, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveOrganizationDataRoot(organizationId, cwd), 'mcp-templates');
+}
+
+export function resolveSystemDataRoot(cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveCanvasDataRoot(cwd), 'system');
+}
+
+export function resolveSystemSettingsDir(cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveSystemDataRoot(cwd), 'settings');
+}
+
+export function resolveSystemSecretsDir(cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveSystemDataRoot(cwd), 'secrets');
+}
+
+export function resolveSystemManagedDir(cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveSystemDataRoot(cwd), 'managed');
+}
+
+export function resolveSystemBackupsDir(cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveSystemDataRoot(cwd), 'backups');
+}
+
+export function resolveSystemMigrationDir(cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveSystemDataRoot(cwd), 'migration');
+}
+
+export function resolveSystemLogsDir(cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveSystemDataRoot(cwd), 'logs');
 }
 
 export function resolveSettingsStorageDir(cwd?: string): string {

--- a/app/lib/runtime-data-paths.ts
+++ b/app/lib/runtime-data-paths.ts
@@ -16,6 +16,11 @@ function resolveProjectDataRoot(cwd?: string): string {
   return path.resolve(/* turbopackIgnore: true */ resolvedCwd, 'data');
 }
 
+export function isDefaultDataEnvValue(value: string): boolean {
+  const normalized = path.posix.normalize(value.replace(/\\/g, '/')).replace(/\/+$/, '');
+  return normalized === 'data';
+}
+
 export function resolveCanvasDataRoot(cwd?: string): string {
   const configured = process.env.CANVAS_DATA_ROOT?.trim();
   if (configured) {
@@ -23,7 +28,7 @@ export function resolveCanvasDataRoot(cwd?: string): string {
   }
 
   const data = process.env.DATA?.trim();
-  if (data && data !== './data' && data !== 'data') {
+  if (data && !isDefaultDataEnvValue(data)) {
     return path.isAbsolute(data)
       ? data
       : path.resolve(cwd ?? process.cwd(), data);

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -246,12 +246,24 @@
     {
       "id": 17,
       "title": "Plugins, Skills und Agent-Definitionen auf User-Scope mit optionaler Organization-Teilung migrieren",
-      "status": "pending",
+      "status": "in_progress",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/08-user-scoped-secrets-runtime.md",
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md",
         "docs/architecture/canvas-notebook/team-workspace/10-agent-tool-execution-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/runtime-data-paths.ts",
+        "app/lib/agents/storage.ts",
+        "app/lib/agents/memory-store.ts",
+        "app/lib/agents/system-prompt.ts",
+        "app/lib/pi/system-prompt-snapshot.ts",
+        "app/api/agents/files/route.ts",
+        "app/lib/onboarding/profile.ts",
+        "scripts/scoped-runtime-paths-test.ts",
+        "scripts/agent-memory-store-test.ts",
+        "scripts/agent-runtime-config-test.ts"
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:pi:delegate-task": "tsx scripts/pi-delegate-task-tool-test.ts",
     "test:pi:continuation": "tsx scripts/pi-run-continuation-guard-test.ts",
     "test:agent:memory": "tsx scripts/agent-memory-store-test.ts",
+    "test:scoped-data-paths": "tsx scripts/scoped-runtime-paths-test.ts",
     "test:mcp:config": "tsx scripts/mcp-config-test.ts",
     "test:mcp:proxy": "tsx scripts/mcp-proxy-test.ts",
     "test:mcp:manager": "tsx scripts/mcp-manager-test.ts",

--- a/scripts/agent-memory-store-test.ts
+++ b/scripts/agent-memory-store-test.ts
@@ -73,6 +73,43 @@ async function main() {
       /Europe\/Berlin/,
     );
 
+    const scopedAgentAdded = await addMemory({
+      target: 'agent',
+      agentId: 'research-agent',
+      userId: 'user_a',
+      content: 'Scoped agent memory belongs to user A.',
+    });
+    assert.equal(scopedAgentAdded.changed, true);
+    assert.equal(scopedAgentAdded.agentId, 'research-agent');
+    assert.match(
+      await fs.readFile(path.join(dataDir, 'users', 'user_a', 'agents', 'research-agent', 'MEMORY.md'), 'utf8'),
+      /Scoped agent memory belongs to user A/,
+    );
+    assert.doesNotMatch(await fs.readFile(agentMemoryPath, 'utf8'), /Scoped agent memory belongs to user A/);
+
+    const scopedOtherUser = await readMemory({
+      target: 'agent',
+      agentId: 'research-agent',
+      userId: 'user_b',
+    });
+    assert.deepEqual(scopedOtherUser.entries, []);
+
+    const scopedUserAdded = await addMemory({
+      target: 'user',
+      agentId: 'research-agent',
+      userId: 'user_a',
+      content: 'Scoped user memory belongs to user A.',
+    });
+    assert.equal(scopedUserAdded.agentId, 'canvas-agent');
+    assert.match(
+      await fs.readFile(path.join(dataDir, 'users', 'user_a', 'agents', 'canvas-agent', 'USER.md'), 'utf8'),
+      /Scoped user memory belongs to user A/,
+    );
+    assert.doesNotMatch(
+      await fs.readFile(path.join(dataDir, 'agents', 'canvas-agent', 'USER.md'), 'utf8'),
+      /Scoped user memory belongs to user A/,
+    );
+
     await assert.rejects(
       () => addMemory({
         target: 'user',
@@ -89,6 +126,7 @@ async function main() {
     assert.equal(deleted.changed, true);
     assert.deepEqual(deleted.entries, []);
 
+    await fs.rm(path.join(dataDir, 'agents', 'canvas-agent', 'MEMORY.md'), { force: true });
     await fs.mkdir(path.join(dataDir, 'canvas-agent'), { recursive: true });
     await fs.writeFile(path.join(dataDir, 'canvas-agent', 'MEMORY.md'), 'Legacy canvas memory.\n', 'utf8');
     const migrated = await readMemory({ target: 'agent', agentId: 'canvas-agent' });

--- a/scripts/agent-runtime-config-test.ts
+++ b/scripts/agent-runtime-config-test.ts
@@ -50,6 +50,9 @@ async function main() {
         },
       };
     }
+    if (request === '@earendil-works/pi-ai/oauth') {
+      return {};
+    }
     return originalLoad(request, parent, isMain);
   };
 
@@ -156,6 +159,31 @@ async function main() {
       expectedSeed,
     );
   }
+
+  await fs.writeFile(path.join(dataDir, 'canvas-agent', 'USER.md'), 'Legacy user profile should not leak.\n', 'utf8');
+  const scopedUserId = 'runtime-user-a';
+  assert.doesNotMatch(
+    await readManagedAgentFile('USER.md', DEFAULT_MANAGED_AGENT_ID, { userId: scopedUserId }),
+    /Legacy user profile should not leak/,
+  );
+  await writeManagedAgentFile('AGENTS.md', 'Scoped runtime prompt.\n', DEFAULT_MANAGED_AGENT_ID, {
+    userId: scopedUserId,
+  });
+  const scopedPrompt = await loadManagedAgentSystemPrompt(DEFAULT_MANAGED_AGENT_ID, { userId: scopedUserId });
+  assert.match(scopedPrompt.systemPrompt, /Scoped runtime prompt/);
+  assert.ok(scopedPrompt.systemPrompt.includes(
+    `Source: ${path.join(dataDir, 'users', scopedUserId, 'agents', 'canvas-agent', 'AGENTS.md')}`,
+  ));
+  assert.match(
+    await fs.readFile(path.join(dataDir, 'users', scopedUserId, 'agents', 'canvas-agent', 'AGENTS.md'), 'utf8'),
+    /Scoped runtime prompt/,
+  );
+  await assert.rejects(
+    () => writeManagedAgentFile('AGENTS.md', 'Invalid scoped prompt.\n', DEFAULT_MANAGED_AGENT_ID, {
+      userId: '../other-user',
+    }),
+    /Invalid userId/,
+  );
 
   const inheritedAgent = await createAgentProfile({ name: 'Inherited Agent' });
   assert.equal(inheritedAgent.iconId, 'bot');
@@ -336,6 +364,9 @@ async function main() {
   assert.equal(storedSnapshot.systemPrompt, originalSnapshot.systemPrompt);
   assert.doesNotMatch(storedSnapshot.systemPrompt, /Changed after session start/);
 
+  await writeManagedAgentFile('AGENTS.md', 'Snapshot user scoped prompt.\n', customAgent.agentId, {
+    userId: 'snapshot-user',
+  });
   await db.insert(piSessions).values({
     sessionId: 'legacy-unsnapshotted-session',
     userId: 'snapshot-user',
@@ -354,7 +385,8 @@ async function main() {
   });
   assert.ok(legacySession);
   const legacySnapshot = await ensurePiSessionSystemPromptSnapshot(legacySession);
-  assert.match(legacySnapshot.systemPrompt, /Changed after session start/);
+  assert.match(legacySnapshot.systemPrompt, /Snapshot user scoped prompt/);
+  assert.doesNotMatch(legacySnapshot.systemPrompt, /Changed after session start/);
   const updatedLegacySession = await db.query.piSessions.findFirst({
     where: eq(piSessions.sessionId, 'legacy-unsnapshotted-session'),
   });

--- a/scripts/onboarding-profile-test.ts
+++ b/scripts/onboarding-profile-test.ts
@@ -238,21 +238,22 @@ async function main() {
     assert.equal(completed.success, true);
     assert.equal(completed.deletedBootstrap, true);
     await assert.rejects(() => fs.stat(bootstrapPath), /ENOENT/);
-    assert.match(await fs.readFile(path.join(dataDir, 'agents', 'canvas-agent', 'USER.md'), 'utf8'), /Frank/);
-    assert.match(await fs.readFile(path.join(dataDir, 'agents', 'canvas-agent', 'SOUL.md'), 'utf8'), /Canvas Agent/);
+    const scopedCanvasAgentPath = path.join(dataDir, 'users', userId, 'agents', 'canvas-agent');
+    assert.match(await fs.readFile(path.join(scopedCanvasAgentPath, 'USER.md'), 'utf8'), /Frank/);
+    assert.match(await fs.readFile(path.join(scopedCanvasAgentPath, 'SOUL.md'), 'utf8'), /Canvas Agent/);
     assert.equal(await isOnboardingComplete(), true);
 
     await db.delete(onboardingLog).where(eq(onboardingLog.method, 'ui'));
     await fs.writeFile(bootstrapPath, 'Bootstrap setup instructions.\n', 'utf8');
-    await fs.writeFile(path.join(dataDir, 'agents', 'canvas-agent', 'USER.md'), '', 'utf8');
-    await fs.writeFile(path.join(dataDir, 'agents', 'canvas-agent', 'SOUL.md'), 'Default soul.\n', 'utf8');
+    await fs.writeFile(path.join(scopedCanvasAgentPath, 'USER.md'), '', 'utf8');
+    await fs.writeFile(path.join(scopedCanvasAgentPath, 'SOUL.md'), 'Default soul.\n', 'utf8');
 
     const skipped = await skipOnboardingProfile({ userId });
     assert.equal(skipped.success, true);
     assert.equal(skipped.deletedBootstrap, true);
     assert.equal(skipped.alreadyComplete, false);
-    assert.equal(await fs.readFile(path.join(dataDir, 'agents', 'canvas-agent', 'USER.md'), 'utf8'), '');
-    assert.equal(await fs.readFile(path.join(dataDir, 'agents', 'canvas-agent', 'SOUL.md'), 'utf8'), 'Default soul.\n');
+    assert.equal(await fs.readFile(path.join(scopedCanvasAgentPath, 'USER.md'), 'utf8'), '');
+    assert.equal(await fs.readFile(path.join(scopedCanvasAgentPath, 'SOUL.md'), 'utf8'), 'Default soul.\n');
     const skipLog = await db.query.onboardingLog.findFirst({
       where: eq(onboardingLog.method, 'ui'),
     });

--- a/scripts/pi-delegate-task-tool-test.ts
+++ b/scripts/pi-delegate-task-tool-test.ts
@@ -38,6 +38,16 @@ async function main() {
     if (request === 'server-only') {
       return {};
     }
+    if (request === '@earendil-works/pi-ai') {
+      return {
+        registerBuiltInApiProviders: () => undefined,
+        getProviders: () => [],
+        getModels: () => [],
+      };
+    }
+    if (request === '@earendil-works/pi-ai/oauth') {
+      return {};
+    }
     return originalLoad.call(this, request, parent, isMain);
   };
 

--- a/scripts/scoped-runtime-paths-test.ts
+++ b/scripts/scoped-runtime-paths-test.ts
@@ -13,6 +13,7 @@ async function main() {
     process.env.DATA = '';
 
     const {
+      isDefaultDataEnvValue,
       normalizeDataScopeId,
       resolveCanvasDataRoot,
       resolveOrganizationAgentTemplatesDir,
@@ -37,6 +38,13 @@ async function main() {
     } = await import('../app/lib/runtime-data-paths');
 
     assert.equal(resolveCanvasDataRoot(), dataDir);
+    for (const defaultDataValue of ['data', './data', 'data/', './data/', 'data/.', './data/.']) {
+      assert.equal(isDefaultDataEnvValue(defaultDataValue), true);
+    }
+    for (const configuredDataValue of ['/data', 'canvas-data', './canvas-data', '../data']) {
+      assert.equal(isDefaultDataEnvValue(configuredDataValue), false);
+    }
+
     assert.equal(normalizeDataScopeId(' user_a ', 'userId'), 'user_a');
     assert.equal(resolveUserSettingsDir('user_a'), path.join(dataDir, 'users', 'user_a', 'settings'));
     assert.equal(resolveUserSecretsDir('user_a'), path.join(dataDir, 'users', 'user_a', 'secrets'));

--- a/scripts/scoped-runtime-paths-test.ts
+++ b/scripts/scoped-runtime-paths-test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+async function main() {
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-scoped-paths-'));
+  const previousCanvasDataRoot = process.env.CANVAS_DATA_ROOT;
+  const previousData = process.env.DATA;
+
+  try {
+    process.env.CANVAS_DATA_ROOT = dataDir;
+    process.env.DATA = '';
+
+    const {
+      normalizeDataScopeId,
+      resolveCanvasDataRoot,
+      resolveOrganizationAgentTemplatesDir,
+      resolveOrganizationMcpTemplatesDir,
+      resolveOrganizationPluginTemplatesDir,
+      resolveOrganizationPoliciesDir,
+      resolveOrganizationSecretsDir,
+      resolveOrganizationSkillTemplatesDir,
+      resolveOrganizationDataRoot,
+      resolveSystemBackupsDir,
+      resolveSystemLogsDir,
+      resolveSystemManagedDir,
+      resolveSystemMigrationDir,
+      resolveSystemSecretsDir,
+      resolveUserAgentsDir,
+      resolveUserMailDir,
+      resolveUserMcpDir,
+      resolveUserPluginsDir,
+      resolveUserSecretsDir,
+      resolveUserSettingsDir,
+      resolveUserSkillsDir,
+    } = await import('../app/lib/runtime-data-paths');
+
+    assert.equal(resolveCanvasDataRoot(), dataDir);
+    assert.equal(normalizeDataScopeId(' user_a ', 'userId'), 'user_a');
+    assert.equal(resolveUserSettingsDir('user_a'), path.join(dataDir, 'users', 'user_a', 'settings'));
+    assert.equal(resolveUserSecretsDir('user_a'), path.join(dataDir, 'users', 'user_a', 'secrets'));
+    assert.equal(resolveUserAgentsDir('user_a'), path.join(dataDir, 'users', 'user_a', 'agents'));
+    assert.equal(resolveUserSkillsDir('user_a'), path.join(dataDir, 'users', 'user_a', 'skills'));
+    assert.equal(resolveUserPluginsDir('user_a'), path.join(dataDir, 'users', 'user_a', 'plugins'));
+    assert.equal(resolveUserMcpDir('user_a'), path.join(dataDir, 'users', 'user_a', 'mcp'));
+    assert.equal(resolveUserMailDir('user_a'), path.join(dataDir, 'users', 'user_a', 'mail'));
+
+    assert.equal(resolveOrganizationDataRoot('org_1'), path.join(dataDir, 'organizations', 'org_1'));
+    assert.equal(resolveOrganizationSecretsDir('org_1'), path.join(dataDir, 'organizations', 'org_1', 'secrets'));
+    assert.equal(resolveOrganizationPoliciesDir('org_1'), path.join(dataDir, 'organizations', 'org_1', 'policies'));
+    assert.equal(resolveOrganizationAgentTemplatesDir('org_1'), path.join(dataDir, 'organizations', 'org_1', 'agent-templates'));
+    assert.equal(resolveOrganizationSkillTemplatesDir('org_1'), path.join(dataDir, 'organizations', 'org_1', 'skill-templates'));
+    assert.equal(resolveOrganizationPluginTemplatesDir('org_1'), path.join(dataDir, 'organizations', 'org_1', 'plugin-templates'));
+    assert.equal(resolveOrganizationMcpTemplatesDir('org_1'), path.join(dataDir, 'organizations', 'org_1', 'mcp-templates'));
+
+    assert.equal(resolveSystemSecretsDir(), path.join(dataDir, 'system', 'secrets'));
+    assert.equal(resolveSystemManagedDir(), path.join(dataDir, 'system', 'managed'));
+    assert.equal(resolveSystemBackupsDir(), path.join(dataDir, 'system', 'backups'));
+    assert.equal(resolveSystemMigrationDir(), path.join(dataDir, 'system', 'migration'));
+    assert.equal(resolveSystemLogsDir(), path.join(dataDir, 'system', 'logs'));
+
+    for (const invalid of ['', ' ', '.', '..', '../user', 'team/a', 'team\\a', `team${String.fromCharCode(0)}a`]) {
+      assert.throws(() => normalizeDataScopeId(invalid, 'scope'), /Invalid scope/);
+    }
+
+    const dataEnvRoot = path.join(dataDir, 'data-env-root');
+    process.env.CANVAS_DATA_ROOT = '';
+    process.env.DATA = dataEnvRoot;
+    assert.equal(resolveCanvasDataRoot(), dataEnvRoot);
+
+    console.log('scoped-runtime-paths-test: ok');
+  } finally {
+    if (previousCanvasDataRoot === undefined) {
+      delete process.env.CANVAS_DATA_ROOT;
+    } else {
+      process.env.CANVAS_DATA_ROOT = previousCanvasDataRoot;
+    }
+    if (previousData === undefined) {
+      delete process.env.DATA;
+    } else {
+      process.env.DATA = previousData;
+    }
+    await fs.rm(dataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add central scoped runtime path helpers for user, organization, and system data roots
- bind editable agent-managed files, onboarding profile writes, memory writes, and prompt snapshots to the active user scope
- preserve legacy global agent storage behavior when no user scope is provided, while preventing automatic legacy personal-file copying into every user scope
- mark Task 17 as in progress with the completed agent-storage foundation artifacts

## Verification
- `npm run test:scoped-data-paths`
- `npm run test:agent:memory`
- `npm run test:onboarding:profile`
- `npm run test:agents:runtime`
- `npm run test:pi:tools`
- `npm run test:agent:session-workspace`
- `npm run test:channels:db`
- `npm run test:pi:delegate-task`
- `npm run lint`
- `npm run build`

## Greptile
Automatic first review expected after PR creation. No manual greploop trigger for this head SHA yet.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a central `runtime-data-paths.ts` helper layer (user, org, and system roots) and threads a `userId`-carrying `AgentStorageScope` through managed-file reads and writes, memory operations, onboarding profile writes, and prompt snapshot creation. Legacy callers that omit the scope continue to use the global agents storage root, and a `resolveScopedChildPath` traversal guard in `storage.ts` provides defence-in-depth on top of `normalizeDataScopeId`.

- `AgentStorageScope` is wired through all public storage functions (`readManagedAgentFile`, `writeManagedAgentFile`, `readRuntimeManagedAgentFiles`, memory store, onboarding) and all session-creation paths that previously used the global root.
- The new `DATA` env-var fallback in `resolveCanvasDataRoot` is handled with an `isDefaultDataEnvValue` guard that normalises trailing slashes and dot segments via `path.posix.normalize`, covered by the new `scoped-runtime-paths-test.ts`.
- Legacy personal-file migration is explicitly suppressed when a `userId` scope is active, preventing global seed data from leaking into every new user scope.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all storage mutations are correctly scoped, path traversal is guarded at two independent layers, and the legacy fallback is preserved for callers that don't pass a scope.

No correctness or isolation bugs were found. The traversal protection in resolveScopedChildPath combined with normalizeDataScopeId makes cross-user path escapes effectively impossible. All API call sites correctly extract session.user.id before passing it as the scope. The single minor inconsistency (relative CANVAS_DATA_ROOT ignoring the cwd parameter) only matters in test scenarios with an explicit non-default cwd argument and has no production impact.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/lib/runtime-data-paths.ts | New scoped path helpers for user, org, and system data roots; adds DATA env-var resolution with default-value exclusion and normalizeDataScopeId validation |
| app/lib/agents/storage.ts | Scope parameter threaded through all managed-file helpers; resolveScopedChildPath adds traversal protection; legacy migration correctly skipped when userId scope present |
| app/lib/agents/memory-store.ts | MemoryScopeParams added and scope wired through read/write helpers; resolveMemoryStorageScope bridges the internal type to AgentStorageScope |
| app/lib/agents/system-prompt-shared.ts | scope added to ManagedPromptSource; getPromptSourcePath resolves user-scoped display path dynamically; MANAGED_FILES_INTRO generalized to not expose storage path |
| app/lib/pi/system-prompt-snapshot.ts | userId added to PiSessionPromptSnapshotRow pick and threaded into snapshot creation; ensurePiSessionSystemPromptSnapshot now uses session.userId for scoped prompt resolution |
| app/lib/onboarding/profile.ts | completeOnboardingProfile now writes USER.md and SOUL.md to user-scoped path; bootstrap file read/delete remain global-scope, consistent with legacy intent |
| app/lib/organization/bootstrap.ts | buildScopedPaths refactored to use runtime-data-paths helpers instead of inline path.join; no behavioral change, paths are identical |
| app/api/agents/files/route.ts | userId extracted from session and passed as scope to all managed-file operations; extra !session guards added after requireSession for GET, PUT, POST handlers |
| app/lib/pi/tool-registry.ts | createMemoryTool now accepts userId and passes it to all memory operations; createUserScopedTools passes userId down to createMemoryTool |
| app/lib/channels/session-resolver.ts | createPiSystemPromptSnapshot now receives userId scope when creating a channel session |
| scripts/scoped-runtime-paths-test.ts | New test covering all path helpers, default DATA value detection, and invalid scope ID rejection |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/lib/pi/system-prompt-snapshot.ts`, line 729-733 ([link](https://github.com/canvascoding/canvas-notebook/blob/d993387ea1641a5e20eff541a4cbd91cc9b8dc28/app/lib/pi/system-prompt-snapshot.ts#L729-L733)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inline scope type doesn't use `AgentStorageScope`**

   `createPiSystemPromptSnapshot` declares its `scope` parameter with an inline type `{ userId?: string | null }` instead of the exported `AgentStorageScope` from `storage.ts`. Every other function in the call chain (`loadManagedAgentSystemPrompt`, `readRuntimeManagedAgentFiles`, `writeManagedAgentFile`) uses `AgentStorageScope`. If the type ever gains a second field (e.g. `orgId`), the snapshot function won't pick it up automatically and scoping will silently degrade to userId-only.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-scoped-agent-assets%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-scoped-agent-assets%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Fpi%2Fsystem-prompt-snapshot.ts%0ALine%3A%20729-733%0A%0AComment%3A%0A**Inline%20scope%20type%20doesn't%20use%20%60AgentStorageScope%60**%0A%0A%60createPiSystemPromptSnapshot%60%20declares%20its%20%60scope%60%20parameter%20with%20an%20inline%20type%20%60%7B%20userId%3F%3A%20string%20%7C%20null%20%7D%60%20instead%20of%20the%20exported%20%60AgentStorageScope%60%20from%20%60storage.ts%60.%20Every%20other%20function%20in%20the%20call%20chain%20%28%60loadManagedAgentSystemPrompt%60%2C%20%60readRuntimeManagedAgentFiles%60%2C%20%60writeManagedAgentFile%60%29%20uses%20%60AgentStorageScope%60.%20If%20the%20type%20ever%20gains%20a%20second%20field%20%28e.g.%20%60orgId%60%29%2C%20the%20snapshot%20function%20won't%20pick%20it%20up%20automatically%20and%20scoping%20will%20silently%20degrade%20to%20userId-only.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-scoped-agent-assets%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-scoped-agent-assets%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Flib%2Fruntime-data-paths.ts%3A25-28%0A%60CANVAS_DATA_ROOT%60%20ignores%20the%20%60cwd%60%20parameter%20when%20resolving%20a%20relative%20path%20%28it%20calls%20%60path.resolve%28configured%29%60%20which%20is%20equivalent%20to%20%60path.resolve%28process.cwd%28%29%2C%20configured%29%60%29%2C%20while%20the%20new%20%60DATA%60%20branch%20correctly%20uses%20%60path.resolve%28cwd%20%3F%3F%20process.cwd%28%29%2C%20data%29%60.%20This%20is%20inconsistent%20%E2%80%94%20if%20a%20caller%20ever%20passes%20a%20non-default%20%60cwd%60%2C%20the%20two%20env%20vars%20would%20resolve%20relative%20paths%20against%20different%20bases.%20In%20production%20both%20are%20set%20to%20absolute%20paths%20so%20there's%20no%20immediate%20impact%2C%20but%20the%20asymmetry%20is%20worth%20closing.%0A%0A%60%60%60suggestion%0A%20%20const%20configured%20%3D%20process.env.CANVAS_DATA_ROOT%3F.trim%28%29%3B%0A%20%20if%20%28configured%29%20%7B%0A%20%20%20%20return%20path.isAbsolute%28configured%29%0A%20%20%20%20%20%20%3F%20configured%0A%20%20%20%20%20%20%3A%20path.resolve%28cwd%20%3F%3F%20process.cwd%28%29%2C%20configured%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address scoped storage review feedback"](https://github.com/canvascoding/canvas-notebook/commit/b2b7c840d49b70999c5a73d246f851fab6e17898) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38801379)</sub>

<!-- /greptile_comment -->