### PR TITLE
Scope Composio and email credentials per user

### DIFF
--- a/app/api/agents/connection-options/route.ts
+++ b/app/api/agents/connection-options/route.ts
@@ -13,12 +13,12 @@ async function requireSession(request: NextRequest) {
   if (!session) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
   }
-  return null;
+  return session;
 }
 
 export async function GET(request: NextRequest) {
-  const unauthorized = await requireSession(request);
-  if (unauthorized) return unauthorized;
+  const session = await requireSession(request);
+  if (session instanceof NextResponse) return session;
 
   const limited = rateLimit(request, {
     limit: 60,
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
     const query = request.nextUrl.searchParams.get('query')?.trim().toLowerCase() || '';
     const page = parsePositiveInteger(request.nextUrl.searchParams.get('page'), 1);
     const limit = parsePositiveInteger(request.nextUrl.searchParams.get('limit'), DEFAULT_LIMIT, MAX_LIMIT);
-    const options = await loadAgentConnectionOptions({ query });
+    const options = await loadAgentConnectionOptions({ query, userId: session.user.id });
     const { items, pagination } = paginateItems(options, page, limit);
 
     return NextResponse.json({

--- a/app/api/automations/jobs/[jobId]/route.ts
+++ b/app/api/automations/jobs/[jobId]/route.ts
@@ -53,7 +53,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     }
     assertCanCreateRequestedAutomation(payload, session.user);
     if (existing.composioTriggerId && (payload?.status === 'active' || payload?.status === 'paused')) {
-      await updateGatewayTrigger(existing.composioTriggerId, { status: payload.status });
+      await updateGatewayTrigger(existing.composioTriggerId, { status: payload.status }, { userId: session.user.id });
     }
     const updated = await updateAutomationJob(jobId, payload);
     if (!updated) {
@@ -86,7 +86,7 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ success: false, error: 'Automation not found.' }, { status: 404 });
   }
   if (existing.composioTriggerId) {
-    await deleteGatewayTrigger(existing.composioTriggerId);
+    await deleteGatewayTrigger(existing.composioTriggerId, { userId: session.user.id });
   }
   const deleted = await deleteAutomationJob(jobId);
   if (!deleted) {

--- a/app/api/composio/connect/[toolkit]/route.ts
+++ b/app/api/composio/connect/[toolkit]/route.ts
@@ -1,12 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/app/lib/auth';
 import { clearComposioGatewayCaches, connectGatewayToolkit, getComposioGatewayMode } from '@/app/lib/composio/composio-gateway';
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ toolkit: string }> },
 ) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
-    if ((await getComposioGatewayMode()) === 'disabled') {
+    const storageScope = { userId: session.user.id };
+    if ((await getComposioGatewayMode(storageScope)) === 'disabled') {
       return NextResponse.json({ error: 'Composio not configured' }, { status: 400 });
     }
 
@@ -15,7 +22,7 @@ export async function POST(
       return NextResponse.json({ error: 'Toolkit slug is required' }, { status: 400 });
     }
 
-    const { redirectUrl, noAuth } = await connectGatewayToolkit(toolkit);
+    const { redirectUrl, noAuth } = await connectGatewayToolkit(toolkit, storageScope);
     if (noAuth) {
       clearComposioGatewayCaches();
       return NextResponse.json({ noAuth: true, redirectUrl: null });

--- a/app/api/composio/disconnect/[toolkit]/route.ts
+++ b/app/api/composio/disconnect/[toolkit]/route.ts
@@ -1,12 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/app/lib/auth';
 import { clearComposioGatewayCaches, disconnectGatewayToolkit, getComposioGatewayMode } from '@/app/lib/composio/composio-gateway';
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ toolkit: string }> },
 ) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
-    if ((await getComposioGatewayMode()) === 'disabled') {
+    const storageScope = { userId: session.user.id };
+    if ((await getComposioGatewayMode(storageScope)) === 'disabled') {
       return NextResponse.json({ error: 'Composio not configured' }, { status: 400 });
     }
 
@@ -15,7 +22,7 @@ export async function DELETE(
       return NextResponse.json({ error: 'Toolkit slug is required' }, { status: 400 });
     }
 
-    await disconnectGatewayToolkit(toolkit);
+    await disconnectGatewayToolkit(toolkit, storageScope);
     clearComposioGatewayCaches();
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/composio/refresh/[toolkit]/route.ts
+++ b/app/api/composio/refresh/[toolkit]/route.ts
@@ -1,12 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/app/lib/auth';
 import { clearComposioGatewayCaches, getComposioGatewayMode, refreshGatewayToolkit } from '@/app/lib/composio/composio-gateway';
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ toolkit: string }> },
 ) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
