### PR TITLE
Add user-scoped skills and plugins storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ eröffne ausschließlich auf localhost 3000 einen dev server. starte keine neuen
 - Use the `greploop` skill only after the user confirms the automatic Greptile review is available or explicitly asks for it.
 - Before any PR is merged into `main`, review the Greptile/greploop result for that PR and document the resulting score in the PR.
 - Trigger Greptile/greploop at most once per PR head SHA. If Greptile accepts the trigger but does not publish an updated score, wait and treat the PR as blocked; do not post another `@greptile review` for the same head.
+- To detect whether Greptile accepted a manual `@greptile review` trigger, inspect the trigger comment reactions. An `eyes` reaction from `greptile-apps[bot]` or another Greptile bot means Greptile is working; wait for the result and do not post another trigger for the same head SHA.
 - After addressing review feedback and pushing a new commit, the new head SHA may be reviewed once.
 - A `greploop` score of 4 out of 5 is sufficient for merge; a perfect 5 out of 5 is not required.
 - Every Greptile/greploop comment must still be reviewed. Actionable comments must be fixed; non-actionable or false-positive comments must be documented and resolved.

--- a/app/api/plugins/[name]/disable/route.ts
+++ b/app/api/plugins/[name]/disable/route.ts
@@ -13,7 +13,12 @@ export async function POST(
   if (!pluginPermission.ok) return pluginPermission.response;
 
   const { name } = await params;
-  const result = await setCanvasPluginEnabled(name, false);
+  const result = await setCanvasPluginEnabled(
+    name,
+    false,
+    { userId: pluginPermission.session.user.id },
+    pluginPermission.session.user.email || pluginPermission.session.user.id,
+  );
   if (!result.success) {
     return NextResponse.json(
       { success: false, error: result.error },

--- a/app/api/plugins/[name]/enable/route.ts
+++ b/app/api/plugins/[name]/enable/route.ts
@@ -13,7 +13,12 @@ export async function POST(
   if (!pluginPermission.ok) return pluginPermission.response;
 
   const { name } = await params;
-  const result = await setCanvasPluginEnabled(name, true);
+  const result = await setCanvasPluginEnabled(
+    name,
+    true,
+    { userId: pluginPermission.session.user.id },
+    pluginPermission.session.user.email || pluginPermission.session.user.id,
+  );
   if (!result.success) {
     return NextResponse.json(
       { success: false, error: result.error },

--- a/app/api/plugins/[name]/route.ts
+++ b/app/api/plugins/[name]/route.ts
@@ -20,7 +20,7 @@ export async function GET(
     return NextResponse.json({ success: false, error: 'Invalid plugin name' }, { status: 400 });
   }
 
-  const plugin = await getCanvasPlugin(name);
+  const plugin = await getCanvasPlugin(name, { userId: session.user.id });
   if (!plugin) {
     return NextResponse.json({ success: false, error: 'Plugin not found' }, { status: 404 });
   }
@@ -38,7 +38,11 @@ export async function DELETE(
   if (!pluginPermission.ok) return pluginPermission.response;
 
   const { name } = await params;
-  const result = await deleteCanvasPlugin(name);
+  const result = await deleteCanvasPlugin(
+    name,
+    { userId: pluginPermission.session.user.id },
+    pluginPermission.session.user.email || pluginPermission.session.user.id,
+  );
   if (!result.success) {
     return NextResponse.json(
       { success: false, error: result.error },

--- a/app/api/plugins/asset/route.ts
+++ b/app/api/plugins/asset/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'path parameter is required' }, { status: 400 });
   }
 
-  const plugin = await getCanvasPlugin(pluginName);
+  const plugin = await getCanvasPlugin(pluginName, { userId: session.user.id });
   if (!plugin) {
     return NextResponse.json({ success: false, error: 'Plugin not found' }, { status: 404 });
   }

--- a/app/api/plugins/install/route.ts
+++ b/app/api/plugins/install/route.ts
@@ -27,6 +27,7 @@ export async function POST(request: Request) {
       enable: body.enable !== false,
       replace: body.replace === true,
       installedBy: pluginPermission.session.user.email || pluginPermission.session.user.id,
+      scope: { userId: pluginPermission.session.user.id },
     });
 
     if (!result.success) {

--- a/app/api/plugins/route.ts
+++ b/app/api/plugins/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
   }
 
   try {
-    const plugins = await listCanvasPlugins();
+    const plugins = await listCanvasPlugins({ userId: session.user.id });
     return NextResponse.json({
       success: true,
       plugins,

--- a/app/api/plugins/store/install/route.ts
+++ b/app/api/plugins/store/install/route.ts
@@ -31,6 +31,7 @@ export async function POST(request: Request) {
         enable: body.enable !== false,
         replace: body.replace !== false,
         installedBy: pluginPermission.session.user.email || pluginPermission.session.user.id,
+        scope: { userId: pluginPermission.session.user.id },
       },
     );
 

--- a/app/api/plugins/store/preflight/route.ts
+++ b/app/api/plugins/store/preflight/route.ts
@@ -27,6 +27,7 @@ export async function POST(request: Request) {
       body.name.trim(),
       typeof body.version === 'string' ? body.version.trim() : undefined,
       session.user.id,
+      { userId: session.user.id },
     );
 
     return NextResponse.json({ success: true, preflight });

--- a/app/api/plugins/store/route.ts
+++ b/app/api/plugins/store/route.ts
@@ -22,11 +22,13 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    const scope = { userId: session.user.id };
     const store = await listCanvasPluginStore({
       page: parsePositiveInteger(request.nextUrl.searchParams.get('page')),
       pageSize: parsePositiveInteger(request.nextUrl.searchParams.get('pageSize')),
       query: request.nextUrl.searchParams.get('q') || '',
       state: parseState(request.nextUrl.searchParams.get('state')),
+      scope,
     });
     return NextResponse.json({
       success: true,

--- a/app/api/skills/[name]/delete/route.ts
+++ b/app/api/skills/[name]/delete/route.ts
@@ -14,6 +14,7 @@ export async function DELETE(
     if (!skillPermission.ok) return skillPermission.response;
 
     const { name } = await params;
+    const scope = { userId: skillPermission.session.user.id };
 
     if (!name || !/^[a-z0-9]+([a-z0-9-]*[a-z0-9]+)?$/.test(name)) {
       return NextResponse.json(
@@ -22,7 +23,7 @@ export async function DELETE(
       );
     }
 
-    const result = await deleteSkillDirectory(name);
+    const result = await deleteSkillDirectory(name, scope);
 
     if (!result.success) {
       const status = result.error?.includes('not found')
@@ -36,7 +37,7 @@ export async function DELETE(
       );
     }
 
-    await removeCanvasSkillRegistryRecord(name).catch((registryError) => {
+    await removeCanvasSkillRegistryRecord(name, scope).catch((registryError) => {
       console.warn('[Skills API] Deleted skill directory but failed to remove registry record:', registryError);
     });
 

--- a/app/api/skills/[name]/disable/route.ts
+++ b/app/api/skills/[name]/disable/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
-import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
 import { disableSkillInConfig, resolveEnabledSkillNames } from '@/app/lib/skills/enabled-skills';
 import { loadSkillsFromDisk } from '@/app/lib/skills/skill-loader';
+import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 
 export async function POST(
   request: Request,
@@ -15,24 +15,24 @@ export async function POST(
     if (!skillPermission.ok) return skillPermission.response;
 
     const { name } = await params;
+    const scope = { userId: skillPermission.session.user.id };
     
-    // Read current config
-    const config = await readPiRuntimeConfig();
-    const allSkills = await loadSkillsFromDisk();
+    const enabledSkills = await readEnabledSkillsForScope(scope);
+    const allSkills = await loadSkillsFromDisk(undefined, scope);
     const allSkillNames = allSkills.map((skill) => skill.name);
-    const nextEnabledSkills = disableSkillInConfig(name, config.enabledSkills, allSkillNames);
+    const nextEnabledSkills = disableSkillInConfig(name, enabledSkills, allSkillNames);
 
-    if (JSON.stringify(nextEnabledSkills) !== JSON.stringify(config.enabledSkills || [])) {
-      config.enabledSkills = nextEnabledSkills;
-      config.updatedAt = new Date().toISOString();
-      config.updatedBy = skillPermission.session.user.email || 'unknown';
-      await writePiRuntimeConfig(config);
+    if (JSON.stringify(nextEnabledSkills) !== JSON.stringify(enabledSkills || [])) {
+      await writeEnabledSkillsForScope(nextEnabledSkills, {
+        scope,
+        updatedBy: skillPermission.session.user.email || skillPermission.session.user.id,
+      });
     }
 
     return NextResponse.json({
       success: true,
       message: `Skill "${name}" disabled`,
-      enabledSkills: Array.from(resolveEnabledSkillNames(allSkillNames, config.enabledSkills)),
+      enabledSkills: Array.from(resolveEnabledSkillNames(allSkillNames, nextEnabledSkills)),
     });
   } catch (error) {
     console.error('[Skills API] Error disabling skill:', error);

--- a/app/api/skills/[name]/enable/route.ts
+++ b/app/api/skills/[name]/enable/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
-import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
 import { enableSkillInConfig, resolveEnabledSkillNames } from '@/app/lib/skills/enabled-skills';
 import { loadSkillsFromDisk } from '@/app/lib/skills/skill-loader';
+import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 
 export async function POST(
   request: Request,
@@ -15,24 +15,24 @@ export async function POST(
     if (!skillPermission.ok) return skillPermission.response;
 
     const { name } = await params;
+    const scope = { userId: skillPermission.session.user.id };
     
-    // Read current config
-    const config = await readPiRuntimeConfig();
-    const allSkills = await loadSkillsFromDisk();
+    const enabledSkills = await readEnabledSkillsForScope(scope);
+    const allSkills = await loadSkillsFromDisk(undefined, scope);
     const allSkillNames = allSkills.map((skill) => skill.name);
-    const nextEnabledSkills = enableSkillInConfig(name, config.enabledSkills, allSkillNames);
+    const nextEnabledSkills = enableSkillInConfig(name, enabledSkills, allSkillNames);
 
-    if (JSON.stringify(nextEnabledSkills) !== JSON.stringify(config.enabledSkills || [])) {
-      config.enabledSkills = nextEnabledSkills;
-      config.updatedAt = new Date().toISOString();
-      config.updatedBy = skillPermission.session.user.email || 'unknown';
-      await writePiRuntimeConfig(config);
+    if (JSON.stringify(nextEnabledSkills) !== JSON.stringify(enabledSkills || [])) {
+      await writeEnabledSkillsForScope(nextEnabledSkills, {
+        scope,
+        updatedBy: skillPermission.session.user.email || skillPermission.session.user.id,
+      });
     }
 
     return NextResponse.json({
       success: true,
       message: `Skill "${name}" enabled`,
-      enabledSkills: Array.from(resolveEnabledSkillNames(allSkillNames, config.enabledSkills)),
+      enabledSkills: Array.from(resolveEnabledSkillNames(allSkillNames, nextEnabledSkills)),
     });
   } catch (error) {
     console.error('[Skills API] Error enabling skill:', error);

--- a/app/api/skills/[name]/readme/route.ts
+++ b/app/api/skills/[name]/readme/route.ts
@@ -7,8 +7,6 @@ import { requireOrganizationPermission } from '@/app/lib/organization/permission
 import { getSkillsDir } from '@/app/lib/skills/canvas-skill-manifest';
 import { loadSkillByName } from '@/app/lib/skills/skill-loader';
 
-const SKILLS_DIR = getSkillsDir();
-
 function sanitizeSkillName(name: string): string {
   return name.replace(/[^a-z0-9-]/g, '');
 }
@@ -24,7 +22,7 @@ export async function GET(
     }
 
     const { name } = await params;
-    const skill = await loadSkillByName(name);
+    const skill = await loadSkillByName(name, { userId: session.user.id });
     if (!skill) {
       return NextResponse.json(
         { success: false, error: 'Skill not found' },
@@ -61,6 +59,7 @@ export async function PUT(
 
     const { name } = await params;
     const sanitizedName = sanitizeSkillName(name);
+    const skillsDir = getSkillsDir({ userId: skillPermission.session.user.id });
     
     if (!sanitizedName) {
       return NextResponse.json(
@@ -69,11 +68,11 @@ export async function PUT(
       );
     }
 
-    const skillMdPath = path.join(SKILLS_DIR, sanitizedName, 'SKILL.md');
+    const skillMdPath = path.join(skillsDir, sanitizedName, 'SKILL.md');
     
     // Verify the path is within the skills directory (path traversal protection)
     const resolvedPath = path.resolve(/*turbopackIgnore: true*/ skillMdPath);
-    const resolvedSkillsDir = path.resolve(/*turbopackIgnore: true*/ SKILLS_DIR);
+    const resolvedSkillsDir = path.resolve(/*turbopackIgnore: true*/ skillsDir);
     if (!resolvedPath.startsWith(`${resolvedSkillsDir}${path.sep}`)) {
       return NextResponse.json(
         { success: false, error: 'Plugin-managed skills cannot be edited from the standalone skill editor' },

--- a/app/api/skills/[name]/readme/route.ts
+++ b/app/api/skills/[name]/readme/route.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { headers } from 'next/headers';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { getSkillsDir } from '@/app/lib/skills/canvas-skill-manifest';
+import { adoptLegacyStandaloneSkillsForScope } from '@/app/lib/skills/legacy-skill-adoption';
 import { loadSkillByName } from '@/app/lib/skills/skill-loader';
 
 function sanitizeSkillName(name: string): string {
@@ -59,7 +60,6 @@ export async function PUT(
 
     const { name } = await params;
     const sanitizedName = sanitizeSkillName(name);
-    const skillsDir = getSkillsDir({ userId: skillPermission.session.user.id });
     
     if (!sanitizedName) {
       return NextResponse.json(
@@ -68,6 +68,9 @@ export async function PUT(
       );
     }
 
+    const scope = { userId: skillPermission.session.user.id };
+    await adoptLegacyStandaloneSkillsForScope(scope);
+    const skillsDir = getSkillsDir(scope);
     const skillMdPath = path.join(skillsDir, sanitizedName, 'SKILL.md');
     
     // Verify the path is within the skills directory (path traversal protection)

--- a/app/api/skills/[name]/restore/route.ts
+++ b/app/api/skills/[name]/restore/route.ts
@@ -24,6 +24,8 @@ export async function POST(
       prefer,
       version: typeof body.version === 'string' ? body.version.trim() : undefined,
       enable: body.enable !== false,
+      scope: { userId: skillPermission.session.user.id },
+      updatedBy: skillPermission.session.user.email || skillPermission.session.user.id,
     });
 
     if (!result.success) {

--- a/app/api/skills/asset/route.ts
+++ b/app/api/skills/asset/route.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { headers } from 'next/headers';
 
 import { auth } from '@/app/lib/auth';
-import { getSkillsDir } from '@/app/lib/skills/canvas-skill-manifest';
+import { resolveReadableScopedSkillsDataDir } from '@/app/lib/runtime-data-paths';
 
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
   '.gif': 'image/gif',
@@ -25,18 +25,6 @@ function sanitizeAssetPath(filePath: string): string {
     .replace(/\/$/, '');
 }
 
-async function directoryExists(targetPath: string): Promise<boolean> {
-  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
-}
-
-async function resolveReadableSkillsDir(userId: string): Promise<string> {
-  const scopedDir = getSkillsDir({ userId });
-  if (!(await directoryExists(scopedDir))) {
-    return getSkillsDir();
-  }
-  return scopedDir;
-}
-
 export async function GET(request: NextRequest) {
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) {
@@ -55,7 +43,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'Only image assets are supported' }, { status: 400 });
   }
 
-  const skillsDir = await resolveReadableSkillsDir(session.user.id);
+  const skillsDir = await resolveReadableScopedSkillsDataDir({ userId: session.user.id });
   const fullPath = path.join(skillsDir, sanitizedPath);
   const resolvedPath = path.resolve(/*turbopackIgnore: true*/ fullPath);
   const resolvedSkillsDir = path.resolve(/*turbopackIgnore: true*/ skillsDir);

--- a/app/api/skills/asset/route.ts
+++ b/app/api/skills/asset/route.ts
@@ -25,6 +25,18 @@ function sanitizeAssetPath(filePath: string): string {
     .replace(/\/$/, '');
 }
 
+async function directoryExists(targetPath: string): Promise<boolean> {
+  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
+}
+
+async function resolveReadableSkillsDir(userId: string): Promise<string> {
+  const scopedDir = getSkillsDir({ userId });
+  if (!(await directoryExists(scopedDir))) {
+    return getSkillsDir();
+  }
+  return scopedDir;
+}
+
 export async function GET(request: NextRequest) {
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) {
@@ -43,7 +55,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'Only image assets are supported' }, { status: 400 });
   }
 
-  const skillsDir = getSkillsDir();
+  const skillsDir = await resolveReadableSkillsDir(session.user.id);
   const fullPath = path.join(skillsDir, sanitizedPath);
   const resolvedPath = path.resolve(/*turbopackIgnore: true*/ fullPath);
   const resolvedSkillsDir = path.resolve(/*turbopackIgnore: true*/ skillsDir);

--- a/app/api/skills/disable-all/route.ts
+++ b/app/api/skills/disable-all/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
-import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
 import { loadSkillsFromDisk } from '@/app/lib/skills/skill-loader';
+import { DISABLED_ALL_SKILLS_SENTINEL } from '@/app/lib/skills/enabled-skills';
+import { writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 
 export async function POST(request: Request) {
   try {
@@ -10,22 +11,16 @@ export async function POST(request: Request) {
     });
     if (!skillPermission.ok) return skillPermission.response;
 
-    // Read current config
-    const config = await readPiRuntimeConfig();
+    const scope = { userId: skillPermission.session.user.id };
     
     // Load all available skills
-    const allSkills = await loadSkillsFromDisk();
+    const allSkills = await loadSkillsFromDisk(undefined, scope);
     
-    // Disable all skills by adding all to enabledSkills (empty list = all enabled, so we need to add all)
-    // Actually, to disable all, we need to set enabledSkills to a list that doesn't include any
-    // But since empty list means "all enabled", we need a different approach
-    // Let's add a dummy entry that won't match any real skill
-    config.enabledSkills = ['__none__'];
-    config.updatedAt = new Date().toISOString();
-    config.updatedBy = skillPermission.session.user.email || 'unknown';
-    
-    // Write updated config
-    await writePiRuntimeConfig(config);
+    // Empty enabledSkills means "all enabled", so use the sentinel to disable every skill.
+    await writeEnabledSkillsForScope([DISABLED_ALL_SKILLS_SENTINEL], {
+      scope,
+      updatedBy: skillPermission.session.user.email || skillPermission.session.user.id,
+    });
     
     return NextResponse.json({
       success: true,

--- a/app/api/skills/enable-all/route.ts
+++ b/app/api/skills/enable-all/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
-import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
 import { loadSkillsFromDisk } from '@/app/lib/skills/skill-loader';
+import { writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 
 export async function POST(request: Request) {
   try {
@@ -10,20 +10,17 @@ export async function POST(request: Request) {
     });
     if (!skillPermission.ok) return skillPermission.response;
 
-    // Read current config
-    const config = await readPiRuntimeConfig();
+    const scope = { userId: skillPermission.session.user.id };
     
     // Load all available skills
-    const allSkills = await loadSkillsFromDisk();
+    const allSkills = await loadSkillsFromDisk(undefined, scope);
     const allSkillNames = allSkills.map(s => s.name);
     
     // Enable all skills by setting enabledSkills to empty array (which means all enabled)
-    config.enabledSkills = [];
-    config.updatedAt = new Date().toISOString();
-    config.updatedBy = skillPermission.session.user.email || 'unknown';
-    
-    // Write updated config
-    await writePiRuntimeConfig(config);
+    await writeEnabledSkillsForScope([], {
+      scope,
+      updatedBy: skillPermission.session.user.email || skillPermission.session.user.id,
+    });
     
     return NextResponse.json({
       success: true,

--- a/app/api/skills/file/route.ts
+++ b/app/api/skills/file/route.ts
@@ -5,8 +5,6 @@ import { headers } from 'next/headers';
 import { auth } from '@/app/lib/auth';
 import { getSkillsDir } from '@/app/lib/skills/canvas-skill-manifest';
 
-const SKILLS_DIR = getSkillsDir();
-
 function sanitizeFilePath(filePath: string): string {
   let clean = filePath;
   clean = clean.replace(/\.\./g, '');
@@ -14,6 +12,18 @@ function sanitizeFilePath(filePath: string): string {
   clean = clean.replace(/^\//, '');
   clean = clean.replace(/\/$/, '');
   return clean;
+}
+
+async function directoryExists(targetPath: string): Promise<boolean> {
+  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
+}
+
+async function resolveReadableSkillsDir(userId: string): Promise<string> {
+  const scopedDir = getSkillsDir({ userId });
+  if (!(await directoryExists(scopedDir))) {
+    return getSkillsDir();
+  }
+  return scopedDir;
 }
 
 export async function GET(request: NextRequest) {
@@ -31,9 +41,10 @@ export async function GET(request: NextRequest) {
     }
 
     const sanitizedPath = sanitizeFilePath(filePath);
-    const fullPath = path.join(SKILLS_DIR, sanitizedPath);
+    const skillsDir = await resolveReadableSkillsDir(session.user.id);
+    const fullPath = path.join(skillsDir, sanitizedPath);
     const resolvedPath = path.resolve(fullPath);
-    const resolvedSkillsDir = path.resolve(SKILLS_DIR);
+    const resolvedSkillsDir = path.resolve(skillsDir);
 
     if (!resolvedPath.startsWith(`${resolvedSkillsDir}${path.sep}`)) {
       return NextResponse.json({ success: false, error: 'Invalid path' }, { status: 400 });

--- a/app/api/skills/file/route.ts
+++ b/app/api/skills/file/route.ts
@@ -7,6 +7,7 @@ import { resolveReadableScopedSkillsDataDir } from '@/app/lib/runtime-data-paths
 
 function sanitizeFilePath(filePath: string): string {
   let clean = filePath;
+  clean = clean.replace(/\0/g, '');
   clean = clean.replace(/\.\./g, '');
   clean = clean.replace(/\/\/+/g, '/');
   clean = clean.replace(/^\//, '');

--- a/app/api/skills/file/route.ts
+++ b/app/api/skills/file/route.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { headers } from 'next/headers';
 import { auth } from '@/app/lib/auth';
-import { getSkillsDir } from '@/app/lib/skills/canvas-skill-manifest';
+import { resolveReadableScopedSkillsDataDir } from '@/app/lib/runtime-data-paths';
 
 function sanitizeFilePath(filePath: string): string {
   let clean = filePath;
@@ -12,18 +12,6 @@ function sanitizeFilePath(filePath: string): string {
   clean = clean.replace(/^\//, '');
   clean = clean.replace(/\/$/, '');
   return clean;
-}
-
-async function directoryExists(targetPath: string): Promise<boolean> {
-  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
-}
-
-async function resolveReadableSkillsDir(userId: string): Promise<string> {
-  const scopedDir = getSkillsDir({ userId });
-  if (!(await directoryExists(scopedDir))) {
-    return getSkillsDir();
-  }
-  return scopedDir;
 }
 
 export async function GET(request: NextRequest) {
@@ -41,7 +29,7 @@ export async function GET(request: NextRequest) {
     }
 
     const sanitizedPath = sanitizeFilePath(filePath);
-    const skillsDir = await resolveReadableSkillsDir(session.user.id);
+    const skillsDir = await resolveReadableScopedSkillsDataDir({ userId: session.user.id });
     const fullPath = path.join(skillsDir, sanitizedPath);
     const resolvedPath = path.resolve(fullPath);
     const resolvedSkillsDir = path.resolve(skillsDir);

--- a/app/api/skills/reset/route.ts
+++ b/app/api/skills/reset/route.ts
@@ -25,7 +25,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const result = await resetCanvasSkillsDirectory(workspaceResult.session.user.email || 'unknown');
+    const result = await resetCanvasSkillsDirectory(
+      workspaceResult.session.user.email || workspaceResult.session.user.id,
+      { userId: workspaceResult.session.user.id },
+    );
     return NextResponse.json(result);
   } catch (error) {
     console.error('[Skills API] Error resetting skills directory:', error);

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { headers } from 'next/headers';
 
 import { auth } from '@/app/lib/auth';
-import { readPiRuntimeConfig } from '@/app/lib/agents/storage';
 import { loadSkillSummaries, matchesSkillSummaryQuery, type SkillSummary } from '@/app/lib/skills/skill-summaries';
+import { readEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 import { paginateItems, parsePositiveInteger } from '@/app/lib/utils/pagination';
 
 const DEFAULT_SUMMARY_LIMIT = 50;
@@ -16,11 +16,12 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    const scope = { userId: session.user.id };
     const summaryOnly = request.nextUrl.searchParams.get('summary') === '1';
-    const config = await readPiRuntimeConfig();
+    const enabledSkills = await readEnabledSkillsForScope(scope);
     const skills = summaryOnly
-      ? await loadSkillSummaries(config.enabledSkills)
-      : await (await import('@/app/lib/skills/skill-loader')).loadSkillsFromDisk(config.enabledSkills);
+      ? await loadSkillSummaries(enabledSkills, scope)
+      : await (await import('@/app/lib/skills/skill-loader')).loadSkillsFromDisk(enabledSkills, scope);
     const query = request.nextUrl.searchParams.get('query')?.trim().toLowerCase() || '';
     const enabledOnly = request.nextUrl.searchParams.get('enabledOnly') === '1';
     const paginated = summaryOnly && (

--- a/app/api/skills/status/route.ts
+++ b/app/api/skills/status/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/app/lib/auth';
-import { readPiRuntimeConfig } from '@/app/lib/agents/storage';
 import { resolveEnabledSkillNames } from '@/app/lib/skills/enabled-skills';
 import { loadSkillsFromDisk } from '@/app/lib/skills/skill-loader';
+import { readEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 import { headers } from 'next/headers';
 
 export async function GET() {
@@ -12,11 +12,11 @@ export async function GET() {
       return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
     }
 
-    // Read current config
-    const config = await readPiRuntimeConfig();
-    const skills = await loadSkillsFromDisk();
+    const scope = { userId: session.user.id };
+    const enabledSkills = await readEnabledSkillsForScope(scope);
+    const skills = await loadSkillsFromDisk(undefined, scope);
     const allSkillNames = skills.map((skill) => skill.name);
-    const enabledSkillNames = Array.from(resolveEnabledSkillNames(allSkillNames, config.enabledSkills));
+    const enabledSkillNames = Array.from(resolveEnabledSkillNames(allSkillNames, enabledSkills));
 
     return NextResponse.json({
       success: true,

--- a/app/api/skills/store/install/route.ts
+++ b/app/api/skills/store/install/route.ts
@@ -30,6 +30,8 @@ export async function POST(request: Request) {
       {
         enable: body.enable !== false,
         replace: body.replace !== false,
+        scope: { userId: skillPermission.session.user.id },
+        updatedBy: skillPermission.session.user.email || skillPermission.session.user.id,
       },
     );
 

--- a/app/api/skills/store/route.ts
+++ b/app/api/skills/store/route.ts
@@ -22,11 +22,13 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    const scope = { userId: session.user.id };
     const store = await listCanvasSkillStore({
       page: parsePositiveInteger(request.nextUrl.searchParams.get('page')),
       pageSize: parsePositiveInteger(request.nextUrl.searchParams.get('pageSize')),
       query: request.nextUrl.searchParams.get('q') || '',
       state: parseState(request.nextUrl.searchParams.get('state')),
+      scope,
     });
     return NextResponse.json({
       success: true,

--- a/app/api/skills/tree/route.ts
+++ b/app/api/skills/tree/route.ts
@@ -5,7 +5,17 @@ import { auth } from '@/app/lib/auth';
 import { getSkillsDir } from '@/app/lib/skills/canvas-skill-manifest';
 import { buildSkillTree } from '@/app/lib/skills/skill-tree';
 
-const SKILLS_DIR = getSkillsDir();
+async function directoryExists(targetPath: string): Promise<boolean> {
+  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
+}
+
+async function resolveReadableSkillsDir(userId: string): Promise<string> {
+  const scopedDir = getSkillsDir({ userId });
+  if (!(await directoryExists(scopedDir))) {
+    return getSkillsDir();
+  }
+  return scopedDir;
+}
 
 export async function GET(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
@@ -17,7 +27,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const depth = parseInt(searchParams.get('depth') || '4');
 
-    const resolvedSkillsDir = path.resolve(SKILLS_DIR);
+    const resolvedSkillsDir = path.resolve(await resolveReadableSkillsDir(session.user.id));
 
     try {
       await fs.access(resolvedSkillsDir);

--- a/app/api/skills/tree/route.ts
+++ b/app/api/skills/tree/route.ts
@@ -2,20 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { auth } from '@/app/lib/auth';
-import { getSkillsDir } from '@/app/lib/skills/canvas-skill-manifest';
+import { resolveReadableScopedSkillsDataDir } from '@/app/lib/runtime-data-paths';
 import { buildSkillTree } from '@/app/lib/skills/skill-tree';
-
-async function directoryExists(targetPath: string): Promise<boolean> {
-  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
-}
-
-async function resolveReadableSkillsDir(userId: string): Promise<string> {
-  const scopedDir = getSkillsDir({ userId });
-  if (!(await directoryExists(scopedDir))) {
-    return getSkillsDir();
-  }
-  return scopedDir;
-}
 
 export async function GET(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
@@ -27,7 +15,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const depth = parseInt(searchParams.get('depth') || '4');
 
-    const resolvedSkillsDir = path.resolve(await resolveReadableSkillsDir(session.user.id));
+    const resolvedSkillsDir = path.resolve(await resolveReadableScopedSkillsDataDir({ userId: session.user.id }));
 
     try {
       await fs.access(resolvedSkillsDir);

--- a/app/api/skills/upload/route.ts
+++ b/app/api/skills/upload/route.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { getSkillsDir, parseFrontmatter, validateFrontmatter } from '@/app/lib/skills/canvas-skill-manifest';
 import { enableSkillInConfig } from '@/app/lib/skills/enabled-skills';
+import { adoptLegacyStandaloneSkillsForScope } from '@/app/lib/skills/legacy-skill-adoption';
 import { getSkillNames } from '@/app/lib/skills/skill-loader';
 import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 
@@ -19,7 +20,6 @@ export async function POST(request: Request) {
 
   try {
     const scope = { userId: skillPermission.session.user.id };
-    const skillsDir = getSkillsDir(scope);
     const body = await request.json();
     const { content, name: providedName } = body;
 
@@ -72,6 +72,8 @@ export async function POST(request: Request) {
       );
     }
 
+    await adoptLegacyStandaloneSkillsForScope(scope);
+    const skillsDir = getSkillsDir(scope);
     const skillDir = path.join(skillsDir, skillName);
     const resolvedSkillDir = path.resolve(skillDir);
     const resolvedSkillsDir = path.resolve(skillsDir);

--- a/app/api/skills/upload/route.ts
+++ b/app/api/skills/upload/route.ts
@@ -3,11 +3,9 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { getSkillsDir, parseFrontmatter, validateFrontmatter } from '@/app/lib/skills/canvas-skill-manifest';
-import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
 import { enableSkillInConfig } from '@/app/lib/skills/enabled-skills';
 import { getSkillNames } from '@/app/lib/skills/skill-loader';
-
-const SKILLS_DIR = getSkillsDir();
+import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 
 function sanitizeSkillName(name: string): string {
   return name.replace(/[^a-z0-9-]/g, '');
@@ -20,6 +18,8 @@ export async function POST(request: Request) {
   if (!skillPermission.ok) return skillPermission.response;
 
   try {
+    const scope = { userId: skillPermission.session.user.id };
+    const skillsDir = getSkillsDir(scope);
     const body = await request.json();
     const { content, name: providedName } = body;
 
@@ -72,9 +72,9 @@ export async function POST(request: Request) {
       );
     }
 
-    const skillDir = path.join(SKILLS_DIR, skillName);
+    const skillDir = path.join(skillsDir, skillName);
     const resolvedSkillDir = path.resolve(skillDir);
-    const resolvedSkillsDir = path.resolve(SKILLS_DIR);
+    const resolvedSkillsDir = path.resolve(skillsDir);
     if (!resolvedSkillDir.startsWith(`${resolvedSkillsDir}${path.sep}`)) {
       return NextResponse.json(
         { success: false, error: 'Invalid skill name: path traversal detected' },
@@ -96,10 +96,13 @@ export async function POST(request: Request) {
     await fs.writeFile(skillMdPath, content, 'utf-8');
 
     try {
-      const config = await readPiRuntimeConfig();
-      const allSkillNames = await getSkillNames();
-      config.enabledSkills = enableSkillInConfig(skillName, config.enabledSkills, allSkillNames);
-      await writePiRuntimeConfig(config);
+      const enabledSkills = await readEnabledSkillsForScope(scope);
+      const allSkillNames = await getSkillNames(scope);
+      const nextEnabledSkills = enableSkillInConfig(skillName, enabledSkills, allSkillNames);
+      await writeEnabledSkillsForScope(nextEnabledSkills, {
+        scope,
+        updatedBy: skillPermission.session.user.email || skillPermission.session.user.id,
+      });
     } catch (cfgError) {
       console.warn('[Skills Upload API] Could not auto-enable skill:', skillName, cfgError);
     }

--- a/app/lib/agents/system-prompt.ts
+++ b/app/lib/agents/system-prompt.ts
@@ -4,7 +4,6 @@ import {
   CANVAS_INHERITED_FILE_NAMES,
   DEFAULT_MANAGED_AGENT_ID,
   readRuntimeManagedAgentFiles,
-  readPiRuntimeConfig,
   type AgentStorageScope,
 } from './storage';
 import { resolveAgentRuntimeConfig } from './effective-runtime-config';
@@ -14,6 +13,7 @@ import {
 } from './system-prompt-shared';
 import { getAgentProfile } from './registry';
 import { loadSkillsFromDisk, getSkillsContext } from '../skills/skill-loader';
+import { readEnabledSkillsForScope } from '../skills/skill-settings';
 import { isComposioConfigured } from '../composio/composio-client';
 import {
   isDefaultToolsConfig,
@@ -281,12 +281,12 @@ export async function loadManagedAgentSystemPrompt(
     const files = await readRuntimeManagedAgentFiles(normalizedAgentId, scope);
     const agentProfile = await getAgentProfile(normalizedAgentId);
     
-    // Load PI config to get enabled skills and check composio tools
-    const piConfig = await readPiRuntimeConfig();
+    // Load enabled skills for the effective user scope.
+    const enabledSkills = await readEnabledSkillsForScope(scope);
     
     // The Canvas Agent receives all globally enabled skills. Specialized agents
     // receive only their selected relevant skills, intersected with global enablement.
-    const skills = await loadSkillsFromDisk(piConfig.enabledSkills);
+    const skills = await loadSkillsFromDisk(enabledSkills, scope);
     const promptSkills = getPromptSkillsForAgent(normalizedAgentId, skills, agentProfile?.relevantSkills);
     const skillsContext = getSkillsContext(promptSkills);
     

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -909,7 +909,7 @@ class LivePiRuntime {
 
     if (latestUserMessageText) {
       try {
-        const pluginBlock = await buildReferencedPluginRuntimeContext(latestUserMessageText);
+        const pluginBlock = await buildReferencedPluginRuntimeContext(latestUserMessageText, { userId: this.userId });
         if (pluginBlock) {
           sections.push(pluginBlock);
         }

--- a/app/lib/plugins/canvas-plugin-registry.ts
+++ b/app/lib/plugins/canvas-plugin-registry.ts
@@ -10,6 +10,7 @@ import {
   resolveScopedSkillRegistryPath,
   resolveScopedSkillsDataDir,
   shouldUseLegacyScopedPluginsFallback,
+  shouldUseLegacyScopedSkillsFallback,
   type UserScopedDataStorageScope,
 } from '@/app/lib/runtime-data-paths';
 import {
@@ -218,6 +219,7 @@ async function adoptLegacyPluginRegistryForScope(
   scope?: CanvasPluginStorageScope | null,
 ): Promise<CanvasPluginRegistry> {
   const scopedRegistry = createEmptyRegistry();
+  await adoptLegacyStandaloneSkillsForScope(scope);
 
   for (const [name, record] of Object.entries(legacyRegistry.plugins)) {
     const adopted = await adoptLegacyPluginRecordForScope(record, scope).catch((error) => {
@@ -230,6 +232,74 @@ async function adoptLegacyPluginRegistryForScope(
   }
 
   return scopedRegistry;
+}
+
+async function adoptLegacyStandaloneSkillsForScope(scope?: CanvasPluginStorageScope | null): Promise<void> {
+  if (!(await shouldUseLegacyScopedSkillsFallback(scope))) {
+    return;
+  }
+
+  const legacySkillsDir = resolveScopedSkillsDataDir();
+  const scopedSkillsDir = resolveScopedSkillsDataDir(scope);
+  if (path.resolve(/*turbopackIgnore: true*/ legacySkillsDir) === path.resolve(/*turbopackIgnore: true*/ scopedSkillsDir)) {
+    return;
+  }
+
+  const entries = await fs.readdir(legacySkillsDir, { withFileTypes: true }).catch(() => []);
+  await fs.mkdir(scopedSkillsDir, { recursive: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === '.backups') {
+      continue;
+    }
+
+    const sourceDir = path.join(legacySkillsDir, entry.name);
+    const skillPath = path.join(sourceDir, 'SKILL.md');
+    const isSkillDir = await fs.stat(skillPath).then((stat) => stat.isFile()).catch(() => false);
+    if (!isSkillDir) {
+      continue;
+    }
+
+    const targetDir = path.join(scopedSkillsDir, entry.name);
+    const targetExists = await fs.stat(targetDir).then((stat) => stat.isDirectory()).catch(() => false);
+    if (targetExists) {
+      continue;
+    }
+
+    await fs.cp(sourceDir, targetDir, {
+      recursive: true,
+      preserveTimestamps: true,
+      filter: (source) => !IGNORED_CHECKSUM_ENTRIES.has(path.basename(source)),
+    });
+  }
+
+  const legacyRegistry = await readStandaloneSkillRegistry();
+  const scopedRegistry = await readStandaloneSkillRegistry(scope);
+  for (const [skillName, record] of Object.entries(legacyRegistry.skills)) {
+    if (scopedRegistry.skills[skillName]) {
+      continue;
+    }
+    scopedRegistry.skills[skillName] = rebaseLegacyStandaloneSkillRecord(record, legacySkillsDir, scopedSkillsDir);
+  }
+  await writeStandaloneSkillRegistry(scopedRegistry, scope);
+}
+
+function rebaseLegacyStandaloneSkillRecord(
+  record: StandaloneSkillRegistryRecord,
+  legacySkillsDir: string,
+  scopedSkillsDir: string,
+): StandaloneSkillRegistryRecord {
+  const rebaseSkillPath = (value: string): string => {
+    return isPathInside(legacySkillsDir, value)
+      ? path.join(scopedSkillsDir, path.relative(legacySkillsDir, value))
+      : value;
+  };
+
+  return {
+    ...record,
+    installDir: rebaseSkillPath(record.installDir),
+    skillPath: rebaseSkillPath(record.skillPath),
+  };
 }
 
 async function adoptLegacyPluginRecordForScope(

--- a/app/lib/plugins/canvas-plugin-registry.ts
+++ b/app/lib/plugins/canvas-plugin-registry.ts
@@ -3,11 +3,13 @@ import { promises as fs } from 'fs';
 import path from 'path';
 
 import {
+  resolveReadableScopedSkillsDataDir,
   resolveScopedInstalledPluginsDir,
   resolveScopedPluginRegistryPath,
   resolveScopedPluginsDataDir,
   resolveScopedSkillRegistryPath,
   resolveScopedSkillsDataDir,
+  shouldUseLegacyScopedPluginsFallback,
   type UserScopedDataStorageScope,
 } from '@/app/lib/runtime-data-paths';
 import {
@@ -143,10 +145,6 @@ async function ensurePluginsRoot(scope?: CanvasPluginStorageScope | null): Promi
   await fs.mkdir(resolveScopedInstalledPluginsDir(scope), { recursive: true });
 }
 
-async function directoryExists(targetPath: string): Promise<boolean> {
-  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
-}
-
 async function readCanvasPluginRegistryFile(registryPath: string): Promise<CanvasPluginRegistry | null> {
   try {
     const raw = await fs.readFile(registryPath, 'utf-8');
@@ -171,7 +169,7 @@ export async function readCanvasPluginRegistry(scope?: CanvasPluginStorageScope 
     return registry;
   }
 
-  if (scope?.userId?.trim()) {
+  if (await shouldUseLegacyScopedPluginsFallback(scope)) {
     const legacyRegistry = await readCanvasPluginRegistryFile(resolveScopedPluginRegistryPath());
     if (legacyRegistry) {
       return legacyRegistry;
@@ -201,7 +199,109 @@ async function readCanvasPluginRegistryForWrite(
   scope?: CanvasPluginStorageScope | null,
 ): Promise<CanvasPluginRegistry> {
   const registry = await readCanvasPluginRegistryFile(resolveScopedPluginRegistryPath(scope));
-  return registry || createEmptyRegistry();
+  if (registry) {
+    return registry;
+  }
+
+  if (await shouldUseLegacyScopedPluginsFallback(scope)) {
+    const legacyRegistry = await readCanvasPluginRegistryFile(resolveScopedPluginRegistryPath());
+    if (legacyRegistry) {
+      return adoptLegacyPluginRegistryForScope(legacyRegistry, scope);
+    }
+  }
+
+  return createEmptyRegistry();
+}
+
+async function adoptLegacyPluginRegistryForScope(
+  legacyRegistry: CanvasPluginRegistry,
+  scope?: CanvasPluginStorageScope | null,
+): Promise<CanvasPluginRegistry> {
+  const scopedRegistry = createEmptyRegistry();
+
+  for (const [name, record] of Object.entries(legacyRegistry.plugins)) {
+    const adopted = await adoptLegacyPluginRecordForScope(record, scope).catch((error) => {
+      console.warn(`[CanvasPluginRegistry] Failed to adopt legacy plugin "${name}" for user scope:`, error);
+      return null;
+    });
+    if (adopted) {
+      scopedRegistry.plugins[name] = adopted;
+    }
+  }
+
+  return scopedRegistry;
+}
+
+async function adoptLegacyPluginRecordForScope(
+  record: CanvasPluginInstallRecord,
+  scope?: CanvasPluginStorageScope | null,
+): Promise<CanvasPluginInstallRecord> {
+  const installDir = resolvePluginInstallDir(record.name, record.version, scope);
+  if (path.resolve(/*turbopackIgnore: true*/ record.installDir) !== path.resolve(/*turbopackIgnore: true*/ installDir)) {
+    await copyPluginPackage(record.installDir, installDir);
+  }
+
+  const validation = await validateCanvasPluginPackage(installDir);
+  if (validation.valid && validation.manifest && validation.rootDir) {
+    const built = await buildPluginRecordFromInstalledPackage(
+      validation.manifest,
+      record.sourcePath || record.installDir,
+      installDir,
+      record.enabled,
+      {
+        sourcePathLabel: record.sourcePath,
+        sourceRegistryId: record.sourceRegistryId,
+        sourceRegistryUrl: record.sourceRegistryUrl,
+        scope,
+      },
+    );
+
+    if (built.record) {
+      built.record.skills = await materializePluginSkills(built.record, scope);
+      return {
+        ...built.record,
+        installedAt: record.installedAt,
+        updatedAt: record.updatedAt,
+      };
+    }
+  }
+
+  return rebaseLegacyPluginRecordPaths(record, installDir, scope);
+}
+
+function rebaseLegacyPluginRecordPaths(
+  record: CanvasPluginInstallRecord,
+  installDir: string,
+  scope?: CanvasPluginStorageScope | null,
+): CanvasPluginInstallRecord {
+  const rebasePluginPath = (value?: string): string | undefined => {
+    if (!value) return undefined;
+    return isPathInside(record.installDir, value)
+      ? path.join(installDir, path.relative(record.installDir, value))
+      : value;
+  };
+  const rebaseSkillPath = (value?: string): string | undefined => {
+    if (!value) return undefined;
+    const legacySkillsDir = resolveScopedSkillsDataDir();
+    if (!isPathInside(legacySkillsDir, value)) {
+      return value;
+    }
+    return path.join(resolveScopedSkillsDataDir(scope), path.relative(legacySkillsDir, value));
+  };
+
+  return {
+    ...record,
+    installDir,
+    manifestPath: rebasePluginPath(record.manifestPath) || path.join(installDir, '.canvas-plugin', 'plugin.json'),
+    skillsDir: rebasePluginPath(record.skillsDir),
+    skills: record.skills.map((skill) => ({
+      ...skill,
+      path: rebasePluginPath(skill.path) || skill.path,
+      directory: rebasePluginPath(skill.directory) || skill.directory,
+      standaloneDir: rebaseSkillPath(skill.standaloneDir),
+    })),
+    updatedAt: nowIso(),
+  };
 }
 
 async function readStandaloneSkillRegistry(scope?: CanvasPluginStorageScope | null): Promise<StandaloneSkillRegistry> {
@@ -443,16 +543,8 @@ async function parsePluginSkillsFromManifest(
   };
 }
 
-async function resolveReadableSkillsDataDir(scope?: CanvasPluginStorageScope | null): Promise<string> {
-  const scopedDir = resolveScopedSkillsDataDir(scope);
-  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
-    return resolveScopedSkillsDataDir();
-  }
-  return scopedDir;
-}
-
 async function getStandaloneSkillNames(scope?: CanvasPluginStorageScope | null): Promise<Set<string>> {
-  const skillsDir = await resolveReadableSkillsDataDir(scope);
+  const skillsDir = await resolveReadableScopedSkillsDataDir(scope);
   const names = new Set<string>();
 
   try {

--- a/app/lib/plugins/canvas-plugin-registry.ts
+++ b/app/lib/plugins/canvas-plugin-registry.ts
@@ -837,6 +837,7 @@ export async function installCanvasPluginFromPath(
   }
 
   const manifest = validation.manifest;
+  await adoptLegacyStandaloneSkillsForScope(options.scope);
   const installDir = resolvePluginInstallDir(manifest.name, manifest.version, options.scope);
   const registry = await readCanvasPluginRegistryForWrite(options.scope);
   const existingRecord = registry.plugins[manifest.name];

--- a/app/lib/plugins/canvas-plugin-registry.ts
+++ b/app/lib/plugins/canvas-plugin-registry.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 
 import {
+  createAtomicTempPath,
   resolveReadableScopedSkillsDataDir,
   resolveScopedInstalledPluginsDir,
   resolveScopedPluginRegistryPath,
@@ -186,7 +187,7 @@ export async function writeCanvasPluginRegistry(
 ): Promise<void> {
   await ensurePluginsRoot(scope);
   const registryPath = resolveScopedPluginRegistryPath(scope);
-  const tmpPath = `${registryPath}.tmp`;
+  const tmpPath = createAtomicTempPath(registryPath);
   const nextRegistry: CanvasPluginRegistry = {
     ...registry,
     version: 1,
@@ -326,7 +327,7 @@ async function writeStandaloneSkillRegistry(
 ): Promise<void> {
   await fs.mkdir(resolveScopedSkillsDataDir(scope), { recursive: true });
   const registryPath = resolveScopedSkillRegistryPath(scope);
-  const tmpPath = `${registryPath}.tmp`;
+  const tmpPath = createAtomicTempPath(registryPath);
   await fs.writeFile(tmpPath, `${JSON.stringify({
     ...registry,
     version: 1,

--- a/app/lib/plugins/canvas-plugin-registry.ts
+++ b/app/lib/plugins/canvas-plugin-registry.ts
@@ -10,7 +10,6 @@ import {
   resolveScopedSkillRegistryPath,
   resolveScopedSkillsDataDir,
   shouldUseLegacyScopedPluginsFallback,
-  shouldUseLegacyScopedSkillsFallback,
   type UserScopedDataStorageScope,
 } from '@/app/lib/runtime-data-paths';
 import {
@@ -22,6 +21,7 @@ import {
   parseSkillFile,
   type CanvasSkill,
 } from '@/app/lib/skills/canvas-skill-manifest';
+import { adoptLegacyStandaloneSkillsForScope } from '@/app/lib/skills/legacy-skill-adoption';
 import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 import {
   isPathInside,
@@ -232,74 +232,6 @@ async function adoptLegacyPluginRegistryForScope(
   }
 
   return scopedRegistry;
-}
-
-async function adoptLegacyStandaloneSkillsForScope(scope?: CanvasPluginStorageScope | null): Promise<void> {
-  if (!(await shouldUseLegacyScopedSkillsFallback(scope))) {
-    return;
-  }
-
-  const legacySkillsDir = resolveScopedSkillsDataDir();
-  const scopedSkillsDir = resolveScopedSkillsDataDir(scope);
-  if (path.resolve(/*turbopackIgnore: true*/ legacySkillsDir) === path.resolve(/*turbopackIgnore: true*/ scopedSkillsDir)) {
-    return;
-  }
-
-  const entries = await fs.readdir(legacySkillsDir, { withFileTypes: true }).catch(() => []);
-  await fs.mkdir(scopedSkillsDir, { recursive: true });
-
-  for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name === '.backups') {
-      continue;
-    }
-
-    const sourceDir = path.join(legacySkillsDir, entry.name);
-    const skillPath = path.join(sourceDir, 'SKILL.md');
-    const isSkillDir = await fs.stat(skillPath).then((stat) => stat.isFile()).catch(() => false);
-    if (!isSkillDir) {
-      continue;
-    }
-
-    const targetDir = path.join(scopedSkillsDir, entry.name);
-    const targetExists = await fs.stat(targetDir).then((stat) => stat.isDirectory()).catch(() => false);
-    if (targetExists) {
-      continue;
-    }
-
-    await fs.cp(sourceDir, targetDir, {
-      recursive: true,
-      preserveTimestamps: true,
-      filter: (source) => !IGNORED_CHECKSUM_ENTRIES.has(path.basename(source)),
-    });
-  }
-
-  const legacyRegistry = await readStandaloneSkillRegistry();
-  const scopedRegistry = await readStandaloneSkillRegistry(scope);
-  for (const [skillName, record] of Object.entries(legacyRegistry.skills)) {
-    if (scopedRegistry.skills[skillName]) {
-      continue;
-    }
-    scopedRegistry.skills[skillName] = rebaseLegacyStandaloneSkillRecord(record, legacySkillsDir, scopedSkillsDir);
-  }
-  await writeStandaloneSkillRegistry(scopedRegistry, scope);
-}
-
-function rebaseLegacyStandaloneSkillRecord(
-  record: StandaloneSkillRegistryRecord,
-  legacySkillsDir: string,
-  scopedSkillsDir: string,
-): StandaloneSkillRegistryRecord {
-  const rebaseSkillPath = (value: string): string => {
-    return isPathInside(legacySkillsDir, value)
-      ? path.join(scopedSkillsDir, path.relative(legacySkillsDir, value))
-      : value;
-  };
-
-  return {
-    ...record,
-    installDir: rebaseSkillPath(record.installDir),
-    skillPath: rebaseSkillPath(record.skillPath),
-  };
 }
 
 async function adoptLegacyPluginRecordForScope(

--- a/app/lib/plugins/canvas-plugin-registry.ts
+++ b/app/lib/plugins/canvas-plugin-registry.ts
@@ -3,11 +3,12 @@ import { promises as fs } from 'fs';
 import path from 'path';
 
 import {
-  resolveInstalledPluginsDir,
-  resolvePluginRegistryPath,
-  resolvePluginsDataDir,
-  resolveSkillRegistryPath,
-  resolveSkillsDataDir,
+  resolveScopedInstalledPluginsDir,
+  resolveScopedPluginRegistryPath,
+  resolveScopedPluginsDataDir,
+  resolveScopedSkillRegistryPath,
+  resolveScopedSkillsDataDir,
+  type UserScopedDataStorageScope,
 } from '@/app/lib/runtime-data-paths';
 import {
   disableSkillInConfig,
@@ -18,7 +19,7 @@ import {
   parseSkillFile,
   type CanvasSkill,
 } from '@/app/lib/skills/canvas-skill-manifest';
-import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
+import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 import {
   isPathInside,
   isValidCanvasPluginName,
@@ -102,6 +103,7 @@ export interface CanvasPluginInstallOptions {
   sourcePathLabel?: string;
   sourceRegistryId?: string;
   sourceRegistryUrl?: string;
+  scope?: CanvasPluginStorageScope | null;
 }
 
 export interface CanvasPluginInstallResult {
@@ -110,6 +112,8 @@ export interface CanvasPluginInstallResult {
   validation?: CanvasPluginValidationResult;
   plugin?: CanvasPluginInstallRecord;
 }
+
+export type CanvasPluginStorageScope = UserScopedDataStorageScope;
 
 const IGNORED_CHECKSUM_ENTRIES = new Set(['.git', 'node_modules', '.DS_Store']);
 const SEED_SKILLS_DIR = path.join(process.cwd(), 'seed_skills');
@@ -134,14 +138,16 @@ function createEmptyStandaloneSkillRegistry(): StandaloneSkillRegistry {
   };
 }
 
-async function ensurePluginsRoot(): Promise<void> {
-  await fs.mkdir(resolvePluginsDataDir(), { recursive: true });
-  await fs.mkdir(resolveInstalledPluginsDir(), { recursive: true });
+async function ensurePluginsRoot(scope?: CanvasPluginStorageScope | null): Promise<void> {
+  await fs.mkdir(resolveScopedPluginsDataDir(scope), { recursive: true });
+  await fs.mkdir(resolveScopedInstalledPluginsDir(scope), { recursive: true });
 }
 
-export async function readCanvasPluginRegistry(): Promise<CanvasPluginRegistry> {
-  await ensurePluginsRoot();
-  const registryPath = resolvePluginRegistryPath();
+async function directoryExists(targetPath: string): Promise<boolean> {
+  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
+}
+
+async function readCanvasPluginRegistryFile(registryPath: string): Promise<CanvasPluginRegistry | null> {
   try {
     const raw = await fs.readFile(registryPath, 'utf-8');
     const parsed = JSON.parse(raw) as CanvasPluginRegistry;
@@ -151,16 +157,36 @@ export async function readCanvasPluginRegistry(): Promise<CanvasPluginRegistry> 
     return parsed;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return createEmptyRegistry();
+      return null;
     }
     console.warn('[CanvasPluginRegistry] Failed to read registry, using empty registry:', error);
     return createEmptyRegistry();
   }
 }
 
-export async function writeCanvasPluginRegistry(registry: CanvasPluginRegistry): Promise<void> {
-  await ensurePluginsRoot();
-  const registryPath = resolvePluginRegistryPath();
+export async function readCanvasPluginRegistry(scope?: CanvasPluginStorageScope | null): Promise<CanvasPluginRegistry> {
+  const registryPath = resolveScopedPluginRegistryPath(scope);
+  const registry = await readCanvasPluginRegistryFile(registryPath);
+  if (registry) {
+    return registry;
+  }
+
+  if (scope?.userId?.trim()) {
+    const legacyRegistry = await readCanvasPluginRegistryFile(resolveScopedPluginRegistryPath());
+    if (legacyRegistry) {
+      return legacyRegistry;
+    }
+  }
+
+  return createEmptyRegistry();
+}
+
+export async function writeCanvasPluginRegistry(
+  registry: CanvasPluginRegistry,
+  scope?: CanvasPluginStorageScope | null,
+): Promise<void> {
+  await ensurePluginsRoot(scope);
+  const registryPath = resolveScopedPluginRegistryPath(scope);
   const tmpPath = `${registryPath}.tmp`;
   const nextRegistry: CanvasPluginRegistry = {
     ...registry,
@@ -171,10 +197,17 @@ export async function writeCanvasPluginRegistry(registry: CanvasPluginRegistry):
   await fs.rename(tmpPath, registryPath);
 }
 
-async function readStandaloneSkillRegistry(): Promise<StandaloneSkillRegistry> {
-  await fs.mkdir(resolveSkillsDataDir(), { recursive: true });
+async function readCanvasPluginRegistryForWrite(
+  scope?: CanvasPluginStorageScope | null,
+): Promise<CanvasPluginRegistry> {
+  const registry = await readCanvasPluginRegistryFile(resolveScopedPluginRegistryPath(scope));
+  return registry || createEmptyRegistry();
+}
+
+async function readStandaloneSkillRegistry(scope?: CanvasPluginStorageScope | null): Promise<StandaloneSkillRegistry> {
+  await fs.mkdir(resolveScopedSkillsDataDir(scope), { recursive: true });
   try {
-    const raw = await fs.readFile(resolveSkillRegistryPath(), 'utf-8');
+    const raw = await fs.readFile(resolveScopedSkillRegistryPath(scope), 'utf-8');
     const parsed = JSON.parse(raw) as StandaloneSkillRegistry;
     if (parsed?.version === 1 && parsed.skills && typeof parsed.skills === 'object') {
       return parsed;
@@ -185,9 +218,12 @@ async function readStandaloneSkillRegistry(): Promise<StandaloneSkillRegistry> {
   return createEmptyStandaloneSkillRegistry();
 }
 
-async function writeStandaloneSkillRegistry(registry: StandaloneSkillRegistry): Promise<void> {
-  await fs.mkdir(resolveSkillsDataDir(), { recursive: true });
-  const registryPath = resolveSkillRegistryPath();
+async function writeStandaloneSkillRegistry(
+  registry: StandaloneSkillRegistry,
+  scope?: CanvasPluginStorageScope | null,
+): Promise<void> {
+  await fs.mkdir(resolveScopedSkillsDataDir(scope), { recursive: true });
+  const registryPath = resolveScopedSkillRegistryPath(scope);
   const tmpPath = `${registryPath}.tmp`;
   await fs.writeFile(tmpPath, `${JSON.stringify({
     ...registry,
@@ -197,8 +233,12 @@ async function writeStandaloneSkillRegistry(registry: StandaloneSkillRegistry): 
   await fs.rename(tmpPath, registryPath);
 }
 
-function resolvePluginInstallDir(name: string, version: string): string {
-  return path.join(resolveInstalledPluginsDir(), name, version);
+function resolvePluginInstallDir(
+  name: string,
+  version: string,
+  scope?: CanvasPluginStorageScope | null,
+): string {
+  return path.join(resolveScopedInstalledPluginsDir(scope), name, version);
 }
 
 async function listFilesForChecksum(rootDir: string, currentDir = rootDir): Promise<string[]> {
@@ -403,8 +443,16 @@ async function parsePluginSkillsFromManifest(
   };
 }
 
-async function getStandaloneSkillNames(): Promise<Set<string>> {
-  const skillsDir = resolveSkillsDataDir();
+async function resolveReadableSkillsDataDir(scope?: CanvasPluginStorageScope | null): Promise<string> {
+  const scopedDir = resolveScopedSkillsDataDir(scope);
+  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
+    return resolveScopedSkillsDataDir();
+  }
+  return scopedDir;
+}
+
+async function getStandaloneSkillNames(scope?: CanvasPluginStorageScope | null): Promise<Set<string>> {
+  const skillsDir = await resolveReadableSkillsDataDir(scope);
   const names = new Set<string>();
 
   try {
@@ -443,12 +491,12 @@ async function copyPluginPackage(sourceRoot: string, targetRoot: string): Promis
   });
 }
 
-function resolveStandaloneSkillDir(skillName: string): string {
-  return path.join(resolveSkillsDataDir(), skillName);
+function resolveStandaloneSkillDir(skillName: string, scope?: CanvasPluginStorageScope | null): string {
+  return path.join(resolveScopedSkillsDataDir(scope), skillName);
 }
 
-async function hasStandaloneSkill(skillName: string): Promise<boolean> {
-  const stat = await fs.stat(path.join(resolveStandaloneSkillDir(skillName), 'SKILL.md')).catch(() => null);
+async function hasStandaloneSkill(skillName: string, scope?: CanvasPluginStorageScope | null): Promise<boolean> {
+  const stat = await fs.stat(path.join(resolveStandaloneSkillDir(skillName, scope), 'SKILL.md')).catch(() => null);
   return Boolean(stat?.isFile());
 }
 
@@ -461,6 +509,7 @@ async function writeMaterializedSkillRecord(params: {
   pluginName: string;
   pluginVersion: string;
   installDir: string;
+  scope?: CanvasPluginStorageScope | null;
 }): Promise<void> {
   const skillPath = path.join(params.installDir, 'SKILL.md');
   const skill = await parseSkillFile(skillPath);
@@ -468,7 +517,7 @@ async function writeMaterializedSkillRecord(params: {
     throw new Error(`Materialized skill "${params.skillName}" is invalid.`);
   }
 
-  const registry = await readStandaloneSkillRegistry();
+  const registry = await readStandaloneSkillRegistry(params.scope);
   const existing = registry.skills[params.skillName];
   registry.skills[params.skillName] = {
     name: skill.name,
@@ -488,17 +537,20 @@ async function writeMaterializedSkillRecord(params: {
     skillPath,
     interface: skill.interface,
   };
-  await writeStandaloneSkillRegistry(registry);
+  await writeStandaloneSkillRegistry(registry, params.scope);
 }
 
-async function materializePluginSkills(record: CanvasPluginInstallRecord): Promise<CanvasPluginSkillRecord[]> {
-  const skillsDir = resolveSkillsDataDir();
+async function materializePluginSkills(
+  record: CanvasPluginInstallRecord,
+  scope?: CanvasPluginStorageScope | null,
+): Promise<CanvasPluginSkillRecord[]> {
+  const skillsDir = resolveScopedSkillsDataDir(scope);
   await fs.mkdir(skillsDir, { recursive: true });
   const materializedSkills: CanvasPluginSkillRecord[] = [];
-  const standaloneRegistry = await readStandaloneSkillRegistry();
+  const standaloneRegistry = await readStandaloneSkillRegistry(scope);
 
   for (const skill of record.skills) {
-    const standaloneDir = resolveStandaloneSkillDir(skill.name);
+    const standaloneDir = resolveStandaloneSkillDir(skill.name, scope);
     const resolvedStandaloneDir = path.resolve(/*turbopackIgnore: true*/ standaloneDir);
     if (!isPathInside(skillsDir, resolvedStandaloneDir)) {
       throw new Error(`Invalid skill name "${skill.name}": path traversal detected.`);
@@ -510,7 +562,7 @@ async function materializePluginSkills(record: CanvasPluginInstallRecord): Promi
       && standaloneRecord.sourcePluginName === record.name,
     );
 
-    if (await hasStandaloneSkill(skill.name) && !pluginOwnedStandalone) {
+    if (await hasStandaloneSkill(skill.name, scope) && !pluginOwnedStandalone) {
       materializedSkills.push({
         ...skill,
         materialized: false,
@@ -553,6 +605,7 @@ async function materializePluginSkills(record: CanvasPluginInstallRecord): Promi
       pluginName: record.name,
       pluginVersion: record.version,
       installDir: standaloneDir,
+      scope,
     });
     materializedSkills.push({
       ...skill,
@@ -659,10 +712,12 @@ async function buildPluginRecordFromInstalledPackage(
 async function updateRuntimeConfigForPluginSkills(
   skillNames: string[],
   enabled: boolean,
+  scope?: CanvasPluginStorageScope | null,
+  updatedBy?: string,
 ): Promise<void> {
-  const config = await readPiRuntimeConfig();
-  const allSkillNames = await getAllKnownSkillNames();
-  let nextEnabledSkills = config.enabledSkills;
+  const enabledSkills = await readEnabledSkillsForScope(scope);
+  const allSkillNames = await getAllKnownSkillNames(scope);
+  let nextEnabledSkills = enabledSkills || [];
 
   for (const skillName of skillNames) {
     nextEnabledSkills = enabled
@@ -670,9 +725,7 @@ async function updateRuntimeConfigForPluginSkills(
       : disableSkillInConfig(skillName, nextEnabledSkills, allSkillNames);
   }
 
-  config.enabledSkills = nextEnabledSkills;
-  config.updatedAt = nowIso();
-  await writePiRuntimeConfig(config);
+  await writeEnabledSkillsForScope(nextEnabledSkills, { scope, updatedBy });
 }
 
 export async function installCanvasPluginFromPath(
@@ -689,8 +742,8 @@ export async function installCanvasPluginFromPath(
   }
 
   const manifest = validation.manifest;
-  const installDir = resolvePluginInstallDir(manifest.name, manifest.version);
-  const registry = await readCanvasPluginRegistry();
+  const installDir = resolvePluginInstallDir(manifest.name, manifest.version, options.scope);
+  const registry = await readCanvasPluginRegistryForWrite(options.scope);
   const existingRecord = registry.plugins[manifest.name];
 
   if (existingRecord && existingRecord.version === manifest.version && !options.replace) {
@@ -742,7 +795,7 @@ export async function installCanvasPluginFromPath(
       };
     }
 
-    built.record.skills = await materializePluginSkills(built.record);
+    built.record.skills = await materializePluginSkills(built.record, options.scope);
 
     if (existingRecord && existingRecord.version !== manifest.version) {
       await fs.rm(existingRecord.installDir, { recursive: true, force: true }).catch(() => undefined);
@@ -753,10 +806,15 @@ export async function installCanvasPluginFromPath(
       installedAt: existingRecord?.installedAt || built.record.installedAt,
       updatedAt: nowIso(),
     };
-    await writeCanvasPluginRegistry(registry);
+    await writeCanvasPluginRegistry(registry, options.scope);
 
     if (built.record.enabled) {
-      await updateRuntimeConfigForPluginSkills(getPluginInstallEnabledSkillNames(built.record), true).catch((error) => {
+      await updateRuntimeConfigForPluginSkills(
+        getPluginInstallEnabledSkillNames(built.record),
+        true,
+        options.scope,
+        options.installedBy,
+      ).catch((error) => {
         console.warn('[CanvasPluginRegistry] Failed to auto-enable plugin skills:', error);
       });
     }
@@ -777,27 +835,34 @@ export async function installCanvasPluginFromPath(
   }
 }
 
-export async function listCanvasPlugins(): Promise<CanvasPluginInstallRecord[]> {
-  const registry = await readCanvasPluginRegistry();
+export async function listCanvasPlugins(
+  scope?: CanvasPluginStorageScope | null,
+): Promise<CanvasPluginInstallRecord[]> {
+  const registry = await readCanvasPluginRegistry(scope);
   return Object.values(registry.plugins)
     .sort((left, right) => left.name.localeCompare(right.name));
 }
 
-export async function getCanvasPlugin(name: string): Promise<CanvasPluginInstallRecord | null> {
+export async function getCanvasPlugin(
+  name: string,
+  scope?: CanvasPluginStorageScope | null,
+): Promise<CanvasPluginInstallRecord | null> {
   if (!isValidCanvasPluginName(name)) return null;
-  const registry = await readCanvasPluginRegistry();
+  const registry = await readCanvasPluginRegistry(scope);
   return registry.plugins[name] || null;
 }
 
 export async function setCanvasPluginEnabled(
   name: string,
   enabled: boolean,
+  scope?: CanvasPluginStorageScope | null,
+  updatedBy?: string,
 ): Promise<{ success: boolean; error?: string; plugin?: CanvasPluginInstallRecord }> {
   if (!isValidCanvasPluginName(name)) {
     return { success: false, error: 'Invalid plugin name' };
   }
 
-  const registry = await readCanvasPluginRegistry();
+  const registry = await readCanvasPluginRegistryForWrite(scope);
   const plugin = registry.plugins[name];
   if (!plugin) {
     return { success: false, error: `Plugin "${name}" not found` };
@@ -805,9 +870,9 @@ export async function setCanvasPluginEnabled(
 
   plugin.enabled = enabled;
   plugin.updatedAt = nowIso();
-  await writeCanvasPluginRegistry(registry);
+  await writeCanvasPluginRegistry(registry, scope);
 
-  await updateRuntimeConfigForPluginSkills(getPluginRuntimeSkillNames(plugin), enabled).catch((error) => {
+  await updateRuntimeConfigForPluginSkills(getPluginRuntimeSkillNames(plugin), enabled, scope, updatedBy).catch((error) => {
     console.warn('[CanvasPluginRegistry] Failed to update runtime config for plugin skills:', error);
   });
 
@@ -816,31 +881,36 @@ export async function setCanvasPluginEnabled(
 
 export async function deleteCanvasPlugin(
   name: string,
+  scope?: CanvasPluginStorageScope | null,
+  updatedBy?: string,
 ): Promise<{ success: boolean; error?: string }> {
   if (!isValidCanvasPluginName(name)) {
     return { success: false, error: 'Invalid plugin name' };
   }
 
-  const registry = await readCanvasPluginRegistry();
+  const registry = await readCanvasPluginRegistryForWrite(scope);
   const plugin = registry.plugins[name];
   if (!plugin) {
     return { success: false, error: `Plugin "${name}" not found` };
   }
 
   delete registry.plugins[name];
-  await writeCanvasPluginRegistry(registry);
+  await writeCanvasPluginRegistry(registry, scope);
   await fs.rm(plugin.installDir, { recursive: true, force: true }).catch(() => undefined);
-  await updateRuntimeConfigForPluginSkills(getPluginRuntimeSkillNames(plugin), false).catch((error) => {
+  await updateRuntimeConfigForPluginSkills(getPluginRuntimeSkillNames(plugin), false, scope, updatedBy).catch((error) => {
     console.warn('[CanvasPluginRegistry] Failed to disable removed plugin skills:', error);
   });
 
   return { success: true };
 }
 
-export async function loadEnabledPluginSkills(enabledSkills?: string[]): Promise<CanvasSkill[]> {
-  const registry = await readCanvasPluginRegistry();
+export async function loadEnabledPluginSkills(
+  enabledSkills?: string[],
+  scope?: CanvasPluginStorageScope | null,
+): Promise<CanvasSkill[]> {
+  const registry = await readCanvasPluginRegistry(scope);
   const pluginSkills: CanvasSkill[] = [];
-  const allSkillNames = await getAllKnownSkillNames(registry);
+  const allSkillNames = await getAllKnownSkillNames(scope, registry);
   const enabledSkillNameSet = resolveEnabledSkillNames(allSkillNames, enabledSkills);
 
   for (const plugin of Object.values(registry.plugins)) {
@@ -862,8 +932,8 @@ export async function loadEnabledPluginSkills(enabledSkills?: string[]): Promise
   return pluginSkills.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-export async function getActivePluginSkillNames(): Promise<string[]> {
-  const registry = await readCanvasPluginRegistry();
+export async function getActivePluginSkillNames(scope?: CanvasPluginStorageScope | null): Promise<string[]> {
+  const registry = await readCanvasPluginRegistry(scope);
   const names: string[] = [];
   for (const plugin of Object.values(registry.plugins)) {
     if (!plugin.enabled) continue;
@@ -872,9 +942,12 @@ export async function getActivePluginSkillNames(): Promise<string[]> {
   return Array.from(new Set(names)).sort((left, right) => left.localeCompare(right));
 }
 
-export async function getAllKnownSkillNames(registry?: CanvasPluginRegistry): Promise<string[]> {
-  const standaloneNames = await getStandaloneSkillNames();
-  const pluginRegistry = registry || await readCanvasPluginRegistry();
+export async function getAllKnownSkillNames(
+  scope?: CanvasPluginStorageScope | null,
+  registry?: CanvasPluginRegistry,
+): Promise<string[]> {
+  const standaloneNames = await getStandaloneSkillNames(scope);
+  const pluginRegistry = registry || await readCanvasPluginRegistry(scope);
   for (const plugin of Object.values(pluginRegistry.plugins)) {
     if (!plugin.enabled) continue;
     for (const skill of plugin.skills) {

--- a/app/lib/plugins/canvas-plugin-store.ts
+++ b/app/lib/plugins/canvas-plugin-store.ts
@@ -26,7 +26,7 @@ import { getGatewayStatus, getGatewayToolkits } from '@/app/lib/composio/composi
 import { listEmailAccounts } from '@/app/lib/email/service';
 import { readMcpConfig } from '@/app/lib/mcp/config';
 import { readCanvasSkillRegistry, type CanvasSkillInstallRecord } from '@/app/lib/skills/canvas-skill-store';
-import { resolveScopedSkillsDataDir } from '@/app/lib/runtime-data-paths';
+import { resolveReadableScopedSkillsDataDir } from '@/app/lib/runtime-data-paths';
 
 export const DEFAULT_CANVAS_PLUGIN_STORE_REGISTRY_URL =
   'https://raw.githubusercontent.com/canvascoding/canvas-notebook-plugin-marketplace/main/registry.json';
@@ -269,20 +269,8 @@ function summarizeSkillStates(skills: CanvasPluginStoreSkillState[]): CanvasPlug
   };
 }
 
-async function directoryExists(targetPath: string): Promise<boolean> {
-  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
-}
-
-async function resolveReadableSkillsDataDir(scope?: CanvasPluginStorageScope | null): Promise<string> {
-  const scopedDir = resolveScopedSkillsDataDir(scope);
-  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
-    return resolveScopedSkillsDataDir();
-  }
-  return scopedDir;
-}
-
 async function skillFileExists(skillName: string, scope?: CanvasPluginStorageScope | null): Promise<boolean> {
-  const skillsDir = await resolveReadableSkillsDataDir(scope);
+  const skillsDir = await resolveReadableScopedSkillsDataDir(scope);
   const stat = await fs.stat(path.join(skillsDir, skillName, 'SKILL.md')).catch(() => null);
   return Boolean(stat?.isFile());
 }
@@ -293,7 +281,7 @@ async function computeInstalledSkillModified(
   scope?: CanvasPluginStorageScope | null,
 ): Promise<boolean> {
   if (!installedSkill?.checksum) return false;
-  const installDir = path.join(await resolveReadableSkillsDataDir(scope), skillName);
+  const installDir = path.join(await resolveReadableScopedSkillsDataDir(scope), skillName);
   const currentChecksum = await computeCanvasPluginChecksum(installDir).catch(() => '');
   return Boolean(currentChecksum && currentChecksum !== installedSkill.checksum);
 }

--- a/app/lib/plugins/canvas-plugin-store.ts
+++ b/app/lib/plugins/canvas-plugin-store.ts
@@ -9,6 +9,7 @@ import {
   computeCanvasPluginChecksum,
   installCanvasPluginFromPath,
   listCanvasPlugins,
+  type CanvasPluginStorageScope,
   type CanvasPluginInstallRecord,
   type CanvasPluginInstallResult,
 } from '@/app/lib/plugins/canvas-plugin-registry';
@@ -25,7 +26,7 @@ import { getGatewayStatus, getGatewayToolkits } from '@/app/lib/composio/composi
 import { listEmailAccounts } from '@/app/lib/email/service';
 import { readMcpConfig } from '@/app/lib/mcp/config';
 import { readCanvasSkillRegistry, type CanvasSkillInstallRecord } from '@/app/lib/skills/canvas-skill-store';
-import { resolveSkillsDataDir } from '@/app/lib/runtime-data-paths';
+import { resolveScopedSkillsDataDir } from '@/app/lib/runtime-data-paths';
 
 export const DEFAULT_CANVAS_PLUGIN_STORE_REGISTRY_URL =
   'https://raw.githubusercontent.com/canvascoding/canvas-notebook-plugin-marketplace/main/registry.json';
@@ -105,6 +106,7 @@ export interface CanvasPluginStoreListOptions {
   pageSize?: number;
   query?: string;
   state?: CanvasPluginStoreStateFilter;
+  scope?: CanvasPluginStorageScope | null;
 }
 
 export interface CanvasPluginStorePagination {
@@ -267,17 +269,31 @@ function summarizeSkillStates(skills: CanvasPluginStoreSkillState[]): CanvasPlug
   };
 }
 
-async function skillFileExists(skillName: string): Promise<boolean> {
-  const stat = await fs.stat(path.join(resolveSkillsDataDir(), skillName, 'SKILL.md')).catch(() => null);
+async function directoryExists(targetPath: string): Promise<boolean> {
+  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
+}
+
+async function resolveReadableSkillsDataDir(scope?: CanvasPluginStorageScope | null): Promise<string> {
+  const scopedDir = resolveScopedSkillsDataDir(scope);
+  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
+    return resolveScopedSkillsDataDir();
+  }
+  return scopedDir;
+}
+
+async function skillFileExists(skillName: string, scope?: CanvasPluginStorageScope | null): Promise<boolean> {
+  const skillsDir = await resolveReadableSkillsDataDir(scope);
+  const stat = await fs.stat(path.join(skillsDir, skillName, 'SKILL.md')).catch(() => null);
   return Boolean(stat?.isFile());
 }
 
 async function computeInstalledSkillModified(
   skillName: string,
   installedSkill: CanvasSkillInstallRecord | undefined,
+  scope?: CanvasPluginStorageScope | null,
 ): Promise<boolean> {
   if (!installedSkill?.checksum) return false;
-  const installDir = path.join(resolveSkillsDataDir(), skillName);
+  const installDir = path.join(await resolveReadableSkillsDataDir(scope), skillName);
   const currentChecksum = await computeCanvasPluginChecksum(installDir).catch(() => '');
   return Boolean(currentChecksum && currentChecksum !== installedSkill.checksum);
 }
@@ -287,6 +303,7 @@ async function buildInstalledPluginSkillState(
   installedPlugin: CanvasPluginInstallRecord | undefined,
   targetVersion: string | undefined,
   skillRegistry: Awaited<ReturnType<typeof readCanvasSkillRegistry>>,
+  scope?: CanvasPluginStorageScope | null,
 ): Promise<{ skills: CanvasPluginStoreSkillState[]; summary: CanvasPluginStoreSkillSummary }> {
   if (!installedPlugin) {
     return { skills: [], summary: emptySkillSummary() };
@@ -316,7 +333,7 @@ async function buildInstalledPluginSkillState(
 
   const skills = await Promise.all(Array.from(expectedByName.values()).map(async (skill) => {
     const installedSkill = skillRegistry.skills[skill.name];
-    const installed = await skillFileExists(skill.name);
+    const installed = await skillFileExists(skill.name, scope);
     const pluginOwned = Boolean(
       installedSkill?.sourceType === 'plugin'
       && installedSkill.sourcePluginName === installedPlugin.name,
@@ -330,7 +347,7 @@ async function buildInstalledPluginSkillState(
     );
     const updateAvailable = pluginUpdateAvailable || skillVersionUpdateAvailable;
     const modified = installed && pluginOwned
-      ? await computeInstalledSkillModified(skill.name, installedSkill)
+      ? await computeInstalledSkillModified(skill.name, installedSkill, scope)
       : false;
     let status: CanvasPluginStoreSkillStatus = 'ok';
 
@@ -574,9 +591,10 @@ export async function readCanvasPluginStoreRegistry(): Promise<CanvasPluginStore
 async function enrichStorePluginsWithInstalledState(
   registry: CanvasPluginStoreRegistry,
   installedPlugins: CanvasPluginInstallRecord[],
+  scope?: CanvasPluginStorageScope | null,
 ): Promise<{ registry: Omit<CanvasPluginStoreRegistry, 'plugins'>; plugins: CanvasPluginStorePluginWithState[]; stats: Omit<CanvasPluginStoreStats, 'filteredTotal'> }> {
   const installedByName = new Map(installedPlugins.map((plugin) => [plugin.name, plugin]));
-  const skillRegistry = await readCanvasSkillRegistry();
+  const skillRegistry = await readCanvasSkillRegistry(scope);
   const plugins = await Promise.all(registry.plugins.map(async (plugin) => {
     const installedPlugin = installedByName.get(plugin.name);
     const updateAvailable = Boolean(
@@ -587,6 +605,7 @@ async function enrichStorePluginsWithInstalledState(
       installedPlugin,
       plugin.latestVersion,
       skillRegistry,
+      scope,
     );
 
     return {
@@ -640,9 +659,9 @@ function matchesState(plugin: CanvasPluginStorePluginWithState, state: CanvasPlu
 export async function listCanvasPluginStore(options: CanvasPluginStoreListOptions = {}): Promise<CanvasPluginStoreList> {
   const [registry, installedPlugins] = await Promise.all([
     readCanvasPluginStoreRegistry(),
-    listCanvasPlugins(),
+    listCanvasPlugins(options.scope),
   ]);
-  const enriched = await enrichStorePluginsWithInstalledState(registry, installedPlugins);
+  const enriched = await enrichStorePluginsWithInstalledState(registry, installedPlugins, options.scope);
   const pageSize = clampPositiveInteger(options.pageSize, 12, 50);
   const page = clampPositiveInteger(options.page, 1, 100000);
   const state = options.state || 'all';
@@ -741,7 +760,12 @@ async function verifyPackageChecksum(packageRoot: string, expectedChecksum: stri
 export async function installCanvasPluginFromStore(
   pluginName: string,
   version?: string,
-  options: { enable?: boolean; replace?: boolean; installedBy?: string } = {},
+  options: {
+    enable?: boolean;
+    replace?: boolean;
+    installedBy?: string;
+    scope?: CanvasPluginStorageScope | null;
+  } = {},
 ): Promise<CanvasPluginStoreInstallResult> {
   if (!isValidCanvasPluginName(pluginName)) {
     return { success: false, error: 'Invalid plugin name' };
@@ -776,6 +800,7 @@ export async function installCanvasPluginFromStore(
       sourcePathLabel: storeVersion.downloadUrl,
       sourceRegistryId: registry.id,
       sourceRegistryUrl: registry.registryUrl,
+      scope: options.scope,
     });
 
     return {
@@ -813,6 +838,7 @@ export async function preflightCanvasPluginFromStore(
   pluginName: string,
   version: string | undefined,
   userId: string,
+  scope?: CanvasPluginStorageScope | null,
 ): Promise<CanvasPluginStorePreflight> {
   if (!isValidCanvasPluginName(pluginName)) {
     throw new Error('Invalid plugin name');
@@ -823,9 +849,9 @@ export async function preflightCanvasPluginFromStore(
 
   const registry = await readCanvasPluginStoreRegistry();
   const { plugin, version: selectedVersion } = getStorePluginOrThrow(registry, pluginName, version);
-  const installedPlugin = (await listCanvasPlugins()).find((entry) => entry.name === plugin.name);
-  const skillRegistry = await readCanvasSkillRegistry();
-  const skillState = await buildInstalledPluginSkillState(plugin, installedPlugin, selectedVersion, skillRegistry);
+  const installedPlugin = (await listCanvasPlugins(scope)).find((entry) => entry.name === plugin.name);
+  const skillRegistry = await readCanvasSkillRegistry(scope);
+  const skillState = await buildInstalledPluginSkillState(plugin, installedPlugin, selectedVersion, skillRegistry, scope);
   const items: CanvasPluginStorePreflightItem[] = [];
 
   const composioConnectors = normalizeComposioConnectors(plugin.connectors);

--- a/app/lib/plugins/plugin-reference-context.ts
+++ b/app/lib/plugins/plugin-reference-context.ts
@@ -1,6 +1,10 @@
 import 'server-only';
 
-import { listCanvasPlugins, type CanvasPluginInstallRecord } from '@/app/lib/plugins/canvas-plugin-registry';
+import {
+  listCanvasPlugins,
+  type CanvasPluginInstallRecord,
+  type CanvasPluginStorageScope,
+} from '@/app/lib/plugins/canvas-plugin-registry';
 import type { CanvasPluginComposioConnector, CanvasPluginMcpConnector } from '@/app/lib/plugins/canvas-plugin-manifest';
 
 const PLUGIN_REFERENCE_PATTERN = /(^|[\s([{"'`,;])\/([a-z0-9]+(?:-[a-z0-9]+)*)(?=$|[\s)\]}",.;:!?])/g;
@@ -119,13 +123,16 @@ function formatPluginContext(plugin: CanvasPluginInstallRecord): string {
   return lines.join('\n');
 }
 
-export async function buildReferencedPluginRuntimeContext(content: string): Promise<string | null> {
+export async function buildReferencedPluginRuntimeContext(
+  content: string,
+  scope?: CanvasPluginStorageScope | null,
+): Promise<string | null> {
   const referenceNames = extractSlashReferenceNames(content);
   if (referenceNames.length === 0) {
     return null;
   }
 
-  const plugins = await listCanvasPlugins();
+  const plugins = await listCanvasPlugins(scope);
   const enabledPluginsByName = new Map(
     plugins
       .filter((plugin) => plugin.enabled)

--- a/app/lib/runtime-data-paths.ts
+++ b/app/lib/runtime-data-paths.ts
@@ -3,6 +3,10 @@ import path from 'node:path';
 
 const CONTAINER_DATA_ROOT = '/data';
 
+export type UserScopedDataStorageScope = {
+  userId?: string | null;
+};
+
 function directoryExists(targetPath: string): boolean {
   try {
     return fs.statSync(targetPath).isDirectory();
@@ -179,6 +183,29 @@ export function resolveSkillsDataDir(cwd?: string): string {
   return path.join(/* turbopackIgnore: true */ resolveCanvasDataRoot(cwd), 'skills');
 }
 
+function resolveScopedUserId(scope?: UserScopedDataStorageScope | null): string | null {
+  const userId = scope?.userId?.trim();
+  return userId ? normalizeDataScopeId(userId, 'userId') : null;
+}
+
+export function resolveScopedSettingsDir(scope?: UserScopedDataStorageScope | null, cwd?: string): string {
+  const userId = resolveScopedUserId(scope);
+  return userId ? resolveUserSettingsDir(userId, cwd) : resolveSettingsStorageDir(cwd);
+}
+
+export function resolveScopedSkillsDataDir(scope?: UserScopedDataStorageScope | null, cwd?: string): string {
+  const userId = resolveScopedUserId(scope);
+  return userId ? resolveUserSkillsDir(userId, cwd) : resolveSkillsDataDir(cwd);
+}
+
+export function resolveScopedSkillRegistryPath(scope?: UserScopedDataStorageScope | null, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveScopedSkillsDataDir(scope, cwd), 'registry.json');
+}
+
+export function resolveScopedSkillBackupsDir(scope?: UserScopedDataStorageScope | null, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveScopedSkillsDataDir(scope, cwd), '.backups');
+}
+
 export function resolveSkillRegistryPath(cwd?: string): string {
   return path.join(/* turbopackIgnore: true */ resolveSkillsDataDir(cwd), 'registry.json');
 }
@@ -197,6 +224,19 @@ export function resolveInstalledPluginsDir(cwd?: string): string {
 
 export function resolvePluginRegistryPath(cwd?: string): string {
   return path.join(/* turbopackIgnore: true */ resolvePluginsDataDir(cwd), 'registry.json');
+}
+
+export function resolveScopedPluginsDataDir(scope?: UserScopedDataStorageScope | null, cwd?: string): string {
+  const userId = resolveScopedUserId(scope);
+  return userId ? resolveUserPluginsDir(userId, cwd) : resolvePluginsDataDir(cwd);
+}
+
+export function resolveScopedInstalledPluginsDir(scope?: UserScopedDataStorageScope | null, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveScopedPluginsDataDir(scope, cwd), 'installed');
+}
+
+export function resolveScopedPluginRegistryPath(scope?: UserScopedDataStorageScope | null, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveScopedPluginsDataDir(scope, cwd), 'registry.json');
 }
 
 export function resolveDefaultIntegrationsEnvPath(cwd?: string): string {

--- a/app/lib/runtime-data-paths.ts
+++ b/app/lib/runtime-data-paths.ts
@@ -19,6 +19,10 @@ export async function directoryExists(targetPath: string): Promise<boolean> {
   return fsPromises.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
 }
 
+export function createAtomicTempPath(targetPath: string): string {
+  return `${targetPath}.tmp-${Date.now()}-${process.pid}-${Math.random().toString(16).slice(2)}`;
+}
+
 function resolveProjectDataRoot(cwd?: string): string {
   const resolvedCwd = cwd ?? process.cwd();
   return path.resolve(/* turbopackIgnore: true */ resolvedCwd, 'data');

--- a/app/lib/runtime-data-paths.ts
+++ b/app/lib/runtime-data-paths.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import fs, { promises as fsPromises } from 'node:fs';
 import path from 'node:path';
 
 const CONTAINER_DATA_ROOT = '/data';
@@ -7,12 +7,16 @@ export type UserScopedDataStorageScope = {
   userId?: string | null;
 };
 
-function directoryExists(targetPath: string): boolean {
+function directoryExistsSync(targetPath: string): boolean {
   try {
     return fs.statSync(targetPath).isDirectory();
   } catch {
     return false;
   }
+}
+
+export async function directoryExists(targetPath: string): Promise<boolean> {
+  return fsPromises.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
 }
 
 function resolveProjectDataRoot(cwd?: string): string {
@@ -38,7 +42,7 @@ export function resolveCanvasDataRoot(cwd?: string): string {
       : path.resolve(cwd ?? process.cwd(), data);
   }
 
-  if (directoryExists(CONTAINER_DATA_ROOT)) {
+  if (directoryExistsSync(CONTAINER_DATA_ROOT)) {
     return CONTAINER_DATA_ROOT;
   }
 
@@ -206,6 +210,23 @@ export function resolveScopedSkillBackupsDir(scope?: UserScopedDataStorageScope 
   return path.join(/* turbopackIgnore: true */ resolveScopedSkillsDataDir(scope, cwd), '.backups');
 }
 
+export async function shouldUseLegacyScopedSkillsFallback(
+  scope?: UserScopedDataStorageScope | null,
+  cwd?: string,
+): Promise<boolean> {
+  const userId = resolveScopedUserId(scope);
+  return Boolean(userId) && !(await directoryExists(resolveScopedSkillsDataDir(scope, cwd)));
+}
+
+export async function resolveReadableScopedSkillsDataDir(
+  scope?: UserScopedDataStorageScope | null,
+  cwd?: string,
+): Promise<string> {
+  return await shouldUseLegacyScopedSkillsFallback(scope, cwd)
+    ? resolveScopedSkillsDataDir(null, cwd)
+    : resolveScopedSkillsDataDir(scope, cwd);
+}
+
 export function resolveSkillRegistryPath(cwd?: string): string {
   return path.join(/* turbopackIgnore: true */ resolveSkillsDataDir(cwd), 'registry.json');
 }
@@ -237,6 +258,23 @@ export function resolveScopedInstalledPluginsDir(scope?: UserScopedDataStorageSc
 
 export function resolveScopedPluginRegistryPath(scope?: UserScopedDataStorageScope | null, cwd?: string): string {
   return path.join(/* turbopackIgnore: true */ resolveScopedPluginsDataDir(scope, cwd), 'registry.json');
+}
+
+export async function shouldUseLegacyScopedPluginsFallback(
+  scope?: UserScopedDataStorageScope | null,
+  cwd?: string,
+): Promise<boolean> {
+  const userId = resolveScopedUserId(scope);
+  return Boolean(userId) && !(await directoryExists(resolveScopedPluginsDataDir(scope, cwd)));
+}
+
+export async function resolveReadableScopedPluginsDataDir(
+  scope?: UserScopedDataStorageScope | null,
+  cwd?: string,
+): Promise<string> {
+  return await shouldUseLegacyScopedPluginsFallback(scope, cwd)
+    ? resolveScopedPluginsDataDir(null, cwd)
+    : resolveScopedPluginsDataDir(scope, cwd);
 }
 
 export function resolveDefaultIntegrationsEnvPath(cwd?: string): string {

--- a/app/lib/skills/canvas-skill-manifest.ts
+++ b/app/lib/skills/canvas-skill-manifest.ts
@@ -2,7 +2,10 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import YAML from 'yaml';
 
-import { resolveSkillsDataDir } from '@/app/lib/runtime-data-paths';
+import {
+  resolveScopedSkillsDataDir,
+  type UserScopedDataStorageScope,
+} from '@/app/lib/runtime-data-paths';
 
 export { getSkillsContext } from './skill-context';
 
@@ -262,6 +265,8 @@ ${content || 'Add your Canvas skill instructions here...'}
 `;
 }
 
-export function getSkillsDir(): string {
-  return resolveSkillsDataDir();
+export type CanvasSkillStorageScope = UserScopedDataStorageScope;
+
+export function getSkillsDir(scope?: CanvasSkillStorageScope | null): string {
+  return resolveScopedSkillsDataDir(scope);
 }

--- a/app/lib/skills/canvas-skill-store.ts
+++ b/app/lib/skills/canvas-skill-store.ts
@@ -25,6 +25,7 @@ import {
 import { loadSkillByName, getSkillNames } from '@/app/lib/skills/skill-loader';
 import { loadSkillSummaries, type SkillSummary } from '@/app/lib/skills/skill-summaries';
 import { DISABLED_ALL_SKILLS_SENTINEL, enableSkillInConfig } from '@/app/lib/skills/enabled-skills';
+import { adoptLegacyStandaloneSkillsForScope } from '@/app/lib/skills/legacy-skill-adoption';
 import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 
 export const DEFAULT_CANVAS_SKILL_STORE_REGISTRY_URL =
@@ -683,7 +684,7 @@ async function backupExistingSkill(
   skillName: string,
   scope?: CanvasSkillStoreScope | null,
 ): Promise<string | undefined> {
-  const skillDir = path.join(resolveScopedSkillsDataDir(scope), skillName);
+  const skillDir = path.join(await resolveReadableScopedSkillsDataDir(scope), skillName);
   const stat = await fs.stat(skillDir).catch(() => null);
   if (!stat?.isDirectory()) return undefined;
 
@@ -799,6 +800,8 @@ export async function installCanvasSkillFromStore(
 
   let tempRoot: string | null = null;
   try {
+    await adoptLegacyStandaloneSkillsForScope(options.scope);
+
     const registry = await readCanvasSkillStoreRegistry();
     const storeSkill = registry.skills.find((skill) => skill.name === skillName);
     if (!storeSkill) {
@@ -864,6 +867,8 @@ async function restoreSeedSkill(
   }
 
   try {
+    await adoptLegacyStandaloneSkillsForScope(options.scope);
+
     await ensureStandaloneSkillInstallAllowed(skillName, options.replace ?? true, options.scope);
     await validateSkillPackage(seedRoot, skillName);
     const backupPath = await backupExistingSkill(skillName, options.scope);

--- a/app/lib/skills/canvas-skill-store.ts
+++ b/app/lib/skills/canvas-skill-store.ts
@@ -8,9 +8,11 @@ import { fileURLToPath } from 'url';
 import JSZip from 'jszip';
 
 import {
+  resolveReadableScopedSkillsDataDir,
   resolveScopedSkillBackupsDir,
   resolveScopedSkillRegistryPath,
   resolveScopedSkillsDataDir,
+  shouldUseLegacyScopedSkillsFallback,
   type UserScopedDataStorageScope,
 } from '@/app/lib/runtime-data-paths';
 import { computeCanvasPluginChecksum } from '@/app/lib/plugins/canvas-plugin-registry';
@@ -377,18 +379,6 @@ async function ensureSkillRoot(scope?: CanvasSkillStoreScope | null): Promise<vo
   await fs.mkdir(resolveScopedSkillsDataDir(scope), { recursive: true });
 }
 
-async function directoryExists(targetPath: string): Promise<boolean> {
-  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
-}
-
-async function resolveReadableSkillsDataDir(scope?: CanvasSkillStoreScope | null): Promise<string> {
-  const scopedDir = resolveScopedSkillsDataDir(scope);
-  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
-    return resolveScopedSkillsDataDir();
-  }
-  return scopedDir;
-}
-
 async function readCanvasSkillRegistryFile(registryPath: string): Promise<CanvasSkillRegistry | null> {
   try {
     const raw = await fs.readFile(registryPath, 'utf-8');
@@ -413,7 +403,7 @@ export async function readCanvasSkillRegistry(scope?: CanvasSkillStoreScope | nu
     return registry;
   }
 
-  if (scope?.userId?.trim() && !(await directoryExists(resolveScopedSkillsDataDir(scope)))) {
+  if (await shouldUseLegacyScopedSkillsFallback(scope)) {
     const legacyRegistry = await readCanvasSkillRegistryFile(resolveScopedSkillRegistryPath());
     if (legacyRegistry) {
       return legacyRegistry;
@@ -555,7 +545,7 @@ async function addPageStateDetails(
 ): Promise<CanvasSkillStoreSkillWithState> {
   if (!skill.installed.installed) return skill;
 
-  const installDir = path.join(await resolveReadableSkillsDataDir(scope), skill.name);
+  const installDir = path.join(await resolveReadableScopedSkillsDataDir(scope), skill.name);
   const record = skill.installed.installedSkill;
   const [seedAvailable, currentChecksum] = await Promise.all([
     seedSkillExists(skill.name),

--- a/app/lib/skills/canvas-skill-store.ts
+++ b/app/lib/skills/canvas-skill-store.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 import JSZip from 'jszip';
 
 import {
+  createAtomicTempPath,
   resolveReadableScopedSkillsDataDir,
   resolveScopedSkillBackupsDir,
   resolveScopedSkillRegistryPath,
@@ -420,7 +421,7 @@ export async function writeCanvasSkillRegistry(
 ): Promise<void> {
   await ensureSkillRoot(scope);
   const registryPath = resolveScopedSkillRegistryPath(scope);
-  const tmpPath = `${registryPath}.tmp`;
+  const tmpPath = createAtomicTempPath(registryPath);
   const nextRegistry: CanvasSkillRegistry = {
     ...registry,
     version: 1,

--- a/app/lib/skills/canvas-skill-store.ts
+++ b/app/lib/skills/canvas-skill-store.ts
@@ -8,9 +8,10 @@ import { fileURLToPath } from 'url';
 import JSZip from 'jszip';
 
 import {
-  resolveSkillBackupsDir,
-  resolveSkillRegistryPath,
-  resolveSkillsDataDir,
+  resolveScopedSkillBackupsDir,
+  resolveScopedSkillRegistryPath,
+  resolveScopedSkillsDataDir,
+  type UserScopedDataStorageScope,
 } from '@/app/lib/runtime-data-paths';
 import { computeCanvasPluginChecksum } from '@/app/lib/plugins/canvas-plugin-registry';
 import { isPathInside, isValidCanvasPluginVersion } from '@/app/lib/plugins/canvas-plugin-manifest';
@@ -21,8 +22,8 @@ import {
 } from '@/app/lib/skills/canvas-skill-manifest';
 import { loadSkillByName, getSkillNames } from '@/app/lib/skills/skill-loader';
 import { loadSkillSummaries, type SkillSummary } from '@/app/lib/skills/skill-summaries';
-import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
 import { DISABLED_ALL_SKILLS_SENTINEL, enableSkillInConfig } from '@/app/lib/skills/enabled-skills';
+import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
 
 export const DEFAULT_CANVAS_SKILL_STORE_REGISTRY_URL =
   'https://raw.githubusercontent.com/canvascoding/canvas-notebook-plugin-marketplace/main/registry.json';
@@ -120,6 +121,7 @@ export interface CanvasSkillStoreListOptions {
   pageSize?: number;
   query?: string;
   state?: CanvasSkillStoreStateFilter;
+  scope?: CanvasSkillStoreScope | null;
 }
 
 export interface CanvasSkillStorePagination {
@@ -154,6 +156,8 @@ export interface CanvasSkillStoreInstallResult {
   storeVersion?: CanvasSkillStoreVersion;
   backupPath?: string;
 }
+
+export type CanvasSkillStoreScope = UserScopedDataStorageScope;
 
 export interface CanvasSkillsResetResult {
   success: boolean;
@@ -369,13 +373,23 @@ function createEmptySkillRegistry(): CanvasSkillRegistry {
   };
 }
 
-async function ensureSkillRoot(): Promise<void> {
-  await fs.mkdir(resolveSkillsDataDir(), { recursive: true });
+async function ensureSkillRoot(scope?: CanvasSkillStoreScope | null): Promise<void> {
+  await fs.mkdir(resolveScopedSkillsDataDir(scope), { recursive: true });
 }
 
-export async function readCanvasSkillRegistry(): Promise<CanvasSkillRegistry> {
-  await ensureSkillRoot();
-  const registryPath = resolveSkillRegistryPath();
+async function directoryExists(targetPath: string): Promise<boolean> {
+  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
+}
+
+async function resolveReadableSkillsDataDir(scope?: CanvasSkillStoreScope | null): Promise<string> {
+  const scopedDir = resolveScopedSkillsDataDir(scope);
+  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
+    return resolveScopedSkillsDataDir();
+  }
+  return scopedDir;
+}
+
+async function readCanvasSkillRegistryFile(registryPath: string): Promise<CanvasSkillRegistry | null> {
   try {
     const raw = await fs.readFile(registryPath, 'utf-8');
     const parsed = JSON.parse(raw) as CanvasSkillRegistry;
@@ -385,16 +399,36 @@ export async function readCanvasSkillRegistry(): Promise<CanvasSkillRegistry> {
     return parsed;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return createEmptySkillRegistry();
+      return null;
     }
     console.warn('[CanvasSkillRegistry] Failed to read registry, using empty registry:', error);
     return createEmptySkillRegistry();
   }
 }
 
-export async function writeCanvasSkillRegistry(registry: CanvasSkillRegistry): Promise<void> {
-  await ensureSkillRoot();
-  const registryPath = resolveSkillRegistryPath();
+export async function readCanvasSkillRegistry(scope?: CanvasSkillStoreScope | null): Promise<CanvasSkillRegistry> {
+  const registryPath = resolveScopedSkillRegistryPath(scope);
+  const registry = await readCanvasSkillRegistryFile(registryPath);
+  if (registry) {
+    return registry;
+  }
+
+  if (scope?.userId?.trim() && !(await directoryExists(resolveScopedSkillsDataDir(scope)))) {
+    const legacyRegistry = await readCanvasSkillRegistryFile(resolveScopedSkillRegistryPath());
+    if (legacyRegistry) {
+      return legacyRegistry;
+    }
+  }
+
+  return createEmptySkillRegistry();
+}
+
+export async function writeCanvasSkillRegistry(
+  registry: CanvasSkillRegistry,
+  scope?: CanvasSkillStoreScope | null,
+): Promise<void> {
+  await ensureSkillRoot(scope);
+  const registryPath = resolveScopedSkillRegistryPath(scope);
   const tmpPath = `${registryPath}.tmp`;
   const nextRegistry: CanvasSkillRegistry = {
     ...registry,
@@ -405,28 +439,30 @@ export async function writeCanvasSkillRegistry(registry: CanvasSkillRegistry): P
   await fs.rename(tmpPath, registryPath);
 }
 
-export async function removeCanvasSkillRegistryRecord(skillName: string): Promise<void> {
-  const registry = await readCanvasSkillRegistry();
+export async function removeCanvasSkillRegistryRecord(
+  skillName: string,
+  scope?: CanvasSkillStoreScope | null,
+): Promise<void> {
+  const registry = await readCanvasSkillRegistry(scope);
   if (!registry.skills[skillName]) {
     return;
   }
   delete registry.skills[skillName];
-  await writeCanvasSkillRegistry(registry);
+  await writeCanvasSkillRegistry(registry, scope);
 }
 
-export async function resetCanvasSkillsDirectory(updatedBy = 'unknown'): Promise<CanvasSkillsResetResult> {
-  const skillsDir = resolveSkillsDataDir();
+export async function resetCanvasSkillsDirectory(
+  updatedBy = 'unknown',
+  scope?: CanvasSkillStoreScope | null,
+): Promise<CanvasSkillsResetResult> {
+  const skillsDir = resolveScopedSkillsDataDir(scope);
   const deletedAt = nowIso();
 
   await fs.rm(skillsDir, { recursive: true, force: true });
   await fs.mkdir(skillsDir, { recursive: true });
-  await writeCanvasSkillRegistry(createEmptySkillRegistry());
+  await writeCanvasSkillRegistry(createEmptySkillRegistry(), scope);
 
-  const config = await readPiRuntimeConfig();
-  config.enabledSkills = [DISABLED_ALL_SKILLS_SENTINEL];
-  config.updatedAt = deletedAt;
-  config.updatedBy = updatedBy;
-  await writePiRuntimeConfig(config);
+  await writeEnabledSkillsForScope([DISABLED_ALL_SKILLS_SENTINEL], { scope, updatedBy });
 
   return {
     success: true,
@@ -435,8 +471,11 @@ export async function resetCanvasSkillsDirectory(updatedBy = 'unknown'): Promise
   };
 }
 
-async function listStandaloneSkillSummaries(enabledSkills?: string[]): Promise<SkillSummary[]> {
-  const summaries = await loadSkillSummaries(enabledSkills);
+async function listStandaloneSkillSummaries(
+  enabledSkills?: string[],
+  scope?: CanvasSkillStoreScope | null,
+): Promise<SkillSummary[]> {
+  const summaries = await loadSkillSummaries(enabledSkills, scope);
   return summaries.filter((skill) => !skill.plugin);
 }
 
@@ -448,12 +487,13 @@ async function seedSkillExists(skillName: string): Promise<boolean> {
 
 async function enrichStoreSkillsWithInstalledState(
   registry: CanvasSkillStoreRegistry,
+  scope?: CanvasSkillStoreScope | null,
 ): Promise<{ registry: Omit<CanvasSkillStoreRegistry, 'skills'>; skills: CanvasSkillStoreSkillWithState[]; stats: Omit<CanvasSkillStoreStats, 'filteredTotal'> }> {
-  const [localRegistry, config] = await Promise.all([
-    readCanvasSkillRegistry(),
-    readPiRuntimeConfig(),
+  const [localRegistry, enabledSkills] = await Promise.all([
+    readCanvasSkillRegistry(scope),
+    readEnabledSkillsForScope(scope),
   ]);
-  const standaloneSkills = await listStandaloneSkillSummaries(config.enabledSkills);
+  const standaloneSkills = await listStandaloneSkillSummaries(enabledSkills, scope);
   const standaloneByName = new Map(standaloneSkills.map((skill) => [skill.name, skill]));
 
   const skills = registry.skills.map((skill) => {
@@ -509,10 +549,13 @@ function matchesState(skill: CanvasSkillStoreSkillWithState, state: CanvasSkillS
   return true;
 }
 
-async function addPageStateDetails(skill: CanvasSkillStoreSkillWithState): Promise<CanvasSkillStoreSkillWithState> {
+async function addPageStateDetails(
+  skill: CanvasSkillStoreSkillWithState,
+  scope?: CanvasSkillStoreScope | null,
+): Promise<CanvasSkillStoreSkillWithState> {
   if (!skill.installed.installed) return skill;
 
-  const installDir = path.join(resolveSkillsDataDir(), skill.name);
+  const installDir = path.join(await resolveReadableSkillsDataDir(scope), skill.name);
   const record = skill.installed.installedSkill;
   const [seedAvailable, currentChecksum] = await Promise.all([
     seedSkillExists(skill.name),
@@ -531,7 +574,7 @@ async function addPageStateDetails(skill: CanvasSkillStoreSkillWithState): Promi
 
 export async function listCanvasSkillStore(options: CanvasSkillStoreListOptions = {}): Promise<CanvasSkillStoreList> {
   const registry = await readCanvasSkillStoreRegistry();
-  const enriched = await enrichStoreSkillsWithInstalledState(registry);
+  const enriched = await enrichStoreSkillsWithInstalledState(registry, options.scope);
   const pageSize = clampPositiveInteger(options.pageSize, 12, 50);
   const page = clampPositiveInteger(options.page, 1, 100000);
   const state = options.state || 'all';
@@ -541,7 +584,7 @@ export async function listCanvasSkillStore(options: CanvasSkillStoreListOptions 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const normalizedPage = Math.min(page, totalPages);
   const offset = (normalizedPage - 1) * pageSize;
-  const pageSkills = await Promise.all(filtered.slice(offset, offset + pageSize).map(addPageStateDetails));
+  const pageSkills = await Promise.all(filtered.slice(offset, offset + pageSize).map((skill) => addPageStateDetails(skill, options.scope)));
 
   return {
     registry: enriched.registry,
@@ -646,19 +689,26 @@ async function validateSkillPackage(packageRoot: string, expectedName: string) {
   return skill;
 }
 
-async function backupExistingSkill(skillName: string): Promise<string | undefined> {
-  const skillDir = path.join(resolveSkillsDataDir(), skillName);
+async function backupExistingSkill(
+  skillName: string,
+  scope?: CanvasSkillStoreScope | null,
+): Promise<string | undefined> {
+  const skillDir = path.join(resolveScopedSkillsDataDir(scope), skillName);
   const stat = await fs.stat(skillDir).catch(() => null);
   if (!stat?.isDirectory()) return undefined;
 
-  const backupDir = path.join(resolveSkillBackupsDir(), skillName, nowIso().replace(/[:.]/g, '-'));
+  const backupDir = path.join(resolveScopedSkillBackupsDir(scope), skillName, nowIso().replace(/[:.]/g, '-'));
   await fs.mkdir(path.dirname(backupDir), { recursive: true });
   await fs.cp(skillDir, backupDir, { recursive: true, preserveTimestamps: true });
   return backupDir;
 }
 
-async function copySkillPackage(packageRoot: string, skillName: string): Promise<string> {
-  const skillsDir = resolveSkillsDataDir();
+async function copySkillPackage(
+  packageRoot: string,
+  skillName: string,
+  scope?: CanvasSkillStoreScope | null,
+): Promise<string> {
+  const skillsDir = resolveScopedSkillsDataDir(scope);
   const targetDir = path.join(skillsDir, skillName);
   const resolvedTarget = path.resolve(/*turbopackIgnore: true*/ targetDir);
   const resolvedSkillsDir = path.resolve(/*turbopackIgnore: true*/ skillsDir);
@@ -676,12 +726,15 @@ async function copySkillPackage(packageRoot: string, skillName: string): Promise
   return targetDir;
 }
 
-async function enableInstalledSkill(skillName: string): Promise<void> {
-  const config = await readPiRuntimeConfig();
-  const allSkillNames = await getSkillNames();
-  config.enabledSkills = enableSkillInConfig(skillName, config.enabledSkills, allSkillNames);
-  config.updatedAt = nowIso();
-  await writePiRuntimeConfig(config);
+async function enableInstalledSkill(
+  skillName: string,
+  scope?: CanvasSkillStoreScope | null,
+  updatedBy?: string,
+): Promise<void> {
+  const enabledSkills = await readEnabledSkillsForScope(scope);
+  const allSkillNames = await getSkillNames(scope);
+  const nextEnabledSkills = enableSkillInConfig(skillName, enabledSkills, allSkillNames);
+  await writeEnabledSkillsForScope(nextEnabledSkills, { scope, updatedBy });
 }
 
 async function writeInstalledSkillRecord(
@@ -691,10 +744,11 @@ async function writeInstalledSkillRecord(
   sourcePath: string,
   sourceRegistry: { id?: string; url?: string } | undefined,
   installDir: string,
+  scope?: CanvasSkillStoreScope | null,
 ): Promise<CanvasSkillInstallRecord> {
   const skill = await validateSkillPackage(installDir, skillName);
   const checksum = await computeCanvasPluginChecksum(installDir);
-  const registry = await readCanvasSkillRegistry();
+  const registry = await readCanvasSkillRegistry(scope);
   const existing = registry.skills[skillName];
   const record: CanvasSkillInstallRecord = {
     name: skill.name,
@@ -713,13 +767,17 @@ async function writeInstalledSkillRecord(
     interface: await loadCanvasSkillInterface(installDir),
   };
   registry.skills[skillName] = record;
-  await writeCanvasSkillRegistry(registry);
+  await writeCanvasSkillRegistry(registry, scope);
   return record;
 }
 
-async function ensureStandaloneSkillInstallAllowed(skillName: string, replace: boolean): Promise<void> {
-  const existing = await loadSkillByName(skillName);
-  const standalonePath = path.join(resolveSkillsDataDir(), skillName, 'SKILL.md');
+async function ensureStandaloneSkillInstallAllowed(
+  skillName: string,
+  replace: boolean,
+  scope?: CanvasSkillStoreScope | null,
+): Promise<void> {
+  const existing = await loadSkillByName(skillName, scope, { legacyFallback: false });
+  const standalonePath = path.join(resolveScopedSkillsDataDir(scope), skillName, 'SKILL.md');
   const hasStandalone = await fs.stat(standalonePath).then((stat) => stat.isFile()).catch(() => false);
   if (existing?.plugin) {
     throw new Error(`Skill "${skillName}" is managed by plugin "${existing.plugin.name}". Remove or disable that plugin first.`);
@@ -735,7 +793,12 @@ async function ensureStandaloneSkillInstallAllowed(skillName: string, replace: b
 export async function installCanvasSkillFromStore(
   skillName: string,
   version?: string,
-  options: { enable?: boolean; replace?: boolean } = {},
+  options: {
+    enable?: boolean;
+    replace?: boolean;
+    scope?: CanvasSkillStoreScope | null;
+    updatedBy?: string;
+  } = {},
 ): Promise<CanvasSkillStoreInstallResult> {
   if (!isValidCanvasSkillName(skillName)) {
     return { success: false, error: 'Invalid skill name' };
@@ -757,14 +820,14 @@ export async function installCanvasSkillFromStore(
       return { success: false, error: `Version ${selectedVersion} is not available for skill "${skillName}".`, storeSkill };
     }
 
-    await ensureStandaloneSkillInstallAllowed(skillName, options.replace ?? true);
+    await ensureStandaloneSkillInstallAllowed(skillName, options.replace ?? true, options.scope);
     const archiveBytes = await readUrlBytes(storeVersion.downloadUrl);
     const extracted = await extractPackageFromArchive(archiveBytes, storeVersion.packagePath);
     tempRoot = extracted.tempRoot;
     await verifyPackageChecksum(extracted.packageRoot, storeVersion.checksum);
     await validateSkillPackage(extracted.packageRoot, skillName);
-    const backupPath = await backupExistingSkill(skillName);
-    const installDir = await copySkillPackage(extracted.packageRoot, skillName);
+    const backupPath = await backupExistingSkill(skillName, options.scope);
+    const installDir = await copySkillPackage(extracted.packageRoot, skillName, options.scope);
     const record = await writeInstalledSkillRecord(
       skillName,
       selectedVersion,
@@ -772,10 +835,11 @@ export async function installCanvasSkillFromStore(
       storeVersion.downloadUrl,
       { id: registry.id, url: registry.registryUrl },
       installDir,
+      options.scope,
     );
 
     if (options.enable !== false) {
-      await enableInstalledSkill(skillName).catch((error) => {
+      await enableInstalledSkill(skillName, options.scope, options.updatedBy).catch((error) => {
         console.warn('[CanvasSkillStore] Failed to auto-enable skill:', error);
       });
     }
@@ -793,7 +857,15 @@ export async function installCanvasSkillFromStore(
   }
 }
 
-async function restoreSeedSkill(skillName: string, options: { enable?: boolean; replace?: boolean } = {}): Promise<CanvasSkillStoreInstallResult> {
+async function restoreSeedSkill(
+  skillName: string,
+  options: {
+    enable?: boolean;
+    replace?: boolean;
+    scope?: CanvasSkillStoreScope | null;
+    updatedBy?: string;
+  } = {},
+): Promise<CanvasSkillStoreInstallResult> {
   const seedRoot = path.join(process.cwd(), 'seed_skills', skillName);
   const skillPath = path.join(seedRoot, 'SKILL.md');
   const stat = await fs.stat(skillPath).catch(() => null);
@@ -802,10 +874,10 @@ async function restoreSeedSkill(skillName: string, options: { enable?: boolean; 
   }
 
   try {
-    await ensureStandaloneSkillInstallAllowed(skillName, options.replace ?? true);
+    await ensureStandaloneSkillInstallAllowed(skillName, options.replace ?? true, options.scope);
     await validateSkillPackage(seedRoot, skillName);
-    const backupPath = await backupExistingSkill(skillName);
-    const installDir = await copySkillPackage(seedRoot, skillName);
+    const backupPath = await backupExistingSkill(skillName, options.scope);
+    const installDir = await copySkillPackage(seedRoot, skillName, options.scope);
     const skill = await validateSkillPackage(installDir, skillName);
     const record = await writeInstalledSkillRecord(
       skillName,
@@ -814,10 +886,11 @@ async function restoreSeedSkill(skillName: string, options: { enable?: boolean; 
       seedRoot,
       undefined,
       installDir,
+      options.scope,
     );
 
     if (options.enable !== false) {
-      await enableInstalledSkill(skillName).catch((error) => {
+      await enableInstalledSkill(skillName, options.scope, options.updatedBy).catch((error) => {
         console.warn('[CanvasSkillStore] Failed to auto-enable restored seed skill:', error);
       });
     }
@@ -833,7 +906,13 @@ async function restoreSeedSkill(skillName: string, options: { enable?: boolean; 
 
 export async function restoreCanvasSkill(
   skillName: string,
-  options: { enable?: boolean; prefer?: 'store' | 'seed'; version?: string } = {},
+  options: {
+    enable?: boolean;
+    prefer?: 'store' | 'seed';
+    version?: string;
+    scope?: CanvasSkillStoreScope | null;
+    updatedBy?: string;
+  } = {},
 ): Promise<CanvasSkillStoreInstallResult> {
   if (!isValidCanvasSkillName(skillName)) {
     return { success: false, error: 'Invalid skill name' };
@@ -843,11 +922,18 @@ export async function restoreCanvasSkill(
     const storeResult = await installCanvasSkillFromStore(skillName, options.version, {
       enable: options.enable,
       replace: true,
+      scope: options.scope,
+      updatedBy: options.updatedBy,
     });
     if (storeResult.success || options.prefer === 'store') {
       return storeResult;
     }
   }
 
-  return restoreSeedSkill(skillName, { enable: options.enable, replace: true });
+  return restoreSeedSkill(skillName, {
+    enable: options.enable,
+    replace: true,
+    scope: options.scope,
+    updatedBy: options.updatedBy,
+  });
 }

--- a/app/lib/skills/legacy-skill-adoption.ts
+++ b/app/lib/skills/legacy-skill-adoption.ts
@@ -105,6 +105,7 @@ export async function adoptLegacyStandaloneSkillsForScope(
   }
 
   const entries = await fs.readdir(legacySkillsDir, { withFileTypes: true }).catch(() => []);
+  const failedSkillCopies = new Set<string>();
   await fs.mkdir(scopedSkillsDir, { recursive: true });
 
   for (const entry of entries) {
@@ -125,17 +126,22 @@ export async function adoptLegacyStandaloneSkillsForScope(
       continue;
     }
 
-    await fs.cp(sourceDir, targetDir, {
-      recursive: true,
-      preserveTimestamps: true,
-      filter: (source) => !IGNORED_SKILL_COPY_ENTRIES.has(path.basename(source)),
-    });
+    try {
+      await fs.cp(sourceDir, targetDir, {
+        recursive: true,
+        preserveTimestamps: true,
+        filter: (source) => !IGNORED_SKILL_COPY_ENTRIES.has(path.basename(source)),
+      });
+    } catch (error) {
+      failedSkillCopies.add(entry.name);
+      console.warn(`[LegacySkillAdoption] Failed to adopt legacy skill "${entry.name}" for user scope:`, error);
+    }
   }
 
   const legacyRegistry = await readStandaloneSkillRegistryFile(resolveScopedSkillRegistryPath()) || createEmptyRegistry();
   const scopedRegistry = await readStandaloneSkillRegistryFile(resolveScopedSkillRegistryPath(scope)) || createEmptyRegistry();
   for (const [skillName, record] of Object.entries(legacyRegistry.skills)) {
-    if (scopedRegistry.skills[skillName]) {
+    if (scopedRegistry.skills[skillName] || failedSkillCopies.has(skillName)) {
       continue;
     }
     scopedRegistry.skills[skillName] = rebaseLegacyStandaloneSkillRecord(record, legacySkillsDir, scopedSkillsDir);

--- a/app/lib/skills/legacy-skill-adoption.ts
+++ b/app/lib/skills/legacy-skill-adoption.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 
 import {
+  createAtomicTempPath,
   resolveScopedSkillRegistryPath,
   resolveScopedSkillsDataDir,
   shouldUseLegacyScopedSkillsFallback,
@@ -63,7 +64,7 @@ async function readStandaloneSkillRegistryFile(registryPath: string): Promise<St
 
 async function writeStandaloneSkillRegistryFile(registryPath: string, registry: StandaloneSkillRegistry): Promise<void> {
   await fs.mkdir(path.dirname(registryPath), { recursive: true });
-  const tmpPath = `${registryPath}.tmp`;
+  const tmpPath = createAtomicTempPath(registryPath);
   await fs.writeFile(tmpPath, `${JSON.stringify({
     ...registry,
     version: 1,

--- a/app/lib/skills/legacy-skill-adoption.ts
+++ b/app/lib/skills/legacy-skill-adoption.ts
@@ -1,0 +1,145 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import {
+  resolveScopedSkillRegistryPath,
+  resolveScopedSkillsDataDir,
+  shouldUseLegacyScopedSkillsFallback,
+  type UserScopedDataStorageScope,
+} from '@/app/lib/runtime-data-paths';
+import { isPathInside } from '@/app/lib/plugins/canvas-plugin-manifest';
+
+type StandaloneSkillRegistryRecord = {
+  name: string;
+  version: string;
+  description: string;
+  license?: string;
+  sourceType: 'store' | 'seed' | 'local' | 'plugin';
+  sourcePath?: string;
+  sourceRegistryId?: string;
+  sourceRegistryUrl?: string;
+  sourcePluginName?: string;
+  sourcePluginVersion?: string;
+  installedAt: string;
+  updatedAt: string;
+  checksum: string;
+  installDir: string;
+  skillPath: string;
+  interface?: unknown;
+};
+
+type StandaloneSkillRegistry = {
+  version: 1;
+  updatedAt: string;
+  skills: Record<string, StandaloneSkillRegistryRecord>;
+};
+
+const IGNORED_SKILL_COPY_ENTRIES = new Set(['.git', 'node_modules', '.DS_Store']);
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function createEmptyRegistry(): StandaloneSkillRegistry {
+  return {
+    version: 1,
+    updatedAt: nowIso(),
+    skills: {},
+  };
+}
+
+async function readStandaloneSkillRegistryFile(registryPath: string): Promise<StandaloneSkillRegistry | null> {
+  try {
+    const raw = await fs.readFile(registryPath, 'utf-8');
+    const parsed = JSON.parse(raw) as StandaloneSkillRegistry;
+    if (parsed?.version === 1 && parsed.skills && typeof parsed.skills === 'object') {
+      return parsed;
+    }
+  } catch {
+    // Missing or invalid legacy registries are treated as empty.
+  }
+  return null;
+}
+
+async function writeStandaloneSkillRegistryFile(registryPath: string, registry: StandaloneSkillRegistry): Promise<void> {
+  await fs.mkdir(path.dirname(registryPath), { recursive: true });
+  const tmpPath = `${registryPath}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify({
+    ...registry,
+    version: 1,
+    updatedAt: nowIso(),
+  }, null, 2)}\n`, 'utf-8');
+  await fs.rename(tmpPath, registryPath);
+}
+
+function rebaseLegacyStandaloneSkillRecord(
+  record: StandaloneSkillRegistryRecord,
+  legacySkillsDir: string,
+  scopedSkillsDir: string,
+): StandaloneSkillRegistryRecord {
+  const rebaseSkillPath = (value: string): string => {
+    return isPathInside(legacySkillsDir, value)
+      ? path.join(scopedSkillsDir, path.relative(legacySkillsDir, value))
+      : value;
+  };
+
+  return {
+    ...record,
+    installDir: rebaseSkillPath(record.installDir),
+    skillPath: rebaseSkillPath(record.skillPath),
+  };
+}
+
+export async function adoptLegacyStandaloneSkillsForScope(
+  scope?: UserScopedDataStorageScope | null,
+): Promise<boolean> {
+  if (!(await shouldUseLegacyScopedSkillsFallback(scope))) {
+    return false;
+  }
+
+  const legacySkillsDir = resolveScopedSkillsDataDir();
+  const scopedSkillsDir = resolveScopedSkillsDataDir(scope);
+  if (path.resolve(/*turbopackIgnore: true*/ legacySkillsDir) === path.resolve(/*turbopackIgnore: true*/ scopedSkillsDir)) {
+    return false;
+  }
+
+  const entries = await fs.readdir(legacySkillsDir, { withFileTypes: true }).catch(() => []);
+  await fs.mkdir(scopedSkillsDir, { recursive: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === '.backups') {
+      continue;
+    }
+
+    const sourceDir = path.join(legacySkillsDir, entry.name);
+    const skillPath = path.join(sourceDir, 'SKILL.md');
+    const isSkillDir = await fs.stat(skillPath).then((stat) => stat.isFile()).catch(() => false);
+    if (!isSkillDir) {
+      continue;
+    }
+
+    const targetDir = path.join(scopedSkillsDir, entry.name);
+    const targetExists = await fs.stat(targetDir).then((stat) => stat.isDirectory()).catch(() => false);
+    if (targetExists) {
+      continue;
+    }
+
+    await fs.cp(sourceDir, targetDir, {
+      recursive: true,
+      preserveTimestamps: true,
+      filter: (source) => !IGNORED_SKILL_COPY_ENTRIES.has(path.basename(source)),
+    });
+  }
+
+  const legacyRegistry = await readStandaloneSkillRegistryFile(resolveScopedSkillRegistryPath()) || createEmptyRegistry();
+  const scopedRegistry = await readStandaloneSkillRegistryFile(resolveScopedSkillRegistryPath(scope)) || createEmptyRegistry();
+  for (const [skillName, record] of Object.entries(legacyRegistry.skills)) {
+    if (scopedRegistry.skills[skillName]) {
+      continue;
+    }
+    scopedRegistry.skills[skillName] = rebaseLegacyStandaloneSkillRecord(record, legacySkillsDir, scopedSkillsDir);
+  }
+  await writeStandaloneSkillRegistryFile(resolveScopedSkillRegistryPath(scope), scopedRegistry);
+
+  return true;
+}

--- a/app/lib/skills/skill-loader.ts
+++ b/app/lib/skills/skill-loader.ts
@@ -8,6 +8,7 @@ import {
   type CanvasSkillStorageScope,
 } from './canvas-skill-manifest';
 import { enableSkillInConfig, disableSkillInConfig, areAllSkillsEnabled } from './enabled-skills';
+import { resolveReadableScopedSkillsDataDir } from '@/app/lib/runtime-data-paths';
 import {
   getAllKnownSkillNames,
   loadEnabledPluginSkills,
@@ -29,24 +30,12 @@ export { getSkillsContext } from './skill-context';
  * Only supports Canvas SKILL.md format
  * Optionally filter by enabled skills list
  */
-async function directoryExists(targetPath: string): Promise<boolean> {
-  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
-}
-
-async function resolveReadableSkillsDir(scope?: CanvasSkillStorageScope | null): Promise<string> {
-  const scopedDir = getSkillsDir(scope);
-  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
-    return getSkillsDir();
-  }
-  return scopedDir;
-}
-
 export async function loadSkillsFromDisk(
   enabledSkills?: string[],
   scope?: CanvasSkillStorageScope | null,
 ): Promise<CanvasSkill[]> {
   const skills: CanvasSkill[] = [];
-  const skillsDir = await resolveReadableSkillsDir(scope);
+  const skillsDir = await resolveReadableScopedSkillsDataDir(scope);
   
   try {
     // Check if skills directory exists
@@ -136,7 +125,7 @@ export async function loadSkillByName(
 ): Promise<CanvasSkill | null> {
   const skillsDir = options.legacyFallback === false
     ? getSkillsDir(scope)
-    : await resolveReadableSkillsDir(scope);
+    : await resolveReadableScopedSkillsDataDir(scope);
   const skillMdPath = path.join(skillsDir, name, 'SKILL.md');
   try {
     await fs.access(skillMdPath);

--- a/app/lib/skills/skill-loader.ts
+++ b/app/lib/skills/skill-loader.ts
@@ -13,6 +13,7 @@ import {
   getAllKnownSkillNames,
   loadEnabledPluginSkills,
 } from '@/app/lib/plugins/canvas-plugin-registry';
+import { adoptLegacyStandaloneSkillsForScope } from '@/app/lib/skills/legacy-skill-adoption';
 import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from './skill-settings';
 // Re-export the Canvas skill manifest API for existing call sites.
 export type { CanvasSkill, ValidationResult } from './canvas-skill-manifest';
@@ -169,6 +170,8 @@ export async function createSkillDirectory(
   scope?: CanvasSkillStorageScope | null,
 ): Promise<{ success: boolean; error?: string; path?: string }> {
   try {
+    await adoptLegacyStandaloneSkillsForScope(scope);
+
     // Check if skill already exists
     if (await skillExists(name, scope, { legacyFallback: false })) {
       return { success: false, error: `Skill "${name}" already exists` };
@@ -297,6 +300,8 @@ export async function deleteSkillDirectory(
   scope?: CanvasSkillStorageScope | null,
 ): Promise<{ success: boolean; error?: string }> {
   try {
+    await adoptLegacyStandaloneSkillsForScope(scope);
+
     const skillsDir = getSkillsDir(scope);
     const skillPath = path.join(skillsDir, name);
     const skillMdPath = path.join(skillPath, 'SKILL.md');

--- a/app/lib/skills/skill-loader.ts
+++ b/app/lib/skills/skill-loader.ts
@@ -1,12 +1,18 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { CanvasSkill, parseSkillFile, getSkillsDir, createDefaultSkillMd } from './canvas-skill-manifest';
-import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
+import {
+  CanvasSkill,
+  parseSkillFile,
+  getSkillsDir,
+  createDefaultSkillMd,
+  type CanvasSkillStorageScope,
+} from './canvas-skill-manifest';
 import { enableSkillInConfig, disableSkillInConfig, areAllSkillsEnabled } from './enabled-skills';
 import {
   getAllKnownSkillNames,
   loadEnabledPluginSkills,
 } from '@/app/lib/plugins/canvas-plugin-registry';
+import { readEnabledSkillsForScope, writeEnabledSkillsForScope } from './skill-settings';
 // Re-export the Canvas skill manifest API for existing call sites.
 export type { CanvasSkill, ValidationResult } from './canvas-skill-manifest';
 export {
@@ -23,9 +29,24 @@ export { getSkillsContext } from './skill-context';
  * Only supports Canvas SKILL.md format
  * Optionally filter by enabled skills list
  */
-export async function loadSkillsFromDisk(enabledSkills?: string[]): Promise<CanvasSkill[]> {
+async function directoryExists(targetPath: string): Promise<boolean> {
+  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
+}
+
+async function resolveReadableSkillsDir(scope?: CanvasSkillStorageScope | null): Promise<string> {
+  const scopedDir = getSkillsDir(scope);
+  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
+    return getSkillsDir();
+  }
+  return scopedDir;
+}
+
+export async function loadSkillsFromDisk(
+  enabledSkills?: string[],
+  scope?: CanvasSkillStorageScope | null,
+): Promise<CanvasSkill[]> {
   const skills: CanvasSkill[] = [];
-  const skillsDir = getSkillsDir();
+  const skillsDir = await resolveReadableSkillsDir(scope);
   
   try {
     // Check if skills directory exists
@@ -84,7 +105,7 @@ export async function loadSkillsFromDisk(enabledSkills?: string[]): Promise<Canv
   }
 
   const standaloneSkillNames = new Set(skills.map((skill) => skill.name));
-  const pluginSkills = await loadEnabledPluginSkills(enabledSkills).catch((error) => {
+  const pluginSkills = await loadEnabledPluginSkills(enabledSkills, scope).catch((error) => {
     console.warn('[SkillLoader] Error loading plugin skills:', error);
     return [];
   });
@@ -108,8 +129,14 @@ export async function loadSkillsFromDisk(enabledSkills?: string[]): Promise<Canv
 /**
  * Load a single skill by name
  */
-export async function loadSkillByName(name: string): Promise<CanvasSkill | null> {
-  const skillsDir = getSkillsDir();
+export async function loadSkillByName(
+  name: string,
+  scope?: CanvasSkillStorageScope | null,
+  options: { legacyFallback?: boolean } = {},
+): Promise<CanvasSkill | null> {
+  const skillsDir = options.legacyFallback === false
+    ? getSkillsDir(scope)
+    : await resolveReadableSkillsDir(scope);
   const skillMdPath = path.join(skillsDir, name, 'SKILL.md');
   try {
     await fs.access(skillMdPath);
@@ -121,22 +148,26 @@ export async function loadSkillByName(name: string): Promise<CanvasSkill | null>
     // Fall through to plugin-managed skills.
   }
 
-  const pluginSkills = await loadEnabledPluginSkills();
+  const pluginSkills = await loadEnabledPluginSkills(undefined, scope);
   return pluginSkills.find((skill) => skill.name === name) || null;
 }
 
 /**
  * Check if a skill exists
  */
-export async function skillExists(name: string): Promise<boolean> {
-  return Boolean(await loadSkillByName(name));
+export async function skillExists(
+  name: string,
+  scope?: CanvasSkillStorageScope | null,
+  options: { legacyFallback?: boolean } = {},
+): Promise<boolean> {
+  return Boolean(await loadSkillByName(name, scope, options));
 }
 
 /**
  * Get all skill names
  */
-export async function getSkillNames(): Promise<string[]> {
-  return getAllKnownSkillNames();
+export async function getSkillNames(scope?: CanvasSkillStorageScope | null): Promise<string[]> {
+  return getAllKnownSkillNames(scope);
 }
 
 /**
@@ -145,16 +176,17 @@ export async function getSkillNames(): Promise<string[]> {
 export async function createSkillDirectory(
   name: string,
   description: string,
-  content?: string
+  content?: string,
+  scope?: CanvasSkillStorageScope | null,
 ): Promise<{ success: boolean; error?: string; path?: string }> {
   try {
     // Check if skill already exists
-    if (await skillExists(name)) {
+    if (await skillExists(name, scope, { legacyFallback: false })) {
       return { success: false, error: `Skill "${name}" already exists` };
     }
 
     // Create skill directory
-    const skillsDir = getSkillsDir();
+    const skillsDir = getSkillsDir(scope);
     const skillPath = path.join(skillsDir, name);
     await fs.mkdir(skillPath, { recursive: true });
 
@@ -165,11 +197,11 @@ export async function createSkillDirectory(
 
     // Auto-enable the new skill in pi-runtime-config
     try {
-      const config = await readPiRuntimeConfig();
-      if (!areAllSkillsEnabled(config.enabledSkills)) {
-        const allSkillNames = await getSkillNames();
-        config.enabledSkills = enableSkillInConfig(name, config.enabledSkills, allSkillNames);
-        await writePiRuntimeConfig(config);
+      const enabledSkills = await readEnabledSkillsForScope(scope);
+      if (!areAllSkillsEnabled(enabledSkills)) {
+        const allSkillNames = await getSkillNames(scope);
+        const nextEnabledSkills = enableSkillInConfig(name, enabledSkills, allSkillNames);
+        await writeEnabledSkillsForScope(nextEnabledSkills, { scope });
         console.log(`[SkillLoader] Auto-enabled skill "${name}" in config`);
       }
     } catch (cfgError) {
@@ -189,12 +221,12 @@ export async function createSkillDirectory(
 /**
  * Get skill statistics
  */
-export async function getSkillStats(): Promise<{
+export async function getSkillStats(scope?: CanvasSkillStorageScope | null): Promise<{
   total: number;
   enabled: number;
   disabled: number;
 }> {
-  const skills = await loadSkillsFromDisk();
+  const skills = await loadSkillsFromDisk(undefined, scope);
   
   return {
     total: skills.length,
@@ -207,13 +239,13 @@ export async function getSkillStats(): Promise<{
  * Validate a skill by name
  * Returns validation result with any errors
  */
-export async function validateSkillByName(name: string): Promise<{
+export async function validateSkillByName(name: string, scope?: CanvasSkillStorageScope | null): Promise<{
   valid: boolean;
   errors: string[];
   skill?: CanvasSkill;
 }> {
   try {
-    const skill = await loadSkillByName(name);
+    const skill = await loadSkillByName(name, scope);
     
     if (!skill) {
       return { 
@@ -238,9 +270,10 @@ export async function validateSkillByName(name: string): Promise<{
  */
 export async function createSkillReadme(
   name: string,
-  skill: CanvasSkill
+  skill: CanvasSkill,
+  scope?: CanvasSkillStorageScope | null,
 ): Promise<void> {
-  const skillsDir = getSkillsDir();
+  const skillsDir = getSkillsDir(scope);
   const readmePath = path.join(skillsDir, name, 'README.md');
   
   const readmeContent = `# ${skill.title}
@@ -271,16 +304,17 @@ ${skill.content}
 }
 
 export async function deleteSkillDirectory(
-  name: string
+  name: string,
+  scope?: CanvasSkillStorageScope | null,
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const skillsDir = getSkillsDir();
+    const skillsDir = getSkillsDir(scope);
     const skillPath = path.join(skillsDir, name);
     const skillMdPath = path.join(skillPath, 'SKILL.md');
     const hasStandaloneSkill = await fs.access(skillMdPath).then(() => true).catch(() => false);
 
     if (!hasStandaloneSkill) {
-      if (await skillExists(name)) {
+      if (await skillExists(name, scope, { legacyFallback: false })) {
         return { success: false, error: `Skill "${name}" is managed by a plugin. Disable or remove the plugin instead.` };
       }
       return { success: false, error: `Skill "${name}" not found` };
@@ -295,10 +329,10 @@ export async function deleteSkillDirectory(
     await fs.rm(skillPath, { recursive: true, force: true });
 
     try {
-      const config = await readPiRuntimeConfig();
-      const allSkillNames = await getSkillNames();
-      config.enabledSkills = disableSkillInConfig(name, config.enabledSkills, allSkillNames);
-      await writePiRuntimeConfig(config);
+      const enabledSkills = await readEnabledSkillsForScope(scope);
+      const allSkillNames = await getSkillNames(scope);
+      const nextEnabledSkills = disableSkillInConfig(name, enabledSkills, allSkillNames);
+      await writeEnabledSkillsForScope(nextEnabledSkills, { scope });
       console.log(`[SkillLoader] Removed skill "${name}" from enabled-skills config`);
     } catch (cfgError) {
       console.warn(`[SkillLoader] Could not remove skill "${name}" from config:`, cfgError);

--- a/app/lib/skills/skill-settings.ts
+++ b/app/lib/skills/skill-settings.ts
@@ -1,0 +1,111 @@
+import 'server-only';
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
+import {
+  resolveScopedSettingsDir,
+  type UserScopedDataStorageScope,
+} from '@/app/lib/runtime-data-paths';
+
+export type SkillSettingsScope = UserScopedDataStorageScope;
+
+export interface CanvasSkillSettings {
+  version: 1;
+  updatedAt: string;
+  updatedBy?: string;
+  enabledSkills: string[];
+}
+
+const SKILL_SETTINGS_FILE = 'skills.json';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function hasUserScope(scope?: SkillSettingsScope | null): boolean {
+  return Boolean(scope?.userId?.trim());
+}
+
+function createSkillSettings(enabledSkills: string[], updatedBy?: string): CanvasSkillSettings {
+  return {
+    version: 1,
+    updatedAt: nowIso(),
+    updatedBy,
+    enabledSkills,
+  };
+}
+
+function resolveSkillSettingsPath(scope?: SkillSettingsScope | null): string {
+  return path.join(resolveScopedSettingsDir(scope), SKILL_SETTINGS_FILE);
+}
+
+async function readUserSkillSettings(scope: SkillSettingsScope): Promise<CanvasSkillSettings | null> {
+  const settingsPath = resolveSkillSettingsPath(scope);
+  try {
+    const raw = await fs.readFile(settingsPath, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<CanvasSkillSettings>;
+    if (
+      parsed.version === 1
+      && Array.isArray(parsed.enabledSkills)
+      && parsed.enabledSkills.every((entry) => typeof entry === 'string')
+    ) {
+      return {
+        version: 1,
+        updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : nowIso(),
+        updatedBy: typeof parsed.updatedBy === 'string' ? parsed.updatedBy : undefined,
+        enabledSkills: parsed.enabledSkills,
+      };
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn('[SkillSettings] Failed to read user skill settings, falling back to legacy runtime config:', error);
+    }
+  }
+  return null;
+}
+
+async function writeUserSkillSettings(settings: CanvasSkillSettings, scope: SkillSettingsScope): Promise<void> {
+  const settingsPath = resolveSkillSettingsPath(scope);
+  await fs.mkdir(path.dirname(settingsPath), { recursive: true });
+  const tmpPath = `${settingsPath}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf-8');
+  await fs.rename(tmpPath, settingsPath);
+}
+
+export async function readEnabledSkillsForScope(
+  scope?: SkillSettingsScope | null,
+): Promise<string[] | undefined> {
+  if (hasUserScope(scope)) {
+    const userSettings = await readUserSkillSettings(scope as SkillSettingsScope);
+    if (userSettings) {
+      return userSettings.enabledSkills;
+    }
+  }
+
+  const legacyConfig = await readPiRuntimeConfig();
+  return legacyConfig.enabledSkills;
+}
+
+export async function writeEnabledSkillsForScope(
+  enabledSkills: string[],
+  options: {
+    scope?: SkillSettingsScope | null;
+    updatedBy?: string;
+  } = {},
+): Promise<void> {
+  if (hasUserScope(options.scope)) {
+    await writeUserSkillSettings(
+      createSkillSettings(enabledSkills, options.updatedBy),
+      options.scope as SkillSettingsScope,
+    );
+    return;
+  }
+
+  const config = await readPiRuntimeConfig();
+  config.enabledSkills = enabledSkills;
+  config.updatedAt = nowIso();
+  config.updatedBy = options.updatedBy || config.updatedBy;
+  await writePiRuntimeConfig(config);
+}

--- a/app/lib/skills/skill-settings.ts
+++ b/app/lib/skills/skill-settings.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
 import {
+  createAtomicTempPath,
   resolveScopedSettingsDir,
   type UserScopedDataStorageScope,
 } from '@/app/lib/runtime-data-paths';
@@ -69,7 +70,7 @@ async function readUserSkillSettings(scope: SkillSettingsScope): Promise<CanvasS
 async function writeUserSkillSettings(settings: CanvasSkillSettings, scope: SkillSettingsScope): Promise<void> {
   const settingsPath = resolveSkillSettingsPath(scope);
   await fs.mkdir(path.dirname(settingsPath), { recursive: true });
-  const tmpPath = `${settingsPath}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const tmpPath = createAtomicTempPath(settingsPath);
   await fs.writeFile(tmpPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf-8');
   await fs.rename(tmpPath, settingsPath);
 }

--- a/app/lib/skills/skill-summaries.ts
+++ b/app/lib/skills/skill-summaries.ts
@@ -4,13 +4,13 @@ import { promises as fs } from 'fs';
 import path from 'path';
 
 import {
-  getSkillsDir,
   loadCanvasSkillInterface,
   parseFrontmatter,
   type CanvasSkillInterface,
   type CanvasSkillStorageScope,
 } from './canvas-skill-manifest';
 import { loadEnabledPluginSkills } from '@/app/lib/plugins/canvas-plugin-registry';
+import { resolveReadableScopedSkillsDataDir } from '@/app/lib/runtime-data-paths';
 
 export type SkillSummary = {
   name: string;
@@ -39,23 +39,11 @@ function parseSkillSummary(content: string, fallbackName: string): Omit<SkillSum
   };
 }
 
-async function directoryExists(targetPath: string): Promise<boolean> {
-  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
-}
-
-async function resolveReadableSkillsDir(scope?: CanvasSkillStorageScope | null): Promise<string> {
-  const scopedDir = getSkillsDir(scope);
-  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
-    return getSkillsDir();
-  }
-  return scopedDir;
-}
-
 export async function loadSkillSummaries(
   enabledSkills?: string[],
   scope?: CanvasSkillStorageScope | null,
 ): Promise<SkillSummary[]> {
-  const skillsDir = await resolveReadableSkillsDir(scope);
+  const skillsDir = await resolveReadableScopedSkillsDataDir(scope);
   const enabledSet = new Set(enabledSkills || []);
   const allEnabled = !enabledSkills || enabledSkills.length === 0;
 

--- a/app/lib/skills/skill-summaries.ts
+++ b/app/lib/skills/skill-summaries.ts
@@ -8,6 +8,7 @@ import {
   loadCanvasSkillInterface,
   parseFrontmatter,
   type CanvasSkillInterface,
+  type CanvasSkillStorageScope,
 } from './canvas-skill-manifest';
 import { loadEnabledPluginSkills } from '@/app/lib/plugins/canvas-plugin-registry';
 
@@ -38,8 +39,23 @@ function parseSkillSummary(content: string, fallbackName: string): Omit<SkillSum
   };
 }
 
-export async function loadSkillSummaries(enabledSkills?: string[]): Promise<SkillSummary[]> {
-  const skillsDir = getSkillsDir();
+async function directoryExists(targetPath: string): Promise<boolean> {
+  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
+}
+
+async function resolveReadableSkillsDir(scope?: CanvasSkillStorageScope | null): Promise<string> {
+  const scopedDir = getSkillsDir(scope);
+  if (scope?.userId?.trim() && !(await directoryExists(scopedDir))) {
+    return getSkillsDir();
+  }
+  return scopedDir;
+}
+
+export async function loadSkillSummaries(
+  enabledSkills?: string[],
+  scope?: CanvasSkillStorageScope | null,
+): Promise<SkillSummary[]> {
+  const skillsDir = await resolveReadableSkillsDir(scope);
   const enabledSet = new Set(enabledSkills || []);
   const allEnabled = !enabledSkills || enabledSkills.length === 0;
 
@@ -72,7 +88,7 @@ export async function loadSkillSummaries(enabledSkills?: string[]): Promise<Skil
       if (summary) validSummaries.push(summary);
     }
     const standaloneNames = new Set(validSummaries.map((summary) => summary.name));
-    const pluginSkills = await loadEnabledPluginSkills(enabledSkills).catch(() => []);
+    const pluginSkills = await loadEnabledPluginSkills(enabledSkills, scope).catch(() => []);
     for (const skill of pluginSkills) {
       if (standaloneNames.has(skill.name)) {
         continue;

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -258,12 +258,25 @@
         "app/lib/agents/storage.ts",
         "app/lib/agents/memory-store.ts",
         "app/lib/agents/system-prompt.ts",
+        "app/lib/skills/skill-settings.ts",
+        "app/lib/skills/skill-loader.ts",
+        "app/lib/skills/skill-summaries.ts",
+        "app/lib/skills/canvas-skill-manifest.ts",
+        "app/lib/skills/canvas-skill-store.ts",
+        "app/lib/plugins/canvas-plugin-registry.ts",
+        "app/lib/plugins/canvas-plugin-store.ts",
+        "app/lib/plugins/plugin-reference-context.ts",
         "app/lib/pi/system-prompt-snapshot.ts",
+        "app/lib/pi/live-runtime.ts",
         "app/api/agents/files/route.ts",
+        "app/api/skills/*",
+        "app/api/plugins/*",
         "app/lib/onboarding/profile.ts",
         "scripts/scoped-runtime-paths-test.ts",
         "scripts/agent-memory-store-test.ts",
-        "scripts/agent-runtime-config-test.ts"
+        "scripts/agent-runtime-config-test.ts",
+        "scripts/canvas-skill-store-test.ts",
+        "scripts/canvas-plugin-runtime-test.ts"
       ]
     },
     {

--- a/scripts/canvas-plugin-runtime-test.ts
+++ b/scripts/canvas-plugin-runtime-test.ts
@@ -197,6 +197,17 @@ async function main() {
 
     const install = await installCanvasPluginFromPath(pluginRoot, { enable: true });
     assert.equal(install.success, true, install.error || JSON.stringify(install.validation));
+    await writeFile(path.join(dataRoot, 'skills', 'legacy-standalone-skill', 'SKILL.md'), `---
+name: legacy-standalone-skill
+description: "Temporary legacy standalone skill for scoped plugin adoption tests."
+metadata:
+  version: "1.0.0"
+---
+
+# Legacy Standalone Skill
+
+This skill lives in the legacy global skills directory.
+`);
 
     let plugins = await listCanvasPlugins();
     assert.equal(plugins.length, 1);
@@ -204,6 +215,10 @@ async function main() {
     const globalPluginInstallDir = plugins[0].installDir;
     const legacyPluginScope = { userId: 'legacy-plugin-user' };
     assert.equal((await listCanvasPlugins(legacyPluginScope)).some((plugin) => plugin.name === 'test-plugin'), true);
+    assert.equal(
+      (await loadSkillsFromDisk(undefined, legacyPluginScope)).some((skill) => skill.name === 'legacy-standalone-skill'),
+      true,
+    );
     const legacyDisable = await setCanvasPluginEnabled('test-plugin', false, legacyPluginScope, 'legacy-plugin-user@example.com');
     assert.equal(legacyDisable.success, true, legacyDisable.error);
     const legacyPlugins = await listCanvasPlugins(legacyPluginScope);
@@ -212,6 +227,14 @@ async function main() {
     assert.match(legacyPlugins[0].installDir, /users\/legacy-plugin-user\/plugins\/installed\/test-plugin\/1\.0\.0$/);
     assert.equal(
       await fs.stat(path.join(dataRoot, 'users', 'legacy-plugin-user', 'plugins', 'installed', 'test-plugin', '1.0.0', '.canvas-plugin', 'plugin.json')).then((stat) => stat.isFile()),
+      true,
+    );
+    assert.equal(
+      await fs.stat(path.join(dataRoot, 'users', 'legacy-plugin-user', 'skills', 'legacy-standalone-skill', 'SKILL.md')).then((stat) => stat.isFile()),
+      true,
+    );
+    assert.equal(
+      (await loadSkillsFromDisk(undefined, legacyPluginScope)).some((skill) => skill.name === 'legacy-standalone-skill'),
       true,
     );
     assert.equal(await fs.stat(globalPluginInstallDir).then((stat) => stat.isDirectory()), true);

--- a/scripts/canvas-plugin-runtime-test.ts
+++ b/scripts/canvas-plugin-runtime-test.ts
@@ -201,6 +201,7 @@ async function main() {
     let plugins = await listCanvasPlugins();
     assert.equal(plugins.length, 1);
     assert.equal(plugins[0].name, 'test-plugin');
+    assert.equal((await listCanvasPlugins({ userId: 'legacy-plugin-user' })).some((plugin) => plugin.name === 'test-plugin'), true);
     assert.equal(plugins[0].skills[0].name, 'test-plugin-skill');
     assert.equal(plugins[0].skills[0].materialized, true);
     assert.equal(plugins[0].skills[0].preexistingStandalone, false);
@@ -301,6 +302,42 @@ async function main() {
     store = await listCanvasPluginStore();
     assert.equal(store.plugins[0].installed.skillSummary.missing, 0);
     assert.equal(store.plugins[0].installed.skillSummary.repairable, 0);
+
+    const pluginScopeA = { userId: 'plugin-user-a' };
+    const pluginScopeB = { userId: 'plugin-user-b' };
+    await fs.mkdir(path.join(dataRoot, 'users', 'plugin-user-a', 'plugins'), { recursive: true });
+    await fs.mkdir(path.join(dataRoot, 'users', 'plugin-user-a', 'skills'), { recursive: true });
+    await fs.mkdir(path.join(dataRoot, 'users', 'plugin-user-b', 'plugins'), { recursive: true });
+    await fs.mkdir(path.join(dataRoot, 'users', 'plugin-user-b', 'skills'), { recursive: true });
+    await writeFile(path.join(dataRoot, 'users', 'plugin-user-b', 'plugins', 'registry.json'), JSON.stringify({
+      version: 1,
+      updatedAt: '2026-06-17T00:00:00.000Z',
+      plugins: {},
+    }, null, 2));
+    const scopedInstall = await installCanvasPluginFromPath(pluginRoot, {
+      enable: true,
+      installedBy: 'plugin-user-a@example.com',
+      scope: pluginScopeA,
+    });
+    assert.equal(scopedInstall.success, true, scopedInstall.error || JSON.stringify(scopedInstall.validation));
+    assert.equal((await listCanvasPlugins(pluginScopeA)).length, 1);
+    assert.equal((await listCanvasPlugins(pluginScopeB)).length, 0);
+    assert.equal(
+      await fs.stat(path.join(dataRoot, 'users', 'plugin-user-a', 'plugins', 'installed', 'test-plugin', '1.0.0', '.canvas-plugin', 'plugin.json')).then((stat) => stat.isFile()),
+      true,
+    );
+    assert.equal(
+      await fs.stat(path.join(dataRoot, 'users', 'plugin-user-a', 'skills', 'test-plugin-skill', 'SKILL.md')).then((stat) => stat.isFile()),
+      true,
+    );
+    await assert.rejects(fs.stat(path.join(dataRoot, 'users', 'plugin-user-b', 'skills', 'test-plugin-skill', 'SKILL.md')));
+    assert.equal((await loadSkillsFromDisk(undefined, pluginScopeA)).some((skill) => skill.name === 'test-plugin-skill'), true);
+    assert.equal((await loadSkillsFromDisk(undefined, pluginScopeB)).some((skill) => skill.name === 'test-plugin-skill'), false);
+    assert.match(
+      await buildReferencedPluginRuntimeContext('Use /test-plugin for this workflow.', pluginScopeA) || '',
+      /Referenced Canvas Plugins/,
+    );
+    assert.equal(await buildReferencedPluginRuntimeContext('Use /test-plugin for this workflow.', pluginScopeB), null);
 
     console.log('canvas plugin runtime test passed');
   } finally {

--- a/scripts/canvas-plugin-runtime-test.ts
+++ b/scripts/canvas-plugin-runtime-test.ts
@@ -201,7 +201,24 @@ async function main() {
     let plugins = await listCanvasPlugins();
     assert.equal(plugins.length, 1);
     assert.equal(plugins[0].name, 'test-plugin');
-    assert.equal((await listCanvasPlugins({ userId: 'legacy-plugin-user' })).some((plugin) => plugin.name === 'test-plugin'), true);
+    const globalPluginInstallDir = plugins[0].installDir;
+    const legacyPluginScope = { userId: 'legacy-plugin-user' };
+    assert.equal((await listCanvasPlugins(legacyPluginScope)).some((plugin) => plugin.name === 'test-plugin'), true);
+    const legacyDisable = await setCanvasPluginEnabled('test-plugin', false, legacyPluginScope, 'legacy-plugin-user@example.com');
+    assert.equal(legacyDisable.success, true, legacyDisable.error);
+    const legacyPlugins = await listCanvasPlugins(legacyPluginScope);
+    assert.equal(legacyPlugins.length, 1);
+    assert.equal(legacyPlugins[0].enabled, false);
+    assert.match(legacyPlugins[0].installDir, /users\/legacy-plugin-user\/plugins\/installed\/test-plugin\/1\.0\.0$/);
+    assert.equal(
+      await fs.stat(path.join(dataRoot, 'users', 'legacy-plugin-user', 'plugins', 'installed', 'test-plugin', '1.0.0', '.canvas-plugin', 'plugin.json')).then((stat) => stat.isFile()),
+      true,
+    );
+    assert.equal(await fs.stat(globalPluginInstallDir).then((stat) => stat.isDirectory()), true);
+    const legacyDeleted = await deleteCanvasPlugin('test-plugin', legacyPluginScope, 'legacy-plugin-user@example.com');
+    assert.equal(legacyDeleted.success, true, legacyDeleted.error);
+    assert.equal((await listCanvasPlugins(legacyPluginScope)).length, 0);
+    assert.equal(await fs.stat(globalPluginInstallDir).then((stat) => stat.isDirectory()), true);
     assert.equal(plugins[0].skills[0].name, 'test-plugin-skill');
     assert.equal(plugins[0].skills[0].materialized, true);
     assert.equal(plugins[0].skills[0].preexistingStandalone, false);

--- a/scripts/canvas-skill-store-test.ts
+++ b/scripts/canvas-skill-store-test.ts
@@ -235,6 +235,34 @@ async function main() {
       await fs.stat(path.join(dataRoot, 'skills', 'test-library-skill', 'SKILL.md')).then((stat) => stat.isFile()),
       true,
     );
+    await writeFile(path.join(dataRoot, 'skills', 'legacy-other-skill', 'SKILL.md'), `---
+name: legacy-other-skill
+description: "Temporary legacy skill used to verify scoped store writes preserve legacy visibility."
+metadata:
+  version: "1.0.0"
+---
+
+# Legacy Other Skill
+
+This skill should remain visible after scoped store writes.
+`);
+    const legacyStoreScope = { userId: 'legacy-store-skill-user' };
+    const legacyStoreInstall = await installCanvasSkillFromStore('test-library-skill', undefined, {
+      enable: true,
+      scope: legacyStoreScope,
+      updatedBy: 'legacy-store-skill-user@example.com',
+    });
+    assert.equal(legacyStoreInstall.success, true, legacyStoreInstall.error);
+    assert.equal((await loadSkillsFromDisk(undefined, legacyStoreScope)).some((skill) => skill.name === 'legacy-other-skill'), true);
+    const legacyRestoreScope = { userId: 'legacy-restore-skill-user' };
+    const legacySeedRestore = await restoreCanvasSkill('pdf', {
+      enable: false,
+      prefer: 'seed',
+      scope: legacyRestoreScope,
+      updatedBy: 'legacy-restore-skill-user@example.com',
+    });
+    assert.equal(legacySeedRestore.success, true, legacySeedRestore.error);
+    assert.equal((await loadSkillsFromDisk(undefined, legacyRestoreScope)).some((skill) => skill.name === 'legacy-other-skill'), true);
     await fs.mkdir(path.join(dataRoot, 'users', 'skill-user-a', 'skills'), { recursive: true });
     await fs.mkdir(path.join(dataRoot, 'users', 'skill-user-b', 'skills'), { recursive: true });
     let scopedStoreA = await listCanvasSkillStore({ scope: userScopeA });

--- a/scripts/canvas-skill-store-test.ts
+++ b/scripts/canvas-skill-store-test.ts
@@ -152,7 +152,7 @@ async function main() {
     const { readPiRuntimeConfig } = await import('../app/lib/agents/storage');
     const { DISABLED_ALL_SKILLS_SENTINEL, resolveEnabledSkillNames } = await import('../app/lib/skills/enabled-skills');
     const { readEnabledSkillsForScope } = await import('../app/lib/skills/skill-settings');
-    const { deleteSkillDirectory, loadSkillsFromDisk } = await import('../app/lib/skills/skill-loader');
+    const { createSkillDirectory, deleteSkillDirectory, loadSkillsFromDisk } = await import('../app/lib/skills/skill-loader');
 
     const checksum = await computeCanvasPluginChecksum(skillRoot);
     const registryPath = await createStoreArchive(skillRoot, checksum);
@@ -225,6 +225,16 @@ async function main() {
     const userScopeB = { userId: 'skill-user-b' };
     const legacyUserScope = { userId: 'legacy-skill-user' };
     assert.equal((await loadSkillsFromDisk(undefined, legacyUserScope)).some((skill) => skill.name === 'test-library-skill'), true);
+    const legacyDuplicateCreate = await createSkillDirectory('test-library-skill', 'Duplicate legacy skill', '', legacyUserScope);
+    assert.equal(legacyDuplicateCreate.success, false);
+    assert.equal(legacyDuplicateCreate.error, 'Skill "test-library-skill" already exists');
+    const legacyDelete = await deleteSkillDirectory('test-library-skill', legacyUserScope);
+    assert.equal(legacyDelete.success, true, legacyDelete.error);
+    await assert.rejects(fs.stat(path.join(dataRoot, 'users', 'legacy-skill-user', 'skills', 'test-library-skill', 'SKILL.md')));
+    assert.equal(
+      await fs.stat(path.join(dataRoot, 'skills', 'test-library-skill', 'SKILL.md')).then((stat) => stat.isFile()),
+      true,
+    );
     await fs.mkdir(path.join(dataRoot, 'users', 'skill-user-a', 'skills'), { recursive: true });
     await fs.mkdir(path.join(dataRoot, 'users', 'skill-user-b', 'skills'), { recursive: true });
     let scopedStoreA = await listCanvasSkillStore({ scope: userScopeA });

--- a/scripts/canvas-skill-store-test.ts
+++ b/scripts/canvas-skill-store-test.ts
@@ -151,6 +151,7 @@ async function main() {
     } = await import('../app/lib/skills/canvas-skill-store');
     const { readPiRuntimeConfig } = await import('../app/lib/agents/storage');
     const { DISABLED_ALL_SKILLS_SENTINEL, resolveEnabledSkillNames } = await import('../app/lib/skills/enabled-skills');
+    const { readEnabledSkillsForScope } = await import('../app/lib/skills/skill-settings');
     const { deleteSkillDirectory, loadSkillsFromDisk } = await import('../app/lib/skills/skill-loader');
 
     const checksum = await computeCanvasPluginChecksum(skillRoot);
@@ -219,6 +220,36 @@ async function main() {
     assert.equal(skillRegistry.skills['test-library-skill'].version, '1.1.0');
     store = await listCanvasSkillStore();
     assert.equal(store.skills[0].installed.updateAvailable, false);
+
+    const userScopeA = { userId: 'skill-user-a' };
+    const userScopeB = { userId: 'skill-user-b' };
+    const legacyUserScope = { userId: 'legacy-skill-user' };
+    assert.equal((await loadSkillsFromDisk(undefined, legacyUserScope)).some((skill) => skill.name === 'test-library-skill'), true);
+    await fs.mkdir(path.join(dataRoot, 'users', 'skill-user-a', 'skills'), { recursive: true });
+    await fs.mkdir(path.join(dataRoot, 'users', 'skill-user-b', 'skills'), { recursive: true });
+    let scopedStoreA = await listCanvasSkillStore({ scope: userScopeA });
+    let scopedStoreB = await listCanvasSkillStore({ scope: userScopeB });
+    assert.equal(scopedStoreA.skills[0].installed.installed, false);
+    assert.equal(scopedStoreB.skills[0].installed.installed, false);
+
+    const scopedInstall = await installCanvasSkillFromStore('test-library-skill', undefined, {
+      enable: true,
+      scope: userScopeA,
+      updatedBy: 'skill-user-a@example.com',
+    });
+    assert.equal(scopedInstall.success, true, scopedInstall.error);
+    assert.equal(
+      await fs.stat(path.join(dataRoot, 'users', 'skill-user-a', 'skills', 'test-library-skill', 'SKILL.md')).then((stat) => stat.isFile()),
+      true,
+    );
+    await assert.rejects(fs.stat(path.join(dataRoot, 'users', 'skill-user-b', 'skills', 'test-library-skill', 'SKILL.md')));
+    assert.equal((await loadSkillsFromDisk(undefined, userScopeA)).some((skill) => skill.name === 'test-library-skill'), true);
+    assert.equal((await loadSkillsFromDisk(undefined, userScopeB)).some((skill) => skill.name === 'test-library-skill'), false);
+    assert.deepEqual(await readEnabledSkillsForScope(userScopeA), []);
+    scopedStoreA = await listCanvasSkillStore({ scope: userScopeA });
+    scopedStoreB = await listCanvasSkillStore({ scope: userScopeB });
+    assert.equal(scopedStoreA.skills[0].installed.installed, true);
+    assert.equal(scopedStoreB.skills[0].installed.installed, false);
 
     const deleteResult = await deleteSkillDirectory('test-library-skill');
     assert.equal(deleteResult.success, true, deleteResult.error);

--- a/scripts/scoped-runtime-paths-test.ts
+++ b/scripts/scoped-runtime-paths-test.ts
@@ -23,6 +23,13 @@ async function main() {
       resolveOrganizationSecretsDir,
       resolveOrganizationSkillTemplatesDir,
       resolveOrganizationDataRoot,
+      resolveScopedInstalledPluginsDir,
+      resolveScopedPluginRegistryPath,
+      resolveScopedPluginsDataDir,
+      resolveScopedSettingsDir,
+      resolveScopedSkillBackupsDir,
+      resolveScopedSkillRegistryPath,
+      resolveScopedSkillsDataDir,
       resolveSystemBackupsDir,
       resolveSystemLogsDir,
       resolveSystemManagedDir,
@@ -53,6 +60,13 @@ async function main() {
     assert.equal(resolveUserPluginsDir('user_a'), path.join(dataDir, 'users', 'user_a', 'plugins'));
     assert.equal(resolveUserMcpDir('user_a'), path.join(dataDir, 'users', 'user_a', 'mcp'));
     assert.equal(resolveUserMailDir('user_a'), path.join(dataDir, 'users', 'user_a', 'mail'));
+    assert.equal(resolveScopedSettingsDir({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'settings'));
+    assert.equal(resolveScopedSkillsDataDir({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'skills'));
+    assert.equal(resolveScopedSkillRegistryPath({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'skills', 'registry.json'));
+    assert.equal(resolveScopedSkillBackupsDir({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'skills', '.backups'));
+    assert.equal(resolveScopedPluginsDataDir({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'plugins'));
+    assert.equal(resolveScopedInstalledPluginsDir({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'plugins', 'installed'));
+    assert.equal(resolveScopedPluginRegistryPath({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'plugins', 'registry.json'));
 
     assert.equal(resolveOrganizationDataRoot('org_1'), path.join(dataDir, 'organizations', 'org_1'));
     assert.equal(resolveOrganizationSecretsDir('org_1'), path.join(dataDir, 'organizations', 'org_1', 'secrets'));


### PR DESCRIPTION
## Summary
- Add scoped data path helpers and per-user skills settings under /data/users/{userId}/settings/skills.json.
- Route skill/plugin loaders, stores, registries, APIs, and agent runtime context through the authenticated user scope.
- Preserve read-only legacy fallback for existing global skill/plugin installs until migration runs, while keeping write operations in the user scope.
- Extend Task 17 tracking and targeted tests for User A/User B isolation and legacy fallback.

## Verification
- npm run test:scoped-data-paths
- npm run test:skills:store
- npm run test:plugins:runtime
- npm run test:agents:runtime
- npm run lint
- npm run build

Greptile: awaiting automatic initial review after PR creation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes all skills and plugins storage to individual users under `/data/users/{userId}/`, with a read-only legacy fallback while each user's directory is absent, and lazy migration (`adoptLegacyStandaloneSkillsForScope`) that copies legacy skill data on first write. Enabled-skills state moves from the shared `pi-runtime-config` to per-user `settings/skills.json`.

- **Path helpers & fallback logic** (`runtime-data-paths.ts`): new `resolveScopedSkills/PluginsDataDir`, `shouldUseLegacyScopedSkills/PluginsFallback`, and `resolveReadableScopedSkills/PluginsDataDir` exports give a clean read-vs-write path split. Atomic temp-file naming (`createAtomicTempPath`) replaces the non-unique `.tmp` suffix used previously.
- **Legacy adoption** (`legacy-skill-adoption.ts`): copies the global skill tree and rebases registry records into the user scope on first write; equivalent plugin adoption is handled inline in `canvas-plugin-registry.ts:adoptLegacyPluginRegistryForScope`, which wraps each plugin copy in `.catch()` to handle partial failures gracefully.
- **API routes** (42 files): all skill and plugin routes now derive a `{ userId }` scope from the authenticated session and thread it through store, loader, registry, and settings calls.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the partial-adoption failure mode in legacy-skill-adoption.ts, which can permanently hide legacy skills for affected users.

The migration function creates the user-scoped skills directory before all skill copies complete. A mid-loop IO error leaves the directory created but only partially populated; the next call to `adoptLegacyStandaloneSkillsForScope` sees the directory and returns early, so un-copied skills are permanently invisible with no recovery path. The companion plugin-adoption code handles this correctly with per-plugin `.catch()` — the same pattern needs to be applied to the per-skill `fs.cp` call in `legacy-skill-adoption.ts`. All other scoping work (path helpers, settings file, registry reads/writes, API route threading) looks solid.

app/lib/skills/legacy-skill-adoption.ts — the skill-copy loop needs per-skill error handling to prevent a single IO failure from permanently blocking the migration for all remaining legacy skills.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/lib/skills/legacy-skill-adoption.ts | New file implementing legacy-to-user-scoped skill migration. Has a partial-failure bug: creating the scoped directory before completing all copies means a mid-loop IO error permanently disables the legacy fallback for that user. |
| app/lib/runtime-data-paths.ts | Adds scoped path helpers (skills + plugins) and exports `directoryExists`, `createAtomicTempPath`. Fallback logic mirrors for both skills and plugins; logic is consistent and correct. |
| app/lib/skills/skill-settings.ts | New file providing per-user skill-settings persistence in `settings/skills.json`, with atomic write and legacy pi-runtime-config fallback. Correctly scoped and typed. |
| app/lib/plugins/canvas-plugin-registry.ts | Major refactor to add user-scoped plugin registry. `readCanvasPluginRegistryForWrite` now has a legacy fallback with adoption, per-plugin error handling via `.catch()`, and atomic writes. Addresses previous-thread concerns about read/write split. |
| app/lib/skills/canvas-skill-store.ts | Scoped all store operations (install, restore, backup, registry read/write). `installCanvasSkillFromStore` and `restoreSeedSkill` now call `adoptLegacyStandaloneSkillsForScope` upfront, addressing previously flagged migration gaps. |
| app/lib/skills/skill-loader.ts | All loader functions accept an optional scope. `createSkillDirectory` and `deleteSkillDirectory` now call `adoptLegacyStandaloneSkillsForScope` before writing. |
| app/api/skills/upload/route.ts | Now calls `adoptLegacyStandaloneSkillsForScope` before writing, fixing the previously flagged missing-adoption issue. Also added null-byte stripping to `sanitizeFilePath`. |
| app/lib/agents/system-prompt.ts | Routes `loadSkillsFromDisk` and `readEnabledSkillsForScope` through the agent scope, so each user's agent gets their own skill context. |
| app/lib/plugins/canvas-plugin-store.ts | Propagates scope through all store list/preflight/install operations. `skillFileExists` and `computeInstalledSkillModified` use readable path with legacy fallback. |
| app/lib/plugins/plugin-reference-context.ts | Passes scope to `listCanvasPlugins` so plugin reference context is user-scoped in live runtime. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `app/lib/skills/skill-loader.ts`, line 295-316 ([link](https://github.com/canvascoding/canvas-notebook/blob/09790cc9778d69c563baa2189f3e0c356d1ee169/app/lib/skills/skill-loader.ts#L295-L316)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Legacy skill deletion silently fails with "Skill not found"**

   `deleteSkillDirectory` resolves the skills directory with `getSkillsDir(scope)`, which calls `resolveScopedSkillsDataDir(scope)` — the user-scoped write path with no legacy fallback. But `GET /api/skills` (and `loadSkillsFromDisk`) uses `resolveReadableScopedSkillsDataDir(scope)`, which falls back to the global legacy dir when the user's scoped dir does not yet exist.

   Concrete failure: a user whose skills still live in the global legacy directory sees all their skills in the UI, but every attempt to delete one reaches `deleteSkillDirectory`, finds no `SKILL.md` at the user-scoped path, sets `hasStandaloneSkill = false`, and returns `{ success: false, error: "Skill not found" }`. The same mismatch affects `createSkillDirectory`, which uses `getSkillsDir` to check existence — it won't detect a legacy skill with the same name and will create a duplicate in the user-scoped dir, leaving both copies on disk.

   The plugin write-side solves this with `adoptLegacyPluginRegistryForScope`, which copies legacy data into the user scope before mutating. A parallel migration step is needed here for standalone skills on their first write operation.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-scoped-skills-plugins%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-scoped-skills-plugins%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Fskills%2Fskill-loader.ts%0ALine%3A%20295-316%0A%0AComment%3A%0A**Legacy%20skill%20deletion%20silently%20fails%20with%20%22Skill%20not%20found%22**%0A%0A%60deleteSkillDirectory%60%20resolves%20the%20skills%20directory%20with%20%60getSkillsDir%28scope%29%60%2C%20which%20calls%20%60resolveScopedSkillsDataDir%28scope%29%60%20%E2%80%94%20the%20user-scoped%20write%20path%20with%20no%20legacy%20fallback.%20But%20%60GET%20%2Fapi%2Fskills%60%20%28and%20%60loadSkillsFromDisk%60%29%20uses%20%60resolveReadableScopedSkillsDataDir%28scope%29%60%2C%20which%20falls%20back%20to%20the%20global%20legacy%20dir%20when%20the%20user's%20scoped%20dir%20does%20not%20yet%20exist.%0A%0AConcrete%20failure%3A%20a%20user%20whose%20skills%20still%20live%20in%20the%20global%20legacy%20directory%20sees%20all%20their%20skills%20in%20the%20UI%2C%20but%20every%20attempt%20to%20delete%20one%20reaches%20%60deleteSkillDirectory%60%2C%20finds%20no%20%60SKILL.md%60%20at%20the%20user-scoped%20path%2C%20sets%20%60hasStandaloneSkill%20%3D%20false%60%2C%20and%20returns%20%60%7B%20success%3A%20false%2C%20error%3A%20%22Skill%20not%20found%22%20%7D%60.%20The%20same%20mismatch%20affects%20%60createSkillDirectory%60%2C%20which%20uses%20%60getSkillsDir%60%20to%20check%20existence%20%E2%80%94%20it%20won't%20detect%20a%20legacy%20skill%20with%20the%20same%20name%20and%20will%20create%20a%20duplicate%20in%20the%20user-scoped%20dir%2C%20leaving%20both%20copies%20on%20disk.%0A%0AThe%20plugin%20write-side%20solves%20this%20with%20%60adoptLegacyPluginRegistryForScope%60%2C%20which%20copies%20legacy%20data%20into%20the%20user%20scope%20before%20mutating.%20A%20parallel%20migration%20step%20is%20needed%20here%20for%20standalone%20skills%20on%20their%20first%20write%20operation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=19&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `app/lib/skills/canvas-skill-store.ts`, line 850-895 ([link](https://github.com/canvascoding/canvas-notebook/blob/488ff8bf5ef2c412b2093d8e206a28553658734c/app/lib/skills/canvas-skill-store.ts#L850-L895)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`restoreSeedSkill` has the same missing adoption as `installCanvasSkillFromStore`**

   `restoreSeedSkill` calls `copySkillPackage`, creating the user-scoped skills directory without first calling `adoptLegacyStandaloneSkillsForScope`. A user with un-migrated legacy skills who restores any seed skill will find all their other legacy skills invisible after the operation, for the same reason described in the companion comment on `installCanvasSkillFromStore`.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-scoped-skills-plugins%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-scoped-skills-plugins%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Fskills%2Fcanvas-skill-store.ts%0ALine%3A%20850-895%0A%0AComment%3A%0A**%60restoreSeedSkill%60%20has%20the%20same%20missing%20adoption%20as%20%60installCanvasSkillFromStore%60**%0A%0A%60restoreSeedSkill%60%20calls%20%60copySkillPackage%60%2C%20creating%20the%20user-scoped%20skills%20directory%20without%20first%20calling%20%60adoptLegacyStandaloneSkillsForScope%60.%20A%20user%20with%20un-migrated%20legacy%20skills%20who%20restores%20any%20seed%20skill%20will%20find%20all%20their%20other%20legacy%20skills%20invisible%20after%20the%20operation%2C%20for%20the%20same%20reason%20described%20in%20the%20companion%20comment%20on%20%60installCanvasSkillFromStore%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=19&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

3. `app/api/skills/[name]/readme/route.ts`, line 62-94 ([link](https://github.com/canvascoding/canvas-notebook/blob/75b704de3bfa99402f6c479c9f6fe91efc4e8765/app/api/skills/[name]/readme/route.ts#L62-L94)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **PUT handler fails for un-migrated legacy users**

   `getSkillsDir({ userId })` returns the user-scoped path (`users/{id}/skills/`), which doesn't exist for un-migrated users. `fs.writeFile` throws `ENOENT` because neither the skill subdirectory nor the parent exists, so every `PUT /api/skills/{name}/readme` request for a legacy user returns 500. The `GET` handler on the same route correctly calls `loadSkillByName` (which has the fallback), so users can read their legacy skill but can never save it.

   Adding `await adoptLegacyStandaloneSkillsForScope({ userId: skillPermission.session.user.id })` before `getSkillsDir` (exactly as `createSkillDirectory`, `deleteSkillDirectory`, and `installCanvasSkillFromStore` do) would migrate skills first so the scoped path exists and the write succeeds.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-scoped-skills-plugins%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-scoped-skills-plugins%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fapi%2Fskills%2F%5Bname%5D%2Freadme%2Froute.ts%0ALine%3A%2062-94%0A%0AComment%3A%0A**PUT%20handler%20fails%20for%20un-migrated%20legacy%20users**%0A%0A%60getSkillsDir%28%7B%20userId%20%7D%29%60%20returns%20the%20user-scoped%20path%20%28%60users%2F%7Bid%7D%2Fskills%2F%60%29%2C%20which%20doesn't%20exist%20for%20un-migrated%20users.%20%60fs.writeFile%60%20throws%20%60ENOENT%60%20because%20neither%20the%20skill%20subdirectory%20nor%20the%20parent%20exists%2C%20so%20every%20%60PUT%20%2Fapi%2Fskills%2F%7Bname%7D%2Freadme%60%20request%20for%20a%20legacy%20user%20returns%20500.%20The%20%60GET%60%20handler%20on%20the%20same%20route%20correctly%20calls%20%60loadSkillByName%60%20%28which%20has%20the%20fallback%29%2C%20so%20users%20can%20read%20their%20legacy%20skill%20but%20can%20never%20save%20it.%0A%0AAdding%20%60await%20adoptLegacyStandaloneSkillsForScope%28%7B%20userId%3A%20skillPermission.session.user.id%20%7D%29%60%20before%20%60getSkillsDir%60%20%28exactly%20as%20%60createSkillDirectory%60%2C%20%60deleteSkillDirectory%60%2C%20and%20%60installCanvasSkillFromStore%60%20do%29%20would%20migrate%20skills%20first%20so%20the%20scoped%20path%20exists%20and%20the%20write%20succeeds.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=19&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-scoped-skills-plugins%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-scoped-skills-plugins%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Flib%2Fskills%2Flegacy-skill-adoption.ts%3A108-120%0A**Partial-copy%20IO%20error%20leaves%20migration%20permanently%20stuck**%0A%0A%60fs.mkdir%28scopedSkillsDir%29%60%20is%20called%20before%20the%20skill-copy%20loop.%20If%20%60fs.cp%60%20throws%20for%20any%20skill%20%28disk%20full%2C%20permission%20error%2C%20etc.%29%2C%20the%20function%20aborts%20but%20%60scopedSkillsDir%60%20now%20exists.%20On%20the%20next%20trigger%20%28e.g.%2C%20next%20install%20retry%29%2C%20%60shouldUseLegacyScopedSkillsFallback%60%20returns%20%60false%60%20because%20the%20directory%20exists%2C%20so%20adoption%20is%20never%20reattempted.%20Every%20skill%20that%20hadn't%20been%20copied%20yet%20becomes%20permanently%20invisible%20%E2%80%94%20there%20is%20no%20recovery%20path.%0A%0A%60adoptLegacyPluginRegistryForScope%60%20handles%20this%20correctly%20by%20wrapping%20each%20plugin%20adoption%20in%20%60.catch%28%29%60%20so%20one%20failure%20doesn't%20abort%20others.%20The%20same%20pattern%20should%20be%20applied%20here%3A%20wrap%20the%20%60await%20fs.cp%28...%29%60%20call%20in%20a%20per-skill%20%60try%2Fcatch%60%20that%20logs%20and%20continues%2C%20so%20a%20single%20bad%20skill%20does%20not%20block%20migration%20of%20the%20remaining%20skills.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=19&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (8): Last reviewed commit: ["Adopt legacy skills before readme and pl..."](https://github.com/canvascoding/canvas-notebook/commit/b0769f96906faade0ad383db8dee65fc0b220910) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38805511)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->