### PR TITLE
Scope integration env secrets

### DIFF
--- a/app/api/channels/status/route.ts
+++ b/app/api/channels/status/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     const manager = getChannelManager();
     const managerStatuses = manager.getChannelStatuses();
 
-    const telegramConfig = await getTelegramConfigFromIntegrations({ userId: session.user.id });
+    const telegramConfig = await getTelegramConfigFromIntegrations({ secretScope: 'legacy' });
     const telegramBinding = telegramConfig.botToken
       ? await getBindingByUser('telegram', session.user.id).catch(() => null)
       : null;

--- a/app/api/channels/status/route.ts
+++ b/app/api/channels/status/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     const manager = getChannelManager();
     const managerStatuses = manager.getChannelStatuses();
 
-    const telegramConfig = await getTelegramConfigFromIntegrations();
+    const telegramConfig = await getTelegramConfigFromIntegrations({ userId: session.user.id });
     const telegramBinding = telegramConfig.botToken
       ? await getBindingByUser('telegram', session.user.id).catch(() => null)
       : null;

--- a/app/api/channels/telegram/register-commands/route.ts
+++ b/app/api/channels/telegram/register-commands/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
   if (!limited.ok) return limited.response;
 
   try {
-    const config = await getTelegramConfigFromIntegrations({ userId: session.user.id });
+    const config = await getTelegramConfigFromIntegrations({ secretScope: 'legacy' });
     if (!config.botToken) {
       return NextResponse.json({ success: false, error: 'TELEGRAM_BOT_TOKEN not configured' }, { status: 400 });
     }

--- a/app/api/channels/telegram/register-commands/route.ts
+++ b/app/api/channels/telegram/register-commands/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
   if (!limited.ok) return limited.response;
 
   try {
-    const config = await getTelegramConfigFromIntegrations();
+    const config = await getTelegramConfigFromIntegrations({ userId: session.user.id });
     if (!config.botToken) {
       return NextResponse.json({ success: false, error: 'TELEGRAM_BOT_TOKEN not configured' }, { status: 400 });
     }

--- a/app/api/integrations/env/route.ts
+++ b/app/api/integrations/env/route.ts
@@ -28,30 +28,34 @@ function parseScope(value: string | null | undefined): EnvScope {
 async function requireSession(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    return {
+      ok: false as const,
+      response: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }),
+    };
   }
-  return null;
+  return { ok: true as const, session };
 }
 
 export async function GET(request: NextRequest) {
-  const unauthorized = await requireSession(request);
-  if (unauthorized) {
-    return unauthorized;
+  const authResult = await requireSession(request);
+  if (!authResult.ok) {
+    return authResult.response;
   }
 
   try {
     const scope = parseScope(request.nextUrl.searchParams.get('scope'));
+    const storageScope = { userId: authResult.session.user.id };
     const limited = rateLimit(request, {
       limit: 60,
       windowMs: 60_000,
-      keyPrefix: `integrations-env-get:${scope}`,
+      keyPrefix: `integrations-env-get:${scope}:${authResult.session.user.id}`,
     });
     if (!limited.ok) {
       return limited.response;
     }
 
     await migrateLegacyAgentEnvIfNeeded();
-    const state = await readScopedEnvState(scope);
+    const state = await readScopedEnvState(scope, storageScope);
     return NextResponse.json({ success: true, data: state });
   } catch (error) {
     console.error('[API] integrations/env GET error:', error);
@@ -61,17 +65,18 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
-  const unauthorized = await requireSession(request);
-  if (unauthorized) {
-    return unauthorized;
+  const authResult = await requireSession(request);
+  if (!authResult.ok) {
+    return authResult.response;
   }
 
   try {
     const requestScope = parseScope(request.nextUrl.searchParams.get('scope'));
+    const storageScope = { userId: authResult.session.user.id };
     const limited = rateLimit(request, {
       limit: 30,
       windowMs: 60_000,
-      keyPrefix: `integrations-env-put:${requestScope}`,
+      keyPrefix: `integrations-env-put:${requestScope}:${authResult.session.user.id}`,
     });
     if (!limited.ok) {
       return limited.response;
@@ -84,13 +89,13 @@ export async function PUT(request: NextRequest) {
     await migrateLegacyAgentEnvIfNeeded();
 
     if (mode === 'raw') {
-      await writeScopedEnvRaw(scope, payload.rawContent ?? '');
-      const updated = await readScopedEnvState(scope);
+      await writeScopedEnvRaw(scope, payload.rawContent ?? '', storageScope);
+      const updated = await readScopedEnvState(scope, storageScope);
       return NextResponse.json({ success: true, data: updated });
     }
 
     const entries = Array.isArray(payload.entries) ? payload.entries : [];
-    const updated = await replaceScopedEnvEntries(scope, entries);
+    const updated = await replaceScopedEnvEntries(scope, entries, storageScope);
     return NextResponse.json({ success: true, data: updated });
   } catch (error) {
     console.error('[API] integrations/env PUT error:', error);

--- a/app/api/integrations/search/status/route.ts
+++ b/app/api/integrations/search/status/route.ts
@@ -7,15 +7,18 @@ import { rateLimit } from '@/app/lib/utils/rate-limit';
 async function requireSession(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    return {
+      ok: false as const,
+      response: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }),
+    };
   }
-  return null;
+  return { ok: true as const, session };
 }
 
 export async function GET(request: NextRequest) {
-  const unauthorized = await requireSession(request);
-  if (unauthorized) {
-    return unauthorized;
+  const authResult = await requireSession(request);
+  if (!authResult.ok) {
+    return authResult.response;
   }
 
   const limited = rateLimit(request, {
@@ -28,7 +31,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const status = await getBraveSearchStatus();
+    const status = await getBraveSearchStatus({ userId: authResult.session.user.id });
     return NextResponse.json({ success: true, data: status });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to load search integration status';

--- a/app/api/studio/aspect-ratio/preview/route.ts
+++ b/app/api/studio/aspect-ratio/preview/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const preview = await createAspectRatioPreview(body);
+    const preview = await createAspectRatioPreview(body, { userId: session.user.id });
     return NextResponse.json({ success: true, preview }, { status: 201 });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Preview failed';

--- a/app/api/studio/config/route.ts
+++ b/app/api/studio/config/route.ts
@@ -9,6 +9,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
   }
 
-  const config = await getStudioProviderConfig();
+  const config = await getStudioProviderConfig({ userId: session.user.id });
   return NextResponse.json({ success: true, config });
 }

--- a/app/lib/channels/availability.ts
+++ b/app/lib/channels/availability.ts
@@ -26,7 +26,7 @@ export async function getChannelDeliveryReadiness(input: string | {
   }
 
   if (normalizedChannelId === TELEGRAM_CHANNEL_ID) {
-    const config = await getTelegramConfigFromIntegrations(userId ? { userId } : undefined);
+    const config = await getTelegramConfigFromIntegrations({ secretScope: 'legacy' });
     if (!config.botToken) {
       return {
         ok: false,

--- a/app/lib/channels/availability.ts
+++ b/app/lib/channels/availability.ts
@@ -26,7 +26,7 @@ export async function getChannelDeliveryReadiness(input: string | {
   }
 
   if (normalizedChannelId === TELEGRAM_CHANNEL_ID) {
-    const config = await getTelegramConfigFromIntegrations();
+    const config = await getTelegramConfigFromIntegrations(userId ? { userId } : undefined);
     if (!config.botToken) {
       return {
         ok: false,

--- a/app/lib/channels/manager.ts
+++ b/app/lib/channels/manager.ts
@@ -35,7 +35,7 @@ class ChannelManager {
     registry.register(createWebChannel());
 
     const { getTelegramConfigFromIntegrations } = await import('@/app/lib/integrations/env-config');
-    const config = await getTelegramConfigFromIntegrations();
+    const config = await getTelegramConfigFromIntegrations({ secretScope: 'legacy' });
 
     if (!config.botToken) {
       console.log('[ChannelManager] TELEGRAM_BOT_TOKEN not configured — skipping Telegram channel');

--- a/app/lib/channels/telegram/config.ts
+++ b/app/lib/channels/telegram/config.ts
@@ -1,7 +1,9 @@
+import type { EnvStorageScope } from '@/app/lib/integrations/env-config';
+
 export async function getTelegramConfig(): Promise<{
   botToken: string | null;
   channelEnabled: boolean;
 }> {
   const { getTelegramConfigFromIntegrations } = await import('@/app/lib/integrations/env-config');
-  return getTelegramConfigFromIntegrations();
+  return getTelegramConfigFromIntegrations({ secretScope: 'legacy' } satisfies EnvStorageScope);
 }

--- a/app/lib/channels/telegram/inbound.ts
+++ b/app/lib/channels/telegram/inbound.ts
@@ -10,6 +10,7 @@ import { handleInboundChannelMessage } from '@/app/lib/channels/router';
 import { TELEGRAM_CHANNEL_ID, telegramChannelSessionKey } from '@/app/lib/channels/constants';
 import { transcribeAudio } from '@/app/lib/integrations/audio-transcription-service';
 import { IntegrationServiceError } from '@/app/lib/integrations/integration-service-error';
+import type { EnvStorageScope } from '@/app/lib/integrations/env-config';
 
 const MAX_TELEGRAM_DOWNLOAD_SIZE = 20 * 1024 * 1024;
 const MEDIA_GROUP_WAIT_MS = 900;
@@ -120,6 +121,7 @@ async function saveAndTranscribeTelegramAudio(
   fileId: string,
   originalName: string,
   providedMimeType?: string,
+  storageScope?: EnvStorageScope | null,
 ): Promise<{ upload: SavedTelegramUpload; transcription: TelegramTranscription } | null> {
   const buffer = await downloadTelegramFile(bot, fileId);
   if (!buffer) return null;
@@ -129,6 +131,7 @@ async function saveAndTranscribeTelegramAudio(
     buffer,
     filename: upload.originalName,
     mimeType: upload.mimeType,
+    storageScope,
   });
 
   return {
@@ -345,6 +348,7 @@ export function setupInboundHandler(bot: Bot, onInbound: (message: InboundMessag
             document.file_id,
             filename,
             document.mime_type,
+            { userId: binding.userId },
           );
           if (audioResult) {
             uploads.push(audioResult.upload);
@@ -384,6 +388,7 @@ export function setupInboundHandler(bot: Bot, onInbound: (message: InboundMessag
           voice.file_id,
           `telegram-voice-${ctx.message.message_id}.ogg`,
           voice.mime_type || 'audio/ogg',
+          { userId: binding.userId },
         );
         if (audioResult) {
           uploads.push(audioResult.upload);
@@ -413,6 +418,7 @@ export function setupInboundHandler(bot: Bot, onInbound: (message: InboundMessag
           audio.file_id,
           filename,
           audio.mime_type || 'audio/mpeg',
+          { userId: binding.userId },
         );
         if (audioResult) {
           uploads.push(audioResult.upload);

--- a/app/lib/integrations/audio-transcription-service.ts
+++ b/app/lib/integrations/audio-transcription-service.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { getGroqApiKeyFromIntegrations, readScopedEnvState } from './env-config';
+import { getGroqApiKeyFromIntegrations, readScopedEnvState, type EnvStorageScope } from './env-config';
 import { IntegrationServiceError } from './integration-service-error';
 
 export const MAX_AUDIO_TRANSCRIPTION_BYTES = 25 * 1024 * 1024;
@@ -15,6 +15,7 @@ export interface TranscribeAudioRequest {
   language?: string;
   prompt?: string;
   signal?: AbortSignal;
+  storageScope?: EnvStorageScope | null;
 }
 
 export interface AudioTranscriptionResult {
@@ -36,9 +37,9 @@ function normalizeOptionalText(value: string | undefined): string | undefined {
   return normalized ? normalized : undefined;
 }
 
-async function getGroqTranscriptionModel(): Promise<string> {
+async function getGroqTranscriptionModel(storageScope?: EnvStorageScope | null): Promise<string> {
   try {
-    const state = await readScopedEnvState('integrations');
+    const state = await readScopedEnvState('integrations', storageScope);
     const byKey = new Map(state.entries.map((entry) => [entry.key, entry.value]));
     return (
       normalizeOptionalText(byKey.get('GROQ_TRANSCRIPTION_MODEL')) ||
@@ -83,7 +84,7 @@ export async function transcribeAudio(request: TranscribeAudioRequest): Promise<
     );
   }
 
-  const apiKey = await getGroqApiKeyFromIntegrations();
+  const apiKey = await getGroqApiKeyFromIntegrations(request.storageScope);
   if (!apiKey) {
     throw new IntegrationServiceError(
       'Voice transcription is not configured. Configure GROQ_API_KEY in /settings?tab=integrations.',
@@ -91,7 +92,7 @@ export async function transcribeAudio(request: TranscribeAudioRequest): Promise<
     );
   }
 
-  const model = await getGroqTranscriptionModel();
+  const model = await getGroqTranscriptionModel(request.storageScope);
   const formData = new FormData();
   formData.set(
     'file',

--- a/app/lib/integrations/brave-search-service.ts
+++ b/app/lib/integrations/brave-search-service.ts
@@ -6,7 +6,7 @@ import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
 import { gfm } from 'turndown-plugin-gfm';
 
-import { readScopedEnvState } from '@/app/lib/integrations/env-config';
+import { readScopedEnvState, type EnvStorageScope } from '@/app/lib/integrations/env-config';
 import { IntegrationServiceError } from '@/app/lib/integrations/integration-service-error';
 import { getManagedControlPlaneBaseUrl } from '@/app/lib/managed/control-plane-url';
 import { fetchExternalResourceSafely } from '@/app/lib/security/safe-external-fetch';
@@ -97,9 +97,9 @@ function throwIfAborted(signal?: AbortSignal): void {
   }
 }
 
-export async function getLocalBraveApiKey(): Promise<string | null> {
+export async function getLocalBraveApiKey(storageScope?: EnvStorageScope | null): Promise<string | null> {
   try {
-    const state = await readScopedEnvState('integrations');
+    const state = await readScopedEnvState('integrations', storageScope);
     const byKey = new Map(state.entries.map((entry) => [entry.key, entry.value]));
     const envKey = byKey.get('BRAVE_API_KEY')?.trim();
     if (envKey) return envKey;
@@ -110,13 +110,13 @@ export async function getLocalBraveApiKey(): Promise<string | null> {
   }
 }
 
-export async function getBraveSearchStatus(): Promise<{
+export async function getBraveSearchStatus(storageScope?: EnvStorageScope | null): Promise<{
   configured: boolean;
   mode: BraveSearchMode;
   localConfigured: boolean;
   managedAvailable: boolean;
 }> {
-  const localConfigured = Boolean(await getLocalBraveApiKey());
+  const localConfigured = Boolean(await getLocalBraveApiKey(storageScope));
   const managedAvailable = isManagedBraveSearchAvailable();
   const mode: BraveSearchMode = localConfigured ? 'local' : managedAvailable ? 'managed' : 'disabled';
   return {
@@ -312,7 +312,11 @@ async function searchWithManagedBrave(input: {
   return Array.isArray(record.results) ? record.results as WebSearchResult[] : [];
 }
 
-export async function searchWeb(input: WebSearchInput, signal?: AbortSignal): Promise<WebSearchResponse> {
+export async function searchWeb(
+  input: WebSearchInput,
+  signal?: AbortSignal,
+  storageScope?: EnvStorageScope | null,
+): Promise<WebSearchResponse> {
   throwIfAborted(signal);
   const query = input.query.trim();
   if (!query) {
@@ -323,7 +327,7 @@ export async function searchWeb(input: WebSearchInput, signal?: AbortSignal): Pr
   const freshness = normalizeFreshness(input.freshness);
   const includeContent = input.includeContent === true;
   const maxContentLength = normalizeContentLength(input.maxContentLength);
-  const localApiKey = await getLocalBraveApiKey();
+  const localApiKey = await getLocalBraveApiKey(storageScope);
   const mode: BraveSearchMode = localApiKey ? 'local' : isManagedBraveSearchAvailable() ? 'managed' : 'disabled';
 
   if (mode === 'disabled') {

--- a/app/lib/integrations/env-config.ts
+++ b/app/lib/integrations/env-config.ts
@@ -1,7 +1,14 @@
 import crypto from 'crypto';
 import path from 'path';
 import { promises as fs } from 'fs';
-import { resolveDefaultAgentsEnvPath, resolveDefaultIntegrationsEnvPath } from '../runtime-data-paths';
+import {
+  createAtomicTempPath,
+  resolveDefaultAgentsEnvPath,
+  resolveDefaultIntegrationsEnvPath,
+  resolveScopedAgentsEnvPath,
+  resolveScopedIntegrationsEnvPath,
+  type SecretDataStorageScope,
+} from '../runtime-data-paths';
 
 const ENCRYPTED_PREFIX = 'enc:v1';
 
@@ -9,6 +16,7 @@ export const DEFAULT_INTEGRATIONS_ENV_PATH = resolveDefaultIntegrationsEnvPath()
 export const DEFAULT_AGENTS_ENV_PATH = resolveDefaultAgentsEnvPath();
 
 export type EnvScope = 'integrations' | 'agents';
+export type EnvStorageScope = SecretDataStorageScope;
 
 type EnvScopeConfig = {
   defaultPath: string;
@@ -54,7 +62,21 @@ function getScopeConfig(scope: EnvScope): EnvScopeConfig {
   return ENV_SCOPE_CONFIG[scope];
 }
 
-export function getEnvFilePath(scope: EnvScope): string {
+function hasExplicitStorageScope(storageScope?: EnvStorageScope | null): boolean {
+  return Boolean(
+    storageScope?.secretScope ||
+    storageScope?.userId?.trim() ||
+    storageScope?.organizationId?.trim(),
+  );
+}
+
+export function getEnvFilePath(scope: EnvScope, storageScope?: EnvStorageScope | null): string {
+  if (hasExplicitStorageScope(storageScope)) {
+    return scope === 'agents'
+      ? resolveScopedAgentsEnvPath(storageScope)
+      : resolveScopedIntegrationsEnvPath(storageScope);
+  }
+
   const { defaultPath, pathEnvName } = getScopeConfig(scope);
   const configuredPath = process.env[pathEnvName]?.trim();
   return configuredPath || defaultPath;
@@ -175,19 +197,26 @@ async function ensureParentDirectory(filePath: string): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
 }
 
-export async function writeScopedEnvRaw(scope: EnvScope, rawContent: string): Promise<void> {
-  const filePath = getEnvFilePath(scope);
+export async function writeScopedEnvRaw(
+  scope: EnvScope,
+  rawContent: string,
+  storageScope?: EnvStorageScope | null,
+): Promise<void> {
+  const filePath = getEnvFilePath(scope, storageScope);
   await ensureParentDirectory(filePath);
 
-  const tmpPath = `${filePath}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const tmpPath = createAtomicTempPath(filePath);
   const content = rawContent.endsWith('\n') || rawContent.length === 0 ? rawContent : `${rawContent}\n`;
   await fs.writeFile(tmpPath, content, { encoding: 'utf8', mode: 0o600 });
   await fs.chmod(tmpPath, 0o600);
   await fs.rename(tmpPath, filePath);
 }
 
-export async function readScopedEnvState(scope: EnvScope): Promise<IntegrationEnvState> {
-  const filePath = getEnvFilePath(scope);
+export async function readScopedEnvState(
+  scope: EnvScope,
+  storageScope?: EnvStorageScope | null,
+): Promise<IntegrationEnvState> {
+  const filePath = getEnvFilePath(scope, storageScope);
   let rawContent = '';
   let exists = true;
 
@@ -241,7 +270,8 @@ export async function readScopedEnvState(scope: EnvScope): Promise<IntegrationEn
 
 export async function replaceScopedEnvEntries(
   scope: EnvScope,
-  entries: Array<{ key: string; value: string }>
+  entries: Array<{ key: string; value: string }>,
+  storageScope?: EnvStorageScope | null,
 ): Promise<IntegrationEnvState> {
   const secret = getMasterSecret(scope);
   const normalized: ParsedEnvEntry[] = [];
@@ -266,8 +296,8 @@ export async function replaceScopedEnvEntries(
   }
 
   const sorted = Array.from(byKey.values()).sort((a, b) => a.key.localeCompare(b.key));
-  await writeScopedEnvRaw(scope, serializeEntries(sorted));
-  return readScopedEnvState(scope);
+  await writeScopedEnvRaw(scope, serializeEntries(sorted), storageScope);
+  return readScopedEnvState(scope, storageScope);
 }
 
 function generateNumericFallback(length = 24): string {
@@ -277,9 +307,9 @@ function generateNumericFallback(length = 24): string {
 export async function ensureGeneratedScopedEnvEntry(
   scope: EnvScope,
   key: string,
-  options?: { length?: number }
+  options?: { length?: number; storageScope?: EnvStorageScope | null },
 ): Promise<string> {
-  const state = await readScopedEnvState(scope);
+  const state = await readScopedEnvState(scope, options?.storageScope);
   const existing = state.entries.find((entry) => entry.key === key)?.value.trim();
   if (existing) {
     return existing;
@@ -291,41 +321,43 @@ export async function ensureGeneratedScopedEnvEntry(
     .map((entry) => ({ key: entry.key, value: entry.value }));
   nextEntries.push({ key, value: generatedValue });
 
-  await replaceScopedEnvEntries(scope, nextEntries);
+  await replaceScopedEnvEntries(scope, nextEntries, options?.storageScope);
   return generatedValue;
 }
 
-export async function writeIntegrationsRaw(rawContent: string): Promise<void> {
-  await writeScopedEnvRaw('integrations', rawContent);
+export async function writeIntegrationsRaw(rawContent: string, storageScope?: EnvStorageScope | null): Promise<void> {
+  await writeScopedEnvRaw('integrations', rawContent, storageScope);
 }
 
-export async function readIntegrationsEnvState(): Promise<IntegrationEnvState> {
-  return readScopedEnvState('integrations');
+export async function readIntegrationsEnvState(storageScope?: EnvStorageScope | null): Promise<IntegrationEnvState> {
+  return readScopedEnvState('integrations', storageScope);
 }
 
 export async function replaceIntegrationsEntries(
-  entries: Array<{ key: string; value: string }>
+  entries: Array<{ key: string; value: string }>,
+  storageScope?: EnvStorageScope | null,
 ): Promise<IntegrationEnvState> {
-  return replaceScopedEnvEntries('integrations', entries);
+  return replaceScopedEnvEntries('integrations', entries, storageScope);
 }
 
-export async function writeAgentsRaw(rawContent: string): Promise<void> {
-  await writeScopedEnvRaw('agents', rawContent);
+export async function writeAgentsRaw(rawContent: string, storageScope?: EnvStorageScope | null): Promise<void> {
+  await writeScopedEnvRaw('agents', rawContent, storageScope);
 }
 
-export async function readAgentsEnvState(): Promise<IntegrationEnvState> {
-  return readScopedEnvState('agents');
+export async function readAgentsEnvState(storageScope?: EnvStorageScope | null): Promise<IntegrationEnvState> {
+  return readScopedEnvState('agents', storageScope);
 }
 
 export async function replaceAgentsEntries(
-  entries: Array<{ key: string; value: string }>
+  entries: Array<{ key: string; value: string }>,
+  storageScope?: EnvStorageScope | null,
 ): Promise<IntegrationEnvState> {
-  return replaceScopedEnvEntries('agents', entries);
+  return replaceScopedEnvEntries('agents', entries, storageScope);
 }
 
-export async function getGeminiApiKeyFromIntegrations(): Promise<string | null> {
+export async function getGeminiApiKeyFromIntegrations(storageScope?: EnvStorageScope | null): Promise<string | null> {
   try {
-    const state = await readScopedEnvState('integrations');
+    const state = await readScopedEnvState('integrations', storageScope);
     const byKey = new Map(state.entries.map((entry) => [entry.key, entry.value]));
     
     const envKey = byKey.get('GEMINI_API_KEY');
@@ -348,9 +380,9 @@ export async function getGeminiApiKeyFromIntegrations(): Promise<string | null> 
   }
 }
 
-export async function getOpenAIApiKeyFromIntegrations(): Promise<string | null> {
+export async function getOpenAIApiKeyFromIntegrations(storageScope?: EnvStorageScope | null): Promise<string | null> {
   try {
-    const state = await readScopedEnvState('integrations');
+    const state = await readScopedEnvState('integrations', storageScope);
     const byKey = new Map(state.entries.map((entry) => [entry.key, entry.value]));
     
     const envKey = byKey.get('OPENAI_API_KEY');
@@ -373,9 +405,9 @@ export async function getOpenAIApiKeyFromIntegrations(): Promise<string | null> 
   }
 }
 
-export async function getGroqApiKeyFromIntegrations(): Promise<string | null> {
+export async function getGroqApiKeyFromIntegrations(storageScope?: EnvStorageScope | null): Promise<string | null> {
   try {
-    const state = await readScopedEnvState('integrations');
+    const state = await readScopedEnvState('integrations', storageScope);
     const byKey = new Map(state.entries.map((entry) => [entry.key, entry.value]));
 
     const envKey = byKey.get('GROQ_API_KEY');
@@ -398,9 +430,9 @@ export async function getGroqApiKeyFromIntegrations(): Promise<string | null> {
   }
 }
 
-export async function getKieApiKeyFromIntegrations(): Promise<string | null> {
+export async function getKieApiKeyFromIntegrations(storageScope?: EnvStorageScope | null): Promise<string | null> {
   try {
-    const state = await readScopedEnvState('integrations');
+    const state = await readScopedEnvState('integrations', storageScope);
     const byKey = new Map(state.entries.map((entry) => [entry.key, entry.value]));
 
     const envKey = byKey.get('KIE_API_KEY');
@@ -423,12 +455,12 @@ export async function getKieApiKeyFromIntegrations(): Promise<string | null> {
   }
 }
 
-export async function getTelegramConfigFromIntegrations(): Promise<{
+export async function getTelegramConfigFromIntegrations(storageScope?: EnvStorageScope | null): Promise<{
   botToken: string | null;
   channelEnabled: boolean;
 }> {
   try {
-    const state = await readScopedEnvState('integrations');
+    const state = await readScopedEnvState('integrations', storageScope);
     const byKey = new Map(state.entries.map((entry) => [entry.key, entry.value]));
 
     const botToken = byKey.get('TELEGRAM_BOT_TOKEN') || process.env.TELEGRAM_BOT_TOKEN || null;

--- a/app/lib/integrations/env-config.ts
+++ b/app/lib/integrations/env-config.ts
@@ -64,7 +64,7 @@ function getScopeConfig(scope: EnvScope): EnvScopeConfig {
 
 function hasExplicitStorageScope(storageScope?: EnvStorageScope | null): boolean {
   return Boolean(
-    storageScope?.secretScope ||
+    (storageScope?.secretScope && storageScope.secretScope !== 'legacy') ||
     storageScope?.userId?.trim() ||
     storageScope?.organizationId?.trim(),
   );

--- a/app/lib/integrations/image-generation-providers.ts
+++ b/app/lib/integrations/image-generation-providers.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { GoogleGenAI } from '@google/genai';
 import OpenAI from 'openai';
-import { getGeminiApiKeyFromIntegrations, getOpenAIApiKeyFromIntegrations } from './env-config';
+import { getGeminiApiKeyFromIntegrations, getOpenAIApiKeyFromIntegrations, type EnvStorageScope } from './env-config';
 import {
   GEMINI_FLASH_IMAGE_MODEL_ID,
   GEMINI_PRO_IMAGE_MODEL_ID,
@@ -50,6 +50,7 @@ export interface ProviderGenerateParams {
   background?: 'transparent' | 'opaque' | 'auto';
   contextPrompt?: string;
   imageSize?: string;
+  storageScope?: EnvStorageScope | null;
 }
 
 export interface ProviderGenerateResult {
@@ -163,7 +164,7 @@ class GeminiImageProvider implements ImageGenerationProvider {
 
   async generate(params: ProviderGenerateParams): Promise<ProviderGenerateResult> {
     const model = normalizeGeminiImageModelId(params.model);
-    const apiKey = await getGeminiApiKeyFromIntegrations();
+    const apiKey = await getGeminiApiKeyFromIntegrations(params.storageScope);
     if (!apiKey) {
       if (isManagedMediaFallbackAvailable()) {
         console.log(`[Gemini Image] Using managed fallback: model=${model}, aspectRatio=${params.aspectRatio}, refs=${params.referenceImages.length}`);
@@ -261,7 +262,7 @@ class OpenAIImageProvider implements ImageGenerationProvider {
   }
 
   async generate(params: ProviderGenerateParams): Promise<ProviderGenerateResult> {
-    const apiKey = await getOpenAIApiKeyFromIntegrations();
+    const apiKey = await getOpenAIApiKeyFromIntegrations(params.storageScope);
     if (!apiKey) {
       if (isManagedMediaFallbackAvailable()) {
         console.log(`[OpenAI Image] Using managed fallback: model=${params.model}, aspectRatio=${params.aspectRatio}, refs=${params.referenceImages.length}, quality=${params.quality || 'auto'}`);

--- a/app/lib/integrations/seedance-generation-service.ts
+++ b/app/lib/integrations/seedance-generation-service.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { getKieApiKeyFromIntegrations } from '@/app/lib/integrations/env-config';
+import { getKieApiKeyFromIntegrations, type EnvStorageScope } from '@/app/lib/integrations/env-config';
 import { IntegrationServiceError } from '@/app/lib/integrations/integration-service-error';
 import {
   ensureStudioOutputsWorkspace,
@@ -50,6 +50,7 @@ export interface GenerateSeedanceVideoRequest {
   caller?: string;
   pollIntervalMs?: number;
   timeoutMs?: number;
+  storageScope?: EnvStorageScope | null;
 }
 
 export interface SeedanceVideoGenerationResult {
@@ -352,7 +353,7 @@ async function downloadVideo(url: string): Promise<{ bytes: Buffer; mimeType: st
 export async function generateSeedanceVideo(
   request: GenerateSeedanceVideoRequest,
 ): Promise<SeedanceVideoGenerationResult> {
-  const apiKey = await getKieApiKeyFromIntegrations();
+  const apiKey = await getKieApiKeyFromIntegrations(request.storageScope);
   const useManagedFallback = !apiKey && isManagedMediaFallbackAvailable();
   if (!apiKey && !useManagedFallback) {
     throw new IntegrationServiceError(

--- a/app/lib/integrations/sound-generation-service.ts
+++ b/app/lib/integrations/sound-generation-service.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import { GoogleGenAI } from '@google/genai';
-import { getGeminiApiKeyFromIntegrations } from './env-config';
+import { getGeminiApiKeyFromIntegrations, type EnvStorageScope } from './env-config';
 import { IntegrationServiceError } from './integration-service-error';
 import { generateManagedMedia, isManagedMediaFallbackAvailable } from './managed-media-client';
 
@@ -21,6 +21,7 @@ export interface GenerateSoundRequest {
   model?: string;
   outputFormat?: SoundOutputFormat;
   referenceImages?: GenerateSoundReferenceImage[];
+  storageScope?: EnvStorageScope | null;
 }
 
 export interface GenerateSoundResult {
@@ -84,7 +85,7 @@ export async function generateSound(request: GenerateSoundRequest): Promise<Gene
   const model = resolveModel(request.model);
   const outputFormat = resolveOutputFormat(model, request.outputFormat);
   const referenceImages = (request.referenceImages || []).slice(0, 10);
-  const apiKey = await getGeminiApiKeyFromIntegrations();
+  const apiKey = await getGeminiApiKeyFromIntegrations(request.storageScope);
   const useManagedFallback = !apiKey && isManagedMediaFallbackAvailable();
   if (!apiKey && !useManagedFallback) {
     throw new IntegrationServiceError('Gemini API key is missing. Configure GEMINI_API_KEY in /settings?tab=integrations.', 400);

--- a/app/lib/integrations/studio-aspect-ratio-service.ts
+++ b/app/lib/integrations/studio-aspect-ratio-service.ts
@@ -9,6 +9,7 @@ import { db } from '@/app/lib/db';
 import { studioGenerationOutputs, studioGenerations } from '@/app/lib/db/schema';
 import { writeFile, type WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 import { getImageGenerationProvider } from '@/app/lib/integrations/image-generation-providers';
+import type { EnvStorageScope } from '@/app/lib/integrations/env-config';
 import { classifyMediaReference, loadMediaReference } from '@/app/lib/integrations/media-reference-resolver';
 import {
   ensureStudioEditsWorkspace,
@@ -325,7 +326,10 @@ async function writeEditResult(buffer: Buffer, fileName: string, mode: AspectRat
   };
 }
 
-export async function createAspectRatioPreview(input: AspectRatioPreviewRequest): Promise<AspectRatioPreviewResult> {
+export async function createAspectRatioPreview(
+  input: AspectRatioPreviewRequest,
+  storageScope?: EnvStorageScope | null,
+): Promise<AspectRatioPreviewResult> {
   const request = validatePreviewRequest(input);
   const source = await loadMediaReference(request.sourcePath, { allowedTypes: ['image'] });
   const sourceBytes = source.bytes;
@@ -405,6 +409,7 @@ export async function createAspectRatioPreview(input: AspectRatioPreviewRequest)
     background: request.background,
     imageSize: request.imageSize,
     contextPrompt: buildExtendContextPrompt(provider.id),
+    storageScope,
   });
 
   const generatedBytes = Buffer.from(generated.imageBytes, 'base64');

--- a/app/lib/integrations/studio-config.ts
+++ b/app/lib/integrations/studio-config.ts
@@ -5,15 +5,16 @@ import {
   getGeminiApiKeyFromIntegrations,
   getKieApiKeyFromIntegrations,
   getOpenAIApiKeyFromIntegrations,
+  type EnvStorageScope,
 } from '@/app/lib/integrations/env-config';
 import { isManagedMediaFallbackAvailable } from '@/app/lib/integrations/managed-media-client';
 
-export async function getStudioProviderConfig(): Promise<StudioProviderConfig> {
+export async function getStudioProviderConfig(storageScope?: EnvStorageScope | null): Promise<StudioProviderConfig> {
   try {
     const [geminiApiKey, openaiApiKey, kieApiKey] = await Promise.all([
-      getGeminiApiKeyFromIntegrations(),
-      getOpenAIApiKeyFromIntegrations(),
-      getKieApiKeyFromIntegrations(),
+      getGeminiApiKeyFromIntegrations(storageScope),
+      getOpenAIApiKeyFromIntegrations(storageScope),
+      getKieApiKeyFromIntegrations(storageScope),
     ]);
 
     return {

--- a/app/lib/integrations/studio-generation-service.ts
+++ b/app/lib/integrations/studio-generation-service.ts
@@ -45,6 +45,7 @@ import {
   VEO_MAX_REFERENCE_IMAGES,
   normalizeGeminiImageModelId,
 } from '@/app/lib/integrations/image-generation-constants';
+import type { EnvStorageScope } from '@/app/lib/integrations/env-config';
 
 type ProviderReferenceImage = { imageBytes: string; mimeType: string };
 type ProviderReferenceMedia = { imageBytes: string; mimeType: string; fileName?: string };
@@ -882,6 +883,7 @@ async function executeStudioGenerationProcessing(
   const aspectRatio = generation.aspectRatio;
   const rawPrompt = generation.prompt || '';
   const model = generation.model;
+  const storageScope: EnvStorageScope = { userId };
 
   console.log(`[Studio Generation] Starting background processing: id=${generationId}, mode=${mode}, provider=${providerId}`);
 
@@ -977,6 +979,7 @@ async function executeStudioGenerationProcessing(
           webSearch: parsedMeta.videoWebSearch,
           nsfwChecker: parsedMeta.videoNsfwChecker,
         },
+        storageScope,
       );
     } else if (mode === 'sound') {
       outputs = await generateStudioSound(
@@ -987,6 +990,7 @@ async function executeStudioGenerationProcessing(
         model,
         parsedMeta.outputFormat,
         buildSoundContextPrompt(allReferenceImages),
+        storageScope,
       );
     } else {
       const count = Math.min(Math.max(parsedMeta.count || 1, 1), MAX_IMAGE_COUNT);
@@ -995,7 +999,7 @@ async function executeStudioGenerationProcessing(
         outputFormat: parsedMeta.outputFormat,
         background: parsedMeta.background,
         imageSize: parsedMeta.imageSize,
-      }, contextText);
+      }, contextText, storageScope);
     }
 
     await db.update(studioGenerations)
@@ -1029,6 +1033,7 @@ async function generateStudioImages(
   model: string,
   options?: { quality?: 'low' | 'medium' | 'high' | 'auto'; outputFormat?: 'png' | 'jpeg' | 'webp'; background?: 'transparent' | 'opaque' | 'auto'; imageSize?: string },
   contextText?: string,
+  storageScope?: EnvStorageScope | null,
 ): Promise<StudioGenerationOutput[]> {
   const provider = getImageGenerationProvider(providerId);
   if (!provider) {
@@ -1072,6 +1077,7 @@ async function generateStudioImages(
         background: options?.background,
         contextPrompt: contextText,
         imageSize: options?.imageSize,
+        storageScope,
       });
 
       const ext = extensionFromMime(result.mimeType);
@@ -1174,6 +1180,7 @@ async function generateStudioSound(
   model?: string,
   outputFormat?: string,
   contextText?: string,
+  storageScope?: EnvStorageScope | null,
 ): Promise<StudioGenerationOutput[]> {
   if (providerId !== 'gemini') {
     throw new StudioServiceError(
@@ -1196,6 +1203,7 @@ async function generateStudioSound(
     model: resolvedModel,
     outputFormat: resolvedOutputFormat,
     referenceImages: referenceImages.slice(0, 10),
+    storageScope,
   });
 
   await ensureStudioOutputsWorkspace();
@@ -1256,6 +1264,7 @@ async function generateStudioVideo(
     webSearch?: boolean;
     nsfwChecker?: boolean;
   },
+  storageScope?: EnvStorageScope | null,
 ): Promise<StudioGenerationOutput[]> {
   if (!prompt && !videoExtendSourcePath) {
     throw new StudioServiceError(
@@ -1289,6 +1298,7 @@ async function generateStudioVideo(
       referenceVideos,
       referenceAudios,
       videoOptions,
+      storageScope,
     );
   }
 
@@ -1318,6 +1328,7 @@ async function generateStudioVideo(
     inputVideoPath: videoExtendSourcePath || undefined,
     personGeneration: effectivePersonGeneration,
     generateAudio: videoOptions?.generateAudio,
+    storageScope,
   };
 
   if (providerReferenceImages.length > 0) {
@@ -1411,6 +1422,7 @@ async function generateStudioSeedanceVideo(
     webSearch?: boolean;
     nsfwChecker?: boolean;
   },
+  storageScope?: EnvStorageScope | null,
 ): Promise<StudioGenerationOutput[]> {
   console.log(`[Studio Generation] Seedance video: refs=${referenceImages.length}, startFrame=${startFramePath ? 'yes' : 'no'}, endFrame=${endFramePath ? 'yes' : 'no'}, duration=${videoDuration || 6}s`);
   const firstFrame = startFramePath ? await loadSeedanceFrame(startFramePath) : null;
@@ -1462,6 +1474,7 @@ async function generateStudioSeedanceVideo(
     webSearch: videoOptions?.webSearch,
     nsfwChecker: videoOptions?.nsfwChecker,
     caller: 'studio-generation',
+    storageScope,
   });
 
   const outputId = randomUUID();

--- a/app/lib/integrations/studio-preset-service.ts
+++ b/app/lib/integrations/studio-preset-service.ts
@@ -1161,6 +1161,7 @@ export async function generatePresetPreview(
       model,
       aspectRatio,
       referenceImages: [],
+      storageScope: { userId },
     });
 
     const previewPath = 'studio/assets/' + generatePresetPreviewPath(presetId, extensionFromMime(result.mimeType));

--- a/app/lib/integrations/veo-generation-service.ts
+++ b/app/lib/integrations/veo-generation-service.ts
@@ -13,7 +13,7 @@ import {
   writeOutputFile,
 } from '@/app/lib/integrations/studio-workspace';
 import { toMediaUrl } from '@/app/lib/utils/media-url';
-import { getGeminiApiKeyFromIntegrations } from '@/app/lib/integrations/env-config';
+import { getGeminiApiKeyFromIntegrations, type EnvStorageScope } from '@/app/lib/integrations/env-config';
 import { IntegrationServiceError } from '@/app/lib/integrations/integration-service-error';
 import {
   getVideoModelCapabilities,
@@ -43,6 +43,7 @@ export interface GenerateVideoRequestBody {
   enhancePrompt?: boolean;
   generateAudio?: boolean;
   seed?: number;
+  storageScope?: EnvStorageScope | null;
 }
 
 export interface VideoGenerationResultData {
@@ -143,7 +144,7 @@ export async function generateVideo(
   body: GenerateVideoRequestBody,
   callerEmail = 'system',
 ): Promise<VideoGenerationResultData> {
-  const apiKey = await getGeminiApiKeyFromIntegrations();
+  const apiKey = await getGeminiApiKeyFromIntegrations(body.storageScope);
   const useManagedFallback = !apiKey && isManagedMediaFallbackAvailable();
   if (!apiKey && !useManagedFallback) {
     throw new IntegrationServiceError('Gemini API key is missing. Configure GEMINI_API_KEY in /settings.', 400);

--- a/app/lib/pi/api-key-resolver.ts
+++ b/app/lib/pi/api-key-resolver.ts
@@ -3,6 +3,7 @@ import { getProviderApiKey, isOAuthProvider, type OAuthProviderId } from './oaut
 import { supportsBothAuthMethods } from './provider-help';
 import { readPiRuntimeConfig } from '@/app/lib/agents/storage';
 import { CANVAS_CONTROL_PLANE_PROVIDER_ID } from './model-resolver';
+import { getAgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
 
 /**
  * Resolves API keys for PI providers using existing environment stores.
@@ -53,8 +54,10 @@ export async function resolvePiApiKey(provider: string): Promise<string | undefi
   }
 
   // Use existing agents scope for provider keys
-  const agentsState = await readScopedEnvState('agents');
-  const integrationsState = await readScopedEnvState('integrations');
+  const executionContext = getAgentExecutionContext();
+  const storageScope = executionContext ? { userId: executionContext.userId } : undefined;
+  const agentsState = await readScopedEnvState('agents', storageScope);
+  const integrationsState = await readScopedEnvState('integrations', storageScope);
 
   const allEntries = new Map<string, string>([
     ...(integrationsState.entries.map(e => [e.key, e.value]) as [string, string][]),
@@ -78,7 +81,7 @@ export async function resolvePiApiKey(provider: string): Promise<string | undefi
     case 'mistral':
       return allEntries.get('MISTRAL_API_KEY');
     case 'ollama':
-      return allEntries.get('OLLAMA_API_KEY') || await ensureGeneratedScopedEnvEntry('agents', 'OLLAMA_API_KEY');
+      return allEntries.get('OLLAMA_API_KEY') || await ensureGeneratedScopedEnvEntry('agents', 'OLLAMA_API_KEY', { storageScope });
     case 'openai-compatible':
       return allEntries.get('OPENAI_COMPATIBLE_API_KEY') || undefined;
     default:

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -125,7 +125,7 @@ import {
   MAX_AUDIO_TRANSCRIPTION_BYTES,
   transcribeAudio,
 } from '@/app/lib/integrations/audio-transcription-service';
-import { runWithAgentExecutionContext, type AgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
+import { getAgentExecutionContext, runWithAgentExecutionContext, type AgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
 import { resolveAgentExecutionContextForSession } from '@/app/lib/pi/session-workspace-context';
 
 
@@ -1069,6 +1069,7 @@ export function createTranscribeAudioTool(): AgentTool {
         }
 
         const buffer = await fsPromises.readFile(fullPath);
+        const executionContext = getAgentExecutionContext();
         const result = await transcribeAudio({
           buffer,
           filename: path.basename(fullPath),
@@ -1076,6 +1077,7 @@ export function createTranscribeAudioTool(): AgentTool {
           language: input.language,
           prompt: input.prompt,
           signal,
+          storageScope: executionContext ? { userId: executionContext.userId } : undefined,
         });
 
         const text = [
@@ -1573,6 +1575,7 @@ export function createWebSearchTool(): AgentTool {
           include_content?: boolean;
           max_content_length?: number;
         };
+        const executionContext = getAgentExecutionContext();
         const response = await searchWeb({
           query: typeof input.query === 'string' ? input.query : '',
           count: input.count,
@@ -1580,7 +1583,7 @@ export function createWebSearchTool(): AgentTool {
           freshness: input.freshness,
           includeContent: input.include_content === true,
           maxContentLength: input.max_content_length,
-        }, signal);
+        }, signal, executionContext ? { userId: executionContext.userId } : undefined);
         return {
           content: [{ type: 'text', text: formatWebSearchResults(response) }],
           details: response,

--- a/app/lib/runtime-data-paths.ts
+++ b/app/lib/runtime-data-paths.ts
@@ -7,6 +7,11 @@ export type UserScopedDataStorageScope = {
   userId?: string | null;
 };
 
+export type SecretDataStorageScope = UserScopedDataStorageScope & {
+  organizationId?: string | null;
+  secretScope?: 'user' | 'organization' | 'system' | 'legacy';
+};
+
 function directoryExistsSync(targetPath: string): boolean {
   try {
     return fs.statSync(targetPath).isDirectory();
@@ -287,6 +292,49 @@ export function resolveDefaultIntegrationsEnvPath(cwd?: string): string {
 
 export function resolveDefaultAgentsEnvPath(cwd?: string): string {
   return path.join(/* turbopackIgnore: true */ resolveSecretsDir(cwd), 'Canvas-Agents.env');
+}
+
+function resolveSecretDataScope(scope?: SecretDataStorageScope | null): 'user' | 'organization' | 'system' | 'legacy' {
+  if (scope?.secretScope) {
+    return scope.secretScope;
+  }
+  if (scope?.userId?.trim()) {
+    return 'user';
+  }
+  if (scope?.organizationId?.trim()) {
+    return 'organization';
+  }
+  return 'legacy';
+}
+
+export function resolveScopedSecretsDir(scope?: SecretDataStorageScope | null, cwd?: string): string {
+  const secretScope = resolveSecretDataScope(scope);
+  if (secretScope === 'user') {
+    const userId = scope?.userId?.trim();
+    if (!userId) {
+      throw new Error('userId is required for user-scoped secrets.');
+    }
+    return resolveUserSecretsDir(userId, cwd);
+  }
+  if (secretScope === 'organization') {
+    const organizationId = scope?.organizationId?.trim();
+    if (!organizationId) {
+      throw new Error('organizationId is required for organization-scoped secrets.');
+    }
+    return resolveOrganizationSecretsDir(organizationId, cwd);
+  }
+  if (secretScope === 'system') {
+    return resolveSystemSecretsDir(cwd);
+  }
+  return resolveSecretsDir(cwd);
+}
+
+export function resolveScopedIntegrationsEnvPath(scope?: SecretDataStorageScope | null, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveScopedSecretsDir(scope, cwd), 'Canvas-Integrations.env');
+}
+
+export function resolveScopedAgentsEnvPath(scope?: SecretDataStorageScope | null, cwd?: string): string {
+  return path.join(/* turbopackIgnore: true */ resolveScopedSecretsDir(scope, cwd), 'Canvas-Agents.env');
 }
 
 export function getUserUploadsRoot(cwd?: string): string {

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -246,7 +246,7 @@
     {
       "id": 17,
       "title": "Plugins, Skills und Agent-Definitionen auf User-Scope mit optionaler Organization-Teilung migrieren",
-      "status": "in_progress",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/08-user-scoped-secrets-runtime.md",
@@ -282,12 +282,19 @@
     {
       "id": 18,
       "title": "Secrets/Credentials pro User, Organization und Managed/System isolieren",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/08-user-scoped-secrets-runtime.md",
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md",
         "docs/architecture/canvas-notebook/team-workspace/10-agent-tool-execution-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/runtime-data-paths.ts",
+        "app/lib/integrations/env-config.ts",
+        "app/api/integrations/env/route.ts",
+        "scripts/scoped-env-config-test.ts",
+        "scripts/scoped-runtime-paths-test.ts"
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:pi:continuation": "tsx scripts/pi-run-continuation-guard-test.ts",
     "test:agent:memory": "tsx scripts/agent-memory-store-test.ts",
     "test:scoped-data-paths": "tsx scripts/scoped-runtime-paths-test.ts",
+    "test:integrations:env-scope": "tsx scripts/scoped-env-config-test.ts",
     "test:mcp:config": "tsx scripts/mcp-config-test.ts",
     "test:mcp:proxy": "tsx scripts/mcp-proxy-test.ts",
     "test:mcp:manager": "tsx scripts/mcp-manager-test.ts",

--- a/scripts/scoped-env-config-test.ts
+++ b/scripts/scoped-env-config-test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+async function main() {
+  const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-scoped-env-'));
+  const previousCanvasDataRoot = process.env.CANVAS_DATA_ROOT;
+  const previousIntegrationsPath = process.env.INTEGRATIONS_ENV_PATH;
+  const previousAgentsPath = process.env.AGENTS_ENV_PATH;
+  const previousData = process.env.DATA;
+  const previousOpenAiApiKey = process.env.OPENAI_API_KEY;
+
+  try {
+    process.env.CANVAS_DATA_ROOT = dataRoot;
+    delete process.env.INTEGRATIONS_ENV_PATH;
+    delete process.env.AGENTS_ENV_PATH;
+    delete process.env.DATA;
+    delete process.env.OPENAI_API_KEY;
+
+    const {
+      getEnvFilePath,
+      getOpenAIApiKeyFromIntegrations,
+      readScopedEnvState,
+      replaceScopedEnvEntries,
+      writeScopedEnvRaw,
+    } = await import('../app/lib/integrations/env-config');
+
+    const userA = { userId: 'user_a' };
+    const userB = { userId: 'user_b' };
+    const organization = { organizationId: 'org_1' };
+    const system = { secretScope: 'system' as const };
+
+    assert.equal(
+      getEnvFilePath('integrations', userA),
+      path.join(dataRoot, 'users', 'user_a', 'secrets', 'Canvas-Integrations.env'),
+    );
+    assert.equal(
+      getEnvFilePath('agents', userA),
+      path.join(dataRoot, 'users', 'user_a', 'secrets', 'Canvas-Agents.env'),
+    );
+    assert.equal(
+      getEnvFilePath('integrations', organization),
+      path.join(dataRoot, 'organizations', 'org_1', 'secrets', 'Canvas-Integrations.env'),
+    );
+    assert.equal(
+      getEnvFilePath('agents', system),
+      path.join(dataRoot, 'system', 'secrets', 'Canvas-Agents.env'),
+    );
+
+    await writeScopedEnvRaw('integrations', 'OPENAI_API_KEY=user-a-key\n', userA);
+    await writeScopedEnvRaw('integrations', 'OPENAI_API_KEY=user-b-key\n', userB);
+    await replaceScopedEnvEntries('agents', [{ key: 'OPENROUTER_API_KEY', value: 'user-a-router' }], userA);
+    await replaceScopedEnvEntries('integrations', [{ key: 'ORG_API_KEY', value: 'org-key' }], organization);
+    await replaceScopedEnvEntries('integrations', [{ key: 'SYSTEM_API_KEY', value: 'system-key' }], system);
+
+    const userAIntegrations = await readScopedEnvState('integrations', userA);
+    const userBIntegrations = await readScopedEnvState('integrations', userB);
+    const userAAgents = await readScopedEnvState('agents', userA);
+    const orgIntegrations = await readScopedEnvState('integrations', organization);
+    const systemIntegrations = await readScopedEnvState('integrations', system);
+    const legacyIntegrations = await readScopedEnvState('integrations');
+
+    assert.equal(userAIntegrations.entries.find((entry) => entry.key === 'OPENAI_API_KEY')?.value, 'user-a-key');
+    assert.equal(await getOpenAIApiKeyFromIntegrations(userA), 'user-a-key');
+    assert.equal(userBIntegrations.entries.find((entry) => entry.key === 'OPENAI_API_KEY')?.value, 'user-b-key');
+    assert.equal(userAAgents.entries.find((entry) => entry.key === 'OPENROUTER_API_KEY')?.value, 'user-a-router');
+    assert.equal(orgIntegrations.entries.find((entry) => entry.key === 'ORG_API_KEY')?.value, 'org-key');
+    assert.equal(systemIntegrations.entries.find((entry) => entry.key === 'SYSTEM_API_KEY')?.value, 'system-key');
+    assert.equal(legacyIntegrations.exists, false);
+    assert.equal(userAIntegrations.entries.some((entry) => entry.value === 'user-b-key'), false);
+
+    const userAFileMode = (await fs.stat(userAIntegrations.path)).mode & 0o777;
+    assert.equal(userAFileMode, 0o600);
+
+    const overridePath = path.join(dataRoot, 'custom', 'Canvas-Integrations.env');
+    process.env.INTEGRATIONS_ENV_PATH = overridePath;
+    await writeScopedEnvRaw('integrations', 'LEGACY_KEY=legacy\n');
+    assert.equal(getEnvFilePath('integrations'), overridePath);
+    assert.equal(
+      getEnvFilePath('integrations', userA),
+      path.join(dataRoot, 'users', 'user_a', 'secrets', 'Canvas-Integrations.env'),
+    );
+    const legacyOverride = await readScopedEnvState('integrations');
+    assert.equal(legacyOverride.entries.find((entry) => entry.key === 'LEGACY_KEY')?.value, 'legacy');
+
+    console.log('scoped-env-config-test: ok');
+  } finally {
+    restoreEnv('CANVAS_DATA_ROOT', previousCanvasDataRoot);
+    restoreEnv('INTEGRATIONS_ENV_PATH', previousIntegrationsPath);
+    restoreEnv('AGENTS_ENV_PATH', previousAgentsPath);
+    restoreEnv('DATA', previousData);
+    restoreEnv('OPENAI_API_KEY', previousOpenAiApiKey);
+    await fs.rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/scoped-env-config-test.ts
+++ b/scripts/scoped-env-config-test.ts
@@ -85,12 +85,15 @@ async function main() {
     process.env.INTEGRATIONS_ENV_PATH = overridePath;
     await writeScopedEnvRaw('integrations', 'LEGACY_KEY=legacy\n');
     assert.equal(getEnvFilePath('integrations'), overridePath);
+    assert.equal(getEnvFilePath('integrations', { secretScope: 'legacy' }), overridePath);
     assert.equal(
       getEnvFilePath('integrations', userA),
       path.join(dataRoot, 'users', 'user_a', 'secrets', 'Canvas-Integrations.env'),
     );
     const legacyOverride = await readScopedEnvState('integrations');
+    const explicitLegacyOverride = await readScopedEnvState('integrations', { secretScope: 'legacy' });
     assert.equal(legacyOverride.entries.find((entry) => entry.key === 'LEGACY_KEY')?.value, 'legacy');
+    assert.equal(explicitLegacyOverride.entries.find((entry) => entry.key === 'LEGACY_KEY')?.value, 'legacy');
 
     console.log('scoped-env-config-test: ok');
   } finally {

--- a/scripts/scoped-runtime-paths-test.ts
+++ b/scripts/scoped-runtime-paths-test.ts
@@ -24,9 +24,12 @@ async function main() {
       resolveOrganizationSkillTemplatesDir,
       resolveOrganizationDataRoot,
       resolveScopedInstalledPluginsDir,
+      resolveScopedAgentsEnvPath,
+      resolveScopedIntegrationsEnvPath,
       resolveScopedPluginRegistryPath,
       resolveScopedPluginsDataDir,
       resolveScopedSettingsDir,
+      resolveScopedSecretsDir,
       resolveScopedSkillBackupsDir,
       resolveScopedSkillRegistryPath,
       resolveScopedSkillsDataDir,
@@ -61,6 +64,9 @@ async function main() {
     assert.equal(resolveUserMcpDir('user_a'), path.join(dataDir, 'users', 'user_a', 'mcp'));
     assert.equal(resolveUserMailDir('user_a'), path.join(dataDir, 'users', 'user_a', 'mail'));
     assert.equal(resolveScopedSettingsDir({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'settings'));
+    assert.equal(resolveScopedSecretsDir({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'secrets'));
+    assert.equal(resolveScopedIntegrationsEnvPath({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'secrets', 'Canvas-Integrations.env'));
+    assert.equal(resolveScopedAgentsEnvPath({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'secrets', 'Canvas-Agents.env'));
     assert.equal(resolveScopedSkillsDataDir({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'skills'));
     assert.equal(resolveScopedSkillRegistryPath({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'skills', 'registry.json'));
     assert.equal(resolveScopedSkillBackupsDir({ userId: 'user_a' }), path.join(dataDir, 'users', 'user_a', 'skills', '.backups'));
@@ -77,6 +83,10 @@ async function main() {
     assert.equal(resolveOrganizationMcpTemplatesDir('org_1'), path.join(dataDir, 'organizations', 'org_1', 'mcp-templates'));
 
     assert.equal(resolveSystemSecretsDir(), path.join(dataDir, 'system', 'secrets'));
+    assert.equal(resolveScopedSecretsDir({ secretScope: 'system' }), path.join(dataDir, 'system', 'secrets'));
+    assert.equal(resolveScopedSecretsDir({ organizationId: 'org_1' }), path.join(dataDir, 'organizations', 'org_1', 'secrets'));
+    assert.equal(resolveScopedIntegrationsEnvPath({ organizationId: 'org_1' }), path.join(dataDir, 'organizations', 'org_1', 'secrets', 'Canvas-Integrations.env'));
+    assert.equal(resolveScopedAgentsEnvPath({ secretScope: 'system' }), path.join(dataDir, 'system', 'secrets', 'Canvas-Agents.env'));
     assert.equal(resolveSystemManagedDir(), path.join(dataDir, 'system', 'managed'));
     assert.equal(resolveSystemBackupsDir(), path.join(dataDir, 'system', 'backups'));
     assert.equal(resolveSystemMigrationDir(), path.join(dataDir, 'system', 'migration'));


### PR DESCRIPTION
## Summary
- add scoped secret path helpers for user, organization, system, and legacy env storage
- make the integrations env API read/write authenticated user-scoped env files
- keep legacy env path overrides working while adding scoped tests and marking Task 18 complete

## Verification
- npm run test:integrations:env-scope
- npm run test:scoped-data-paths
- npm run lint
- npm run build

## Greptile
- Initial automatic Greptile review pending after PR creation; not manually triggered.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements per-user, per-organization, and system-level secret isolation for integration credentials and agents env files. All routes, service functions, and agent tool invocations now receive an `EnvStorageScope` (derived from the authenticated session's `userId`) so that each user's API keys are stored in their own scoped directory instead of a shared legacy path.

- **New `SecretDataStorageScope` type and helper functions** (`resolveScopedSecretsDir`, `resolveScopedIntegrationsEnvPath`, `resolveScopedAgentsEnvPath`) in `runtime-data-paths.ts` route file I/O to `users/<id>/secrets/`, `organizations/<id>/secrets/`, or `system/secrets/` depending on the scope.
- **All public env-config helpers** (`readScopedEnvState`, `writeScopedEnvRaw`, key resolvers, etc.) now accept an optional `storageScope` parameter, and the API routes pass `{ userId: authResult.session.user.id }` down to these calls.
- **Legacy scope** (`{ secretScope: 'legacy' }`) is intentionally preserved for system-level callers (Telegram channel init, channel availability checks) so that env-var path overrides (`INTEGRATIONS_ENV_PATH`, `AGENTS_ENV_PATH`) continue to work, validated by the new test in `scripts/scoped-env-config-test.ts`.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; all modified paths thread the storageScope correctly, legacy env-var overrides are preserved, and path traversal is guarded by the existing normalizeDataScopeId validator.

The scoping logic is well-bounded: hasExplicitStorageScope correctly excludes 'legacy' so env-var path overrides remain effective, resolveScopedSecretsDir throws early if a userId-less user scope is requested, and the new test covers user/org/system/legacy isolation plus file-mode (0o600) and override compatibility. No cross-user data leakage path was found, and the related repos have no dependency on the changed APIs.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/runtime-data-paths.ts | Adds SecretDataStorageScope type, resolveScopedSecretsDir/IntegrationsEnvPath/AgentsEnvPath helpers, and createAtomicTempPath; path traversal validated via existing normalizeDataScopeId |
| app/lib/integrations/env-config.ts | Adds storageScope parameter to all read/write helpers; hasExplicitStorageScope correctly excludes 'legacy' so env-var overrides are still respected |
| app/api/integrations/env/route.ts | requireSession refactored to return typed result; storageScope now derives from session userId; rate-limit keys per-user to prevent cross-user bucket sharing |
| app/lib/pi/api-key-resolver.ts | Reads execution context to scope env state; falls back to legacy (undefined) when no context, preserving behaviour for non-agent server-side calls |
| app/lib/pi/tool-registry.ts | transcribeAudio and searchWeb tools now pass user-scoped storageScope derived from agent execution context |
| scripts/scoped-env-config-test.ts | New integration test covering user/org/system/legacy path isolation, file mode (0o600), and env-var override compatibility |
| app/lib/integrations/studio-generation-service.ts | storageScope threaded through all generation paths (image/video/sound/seedance) from executeStudioGenerationProcessing down to provider calls |
| app/lib/channels/availability.ts | Telegram config read with legacy scope — correct since bot token is system-level, not per-user |
| app/api/integrations/search/status/route.ts | requireSession refactored, getBraveSearchStatus now receives user ID so local key lookup is user-scoped |

</details>

<sub>Reviews (3): Last reviewed commit: ["Keep telegram bot config on legacy scope"](https://github.com/canvascoding/canvas-notebook/commit/035fb12bb217f8c4a72765fea1eae23a1cf4219b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38815786)</sub>

<!-- /greptile_comment -->