-    if ((await getComposioGatewayMode()) === 'disabled') {
+    const storageScope = { userId: session.user.id };
+    if ((await getComposioGatewayMode(storageScope)) === 'disabled') {
       return NextResponse.json({ error: 'Composio not configured' }, { status: 400 });
     }
 
@@ -15,7 +22,7 @@ export async function POST(
       return NextResponse.json({ error: 'Toolkit slug is required' }, { status: 400 });
     }
 
-    const result = await refreshGatewayToolkit(toolkit);
+    const result = await refreshGatewayToolkit(toolkit, storageScope);
     clearComposioGatewayCaches();
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/composio/status/route.ts
+++ b/app/api/composio/status/route.ts
@@ -1,9 +1,15 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/app/lib/auth';
 import { getGatewayStatus } from '@/app/lib/composio/composio-gateway';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
-    return NextResponse.json(await getGatewayStatus());
+    return NextResponse.json(await getGatewayStatus({ userId: session.user.id }));
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     return NextResponse.json({ configured: true, apiKeyValid: false, mode: 'disabled', connectedAccounts: [], error: message }, { status: 500 });

--- a/app/api/composio/toolkits/[slug]/tools/route.ts
+++ b/app/api/composio/toolkits/[slug]/tools/route.ts
@@ -1,15 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/app/lib/auth';
 import { getGatewayToolkitTools } from '@/app/lib/composio/composio-gateway';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ tools: [], totalCount: 0, error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
     const { slug } = await params;
     const url = new URL(request.url);
     const search = url.searchParams.get('search') || '';
-    return NextResponse.json(await getGatewayToolkitTools(slug, search));
+    return NextResponse.json(await getGatewayToolkitTools(slug, search, { userId: session.user.id }));
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     return NextResponse.json({ tools: [], totalCount: 0, error: message }, { status: 500 });

--- a/app/api/composio/toolkits/route.ts
+++ b/app/api/composio/toolkits/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/app/lib/auth';
 import { getGatewayStatus, getGatewayToolkits } from '@/app/lib/composio/composio-gateway';
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -28,16 +29,22 @@ function toToolkitSummary(value: unknown) {
 }
 
 export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ toolkits: [], error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
+    const storageScope = { userId: session.user.id };
     const connectedOnly = request.nextUrl.searchParams.get('connectedOnly') === '1';
     const summaryOnly = request.nextUrl.searchParams.get('summary') === '1';
     const includeLogos = request.nextUrl.searchParams.get('includeLogos') === '1';
 
     if (connectedOnly) {
-      const status = await getGatewayStatus();
+      const status = await getGatewayStatus(storageScope);
       let toolkitSummaryBySlug = new Map<string, ReturnType<typeof toToolkitSummary>>();
       if (includeLogos) {
-        const result = await getGatewayToolkits().catch(() => ({ toolkits: [] }));
+        const result = await getGatewayToolkits(storageScope).catch(() => ({ toolkits: [] }));
         if (Array.isArray(result.toolkits)) {
           toolkitSummaryBySlug = new Map(
             result.toolkits
@@ -63,7 +70,7 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    const result = await getGatewayToolkits();
+    const result = await getGatewayToolkits(storageScope);
     if (summaryOnly && Array.isArray(result.toolkits)) {
       return NextResponse.json({
         ...result,

--- a/app/api/composio/trigger-apps/route.ts
+++ b/app/api/composio/trigger-apps/route.ts
@@ -1,9 +1,20 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/app/lib/auth';
 import { getGatewayTriggerApps } from '@/app/lib/composio/composio-gateway';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({
+      apps: [],
+      totalCount: 0,
+      status: { configured: false, apiKeyValid: false, mode: 'disabled', connectedAccounts: [] },
+      error: 'Unauthorized',
+    }, { status: 401 });
+  }
+
   try {
-    return NextResponse.json(await getGatewayTriggerApps());
+    return NextResponse.json(await getGatewayTriggerApps({ userId: session.user.id }));
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     return NextResponse.json({

--- a/app/api/composio/triggers/[triggerId]/route.ts
+++ b/app/api/composio/triggers/[triggerId]/route.ts
@@ -32,6 +32,7 @@ export async function PATCH(
     return NextResponse.json({ success: false, error: 'Trigger not found.' }, { status: 404 });
   }
 
+  const storageScope = { userId: session.user.id };
   try {
     const payload = await request.json();
     const status = payload?.status === 'paused' ? 'paused' : payload?.status === 'active' ? 'active' : undefined;
@@ -40,7 +41,7 @@ export async function PATCH(
       status,
       triggerConfig: payload?.triggerConfig && typeof payload.triggerConfig === 'object' && !Array.isArray(payload.triggerConfig) ? payload.triggerConfig : undefined,
       notebookWebhookUrl: typeof payload?.notebookWebhookUrl === 'string' ? payload.notebookWebhookUrl : undefined,
-    });
+    }, storageScope);
     const updatedJob = status ? await updateAutomationJob(job.id, { status }) : job;
     logTriggerRoute('PATCH completed', { triggerId, jobId: job.id, status: status || null });
     return NextResponse.json({ success: true, data: { trigger: updatedTrigger.trigger, job: updatedJob } });
@@ -66,9 +67,10 @@ export async function DELETE(
     return NextResponse.json({ success: false, error: 'Trigger not found.' }, { status: 404 });
   }
 
+  const storageScope = { userId: session.user.id };
   try {
     logTriggerRoute('DELETE started', { triggerId, jobId: job.id });
-    await deleteGatewayTrigger(triggerId);
+    await deleteGatewayTrigger(triggerId, storageScope);
     await deleteAutomationJob(job.id);
     logTriggerRoute('DELETE completed', { triggerId, jobId: job.id });
     return NextResponse.json({ success: true });

--- a/app/api/composio/triggers/route.ts
+++ b/app/api/composio/triggers/route.ts
@@ -37,18 +37,19 @@ export async function GET(request: NextRequest) {
   const { session, response } = await requireAutomationSession(request);
   if (!session || response) return response;
 
+  const storageScope = { userId: session.user.id };
   const toolkit = request.nextUrl.searchParams.get('toolkit') || '';
   try {
     logTriggerRoute('GET started', { toolkit: toolkit || null });
     if (toolkit) {
-      const result = await getGatewayTriggerTypes(toolkit);
+      const result = await getGatewayTriggerTypes(toolkit, storageScope);
       logTriggerRoute('GET trigger types completed', {
         toolkit,
         count: Array.isArray(result.triggerTypes) ? result.triggerTypes.length : 0,
       });
       return NextResponse.json({ success: true, data: result });
     }
-    const result = await listGatewayTriggers();
+    const result = await listGatewayTriggers(storageScope);
     logTriggerRoute('GET active triggers completed', {
       count: Array.isArray(result.triggers) ? result.triggers.length : 0,
     });
@@ -66,6 +67,7 @@ export async function POST(request: NextRequest) {
   const { session, response } = await requireAutomationSession(request);
   if (!session || response) return response;
 
+  const storageScope = { userId: session.user.id };
   try {
     const payload = recordValue(await request.json());
     assertCanCreateRequestedAutomation(payload, session.user);
@@ -91,7 +93,7 @@ export async function POST(request: NextRequest) {
       connectedAccountId: connectedAccountId || undefined,
       triggerConfig,
       notebookWebhookUrl: stringValue(payload.notebookWebhookUrl) || null,
-    });
+    }, storageScope);
     const trigger = recordValue(created.trigger);
     const triggerId = stringValue(trigger.triggerId) || stringValue(trigger.trigger_id);
     if (!triggerId) {
@@ -116,7 +118,7 @@ export async function POST(request: NextRequest) {
       composioTriggerSlug: stringValue(trigger.triggerSlug) || triggerSlug,
       composioToolkitSlug: stringValue(trigger.toolkitSlug) || toolkitSlug || triggerSlug.split('_')[0]?.toLowerCase() || 'unknown',
       composioConnectedAccountId: stringValue(trigger.connectedAccountId) || connectedAccountId || '',
-      composioUserId: stringValue(trigger.composioUserId) || await getComposioUserId(),
+      composioUserId: stringValue(trigger.composioUserId) || await getComposioUserId(storageScope),
       webhookTriggerConfig: triggerConfig,
     }, session.user.id);
 

--- a/app/api/composio/webhook/subscription/route.ts
+++ b/app/api/composio/webhook/subscription/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { auth } from '@/app/lib/auth';
 import { getComposioMode } from '@/app/lib/composio/composio-client';
 import { ensureLocalWebhookSubscription, getLocalWebhookSubscription } from '@/app/lib/composio/composio-gateway';
 
@@ -11,8 +12,14 @@ function currentWebhookUrl(): string {
   return `${base}/api/composio/webhook`;
 }
 
-export async function GET() {
-  const mode = await getComposioMode();
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ configured: false, mode: 'disabled', reason: 'Unauthorized' }, { status: 401 });
+  }
+
+  const storageScope = { userId: session.user.id };
+  const mode = await getComposioMode(storageScope);
   if (mode !== 'local') {
     return NextResponse.json(
       { configured: false, mode, reason: mode === 'managed' ? 'Webhook subscriptions are managed by the Control Plane.' : 'Composio is not configured.' },
@@ -20,7 +27,7 @@ export async function GET() {
     );
   }
 
-  const subscription = await getLocalWebhookSubscription();
+  const subscription = await getLocalWebhookSubscription(storageScope);
   const expectedUrl = currentWebhookUrl();
   if (!subscription) {
     return NextResponse.json({
@@ -51,7 +58,13 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const mode = await getComposioMode();
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const storageScope = { userId: session.user.id };
+  const mode = await getComposioMode(storageScope);
   if (mode !== 'local') {
     return NextResponse.json(
       { error: mode === 'managed' ? 'Webhook subscriptions are managed by the Control Plane.' : 'Composio is not configured.' },
@@ -66,7 +79,7 @@ export async function POST(request: NextRequest) {
   } catch { /* empty body is fine */ }
 
   try {
-    const subscription = await ensureLocalWebhookSubscription({ forceRefresh: rotate });
+    const subscription = await ensureLocalWebhookSubscription({ forceRefresh: rotate, storageScope });
     return NextResponse.json({
       configured: true,
       webhookUrl: subscription.webhookUrl,

--- a/app/api/email/oauth/status/route.ts
+++ b/app/api/email/oauth/status/route.ts
@@ -8,17 +8,17 @@ import { getPublicRequestOrigin } from '@/app/lib/utils/request-origin';
 async function requireSession(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  return null;
+  return session;
 }
 
 export async function GET(request: NextRequest) {
-  const unauthorized = await requireSession(request);
-  if (unauthorized) return unauthorized;
+  const session = await requireSession(request);
+  if (session instanceof NextResponse) return session;
   const limited = rateLimit(request, { limit: 60, windowMs: 60_000, keyPrefix: 'email-oauth-status' });
   if (!limited.ok) return limited.response;
 
   try {
-    const data = await getEmailOAuthStatus({ requestOrigin: getPublicRequestOrigin(request) });
+    const data = await getEmailOAuthStatus({ userId: session.user.id, requestOrigin: getPublicRequestOrigin(request) });
     return NextResponse.json({ success: true, data });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to load email OAuth status';

--- a/app/lib/agents/capability-options.ts
+++ b/app/lib/agents/capability-options.ts
@@ -55,15 +55,16 @@ async function loadMcpConnectionOptions(): Promise<AgentConnectionOption[]> {
     }));
 }
 
-async function loadComposioConnectionOptions(): Promise<AgentConnectionOption[]> {
-  const status = await getGatewayStatus();
+async function loadComposioConnectionOptions(userId?: string | null): Promise<AgentConnectionOption[]> {
+  const storageScope = userId ? { userId } : undefined;
+  const status = await getGatewayStatus(storageScope);
   if (!status.configured || !status.apiKeyValid || status.connectedAccounts.length === 0) {
     return [];
   }
 
   let toolkitSummaryBySlug = new Map<string, ReturnType<typeof toToolkitSummary>>();
   try {
-    const result = await getGatewayToolkits();
+    const result = await getGatewayToolkits(storageScope);
     if (Array.isArray(result.toolkits)) {
       toolkitSummaryBySlug = new Map(
         result.toolkits
@@ -90,11 +91,11 @@ async function loadComposioConnectionOptions(): Promise<AgentConnectionOption[]>
     });
 }
 
-export async function loadAgentConnectionOptions(params: { query?: string } = {}): Promise<AgentConnectionOption[]> {
+export async function loadAgentConnectionOptions(params: { query?: string; userId?: string | null } = {}): Promise<AgentConnectionOption[]> {
   const query = params.query?.trim().toLowerCase() || '';
   const [mcpResult, composioResult] = await Promise.allSettled([
     loadMcpConnectionOptions(),
-    loadComposioConnectionOptions(),
+    loadComposioConnectionOptions(params.userId),
   ]);
 
   return [

--- a/app/lib/agents/system-prompt.ts
+++ b/app/lib/agents/system-prompt.ts
@@ -326,7 +326,7 @@ export async function loadManagedAgentSystemPrompt(
         systemPrompt += '\n\n' + MCP_SYSTEM_PROMPT;
       }
 
-      if ((await isComposioConfigured()) && isComposioGatewayEnabled(enabledTools)) {
+      if ((await isComposioConfigured(scope)) && isComposioGatewayEnabled(enabledTools)) {
         systemPrompt += '\n\n' + COMPOSIO_SYSTEM_PROMPT;
       }
 

--- a/app/lib/composio/composio-auth.ts
+++ b/app/lib/composio/composio-auth.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { getComposio } from './composio-client';
 import { getComposioSession, getComposioUserId } from './composio-session';
 import { getAvailableToolkitsRaw } from './composio-toolkit-registry';
+import type { EnvStorageScope } from '../integrations/env-config';
 
 export type ComposioConnectedAccountStatus =
   | 'INITIALIZING'
@@ -17,11 +18,11 @@ type ConnectedAccountListOptions = {
   statuses?: ComposioConnectedAccountStatus[];
 };
 
-export async function initiateConnection(toolkit: string): Promise<{ redirectUrl: string | null; noAuth?: boolean }> {
-  const composio = await getComposio();
+export async function initiateConnection(toolkit: string, storageScope?: EnvStorageScope | null): Promise<{ redirectUrl: string | null; noAuth?: boolean }> {
+  const composio = await getComposio(storageScope);
   if (!composio) throw new Error('Composio not configured');
 
-  const rawItems = await getAvailableToolkitsRaw();
+  const rawItems = await getAvailableToolkitsRaw(storageScope);
   const toolkitInfo = rawItems.find((item) => {
     const t = item as Record<string, unknown>;
     return t.slug === toolkit;
@@ -33,7 +34,7 @@ export async function initiateConnection(toolkit: string): Promise<{ redirectUrl
     return { redirectUrl: null, noAuth: true };
   }
 
-  const session = await getComposioSession();
+  const session = await getComposioSession(storageScope);
   if (!session) throw new Error('Composio not configured');
 
   const callbackUrl = `${getAppBaseUrl()}/api/composio/callback`;
@@ -41,19 +42,19 @@ export async function initiateConnection(toolkit: string): Promise<{ redirectUrl
   return { redirectUrl: connectionRequest.redirectUrl };
 }
 
-export async function disconnectTool(toolkit: string): Promise<void> {
-  const accounts = await getConnectedAccounts();
+export async function disconnectTool(toolkit: string, storageScope?: EnvStorageScope | null): Promise<void> {
+  const accounts = await getConnectedAccounts({}, storageScope);
   const account = accounts.find((a) => a.toolkit?.slug === toolkit);
 
   if (account) {
-    const composio = await getComposio();
+    const composio = await getComposio(storageScope);
     if (!composio) throw new Error('Composio not configured');
     await composio.connectedAccounts.delete((account as { id: string }).id);
   }
 }
 
-export async function getAuthConfigs(): Promise<Array<Record<string, unknown>>> {
-  const composio = await getComposio();
+export async function getAuthConfigs(storageScope?: EnvStorageScope | null): Promise<Array<Record<string, unknown>>> {
+  const composio = await getComposio(storageScope);
   if (!composio) return [];
 
   try {
@@ -67,11 +68,14 @@ export async function getAuthConfigs(): Promise<Array<Record<string, unknown>>> 
   }
 }
 
-export async function getConnectedAccounts(options: ConnectedAccountListOptions = {}) {
-  const composio = await getComposio();
+export async function getConnectedAccounts(
+  options: ConnectedAccountListOptions = {},
+  storageScope?: EnvStorageScope | null,
+) {
+  const composio = await getComposio(storageScope);
   if (!composio) return [];
 
-  const userId = await getComposioUserId();
+  const userId = await getComposioUserId(storageScope);
   const allItems: Array<{ id: string; toolkit?: { slug?: string; name?: string }; status?: string; createdAt?: string; [key: string]: unknown }> = [];
   let cursor: string | undefined;
 
@@ -88,12 +92,12 @@ export async function getConnectedAccounts(options: ConnectedAccountListOptions 
   return allItems;
 }
 
-export async function getActiveConnectedAccounts() {
-  return getConnectedAccounts({ statuses: ['ACTIVE'] });
+export async function getActiveConnectedAccounts(storageScope?: EnvStorageScope | null) {
+  return getConnectedAccounts({ statuses: ['ACTIVE'] }, storageScope);
 }
 
-export async function getToolkitsWithStatus() {
-  const session = await getComposioSession();
+export async function getToolkitsWithStatus(storageScope?: EnvStorageScope | null) {
+  const session = await getComposioSession(storageScope);
   if (!session) return [];
 
   const { items } = await session.toolkits();

--- a/app/lib/composio/composio-client.ts
+++ b/app/lib/composio/composio-client.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import { Composio } from '@composio/core';
-import { readScopedEnvState } from '../integrations/env-config';
+import { readScopedEnvState, type EnvStorageScope } from '../integrations/env-config';
 import { getManagedControlPlaneBaseUrl } from '../managed/control-plane-url';
 import { getComposioUserId } from './composio-identity';
 
@@ -17,12 +17,19 @@ function isManagedComposioAvailable(): boolean {
   );
 }
 
-export async function getLocalComposioApiKey(): Promise<string | null> {
+export async function getLocalComposioApiKey(storageScope?: EnvStorageScope | null): Promise<string | null> {
   try {
-    const state = await readScopedEnvState('integrations');
+    const state = await readScopedEnvState('integrations', storageScope);
     const byKey = new Map(state.entries.map((entry) => [entry.key, entry.value]));
     const envKey = byKey.get('COMPOSIO_API_KEY');
     if (envKey) return envKey;
+
+    if (storageScope?.userId?.trim() || storageScope?.organizationId?.trim()) {
+      const legacyState = await readScopedEnvState('integrations', { secretScope: 'legacy' });
+      const legacyKey = legacyState.entries.find((entry) => entry.key === 'COMPOSIO_API_KEY')?.value.trim();
+      if (legacyKey) return legacyKey;
+    }
+
     if (!isManagedComposioAvailable() && process.env.COMPOSIO_API_KEY) return process.env.COMPOSIO_API_KEY;
     return null;
   } catch {
@@ -30,8 +37,8 @@ export async function getLocalComposioApiKey(): Promise<string | null> {
   }
 }
 
-export async function getComposioMode(): Promise<ComposioMode> {
-  const localKey = await getLocalComposioApiKey();
+export async function getComposioMode(storageScope?: EnvStorageScope | null): Promise<ComposioMode> {
+  const localKey = await getLocalComposioApiKey(storageScope);
   if (localKey) return 'local';
   if (isManagedComposioAvailable()) return 'managed';
   return 'disabled';
@@ -39,8 +46,8 @@ export async function getComposioMode(): Promise<ComposioMode> {
 
 let cachedApiKey: string | null = null;
 
-export async function getComposio(): Promise<Composio | null> {
-  const apiKey = await getLocalComposioApiKey();
+export async function getComposio(storageScope?: EnvStorageScope | null): Promise<Composio | null> {
+  const apiKey = await getLocalComposioApiKey(storageScope);
   if (!apiKey) return null;
 
   if (composioInstance && cachedApiKey === apiKey) {
@@ -52,19 +59,19 @@ export async function getComposio(): Promise<Composio | null> {
   return composioInstance;
 }
 
-export async function verifyApiKey(): Promise<boolean> {
+export async function verifyApiKey(storageScope?: EnvStorageScope | null): Promise<boolean> {
   try {
-    const composio = await getComposio();
+    const composio = await getComposio(storageScope);
     if (!composio) return false;
-    await composio.connectedAccounts.list({ userIds: [await getComposioUserId()], limit: 1 });
+    await composio.connectedAccounts.list({ userIds: [await getComposioUserId(storageScope)], limit: 1 });
     return true;
   } catch {
     return false;
   }
 }
 
-export async function isComposioConfigured(): Promise<boolean> {
-  return (await getComposioMode()) !== 'disabled';
+export async function isComposioConfigured(storageScope?: EnvStorageScope | null): Promise<boolean> {
+  return (await getComposioMode(storageScope)) !== 'disabled';
 }
 
 export function resetComposioInstance(): void {

--- a/app/lib/composio/composio-client.ts
+++ b/app/lib/composio/composio-client.ts
@@ -5,7 +5,7 @@ import { readScopedEnvState, type EnvStorageScope } from '../integrations/env-co
 import { getManagedControlPlaneBaseUrl } from '../managed/control-plane-url';
 import { getComposioUserId } from './composio-identity';
 
-let composioInstance: Composio | null = null;
+const composioInstances = new Map<string, Composio>();
 
 export type ComposioMode = 'local' | 'managed' | 'disabled';
 
@@ -44,19 +44,18 @@ export async function getComposioMode(storageScope?: EnvStorageScope | null): Pr
   return 'disabled';
 }
 
-let cachedApiKey: string | null = null;
-
 export async function getComposio(storageScope?: EnvStorageScope | null): Promise<Composio | null> {
   const apiKey = await getLocalComposioApiKey(storageScope);
   if (!apiKey) return null;
 
-  if (composioInstance && cachedApiKey === apiKey) {
-    return composioInstance;
+  const cached = composioInstances.get(apiKey);
+  if (cached) {
+    return cached;
   }
 
-  composioInstance = new Composio({ apiKey });
-  cachedApiKey = apiKey;
-  return composioInstance;
+  const composio = new Composio({ apiKey });
+  composioInstances.set(apiKey, composio);
+  return composio;
 }
 
 export async function verifyApiKey(storageScope?: EnvStorageScope | null): Promise<boolean> {
@@ -75,6 +74,5 @@ export async function isComposioConfigured(storageScope?: EnvStorageScope | null
 }
 
 export function resetComposioInstance(): void {
-  composioInstance = null;
-  cachedApiKey = null;
+  composioInstances.clear();
 }

--- a/app/lib/composio/composio-gateway.ts
+++ b/app/lib/composio/composio-gateway.ts
@@ -11,6 +11,7 @@ import { getManagedControlPlaneBaseUrl } from '../managed/control-plane-url';
 import { encryptWebhookSecret, previewWebhookSecret } from './composio-webhook-secret';
 import { db } from '../db';
 import { composioWebhookSubscriptions } from '../db/schema';
+import type { EnvStorageScope } from '../integrations/env-config';
 
 const HIDDEN_TOOLKIT_SLUGS = new Set([
   'gemini',
@@ -137,8 +138,9 @@ function normalizeLocalTriggerInstance(
 async function managedRequest<T>(
   path: string,
   options: { method?: string; body?: Record<string, unknown>; query?: URLSearchParams } = {},
+  storageScope?: EnvStorageScope | null,
 ): Promise<T> {
-  const userId = await getComposioUserId();
+  const userId = await getComposioUserId(storageScope);
   const url = new URL(`${controlPlaneBaseUrl()}/v1/managed/composio${path}`);
   if (options.query) {
     options.query.forEach((value, key) => url.searchParams.set(key, value));
@@ -200,31 +202,31 @@ function connectedAccountResponse(accounts: ComposioConnectedAccount[]) {
   }));
 }
 
-export async function getComposioGatewayMode(): Promise<ComposioMode> {
-  return getComposioMode();
+export async function getComposioGatewayMode(storageScope?: EnvStorageScope | null): Promise<ComposioMode> {
+  return getComposioMode(storageScope);
 }
 
-export async function getGatewayStatus(): Promise<ComposioStatusResult> {
-  const mode = await getComposioMode();
+export async function getGatewayStatus(storageScope?: EnvStorageScope | null): Promise<ComposioStatusResult> {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') {
     return { configured: false, apiKeyValid: false, mode, webhookSubscription: null, connectedAccounts: [] };
   }
 
   if (mode === 'managed') {
-    const result = await managedRequest<ComposioStatusResult>('/status');
+    const result = await managedRequest<ComposioStatusResult>('/status', {}, storageScope);
     result.webhookSubscription = { configured: true, mode: 'managed' };
     result.connectedAccounts = result.connectedAccounts.filter((account) => account.status === 'ACTIVE');
     return result;
   }
 
-  const apiKeyValid = await verifyApiKey();
+  const apiKeyValid = await verifyApiKey(storageScope);
   if (!apiKeyValid) {
     return { configured: true, apiKeyValid: false, mode, webhookSubscription: null, connectedAccounts: [] };
   }
-  const accounts = await getActiveConnectedAccounts();
+  const accounts = await getActiveConnectedAccounts(storageScope);
   let webhookSubscription: ComposioStatusResult['webhookSubscription'] = null;
   try {
-    const sub = await getLocalWebhookSubscription();
+    const sub = await getLocalWebhookSubscription(storageScope);
     if (sub) {
       webhookSubscription = { configured: true, webhookUrl: sub.webhookUrl, status: sub.status, mode: sub.mode };
     } else {
@@ -234,15 +236,15 @@ export async function getGatewayStatus(): Promise<ComposioStatusResult> {
   return { configured: true, apiKeyValid: true, mode, webhookSubscription, connectedAccounts: connectedAccountResponse(accounts) };
 }
 
-export async function getGatewayToolkits() {
-  const mode = await getComposioMode();
+export async function getGatewayToolkits(storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') return { toolkits: [] };
-  if (mode === 'managed') return managedRequest<{ toolkits: unknown[] }>('/toolkits');
-  return { toolkits: await getAvailableToolkits() };
+  if (mode === 'managed') return managedRequest<{ toolkits: unknown[] }>('/toolkits', {}, storageScope);
+  return { toolkits: await getAvailableToolkits(storageScope) };
 }
 
-export async function getGatewayTriggerApps() {
-  const mode = await getComposioMode();
+export async function getGatewayTriggerApps(storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') {
     return {
       apps: [],
@@ -254,7 +256,7 @@ export async function getGatewayTriggerApps() {
   const now = Date.now();
   let baseApps = triggerAppCache && triggerAppCache.expiresAt > now ? triggerAppCache.apps : null;
   if (!baseApps) {
-    const result = await getGatewayTriggerTypes('');
+    const result = await getGatewayTriggerTypes('', storageScope);
     const bySlug = new Map<string, {
       slug: string;
       name: string;
@@ -288,7 +290,7 @@ export async function getGatewayTriggerApps() {
     };
   }
 
-  const status = await getGatewayStatus();
+  const status = await getGatewayStatus(storageScope);
   const connectedBySlug = new Map(status.connectedAccounts.map((account) => [account.toolkit.slug, account]));
   const apps = baseApps
     .map((app) => {
@@ -305,16 +307,16 @@ export async function getGatewayTriggerApps() {
   return { apps, totalCount: apps.length, status };
 }
 
-export async function getGatewayToolkitTools(toolkit: string, search: string) {
-  const mode = await getComposioMode();
+export async function getGatewayToolkitTools(toolkit: string, search: string, storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') return { tools: [], totalCount: 0 };
   if (mode === 'managed') {
     const query = new URLSearchParams();
     if (search) query.set('search', search);
-    return managedRequest<{ tools: unknown[]; totalCount: number; hasMore?: boolean }>(`/toolkits/${encodeURIComponent(toolkit)}/tools`, { query });
+    return managedRequest<{ tools: unknown[]; totalCount: number; hasMore?: boolean }>(`/toolkits/${encodeURIComponent(toolkit)}/tools`, { query }, storageScope);
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) return { tools: [], totalCount: 0 };
   const queryParams: Parameters<typeof composio.tools.getRawComposioTools>[0] = {
     toolkits: [toolkit],
@@ -336,36 +338,36 @@ export async function getGatewayToolkitTools(toolkit: string, search: string) {
   return { tools, totalCount: tools.length, hasMore: toolList.length >= 500 };
 }
 
-export async function connectGatewayToolkit(toolkit: string) {
-  const mode = await getComposioMode();
+export async function connectGatewayToolkit(toolkit: string, storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio not configured');
   if (mode === 'managed') {
     return managedRequest<{ redirectUrl: string | null; noAuth?: boolean }>(`/connect/${encodeURIComponent(toolkit)}`, {
       method: 'POST',
       body: { returnUrl: `${appBaseUrl()}/settings?tab=integrations&connected=${encodeURIComponent(toolkit)}` },
-    });
+    }, storageScope);
   }
-  return initiateConnection(toolkit);
+  return initiateConnection(toolkit, storageScope);
 }
 
-export async function disconnectGatewayToolkit(toolkit: string) {
-  const mode = await getComposioMode();
+export async function disconnectGatewayToolkit(toolkit: string, storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio not configured');
   if (mode === 'managed') {
-    return managedRequest<{ success: boolean }>(`/disconnect/${encodeURIComponent(toolkit)}`, { method: 'DELETE' });
+    return managedRequest<{ success: boolean }>(`/disconnect/${encodeURIComponent(toolkit)}`, { method: 'DELETE' }, storageScope);
   }
-  await disconnectTool(toolkit);
+  await disconnectTool(toolkit, storageScope);
   return { success: true };
 }
 
-export async function refreshGatewayToolkit(toolkit: string) {
-  const mode = await getComposioMode();
+export async function refreshGatewayToolkit(toolkit: string, storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio not configured');
   if (mode === 'managed') {
-    return managedRequest<{ toolkit: string; status: string; connectedAt: string | null }>(`/refresh/${encodeURIComponent(toolkit)}`, { method: 'POST' });
+    return managedRequest<{ toolkit: string; status: string; connectedAt: string | null }>(`/refresh/${encodeURIComponent(toolkit)}`, { method: 'POST' }, storageScope);
   }
 
-  const accounts = await getConnectedAccounts();
+  const accounts = await getConnectedAccounts({}, storageScope);
   const account = accounts.find((a) => a.toolkit?.slug === toolkit);
   if (account) {
     return { toolkit, status: account.status || 'UNKNOWN', connectedAt: account.createdAt || null };
@@ -373,17 +375,17 @@ export async function refreshGatewayToolkit(toolkit: string) {
   return { toolkit, status: 'NOT_CONNECTED', connectedAt: null };
 }
 
-export async function searchGatewayTools(query: string, toolkits?: string[]) {
-  const mode = await getComposioMode();
+export async function searchGatewayTools(query: string, toolkits?: string[], storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations or enable managed Composio.');
   if (mode === 'managed') {
     return managedRequest<{ tools: unknown[]; count: number }>('/tools/search', {
       method: 'POST',
       body: { query, toolkits },
-    });
+    }, storageScope);
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations.');
   const results = await composio.tools.getRawComposioTools({
     search: query,
@@ -407,17 +409,17 @@ export async function searchGatewayTools(query: string, toolkits?: string[]) {
   return { tools: formatted, count: formatted.length };
 }
 
-export async function getGatewayToolSchemas(tools: string[]) {
-  const mode = await getComposioMode();
+export async function getGatewayToolSchemas(tools: string[], storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations or enable managed Composio.');
   if (mode === 'managed') {
     return managedRequest<Record<string, unknown>>('/tools/schemas', {
       method: 'POST',
       body: { tools },
-    });
+    }, storageScope);
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations.');
   const schemas: Record<string, unknown> = {};
   for (const slug of tools.slice(0, 10)) {
@@ -432,50 +434,50 @@ export async function getGatewayToolSchemas(tools: string[]) {
   return schemas;
 }
 
-export async function executeGatewayTool(action: string, params: Record<string, unknown>) {
-  const mode = await getComposioMode();
+export async function executeGatewayTool(action: string, params: Record<string, unknown>, storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations or enable managed Composio.');
   if (mode === 'managed') {
     return managedRequest<unknown>('/execute', {
       method: 'POST',
       body: { action, params, returnUrl: `${appBaseUrl()}/settings?tab=integrations&connected=${encodeURIComponent(action.split('_')[0]?.toLowerCase() ?? '')}` },
-    });
+    }, storageScope);
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations.');
   return composio.tools.execute(action, {
-    userId: await getComposioUserId(),
+    userId: await getComposioUserId(storageScope),
     arguments: params,
     dangerouslySkipVersionCheck: true,
   });
 }
 
-export async function getGatewayAuthRedirect(toolkit: string) {
-  const mode = await getComposioMode();
+export async function getGatewayAuthRedirect(toolkit: string, storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'managed') {
     const result = await managedRequest<{ redirectUrl: string | null; noAuth?: boolean }>(`/connect/${encodeURIComponent(toolkit)}`, {
       method: 'POST',
       body: { returnUrl: `${appBaseUrl()}/settings?tab=integrations&connected=${encodeURIComponent(toolkit)}` },
-    });
+    }, storageScope);
     return result.redirectUrl || '';
   }
-  const session = await getComposioSession();
+  const session = await getComposioSession(storageScope);
   if (!session) return '';
   const connectionRequest = await session.authorize(toolkit, { callbackUrl: `${appBaseUrl()}/api/composio/callback` });
   return connectionRequest.redirectUrl;
 }
 
-export async function getGatewayTriggerTypes(toolkit: string) {
-  const mode = await getComposioMode();
+export async function getGatewayTriggerTypes(toolkit: string, storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations or enable managed Composio.');
   if (mode === 'managed') {
     const query = new URLSearchParams();
     if (toolkit) query.set('toolkit', toolkit);
-    return managedRequest<{ triggerTypes: unknown[]; totalCount: number; hasMore?: boolean; nextCursor?: string | null }>('/triggers/types', { query });
+    return managedRequest<{ triggerTypes: unknown[]; totalCount: number; hasMore?: boolean; nextCursor?: string | null }>('/triggers/types', { query }, storageScope);
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations.');
   logComposioTrigger('Listing local trigger types', { toolkit });
   const result = await composio.triggers.listTypes({
@@ -491,14 +493,14 @@ export async function getGatewayTriggerTypes(toolkit: string) {
   };
 }
 
-export async function listGatewayTriggers() {
-  const mode = await getComposioMode();
+export async function listGatewayTriggers(storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations or enable managed Composio.');
-  if (mode === 'managed') return managedRequest<{ triggers: unknown[] }>('/triggers');
+  if (mode === 'managed') return managedRequest<{ triggers: unknown[] }>('/triggers', {}, storageScope);
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations.');
-  const accounts = await getConnectedAccounts();
+  const accounts = await getConnectedAccounts({}, storageScope);
   const accountById = new Map(accounts.map((account) => [account.id, account as ComposioConnectedAccount]));
   const connectedAccountIds = Array.from(accountById.keys());
   if (connectedAccountIds.length === 0) {
@@ -524,8 +526,8 @@ const COMPOSIO_WEBHOOK_EVENT_TYPES = [
   'composio.trigger.disabled',
 ];
 
-export async function getLocalWebhookSubscription() {
-  const mode = await getComposioMode();
+export async function getLocalWebhookSubscription(storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode !== 'local') return null;
   const [row] = await db
     .select()
@@ -536,17 +538,17 @@ export async function getLocalWebhookSubscription() {
   return row ?? null;
 }
 
-export async function ensureLocalWebhookSubscription(options?: { forceRefresh?: boolean }) {
-  const mode = await getComposioMode();
+export async function ensureLocalWebhookSubscription(options?: { forceRefresh?: boolean; storageScope?: EnvStorageScope | null }) {
+  const mode = await getComposioMode(options?.storageScope);
   if (mode !== 'local') throw new Error('Webhook subscriptions are only supported in local Composio mode.');
-  const apiKey = await import('./composio-client').then((m) => m.getLocalComposioApiKey());
+  const apiKey = await import('./composio-client').then((m) => m.getLocalComposioApiKey(options?.storageScope));
   if (!apiKey) throw new Error('Composio API key is required to create a webhook subscription.');
-  const existing = await getLocalWebhookSubscription();
+  const existing = await getLocalWebhookSubscription(options?.storageScope);
   const currentUrl = `${appBaseUrl()}/api/composio/webhook`;
   if (existing && !options?.forceRefresh) {
     if (existing.webhookUrl !== currentUrl) {
       logComposioTrigger('Webhook URL changed, re-registering subscription', { old: existing.webhookUrl, new: currentUrl });
-      return ensureLocalWebhookSubscription({ forceRefresh: true });
+      return ensureLocalWebhookSubscription({ forceRefresh: true, storageScope: options?.storageScope });
     }
     return existing;
   }
@@ -677,20 +679,20 @@ export async function createGatewayTrigger(input: {
   connectedAccountId?: string;
   triggerConfig?: Record<string, unknown>;
   notebookWebhookUrl?: string | null;
-}) {
-  const mode = await getComposioMode();
+}, storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations or enable managed Composio.');
   if (mode === 'managed') {
-    await managedRequest('/webhook/subscription', { method: 'POST', body: {} });
+    await managedRequest('/webhook/subscription', { method: 'POST', body: {} }, storageScope);
     return managedRequest<{ trigger: Record<string, unknown> }>('/triggers', {
       method: 'POST',
       body: input,
-    });
+    }, storageScope);
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations.');
-  await ensureLocalWebhookSubscription();
+  await ensureLocalWebhookSubscription({ storageScope });
   logComposioTrigger('Creating local trigger', {
     triggerSlug: input.triggerSlug,
     toolkitSlug: input.toolkitSlug,
@@ -698,7 +700,7 @@ export async function createGatewayTrigger(input: {
     hasTriggerConfig: Boolean(input.triggerConfig && Object.keys(input.triggerConfig).length > 0),
   });
   const triggerType = await composio.triggers.getType(input.triggerSlug);
-  const composioUserId = await getComposioUserId();
+  const composioUserId = await getComposioUserId(storageScope);
   const result = await composio.triggers.create(composioUserId, input.triggerSlug, {
     connectedAccountId: input.connectedAccountId,
     triggerConfig: input.triggerConfig || {},
@@ -732,31 +734,35 @@ export async function createGatewayTrigger(input: {
   };
 }
 
-export async function updateGatewayTrigger(triggerId: string, input: { status?: 'active' | 'paused'; triggerConfig?: Record<string, unknown>; notebookWebhookUrl?: string | null }) {
-  const mode = await getComposioMode();
+export async function updateGatewayTrigger(
+  triggerId: string,
+  input: { status?: 'active' | 'paused'; triggerConfig?: Record<string, unknown>; notebookWebhookUrl?: string | null },
+  storageScope?: EnvStorageScope | null,
+) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations or enable managed Composio.');
   if (mode === 'managed') {
     return managedRequest<{ trigger: Record<string, unknown> }>(`/triggers/${encodeURIComponent(triggerId)}`, {
       method: 'PATCH',
       body: input,
-    });
+    }, storageScope);
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations.');
   if (input.status === 'paused') await composio.triggers.disable(triggerId);
   if (input.status === 'active') await composio.triggers.enable(triggerId);
   return { trigger: { triggerId, status: input.status } };
 }
 
-export async function deleteGatewayTrigger(triggerId: string) {
-  const mode = await getComposioMode();
+export async function deleteGatewayTrigger(triggerId: string, storageScope?: EnvStorageScope | null) {
+  const mode = await getComposioMode(storageScope);
   if (mode === 'disabled') throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations or enable managed Composio.');
   if (mode === 'managed') {
-    return managedRequest<{ success: boolean }>(`/triggers/${encodeURIComponent(triggerId)}`, { method: 'DELETE' });
+    return managedRequest<{ success: boolean }>(`/triggers/${encodeURIComponent(triggerId)}`, { method: 'DELETE' }, storageScope);
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) throw new Error('Composio is not configured. Add COMPOSIO_API_KEY in Settings → Integrations.');
   await composio.triggers.delete(triggerId);
   return { success: true };

--- a/app/lib/composio/composio-gateway.ts
+++ b/app/lib/composio/composio-gateway.ts
@@ -24,7 +24,7 @@ const HIDDEN_TOOLKIT_SLUGS = new Set([
 
 const TRIGGER_APP_CACHE_TTL_MS = 30 * 60 * 1000;
 
-let triggerAppCache: {
+type TriggerAppCacheEntry = {
   expiresAt: number;
   apps: Array<{
     slug: string;
@@ -33,7 +33,9 @@ let triggerAppCache: {
     description?: string;
     triggerCount: number;
   }>;
-} | null = null;
+};
+
+const triggerAppCache = new Map<string, TriggerAppCacheEntry>();
 
 export interface ComposioConnectedAccount {
   id: string;
@@ -109,6 +111,13 @@ function logComposioTriggerError(message: string, error: unknown, details?: Reco
     ...details,
     error: error instanceof Error ? error.message : String(error),
   });
+}
+
+function storageScopeCacheKey(storageScope?: EnvStorageScope | null): string {
+  const userId = storageScope?.userId?.trim() || '';
+  const organizationId = storageScope?.organizationId?.trim() || '';
+  const secretScope = storageScope?.secretScope || (userId ? 'user' : organizationId ? 'organization' : 'legacy');
+  return `${secretScope}:${userId}:${organizationId}`;
 }
 
 function normalizeLocalTriggerInstance(
@@ -254,7 +263,9 @@ export async function getGatewayTriggerApps(storageScope?: EnvStorageScope | nul
   }
 
   const now = Date.now();
-  let baseApps = triggerAppCache && triggerAppCache.expiresAt > now ? triggerAppCache.apps : null;
+  const cacheKey = storageScopeCacheKey(storageScope);
+  const cached = triggerAppCache.get(cacheKey);
+  let baseApps = cached && cached.expiresAt > now ? cached.apps : null;
   if (!baseApps) {
     const result = await getGatewayTriggerTypes('', storageScope);
     const bySlug = new Map<string, {
@@ -284,10 +295,10 @@ export async function getGatewayTriggerApps(storageScope?: EnvStorageScope | nul
     }
 
     baseApps = Array.from(bySlug.values()).sort((a, b) => a.name.localeCompare(b.name));
-    triggerAppCache = {
+    triggerAppCache.set(cacheKey, {
       apps: baseApps,
       expiresAt: now + TRIGGER_APP_CACHE_TTL_MS,
-    };
+    });
   }
 
   const status = await getGatewayStatus(storageScope);
@@ -770,5 +781,5 @@ export async function deleteGatewayTrigger(triggerId: string, storageScope?: Env
 
 export function clearComposioGatewayCaches(): void {
   clearToolkitCache();
-  triggerAppCache = null;
+  triggerAppCache.clear();
 }

--- a/app/lib/composio/composio-identity.ts
+++ b/app/lib/composio/composio-identity.ts
@@ -2,18 +2,34 @@ import 'server-only';
 
 import crypto from 'crypto';
 
-import { readScopedEnvState, replaceScopedEnvEntries } from '../integrations/env-config';
+import { readScopedEnvState, replaceScopedEnvEntries, type EnvStorageScope } from '../integrations/env-config';
 import { getManagedControlPlaneBaseUrl } from '../managed/control-plane-url';
 
 const COMPOSIO_USER_ID_KEY = 'COMPOSIO_USER_ID';
 const COMPOSIO_USER_ID_PREFIX = 'canvas-notebook-';
 
-let cachedUserId: string | null = null;
+const cachedUserIds = new Map<string, string>();
 
-function composioUserIdFromInstance(): string | null {
+function scopeCacheKey(storageScope?: EnvStorageScope | null): string {
+  const userId = storageScope?.userId?.trim() || '';
+  const organizationId = storageScope?.organizationId?.trim() || '';
+  const secretScope = storageScope?.secretScope || (userId ? 'user' : organizationId ? 'organization' : 'legacy');
+  return `${secretScope}:${userId}:${organizationId}`;
+}
+
+function stableScopeSuffix(storageScope?: EnvStorageScope | null): string {
+  const userId = storageScope?.userId?.trim();
+  if (userId) return `user-${crypto.createHash('sha256').update(userId).digest('hex').slice(0, 16)}`;
+  const organizationId = storageScope?.organizationId?.trim();
+  if (organizationId) return `org-${crypto.createHash('sha256').update(organizationId).digest('hex').slice(0, 16)}`;
+  return '';
+}
+
+function composioUserIdFromInstance(storageScope?: EnvStorageScope | null): string | null {
   const instanceId = process.env.CANVAS_INSTANCE_ID?.trim();
   if (!instanceId) return null;
-  return `${COMPOSIO_USER_ID_PREFIX}${instanceId}`;
+  const suffix = stableScopeSuffix(storageScope);
+  return suffix ? `${COMPOSIO_USER_ID_PREFIX}${instanceId}-${suffix}` : `${COMPOSIO_USER_ID_PREFIX}${instanceId}`;
 }
 
 function isManagedInstance(): boolean {
@@ -24,66 +40,69 @@ function isManagedInstance(): boolean {
   );
 }
 
-async function persistComposioUserId(value: string): Promise<void> {
-  const state = await readScopedEnvState('integrations');
+async function persistComposioUserId(value: string, storageScope?: EnvStorageScope | null): Promise<void> {
+  const state = await readScopedEnvState('integrations', storageScope);
   const entries = state.entries
     .filter((entry) => entry.key !== COMPOSIO_USER_ID_KEY)
     .map((entry) => ({ key: entry.key, value: entry.value }));
   entries.push({ key: COMPOSIO_USER_ID_KEY, value });
-  await replaceScopedEnvEntries('integrations', entries);
+  await replaceScopedEnvEntries('integrations', entries, storageScope);
 }
 
-export async function getComposioUserId(): Promise<string> {
+export async function getComposioUserId(storageScope?: EnvStorageScope | null): Promise<string> {
+  const cacheKey = scopeCacheKey(storageScope);
+  const cachedUserId = cachedUserIds.get(cacheKey);
   if (cachedUserId) return cachedUserId;
 
   try {
-    const state = await readScopedEnvState('integrations');
+    const state = await readScopedEnvState('integrations', storageScope);
     const envValue = state.entries.find((entry) => entry.key === COMPOSIO_USER_ID_KEY)?.value.trim();
     const hasLocalComposioKey = Boolean(state.entries.find((entry) => entry.key === 'COMPOSIO_API_KEY')?.value.trim());
-    const managedUserId = !hasLocalComposioKey && isManagedInstance() ? composioUserIdFromInstance() : null;
+    const managedUserId = !hasLocalComposioKey && isManagedInstance() ? composioUserIdFromInstance(storageScope) : null;
     if (managedUserId && envValue !== managedUserId) {
       try {
-        await persistComposioUserId(managedUserId);
+        await persistComposioUserId(managedUserId, storageScope);
       } catch (error) {
         console.warn('[Composio] Failed to persist managed COMPOSIO_USER_ID:', error);
       }
-      cachedUserId = managedUserId;
+      cachedUserIds.set(cacheKey, managedUserId);
       return managedUserId;
     }
     if (envValue) {
-      cachedUserId = envValue;
+      cachedUserIds.set(cacheKey, envValue);
       return envValue;
     }
   } catch {
   }
 
-  const managedUserId = isManagedInstance() ? composioUserIdFromInstance() : null;
+  const managedUserId = isManagedInstance() ? composioUserIdFromInstance(storageScope) : null;
   if (managedUserId) {
     try {
-      await persistComposioUserId(managedUserId);
+      await persistComposioUserId(managedUserId, storageScope);
     } catch (error) {
       console.warn('[Composio] Failed to persist managed COMPOSIO_USER_ID:', error);
     }
-    cachedUserId = managedUserId;
+    cachedUserIds.set(cacheKey, managedUserId);
     return managedUserId;
   }
 
   const processValue = process.env.COMPOSIO_USER_ID?.trim();
-  if (processValue) {
-    cachedUserId = processValue;
+  if (processValue && !storageScope?.userId?.trim() && !storageScope?.organizationId?.trim()) {
+    cachedUserIds.set(cacheKey, processValue);
     return processValue;
   }
 
-  const generated = composioUserIdFromInstance() || `${COMPOSIO_USER_ID_PREFIX}${crypto.randomUUID()}`;
+  const generated = composioUserIdFromInstance(storageScope) || `${COMPOSIO_USER_ID_PREFIX}${crypto.randomUUID()}`;
   try {
-    await persistComposioUserId(generated);
+    await persistComposioUserId(generated, storageScope);
   } catch (error) {
     console.warn('[Composio] Failed to persist COMPOSIO_USER_ID:', error);
   }
-  cachedUserId = generated || 'local-user';
-  return cachedUserId;
+  const userId = generated || 'local-user';
+  cachedUserIds.set(cacheKey, userId);
+  return userId;
 }
 
 export function resetComposioUserIdCache(): void {
-  cachedUserId = null;
+  cachedUserIds.clear();
 }

--- a/app/lib/composio/composio-session.ts
+++ b/app/lib/composio/composio-session.ts
@@ -2,15 +2,16 @@ import 'server-only';
 
 import { getComposio, resetComposioInstance } from './composio-client';
 import { getComposioUserId, resetComposioUserIdCache } from './composio-identity';
+import type { EnvStorageScope } from '../integrations/env-config';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const sessionCache = new Map<string, any>();
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function getComposioSession(): Promise<any | null> {
-  const composio = await getComposio();
+export async function getComposioSession(storageScope?: EnvStorageScope | null): Promise<any | null> {
+  const composio = await getComposio(storageScope);
   if (!composio) return null;
-  const userId = await getComposioUserId();
+  const userId = await getComposioUserId(storageScope);
 
   if (sessionCache.has(userId)) {
     return sessionCache.get(userId)!;

--- a/app/lib/composio/composio-toolkit-registry.ts
+++ b/app/lib/composio/composio-toolkit-registry.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { getComposio } from './composio-client';
 import { getConnectedAccounts } from './composio-auth';
 import { getComposioUserId } from './composio-identity';
+import type { EnvStorageScope } from '../integrations/env-config';
 
 export interface ToolkitInfo {
   slug: string;
@@ -34,7 +35,7 @@ const HIDDEN_TOOLKIT_SLUGS = new Set([
 ]);
 
 const toolkitCache = new Map<string, { data: ToolkitInfo[]; expires: number }>();
-let rawToolkitCache: { data: unknown[]; expires: number } | null = null;
+const rawToolkitCache = new Map<string, { data: unknown[]; expires: number }>();
 const toolsCache = new Map<string, { data: ToolkitToolInfo[]; expires: number }>();
 
 const MAX_TOOLS_CACHE_SIZE = 50;
@@ -55,20 +56,29 @@ function cleanupExpiredToolsEntries() {
   }
 }
 
-export async function getAvailableToolkitsRaw(): Promise<unknown[]> {
+function storageScopeCacheKey(storageScope?: EnvStorageScope | null): string {
+  const userId = storageScope?.userId?.trim() || '';
+  const organizationId = storageScope?.organizationId?.trim() || '';
+  const secretScope = storageScope?.secretScope || (userId ? 'user' : organizationId ? 'organization' : 'legacy');
+  return `${secretScope}:${userId}:${organizationId}`;
+}
+
+export async function getAvailableToolkitsRaw(storageScope?: EnvStorageScope | null): Promise<unknown[]> {
   const now = Date.now();
-  if (rawToolkitCache && rawToolkitCache.expires > now) {
-    return rawToolkitCache.data;
+  const cacheKey = storageScopeCacheKey(storageScope);
+  const cached = rawToolkitCache.get(cacheKey);
+  if (cached && cached.expires > now) {
+    return cached.data;
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) return [];
 
   try {
     const response = await composio.toolkits.get({});
     const rawItems = 'items' in response ? (response as { items: unknown[] }).items : Array.isArray(response) ? response : [];
     console.log(`[Composio] Fetched ${rawItems.length} raw toolkits`);
-    rawToolkitCache = { data: rawItems, expires: now + CACHE_TTL_MS };
+    rawToolkitCache.set(cacheKey, { data: rawItems, expires: now + CACHE_TTL_MS });
     return rawItems;
   } catch (error) {
     console.error('[Composio] Failed to fetch raw toolkits:', error);
@@ -76,22 +86,22 @@ export async function getAvailableToolkitsRaw(): Promise<unknown[]> {
   }
 }
 
-export async function getAvailableToolkits(): Promise<ToolkitInfo[]> {
+export async function getAvailableToolkits(storageScope?: EnvStorageScope | null): Promise<ToolkitInfo[]> {
   const now = Date.now();
-  const userId = await getComposioUserId();
+  const userId = await getComposioUserId(storageScope);
   const cacheKey = `local:${userId}`;
   const cachedToolkits = toolkitCache.get(cacheKey);
   if (cachedToolkits && cachedToolkits.expires > now) {
     return cachedToolkits.data;
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) return [];
 
   try {
     const [rawItems, connectedAccounts] = await Promise.all([
-      getAvailableToolkitsRaw(),
-      getConnectedAccounts(),
+      getAvailableToolkitsRaw(storageScope),
+      getConnectedAccounts({}, storageScope),
     ]);
 
     console.log(`[Composio] Processing ${rawItems.length} toolkits, ${connectedAccounts.length} connected accounts`);
@@ -148,16 +158,17 @@ export async function getAvailableToolkits(): Promise<ToolkitInfo[]> {
   }
 }
 
-export async function getToolkitTools(toolkitSlug: string): Promise<ToolkitToolInfo[]> {
+export async function getToolkitTools(toolkitSlug: string, storageScope?: EnvStorageScope | null): Promise<ToolkitToolInfo[]> {
   cleanupExpiredToolsEntries();
 
   const now = Date.now();
-  const cached = toolsCache.get(toolkitSlug);
+  const cacheKey = `${storageScopeCacheKey(storageScope)}:${toolkitSlug}`;
+  const cached = toolsCache.get(cacheKey);
   if (cached && cached.expires > now) {
     return cached.data;
   }
 
-  const composio = await getComposio();
+  const composio = await getComposio(storageScope);
   if (!composio) return [];
 
   try {
@@ -177,7 +188,7 @@ export async function getToolkitTools(toolkitSlug: string): Promise<ToolkitToolI
       };
     });
 
-    toolsCache.set(toolkitSlug, { data: tools, expires: now + CACHE_TTL_MS });
+    toolsCache.set(cacheKey, { data: tools, expires: now + CACHE_TTL_MS });
     return tools;
   } catch (error) {
     console.error('[Composio] Failed to fetch tools for toolkit:', toolkitSlug, error);
@@ -187,6 +198,6 @@ export async function getToolkitTools(toolkitSlug: string): Promise<ToolkitToolI
 
 export function clearToolkitCache(): void {
   toolkitCache.clear();
-  rawToolkitCache = null;
+  rawToolkitCache.clear();
   toolsCache.clear();
 }

--- a/app/lib/composio/composio-tools.ts
+++ b/app/lib/composio/composio-tools.ts
@@ -11,6 +11,7 @@ import {
   searchGatewayTools,
 } from './composio-gateway';
 import type { AgentTool } from '@earendil-works/pi-agent-core';
+import type { EnvStorageScope } from '../integrations/env-config';
 
 const COMPOSIO_TOOL_DESCRIPTIONS = {
   SEARCH_TOOLS: 'Search for available tools across connected external apps (GitHub, Gmail, Slack, etc.). Returns tool name, description, and toolkit. Use this to discover which actions are available before executing. Always search before executing — don\'t guess action names.',
@@ -48,7 +49,7 @@ function textResult(text: string) {
   return { content: [{ type: 'text' as const, text }], details: {} };
 }
 
-export function createComposioSearchToolsTool(): AgentTool {
+export function createComposioSearchToolsTool(storageScope?: EnvStorageScope | null): AgentTool {
   return {
     name: 'COMPOSIO_SEARCH_TOOLS',
     label: 'Search External Tools',
@@ -59,7 +60,7 @@ export function createComposioSearchToolsTool(): AgentTool {
         const p = params as { query: string; toolkits?: string[] };
         const query = String(p.query || '');
         const toolkits = Array.isArray(p.toolkits) ? p.toolkits : undefined;
-        return textResult(JSON.stringify(await searchGatewayTools(query, toolkits)));
+        return textResult(JSON.stringify(await searchGatewayTools(query, toolkits, storageScope)));
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error searching tools';
         return textResult(JSON.stringify({ error: message }));
@@ -68,7 +69,7 @@ export function createComposioSearchToolsTool(): AgentTool {
   };
 }
 
-export function createComposioGetToolSchemasTool(): AgentTool {
+export function createComposioGetToolSchemasTool(storageScope?: EnvStorageScope | null): AgentTool {
   return {
     name: 'COMPOSIO_GET_TOOL_SCHEMAS',
     label: 'Get External Tool Schemas',
@@ -78,7 +79,7 @@ export function createComposioGetToolSchemasTool(): AgentTool {
       try {
         const p = params as { tools: string[] };
         const tools = Array.isArray(p.tools) ? p.tools : [];
-        return textResult(truncateResult(await getGatewayToolSchemas(tools)));
+        return textResult(truncateResult(await getGatewayToolSchemas(tools, storageScope)));
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error getting tool schemas';
         return textResult(JSON.stringify({ error: message }));
@@ -87,7 +88,7 @@ export function createComposioGetToolSchemasTool(): AgentTool {
   };
 }
 
-export function createComposioExecuteTool(): AgentTool {
+export function createComposioExecuteTool(storageScope?: EnvStorageScope | null): AgentTool {
   return {
     name: 'composio_execute',
     label: 'Execute External Tool',
@@ -99,7 +100,7 @@ export function createComposioExecuteTool(): AgentTool {
       const toolParams = (p.params && typeof p.params === 'object') ? p.params as Record<string, unknown> : {};
       const toolkitName = action.split('_')[0]?.toLowerCase() ?? '';
       try {
-        const result = await executeGatewayTool(action, toolParams);
+        const result = await executeGatewayTool(action, toolParams, storageScope);
 
         return textResult(truncateResult(result));
       } catch (error: unknown) {
@@ -107,7 +108,7 @@ export function createComposioExecuteTool(): AgentTool {
         if (err?.statusCode === 401 || err?.code === 'NOT_CONNECTED' || err?.message?.includes('not connected') || err?.message?.includes('not authenticated')) {
           let redirectUrl = '';
           try {
-            redirectUrl = await getGatewayAuthRedirect(toolkitName);
+            redirectUrl = await getGatewayAuthRedirect(toolkitName, storageScope);
           } catch {
             redirectUrl = '';
           }
@@ -129,7 +130,7 @@ export function createComposioExecuteTool(): AgentTool {
   };
 }
 
-export function createComposioManageConnectionsTool(): AgentTool {
+export function createComposioManageConnectionsTool(storageScope?: EnvStorageScope | null): AgentTool {
   return {
     name: 'COMPOSIO_MANAGE_CONNECTIONS',
     label: 'Manage App Connections',
@@ -143,7 +144,7 @@ export function createComposioManageConnectionsTool(): AgentTool {
 
         switch (action) {
           case 'connect': {
-            const connectionRequest = await connectGatewayToolkit(toolkit);
+            const connectionRequest = await connectGatewayToolkit(toolkit, storageScope);
             return textResult(JSON.stringify({
               redirect_url: connectionRequest.redirectUrl,
               message: `Open this URL to connect ${toolkit}. After connecting, return to the chat.`,
@@ -151,12 +152,12 @@ export function createComposioManageConnectionsTool(): AgentTool {
           }
 
           case 'disconnect': {
-            await disconnectGatewayToolkit(toolkit);
+            await disconnectGatewayToolkit(toolkit, storageScope);
             return textResult(JSON.stringify({ success: true, message: `${toolkit} disconnected successfully.` }));
           }
 
           case 'status': {
-            const account = await refreshGatewayToolkit(toolkit);
+            const account = await refreshGatewayToolkit(toolkit, storageScope);
             if (account.status && account.status !== 'NOT_CONNECTED') {
               return textResult(JSON.stringify({
                 connected: true,
@@ -179,11 +180,11 @@ export function createComposioManageConnectionsTool(): AgentTool {
   };
 }
 
-export function createComposioTools(): AgentTool[] {
+export function createComposioTools(storageScope?: EnvStorageScope | null): AgentTool[] {
   return [
-    createComposioSearchToolsTool(),
-    createComposioGetToolSchemasTool(),
-    createComposioExecuteTool(),
-    createComposioManageConnectionsTool(),
+    createComposioSearchToolsTool(storageScope),
+    createComposioGetToolSchemasTool(storageScope),
+    createComposioExecuteTool(storageScope),
+    createComposioManageConnectionsTool(storageScope),
   ];
 }

--- a/app/lib/email/local-service.ts
+++ b/app/lib/email/local-service.ts
@@ -61,7 +61,7 @@ import {
   type EmailFolder,
 } from '@/app/lib/email/imap-service';
 import { readScopedEnvState } from '@/app/lib/integrations/env-config';
-import { resolveSecretsDir } from '@/app/lib/runtime-data-paths';
+import { resolveSecretsDir, resolveUserSecretsDir } from '@/app/lib/runtime-data-paths';
 import { normalizePublicOrigin } from '@/app/lib/utils/request-origin';
 
 export type EmailProvider = 'google' | 'microsoft';
@@ -197,16 +197,24 @@ function normalizeProvider(value: string | undefined): EmailProvider {
   throw new Error(`Unsupported email provider: ${value}`);
 }
 
-function emailRoot(): string {
+function legacyEmailRoot(): string {
   return path.join(resolveSecretsDir(), 'email-oauth');
 }
 
 function accountsPath(): string {
-  return path.join(emailRoot(), 'accounts.json');
+  return path.join(legacyEmailRoot(), 'accounts.json');
 }
 
-function statePath(state: string): string {
-  return path.join(emailRoot(), '.state', `${state.replace(/[^A-Za-z0-9_.-]/g, '_')}.json`);
+function legacyStatePath(state: string): string {
+  return path.join(legacyEmailRoot(), '.state', `${state.replace(/[^A-Za-z0-9_.-]/g, '_')}.json`);
+}
+
+function userEmailRoot(userId: string): string {
+  return path.join(resolveUserSecretsDir(userId), 'email-oauth');
+}
+
+function statePath(userId: string, state: string): string {
+  return path.join(userEmailRoot(userId), '.state', `${state.replace(/[^A-Za-z0-9_.-]/g, '_')}.json`);
 }
 
 async function ensurePrivateDir(dirPath: string): Promise<void> {
@@ -250,7 +258,7 @@ async function singleWorkspaceUserId(): Promise<string | null> {
 
 async function backupOrRemoveLegacyAccountsFile(): Promise<void> {
   const legacyPath = accountsPath();
-  const backupPath = path.join(emailRoot(), 'accounts.legacy.json');
+  const backupPath = path.join(legacyEmailRoot(), 'accounts.legacy.json');
   try {
     await fs.access(backupPath);
     await fs.rm(legacyPath, { force: true });
@@ -297,13 +305,19 @@ async function migrateLegacyEmailAccountsIfSafe(userId: string): Promise<void> {
   legacyMigrationCheckedForUser.add(userId);
 }
 
-async function integrationEnvMap(): Promise<Map<string, string>> {
-  const state = await readScopedEnvState('integrations');
-  return new Map(state.entries.map((entry) => [entry.key, entry.value]));
+async function integrationEnvMap(userId?: string | null): Promise<Map<string, string>> {
+  const legacyState = await readScopedEnvState('integrations', { secretScope: 'legacy' }).catch(() => ({ entries: [] }));
+  const scopedState = userId?.trim()
+    ? await readScopedEnvState('integrations', { userId }).catch(() => ({ entries: [] }))
+    : { entries: [] };
+  return new Map([
+    ...legacyState.entries.map((entry) => [entry.key, entry.value] as const),
+    ...scopedState.entries.map((entry) => [entry.key, entry.value] as const),
+  ]);
 }
 
-async function getOAuthConfig(provider: EmailProvider): Promise<OAuthConfig | null> {
-  const env = await integrationEnvMap();
+async function getOAuthConfig(provider: EmailProvider, userId?: string | null): Promise<OAuthConfig | null> {
+  const env = await integrationEnvMap(userId);
   if (provider === 'google') {
     const clientId = env.get('GOOGLE_OAUTH_CLIENT_ID')?.trim();
     const clientSecret = env.get('GOOGLE_OAUTH_CLIENT_SECRET')?.trim();
@@ -330,9 +344,9 @@ async function getOAuthConfig(provider: EmailProvider): Promise<OAuthConfig | nu
   };
 }
 
-export async function hasLocalEmailOAuthCredentials(provider?: string): Promise<boolean> {
-  if (provider) return Boolean(await getOAuthConfig(normalizeProvider(provider)));
-  const [google, microsoft] = await Promise.all([getOAuthConfig('google'), getOAuthConfig('microsoft')]);
+export async function hasLocalEmailOAuthCredentials(provider?: string, userId?: string | null): Promise<boolean> {
+  if (provider) return Boolean(await getOAuthConfig(normalizeProvider(provider), userId));
+  const [google, microsoft] = await Promise.all([getOAuthConfig('google', userId), getOAuthConfig('microsoft', userId)]);
   return Boolean(google || microsoft);
 }
 
@@ -350,8 +364,8 @@ export function getLocalEmailOAuthRedirectUri(requestOrigin?: string | null): st
   return `${getOrigin(requestOrigin)}/api/email/oauth/callback`;
 }
 
-export async function getLocalEmailOAuthStatus(requestOrigin?: string | null) {
-  const [google, microsoft] = await Promise.all([getOAuthConfig('google'), getOAuthConfig('microsoft')]);
+export async function getLocalEmailOAuthStatus(requestOrigin?: string | null, userId?: string | null) {
+  const [google, microsoft] = await Promise.all([getOAuthConfig('google', userId), getOAuthConfig('microsoft', userId)]);
   return {
     mode: 'local' as const,
     redirectUri: getLocalEmailOAuthRedirectUri(requestOrigin),
@@ -369,7 +383,7 @@ export async function startLocalEmailOAuth(params: {
   returnUrl?: string;
 }) {
   const provider = normalizeProvider(params.provider);
-  const config = await getOAuthConfig(provider);
+  const config = await getOAuthConfig(provider, params.userId);
   if (!config) {
     throw new Error(`${provider === 'google' ? 'Google' : 'Microsoft'} OAuth Client ID and Client Secret are required before connecting.`);
   }
@@ -380,7 +394,7 @@ export async function startLocalEmailOAuth(params: {
   const redirectUri = getLocalEmailOAuthRedirectUri(params.requestOrigin);
   const expiresAt = new Date(Date.now() + 10 * 60_000).toISOString();
 
-  await writeJsonPrivate(statePath(state), {
+  await writeJsonPrivate(statePath(params.userId, state), {
     state,
     userId: params.userId,
     provider,
@@ -444,14 +458,16 @@ async function microsoftProfile(accessToken: string) {
 }
 
 export async function completeLocalEmailOAuth(userId: string, code: string, state: string) {
-  const stored = await readJsonIfExists<OAuthState>(statePath(state));
+  const userStatePath = statePath(userId, state);
+  const stored = await readJsonIfExists<OAuthState>(userStatePath)
+    || await readJsonIfExists<OAuthState>(legacyStatePath(state));
   if (!stored || stored.state !== state || Date.parse(stored.expiresAt) <= Date.now()) {
     throw new Error('Invalid or expired email OAuth state.');
   }
   if (stored.userId !== userId) {
     throw new Error('Email OAuth state does not belong to the current user.');
   }
-  const config = await getOAuthConfig(stored.provider);
+  const config = await getOAuthConfig(stored.provider, userId);
   if (!config) throw new Error('Email OAuth credentials are no longer configured.');
   const params = new URLSearchParams();
   params.set('grant_type', 'authorization_code');
@@ -476,7 +492,8 @@ export async function completeLocalEmailOAuth(userId: string, code: string, stat
       expiresAt: token.expires_in ? new Date(Date.now() + token.expires_in * 1000).toISOString() : undefined,
     },
   });
-  await fs.rm(statePath(state), { force: true }).catch(() => undefined);
+  await fs.rm(userStatePath, { force: true }).catch(() => undefined);
+  await fs.rm(legacyStatePath(state), { force: true }).catch(() => undefined);
   return { account: await publicLocalEmailAccount(account), returnUrl: stored.returnUrl };
 }
 
@@ -503,7 +520,7 @@ async function validAccessToken(account: StoredEmailAccount): Promise<string> {
     await setStoredEmailAccountStatus(account, 'expired');
     throw new Error('Email account authorization expired. Reconnect the account.');
   }
-  const config = await getOAuthConfig(account.provider as EmailProvider);
+  const config = await getOAuthConfig(account.provider as EmailProvider, account.userId);
   if (!config) throw new Error('Email OAuth credentials are no longer configured.');
   const params = new URLSearchParams();
   params.set('grant_type', 'refresh_token');

--- a/app/lib/email/local-service.ts
+++ b/app/lib/email/local-service.ts
@@ -206,7 +206,7 @@ function accountsPath(): string {
 }
 
 function legacyStatePath(state: string): string {
-  return path.join(legacyEmailRoot(), '.state', `${state.replace(/[^A-Za-z0-9_.-]/g, '_')}.json`);
+  return path.join(legacyEmailRoot(), '.state', oauthStateFileName(state));
 }
 
 function userEmailRoot(userId: string): string {
@@ -214,7 +214,11 @@ function userEmailRoot(userId: string): string {
 }
 
 function statePath(userId: string, state: string): string {
-  return path.join(userEmailRoot(userId), '.state', `${state.replace(/[^A-Za-z0-9_.-]/g, '_')}.json`);
+  return path.join(userEmailRoot(userId), '.state', oauthStateFileName(state));
+}
+
+function oauthStateFileName(state: string): string {
+  return `${crypto.createHash('sha256').update(state).digest('hex')}.json`;
 }
 
 async function ensurePrivateDir(dirPath: string): Promise<void> {

--- a/app/lib/email/secret-store.ts
+++ b/app/lib/email/secret-store.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { promises as fs } from 'fs';
 
 import { readScopedEnvState, replaceScopedEnvEntries } from '@/app/lib/integrations/env-config';
-import { resolveSecretsDir } from '@/app/lib/runtime-data-paths';
+import { resolveSecretsDir, resolveUserSecretsDir } from '@/app/lib/runtime-data-paths';
 
 const ENCRYPTED_PREFIX = 'enc:v1';
 const FALLBACK_KEY = 'EMAIL_ACCOUNT_SECRET_ENCRYPTION_KEY';
@@ -43,7 +43,7 @@ function safePathSegment(value: string): string {
   return value.replace(/[^A-Za-z0-9_.-]/g, '_');
 }
 
-function secretRoot(): string {
+function legacySecretRoot(): string {
   return path.join(resolveSecretsDir(), 'email-accounts');
 }
 
@@ -51,9 +51,33 @@ export function emailAccountSecretRef(userId: string, accountId: string): string
   return `${safePathSegment(userId)}/${safePathSegment(accountId)}.json.enc`;
 }
 
+function secretRefSegments(secretRef: string): string[] {
+  return secretRef.split('/').map(safePathSegment).filter(Boolean);
+}
+
+function userIdFromSecretRef(secretRef: string): string | null {
+  const [userId] = secretRefSegments(secretRef);
+  return userId || null;
+}
+
+function scopedSecretRoot(secretRef: string): string {
+  const userId = userIdFromSecretRef(secretRef);
+  return userId
+    ? path.join(resolveUserSecretsDir(userId), 'email-accounts')
+    : legacySecretRoot();
+}
+
 function secretPath(secretRef: string): string {
   const normalized = secretRef.split('/').map(safePathSegment).join('/');
-  return path.join(secretRoot(), normalized);
+  const userId = userIdFromSecretRef(secretRef);
+  if (!userId) return path.join(legacySecretRoot(), normalized);
+  const [, ...rest] = secretRefSegments(secretRef);
+  return path.join(scopedSecretRoot(secretRef), rest.join('/') || `${safePathSegment(secretRef)}.json.enc`);
+}
+
+function legacySecretPath(secretRef: string): string {
+  const normalized = secretRef.split('/').map(safePathSegment).join('/');
+  return path.join(legacySecretRoot(), normalized);
 }
 
 async function ensurePrivateDir(dirPath: string): Promise<void> {
@@ -65,13 +89,15 @@ function deriveEncryptionKey(secret: string): Buffer {
   return crypto.createHash('sha256').update(secret).digest();
 }
 
-async function getMasterSecret(): Promise<string> {
+async function readMasterSecretFromScope(userId: string | null, createIfMissing: boolean): Promise<string | null> {
   const configured = process.env.INTEGRATIONS_ENV_MASTER_KEY?.trim();
   if (configured) return configured;
 
-  const state = await readScopedEnvState('integrations');
+  const storageScope = userId ? { userId } : { secretScope: 'legacy' as const };
+  const state = await readScopedEnvState('integrations', storageScope);
   const existing = state.entries.find((entry) => entry.key === FALLBACK_KEY)?.value.trim();
   if (existing && !existing.startsWith(`${ENCRYPTED_PREFIX}:`)) return existing;
+  if (!createIfMissing) return null;
 
   const generated = crypto.randomBytes(32).toString('base64url');
   await replaceScopedEnvEntries('integrations', [
@@ -79,12 +105,17 @@ async function getMasterSecret(): Promise<string> {
       .filter((entry) => entry.key !== FALLBACK_KEY)
       .map((entry) => ({ key: entry.key, value: entry.value })),
     { key: FALLBACK_KEY, value: generated },
-  ]);
+  ], storageScope);
   return generated;
 }
 
-async function encryptPayload(payload: EmailAccountSecret): Promise<string> {
-  const secret = await getMasterSecret();
+async function getMasterSecretForRef(secretRef: string): Promise<string> {
+  const userId = userIdFromSecretRef(secretRef);
+  return await readMasterSecretFromScope(userId, true) || await readMasterSecretFromScope(null, true) || crypto.randomBytes(32).toString('base64url');
+}
+
+async function encryptPayload(secretRef: string, payload: EmailAccountSecret): Promise<string> {
+  const secret = await getMasterSecretForRef(secretRef);
   const iv = crypto.randomBytes(12);
   const key = deriveEncryptionKey(secret);
   const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
@@ -93,17 +124,12 @@ async function encryptPayload(payload: EmailAccountSecret): Promise<string> {
   return `${ENCRYPTED_PREFIX}:${iv.toString('hex')}:${tag.toString('hex')}:${encrypted.toString('hex')}`;
 }
 
-async function decryptPayload(value: string): Promise<EmailAccountSecret> {
-  if (!value.startsWith(`${ENCRYPTED_PREFIX}:`)) {
-    return JSON.parse(value) as EmailAccountSecret;
-  }
-
+function decryptPayloadWithSecret(value: string, secret: string): EmailAccountSecret {
   const parts = value.split(':');
   if (parts.length !== 5) throw new Error('Invalid email account secret format.');
   const [, version, ivHex, tagHex, encryptedHex] = parts;
   if (version !== 'v1') throw new Error(`Unsupported email account secret version: ${version}`);
 
-  const secret = await getMasterSecret();
   const key = deriveEncryptionKey(secret);
   const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(ivHex, 'hex'));
   decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
@@ -114,20 +140,50 @@ async function decryptPayload(value: string): Promise<EmailAccountSecret> {
   return JSON.parse(plain.toString('utf8')) as EmailAccountSecret;
 }
 
+async function decryptPayload(secretRef: string, value: string): Promise<EmailAccountSecret> {
+  if (!value.startsWith(`${ENCRYPTED_PREFIX}:`)) {
+    return JSON.parse(value) as EmailAccountSecret;
+  }
+
+  const userId = userIdFromSecretRef(secretRef);
+  const candidates = [
+    await readMasterSecretFromScope(userId, false),
+    await readMasterSecretFromScope(null, false),
+  ].filter((entry): entry is string => Boolean(entry));
+
+  let lastError: unknown = null;
+  for (const secret of candidates) {
+    try {
+      return decryptPayloadWithSecret(value, secret);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('Unable to decrypt email account secret.');
+}
+
 export async function writeEmailAccountSecret(secretRef: string, payload: EmailAccountSecret): Promise<void> {
   const filePath = secretPath(secretRef);
   await ensurePrivateDir(path.dirname(filePath));
   const tmpPath = `${filePath}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  await fs.writeFile(tmpPath, await encryptPayload(payload), { encoding: 'utf8', mode: 0o600 });
+  await fs.writeFile(tmpPath, await encryptPayload(secretRef, payload), { encoding: 'utf8', mode: 0o600 });
   await fs.chmod(tmpPath, 0o600).catch(() => undefined);
   await fs.rename(tmpPath, filePath);
   await fs.chmod(filePath, 0o600).catch(() => undefined);
 }
 
 export async function readEmailAccountSecret(secretRef: string): Promise<EmailAccountSecret> {
-  return decryptPayload(await fs.readFile(secretPath(secretRef), 'utf8'));
+  const primaryPath = secretPath(secretRef);
+  const legacyPath = legacySecretPath(secretRef);
+  try {
+    return await decryptPayload(secretRef, await fs.readFile(primaryPath, 'utf8'));
+  } catch (error) {
+    if (primaryPath === legacyPath) throw error;
+    return decryptPayload(secretRef, await fs.readFile(legacyPath, 'utf8'));
+  }
 }
 
 export async function deleteEmailAccountSecret(secretRef: string): Promise<void> {
   await fs.rm(secretPath(secretRef), { force: true }).catch(() => undefined);
+  await fs.rm(legacySecretPath(secretRef), { force: true }).catch(() => undefined);
 }

--- a/app/lib/email/secret-store.ts
+++ b/app/lib/email/secret-store.ts
@@ -111,7 +111,9 @@ async function readMasterSecretFromScope(userId: string | null, createIfMissing:
 
 async function getMasterSecretForRef(secretRef: string): Promise<string> {
   const userId = userIdFromSecretRef(secretRef);
-  return await readMasterSecretFromScope(userId, true) || await readMasterSecretFromScope(null, true) || crypto.randomBytes(32).toString('base64url');
+  const secret = await readMasterSecretFromScope(userId, true);
+  if (!secret) throw new Error('Unable to initialize email account secret encryption key.');
+  return secret;
 }
 
 async function encryptPayload(secretRef: string, payload: EmailAccountSecret): Promise<string> {
@@ -146,10 +148,12 @@ async function decryptPayload(secretRef: string, value: string): Promise<EmailAc
   }
 
   const userId = userIdFromSecretRef(secretRef);
-  const candidates = [
-    await readMasterSecretFromScope(userId, false),
-    await readMasterSecretFromScope(null, false),
-  ].filter((entry): entry is string => Boolean(entry));
+  const candidates = (
+    await Promise.all([
+      readMasterSecretFromScope(userId, false),
+      readMasterSecretFromScope(null, false),
+    ])
+  ).filter((entry): entry is string => Boolean(entry));
 
   let lastError: unknown = null;
   for (const secret of candidates) {
@@ -176,9 +180,10 @@ export async function readEmailAccountSecret(secretRef: string): Promise<EmailAc
   const primaryPath = secretPath(secretRef);
   const legacyPath = legacySecretPath(secretRef);
   try {
-    return await decryptPayload(secretRef, await fs.readFile(primaryPath, 'utf8'));
+    const primaryValue = await fs.readFile(primaryPath, 'utf8');
+    return await decryptPayload(secretRef, primaryValue);
   } catch (error) {
-    if (primaryPath === legacyPath) throw error;
+    if (primaryPath === legacyPath || (error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
     return decryptPayload(secretRef, await fs.readFile(legacyPath, 'utf8'));
   }
 }

--- a/app/lib/email/service.ts
+++ b/app/lib/email/service.ts
@@ -233,6 +233,7 @@ export async function startEmailOAuth(userId: string, params: {
 }
 
 export async function getEmailOAuthStatus(params: {
+  userId?: string | null;
   requestOrigin?: string | null;
 }): Promise<EmailOAuthStatusResponse> {
   if (isManagedEmailAvailable()) {
@@ -246,7 +247,7 @@ export async function getEmailOAuthStatus(params: {
       managedAvailable: true,
     };
   }
-  return getLocalEmailOAuthStatus(params.requestOrigin);
+  return getLocalEmailOAuthStatus(params.requestOrigin, params.userId);
 }
 
 export async function listEmailAccounts(userId: string) {

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -3282,8 +3282,9 @@ export async function buildPiToolRegistryAsync(userId?: string, agentId?: string
   const userScopedTools = createUserScopedTools(userId, agentId, sessionId);
   const overriddenNames = new Set(userScopedTools.map((t) => t.name));
   const coreTools = piTools.filter((t) => !overriddenNames.has(t.name));
-  const composioConfigured = await isComposioConfigured();
-  const composioTools = composioConfigured ? createComposioTools() : [];
+  const composioStorageScope = userId ? { userId } : undefined;
+  const composioConfigured = await isComposioConfigured(composioStorageScope);
+  const composioTools = composioConfigured ? createComposioTools(composioStorageScope) : [];
   const directMcpTools = await buildDirectMcpTools().then((result) => result.tools).catch((error) => {
     console.error('[ToolRegistry] Error building direct MCP tools:', error);
     return [];

--- a/app/lib/plugins/canvas-plugin-store.ts
+++ b/app/lib/plugins/canvas-plugin-store.ts
@@ -844,7 +844,8 @@ export async function preflightCanvasPluginFromStore(
 
   const composioConnectors = normalizeComposioConnectors(plugin.connectors);
   if (composioConnectors.length > 0) {
-    const status = await getGatewayStatus().catch(() => ({
+    const composioScope = scope?.userId ? { userId: scope.userId } : undefined;
+    const status = await getGatewayStatus(composioScope).catch(() => ({
       configured: false,
       apiKeyValid: false,
       connectedAccounts: [],
@@ -856,7 +857,7 @@ export async function preflightCanvasPluginFromStore(
     );
     let toolkitBySlug = new Map<string, { name?: string; logo?: string }>();
     if (status.configured && status.apiKeyValid) {
-      const toolkitResult = await getGatewayToolkits().catch(() => ({ toolkits: [] }));
+      const toolkitResult = await getGatewayToolkits(composioScope).catch(() => ({ toolkits: [] }));
       if (Array.isArray(toolkitResult.toolkits)) {
         toolkitBySlug = new Map(
           toolkitResult.toolkits

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -300,11 +300,28 @@
     {
       "id": 19,
       "title": "Composio-Management, E-Mail-OAuth, Notifications und Channels auf User-/Organization-Scope migrieren",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/08-user-scoped-secrets-runtime.md",
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/composio/composio-identity.ts",
+        "app/lib/composio/composio-client.ts",
+        "app/lib/composio/composio-session.ts",
+        "app/lib/composio/composio-auth.ts",
+        "app/lib/composio/composio-gateway.ts",
+        "app/lib/composio/composio-tools.ts",
+        "app/api/composio/*",
+        "app/lib/email/secret-store.ts",
+        "app/lib/email/local-service.ts",
+        "app/api/email/oauth/status/route.ts",
+        "app/lib/agents/capability-options.ts",
+        "app/api/agents/connection-options/route.ts",
+        "app/lib/plugins/canvas-plugin-store.ts",
+        "scripts/composio-user-scope-test.ts",
+        "scripts/email-accounts-service-test.ts"
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:email:mime": "tsx scripts/email-mime-header-test.ts",
     "test:email:attachments": "tsx scripts/email-attachments-test.ts",
     "test:email:accounts": "tsx scripts/email-accounts-service-test.ts",
+    "test:composio:user-scope": "tsx scripts/composio-user-scope-test.ts",
     "test:auth:setup": "tsx --conditions react-server scripts/auth-setup-test.ts",
     "test:organization:permissions": "tsx --conditions react-server scripts/organization-permission-guards-test.ts",
     "test:license": "tsx --conditions react-server scripts/license-security-test.ts",

--- a/scripts/composio-user-scope-test.ts
+++ b/scripts/composio-user-scope-test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Module from 'node:module';
+
+const moduleInternals = Module as typeof Module & {
+  _load: (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+};
+const originalLoad = moduleInternals._load;
+moduleInternals._load = (request, parent, isMain) => {
+  if (request === 'server-only') return {};
+  if (request === '@composio/core') {
+    return {
+      Composio: class {
+        connectedAccounts = { list: async () => ({ items: [] }) };
+      },
+    };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+async function main() {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-composio-scope-'));
+  process.env.DATA = tmpRoot;
+  process.env.CANVAS_DATA_ROOT = tmpRoot;
+  process.env.CANVAS_MANAGED_SERVICES_ENABLED = 'true';
+  process.env.CANVAS_CONTROL_PLANE_URL = 'https://control.example.test';
+  process.env.CANVAS_INSTANCE_TOKEN = 'instance-token';
+  process.env.CANVAS_INSTANCE_ID = 'vm-123';
+
+  const { getLocalComposioApiKey } = await import('../app/lib/composio/composio-client');
+  const { getComposioUserId, resetComposioUserIdCache } = await import('../app/lib/composio/composio-identity');
+  const { readScopedEnvState, replaceScopedEnvEntries } = await import('../app/lib/integrations/env-config');
+
+  await replaceScopedEnvEntries('integrations', [
+    { key: 'COMPOSIO_API_KEY', value: 'legacy-key' },
+  ], { secretScope: 'legacy' });
+  await replaceScopedEnvEntries('integrations', [
+    { key: 'COMPOSIO_API_KEY', value: 'user-a-key' },
+  ], { userId: 'user-a' });
+
+  assert.equal(await getLocalComposioApiKey({ userId: 'user-a' }), 'user-a-key');
+  assert.equal(await getLocalComposioApiKey({ userId: 'user-b' }), 'legacy-key');
+
+  const userAComposioId = await getComposioUserId({ userId: 'user-a' });
+  const userBComposioId = await getComposioUserId({ userId: 'user-b' });
+  assert.match(userAComposioId, /^canvas-notebook-vm-123-user-/u);
+  assert.match(userBComposioId, /^canvas-notebook-vm-123-user-/u);
+  assert.notEqual(userAComposioId, userBComposioId);
+
+  resetComposioUserIdCache();
+  await replaceScopedEnvEntries('integrations', [
+    { key: 'COMPOSIO_API_KEY', value: 'user-a-key' },
+    { key: 'COMPOSIO_USER_ID', value: 'explicit-user-a' },
+  ], { userId: 'user-a' });
+  assert.equal(await getComposioUserId({ userId: 'user-a' }), 'explicit-user-a');
+
+  const userBEnv = await readScopedEnvState('integrations', { userId: 'user-b' });
+  assert.equal(
+    userBEnv.entries.find((entry) => entry.key === 'COMPOSIO_USER_ID')?.value,
+    userBComposioId,
+  );
+
+  console.log('composio-user-scope-test: ok');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/email-accounts-service-test.ts
+++ b/scripts/email-accounts-service-test.ts
@@ -81,7 +81,7 @@ async function main() {
   secretsDir = path.join(tmpRoot, 'secrets');
   integrationsEnvPath = path.join(secretsDir, 'Canvas-Integrations.env');
   accountsPath = path.join(secretsDir, 'email-oauth', 'accounts.json');
-  stateDir = path.join(secretsDir, 'email-oauth', '.state');
+  stateDir = path.join(tmpRoot, 'users', 'owner-user', 'secrets', 'email-oauth', '.state');
 
   process.env.DATA = tmpRoot;
   process.env.CANVAS_DATA_ROOT = tmpRoot;
@@ -129,6 +129,8 @@ async function main() {
   const otherAccounts = await listEmailAccounts('other-user');
   assert.deepEqual(ownerAccounts.accounts.map((account) => (account as { emailAddress: string }).emailAddress), ['owner@example.test']);
   assert.deepEqual(otherAccounts.accounts.map((account) => (account as { emailAddress: string }).emailAddress), ['other@example.test']);
+  await fs.access(path.join(tmpRoot, 'users', 'owner-user', 'secrets', 'email-accounts', 'local_google_test.json.enc'));
+  await fs.access(path.join(tmpRoot, 'users', 'other-user', 'secrets', 'email-accounts', `${(otherAccounts.accounts[0] as { id: string }).id}.json.enc`));
   const otherPolicy = (otherAccounts.accounts[0] as { policy: { readFrom: string[]; sendTo: string[] } }).policy;
   assert.deepEqual(otherPolicy.readFrom, ['other@example.test']);
   assert.deepEqual(otherPolicy.sendTo, ['other@example.test']);
@@ -151,7 +153,7 @@ async function main() {
   const oauthStartUrl = new URL(oauthStart.authorizationUrl);
   assert.equal(oauthStartUrl.searchParams.get('redirect_uri'), 'https://canvas.example.com/api/email/oauth/callback');
   assert.ok((oauthStartUrl.searchParams.get('scope') || '').split(' ').includes('https://www.googleapis.com/auth/gmail.send'));
-  const oauthStatus = await getEmailOAuthStatus({ requestOrigin: 'https://canvas.example.com' });
+  const oauthStatus = await getEmailOAuthStatus({ userId: 'owner-user', requestOrigin: 'https://canvas.example.com' });
   assert.equal(oauthStatus.redirectUri, 'https://canvas.example.com/api/email/oauth/callback');
   assert.equal(oauthStatus.providers.google.configured, true);
   assert.equal(oauthStatus.providers.microsoft.configured, false);

--- a/scripts/email-accounts-service-test.ts
+++ b/scripts/email-accounts-service-test.ts
@@ -91,6 +91,7 @@ async function main() {
 
   const { createEmailDraft, disconnectEmailAccount, getEmailOAuthStatus, listEmailAccounts, listEmailFolders, listEmailMessages, readEmailMessage, saveEmailSmtpAccount, searchEmail, sendEmailDraft, sendEmailMessage, setEmailMainAccount, startEmailOAuth, testEmailAccount, testEmailSmtpConnection } = await import('../app/lib/email/service');
   const { upsertOAuthEmailAccount } = await import('../app/lib/email/account-store');
+  const { emailAccountSecretRef, readEmailAccountSecret, writeEmailAccountSecret } = await import('../app/lib/email/secret-store');
   const { setSmtpTransportFactoryForTests } = await import('../app/lib/email/smtp-service');
   const { setImapClientFactoryForTests } = await import('../app/lib/email/imap-service');
 
@@ -135,6 +136,27 @@ async function main() {
   assert.deepEqual(otherPolicy.readFrom, ['other@example.test']);
   assert.deepEqual(otherPolicy.sendTo, ['other@example.test']);
   await assert.rejects(() => disconnectEmailAccount('other-user', 'local_google_test'), /not found/i);
+
+  const fallbackSecretRef = emailAccountSecretRef('owner-user', 'fallback-test');
+  const fallbackPrimaryPath = path.join(tmpRoot, 'users', 'owner-user', 'secrets', 'email-accounts', 'fallback-test.json.enc');
+  const fallbackLegacyPath = path.join(secretsDir, 'email-accounts', 'owner-user', 'fallback-test.json.enc');
+  await writeEmailAccountSecret(fallbackSecretRef, {
+    authType: 'oauth',
+    tokenType: 'Bearer',
+    accessToken: 'primary-access',
+  });
+  await fs.mkdir(path.dirname(fallbackLegacyPath), { recursive: true });
+  await fs.writeFile(fallbackLegacyPath, JSON.stringify({
+    authType: 'oauth',
+    tokenType: 'Bearer',
+    accessToken: 'legacy-access',
+  }), 'utf8');
+  await fs.writeFile(fallbackPrimaryPath, 'enc:v1:broken', 'utf8');
+  await assert.rejects(() => readEmailAccountSecret(fallbackSecretRef), /Invalid email account secret format|Unable to decrypt|Unsupported email account secret|auth/i);
+  await fs.rm(fallbackPrimaryPath, { force: true });
+  const legacyFallbackSecret = await readEmailAccountSecret(fallbackSecretRef);
+  assert.equal(legacyFallbackSecret.authType, 'oauth');
+  assert.equal(legacyFallbackSecret.accessToken, 'legacy-access');
 
   await disconnectEmailAccount('owner-user', 'local_google_test');
   const ownerAfterDisconnect = await listEmailAccounts('owner-user');


### PR DESCRIPTION
## Summary
- scope Composio identity, route access, gateway/tool execution, plugin preflight, and agent connection options by Better Auth user
- move local email OAuth state and account secrets under user-scoped secret paths with legacy fallback
- mark Task 19 completed and add user-scope coverage for Composio and email credentials

## Verification
- npm run test:composio:user-scope
- npm run test:email:accounts
- npm run test:integrations:env-scope
- npm run test:pi:tools
- npm run test:automation:webhook
- npm run test:channels
- npm run test:plugins:runtime
- npm run test:automation:delivery
- npm run test:agents:runtime
- npm run lint
- npm run build

Greptile score: 5/5 on c9c15245.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes Composio identity, route access, gateway/tool execution, plugin preflight, and agent connection options by the authenticated BetterAuth user, and moves local email OAuth state and account secrets under user-specific paths with legacy fallback.

- All Composio module-level singletons (`triggerAppCache`, `composioInstance/cachedApiKey`, `cachedUserId`, `rawToolkitCache`) are converted to `Map` structures keyed by resolved scope, so concurrent requests from different users no longer evict each other's entries.
- Every API route in the Composio and email OAuth surface now requires a valid session and forwards `{ userId: session.user.id }` as `storageScope`; email secret encryption is key-separated per user with a candidate-list fallback that allows migration from the global key without data loss.
- New integration tests (`composio-user-scope-test.ts`, extended `email-accounts-service-test.ts`) verify per-user API key resolution, distinct Composio user IDs, and the ENOENT-only legacy secret fallback.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no correctness bugs found in the scoping logic, fallback paths, or encryption key resolution.

All previously flagged cross-user cache contamination issues are addressed. The email secret-store now propagates non-ENOENT decryption errors correctly instead of silently falling back to legacy. The two remaining notes (duplicated `storageScopeCacheKey` helper and unbounded `composioInstances` Map) are quality concerns with no impact on correctness in realistic deployment sizes.

No files require special attention; `composio-client.ts` and the three files defining `storageScopeCacheKey` are worth a second look for the quality nits, but neither blocks merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/lib/composio/composio-client.ts | Replaces single-slot `composioInstance/cachedApiKey` with a `Map<string, Composio>` keyed by API key; adds legacy-scope fallback when a user-scoped key is absent. Map has no eviction strategy — rotated keys accumulate indefinitely. |
| app/lib/composio/composio-gateway.ts | Converts singleton `triggerAppCache` to a `Map` keyed by `storageScopeCacheKey`; adds `storageScope` parameter to all gateway functions; correctly threads scope through `managedRequest`. `storageScopeCacheKey` is duplicated from other modules. |
| app/lib/composio/composio-identity.ts | Per-user Composio userIds now stored in a `Map` keyed by scope; `stableScopeSuffix` ensures deterministic, unique Composio user IDs per BetterAuth user. `scopeCacheKey` is a duplicate of the same function in two other modules. |
| app/lib/composio/composio-toolkit-registry.ts | Converts `rawToolkitCache` singleton to a scoped Map; `getAvailableToolkits` cache key uses Composio userId (consistent with connected-account scoping), while raw/tools caches use storageScope key — minor inconsistency, not a correctness bug. |
| app/lib/email/secret-store.ts | Adds user-scoped secret paths; `readEmailAccountSecret` now falls back to legacy path only on ENOENT (fixing the previously flagged broad-catch issue); `decryptPayload` tries user-scoped and legacy master keys in order to support seamless migration. |
| app/lib/email/local-service.ts | OAuth state files moved to user-scoped paths using SHA256-hashed filenames; `integrationEnvMap` merges legacy + user-scoped env entries with user-scoped taking precedence; `completeLocalEmailOAuth` reads both new and legacy state paths during migration. |
| app/lib/composio/composio-auth.ts | All auth functions now accept optional `storageScope` and thread it through to `getComposio` and `getComposioUserId`. |
| app/lib/composio/composio-tools.ts | Tool factory functions now accept `storageScope` and pass it to all gateway calls; correct per-user scoping for search, execute, and connection-management tools. |
| app/api/composio/webhook/subscription/route.ts | Both GET and POST now require authentication and pass `{ userId }` storageScope; `ensureLocalWebhookSubscription` receives scope via the options object. |
| app/api/composio/trigger-apps/route.ts | Added auth guard and user-scoped `getGatewayTriggerApps` call; unauthenticated requests receive a safe empty response with 401. |
| app/lib/pi/tool-registry.ts | Composio tool registry now derives a per-user `composioStorageScope` from `userId` before checking if Composio is configured and creating tools. |
| app/lib/plugins/canvas-plugin-store.ts | Plugin preflight now derives `composioScope` from the existing `scope?.userId` before calling `getGatewayStatus` and `getGatewayToolkits`. |
| scripts/composio-user-scope-test.ts | New integration test verifying per-user API key resolution, distinct Composio userIds per BetterAuth user, and explicit-id override via env state. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/lib/composio/composio-gateway.ts`, line 27-30 ([link](https://github.com/canvascoding/canvas-notebook/blob/511b085d9efffefc1fb8e1f54ee4aea09fc02159/app/lib/composio/composio-gateway.ts#L27-L30)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unscoped `triggerAppCache` leaks trigger types across users**

   `triggerAppCache` is a module-level singleton with no scope key. Now that per-user API keys are supported, User A's call to `getGatewayTriggerApps` (with their API key / storageScope) will fill this cache, and User B's subsequent call will receive User A's trigger type list verbatim — even if B's API key has a different set of available trigger apps. The `status` overlay (connected accounts) is scoped correctly, but the base app list is not. The parallel fix already applied to `rawToolkitCache` in `composio-toolkit-registry.ts` (converted to `Map<string, …>` keyed by `storageScopeCacheKey`) should be applied identically here.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-scoped-composio-channels%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-scoped-composio-channels%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Fcomposio%2Fcomposio-gateway.ts%0ALine%3A%2027-30%0A%0AComment%3A%0A**Unscoped%20%60triggerAppCache%60%20leaks%20trigger%20types%20across%20users**%0A%0A%60triggerAppCache%60%20is%20a%20module-level%20singleton%20with%20no%20scope%20key.%20Now%20that%20per-user%20API%20keys%20are%20supported%2C%20User%20A's%20call%20to%20%60getGatewayTriggerApps%60%20%28with%20their%20API%20key%20%2F%20storageScope%29%20will%20fill%20this%20cache%2C%20and%20User%20B's%20subsequent%20call%20will%20receive%20User%20A's%20trigger%20type%20list%20verbatim%20%E2%80%94%20even%20if%20B's%20API%20key%20has%20a%20different%20set%20of%20available%20trigger%20apps.%20The%20%60status%60%20overlay%20%28connected%20accounts%29%20is%20scoped%20correctly%2C%20but%20the%20base%20app%20list%20is%20not.%20The%20parallel%20fix%20already%20applied%20to%20%60rawToolkitCache%60%20in%20%60composio-toolkit-registry.ts%60%20%28converted%20to%20%60Map%3Cstring%2C%20%E2%80%A6%3E%60%20keyed%20by%20%60storageScopeCacheKey%60%29%20should%20be%20applied%20identically%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=21&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-scoped-composio-channels%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-scoped-composio-channels%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Flib%2Fcomposio%2Fcomposio-gateway.ts%3A113-121%0A**%60storageScopeCacheKey%60%20duplicated%20across%20three%20files**%0A%0AAn%20identical%20function%20body%20is%20copy-pasted%20in%20%60composio-gateway.ts%60%2C%20%60composio-toolkit-registry.ts%60%2C%20and%20%60composio-identity.ts%60%20%28named%20%60scopeCacheKey%60%20there%29.%20If%20the%20key%20format%20ever%20needs%20changing%20%E2%80%94%20e.g.%2C%20to%20include%20a%20new%20%60organizationId%60%20field%20%E2%80%94%20all%20three%20definitions%20must%20be%20updated%20in%20sync%3B%20missing%20one%20would%20produce%20silent%20cache-key%20mismatches%20between%20modules.%20Consider%20exporting%20a%20single%20%60storageScopeCacheKey%60%20from%20%60composio-identity.ts%60%20%28which%20already%20imports%20%60EnvStorageScope%60%29%20and%20importing%20it%20in%20the%20other%20two%20files.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Flib%2Fcomposio%2Fcomposio-client.ts%3A4%0A**%60composioInstances%60%20Map%20grows%20without%20bound%20when%20API%20keys%20are%20rotated**%0A%0AThe%20Map%20is%20keyed%20by%20the%20raw%20API%20key%20string%20and%20never%20evicts%20entries.%20When%20a%20user%20rotates%20their%20Composio%20API%20key%20the%20old%20%60Composio%60%20instance%20stays%20in%20the%20Map%20permanently%20%28until%20process%20restart%29.%20In%20a%20long-running%20server%20with%20many%20users%20each%20rotating%20keys%20periodically%20this%20accumulates%20stale%20objects.%20A%20simple%20max-size%20LRU%20cap%20would%20keep%20the%20benefit%20of%20per-key%20caching%20without%20the%20leak.%20%60resetComposioInstance%28%29%60%20only%20helps%20if%20callers%20remember%20to%20invoke%20it%20after%20a%20key%20rotation.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=21&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Scope Composio trigger app cache"](https://github.com/canvascoding/canvas-notebook/commit/c9c15245c1551c929e41541f877b6ce16d2f96aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38819760)</sub>

<!-- /greptile_comment -->
