### PR TITLE
Add organization-scoped todos

### DIFF
--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -59,13 +59,17 @@ export async function GET(request: NextRequest, context: RouteContext) {
     return limited.response;
   }
 
-  const { id } = await context.params;
-  const todo = await getTodo(session.user.id, id);
-  if (!todo) {
-    return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
-  }
+  try {
+    const { id } = await context.params;
+    const todo = await getTodo(session.user.id, id);
+    if (!todo) {
+      return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
+    }
 
-  return NextResponse.json({ success: true, data: todo });
+    return NextResponse.json({ success: true, data: todo });
+  } catch (error) {
+    return todoErrorResponse(error, 'Failed to load todo.');
+  }
 }
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
@@ -130,20 +134,24 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
     return limited.response;
   }
 
-  const { id } = await context.params;
-  const existingTodo = await getTodo(session.user.id, id);
-  if (!existingTodo) {
-    return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
-  }
-  const permissionResponse = await requireTodoWriteWorkspace(session, existingTodo);
-  if (permissionResponse) {
-    return permissionResponse;
-  }
+  try {
+    const { id } = await context.params;
+    const existingTodo = await getTodo(session.user.id, id);
+    if (!existingTodo) {
+      return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
+    }
+    const permissionResponse = await requireTodoWriteWorkspace(session, existingTodo);
+    if (permissionResponse) {
+      return permissionResponse;
+    }
 
-  const todo = await archiveTodo(session.user.id, id);
-  if (!todo) {
-    return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
-  }
+    const todo = await archiveTodo(session.user.id, id);
+    if (!todo) {
+      return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
+    }
 
-  return NextResponse.json({ success: true, data: todo });
+    return NextResponse.json({ success: true, data: todo });
+  } catch (error) {
+    return todoErrorResponse(error, 'Failed to delete todo.');
+  }
 }

--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -73,6 +73,9 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       ...(payload?.priority !== undefined ? { priority: parsePriority(payload.priority) } : {}),
       ...(payload?.dueAt !== undefined ? { dueAt: parseOptionalDate(payload.dueAt) ?? null } : {}),
       ...(payload?.status !== undefined ? { status: parseStatus(payload.status) } : {}),
+      ...(payload?.assigneeUserId !== undefined ? {
+        assigneeUserId: typeof payload.assigneeUserId === 'string' ? payload.assigneeUserId : null,
+      } : {}),
       ...(payload?.markSeen === true ? { seenAt: new Date() } : {}),
       ...(payload?.seenAt !== undefined ? { seenAt: parseOptionalDate(payload.seenAt) ?? null } : {}),
       ...(payload?.completionComment !== undefined ? {

--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { applyTodoRateLimit, parseOptionalDate, requireTodoSession, todoErrorResponse } from '@/app/lib/todos/api';
+import { requireSessionWorkspace, type RequestWorkspaceSession } from '@/app/lib/workspaces/request';
 import {
   TODO_PRIORITIES,
   TODO_STATUSES,
@@ -8,6 +9,7 @@ import {
   getTodo,
   updateTodo,
   type TodoFileLinkInput,
+  type TodoWithRelations,
   type TodoPriority,
   type TodoStatus,
 } from '@/app/lib/todos/store';
@@ -30,6 +32,20 @@ function parsePriority(value: unknown): TodoPriority | undefined {
 
 function parseFileLinks(value: unknown): TodoFileLinkInput[] | undefined {
   return Array.isArray(value) ? value as TodoFileLinkInput[] : undefined;
+}
+
+async function requireTodoWriteWorkspace(
+  session: RequestWorkspaceSession,
+  todo: TodoWithRelations,
+) {
+  if (todo.workspaceType !== 'team' || !todo.workspaceId) {
+    return null;
+  }
+  const workspaceResult = await requireSessionWorkspace(session, {
+    workspaceId: todo.workspaceId,
+    permissions: 'canWrite',
+  });
+  return workspaceResult.response;
 }
 
 export async function GET(request: NextRequest, context: RouteContext) {
@@ -66,6 +82,15 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   try {
     const payload = await request.json();
     const { id } = await context.params;
+    const existingTodo = await getTodo(session.user.id, id);
+    if (!existingTodo) {
+      return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
+    }
+    const permissionResponse = await requireTodoWriteWorkspace(session, existingTodo);
+    if (permissionResponse) {
+      return permissionResponse;
+    }
+
     const todo = await updateTodo(session.user.id, id, {
       ...(payload?.title !== undefined ? { title: String(payload.title) } : {}),
       ...(payload?.description !== undefined ? { description: typeof payload.description === 'string' ? payload.description : null } : {}),
@@ -106,6 +131,15 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
   }
 
   const { id } = await context.params;
+  const existingTodo = await getTodo(session.user.id, id);
+  if (!existingTodo) {
+    return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
+  }
+  const permissionResponse = await requireTodoWriteWorkspace(session, existingTodo);
+  if (permissionResponse) {
+    return permissionResponse;
+  }
+
   const todo = await archiveTodo(session.user.id, id);
   if (!todo) {
     return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });

--- a/app/api/todos/assignees/route.ts
+++ b/app/api/todos/assignees/route.ts
@@ -1,0 +1,68 @@
+import { and, asc, eq, ne } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { db } from '@/app/lib/db';
+import { organizationUserPermissions, user } from '@/app/lib/db/schema';
+import { applyTodoRateLimit, requireTodoSession } from '@/app/lib/todos/api';
+import { requireSessionWorkspace } from '@/app/lib/workspaces/request';
+
+type AssigneeCandidate = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  role: string | null;
+};
+
+export async function GET(request: NextRequest) {
+  const { session, response } = await requireTodoSession(request);
+  if (!session || response) {
+    return response;
+  }
+
+  const limited = applyTodoRateLimit(request, 'todo-assignees-get');
+  if (!limited.ok) {
+    return limited.response;
+  }
+
+  const { searchParams } = new URL(request.url);
+  const workspaceId = searchParams.get('workspaceId');
+  const workspaceResult = await requireSessionWorkspace(session, {
+    workspaceId,
+    permissions: 'canRead',
+  });
+  if (workspaceResult.response) {
+    return workspaceResult.response;
+  }
+
+  const workspace = workspaceResult.workspace;
+  if (workspace.workspaceType !== 'team') {
+    const candidate: AssigneeCandidate = {
+      id: session.user.id,
+      name: session.user.name ?? null,
+      email: session.user.email ?? null,
+      role: session.user.role ?? null,
+    };
+    return NextResponse.json({ success: true, data: [candidate] });
+  }
+
+  if (!workspace.organizationId) {
+    return NextResponse.json({ success: false, error: 'Team workspace is missing organization scope.' }, { status: 409 });
+  }
+
+  const candidates = await db
+    .select({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: organizationUserPermissions.role,
+    })
+    .from(organizationUserPermissions)
+    .innerJoin(user, eq(user.id, organizationUserPermissions.userId))
+    .where(and(
+      eq(organizationUserPermissions.organizationId, workspace.organizationId),
+      ne(organizationUserPermissions.role, 'external'),
+    ))
+    .orderBy(asc(user.name), asc(user.email));
+
+  return NextResponse.json({ success: true, data: candidates });
+}

--- a/app/api/todos/route.ts
+++ b/app/api/todos/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { applyTodoRateLimit, parseOptionalDate, requireTodoSession, todoErrorResponse } from '@/app/lib/todos/api';
-import { requireSessionWorkspace, type RequestWorkspaceSession } from '@/app/lib/workspaces/request';
+import {
+  requireSessionWorkspace,
+  type RequestWorkspacePermission,
+  type RequestWorkspaceSession,
+} from '@/app/lib/workspaces/request';
 import {
   TODO_PRIORITIES,
   TODO_SOURCE_TYPES,
@@ -58,9 +62,10 @@ function todoWorkspaceScope(workspace: WorkspaceContext | null) {
 async function resolveRequestedWorkspace(
   session: RequestWorkspaceSession,
   workspaceId: string | null | undefined,
+  permissions?: RequestWorkspacePermission | RequestWorkspacePermission[],
 ) {
   if (!workspaceId) return { workspace: null, response: null };
-  return requireSessionWorkspace(session, { workspaceId });
+  return requireSessionWorkspace(session, { workspaceId, permissions });
 }
 
 export async function GET(request: NextRequest) {
@@ -75,7 +80,7 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url);
-  const workspaceResult = await resolveRequestedWorkspace(session, searchParams.get('workspaceId'));
+  const workspaceResult = await resolveRequestedWorkspace(session, searchParams.get('workspaceId'), 'canRead');
   if (workspaceResult.response) {
     return workspaceResult.response;
   }
@@ -109,6 +114,7 @@ export async function POST(request: NextRequest) {
     const workspaceResult = await resolveRequestedWorkspace(
       session,
       typeof payload?.workspaceId === 'string' ? payload.workspaceId : null,
+      'canWrite',
     );
     if (workspaceResult.response) {
       return workspaceResult.response;

--- a/app/api/todos/route.ts
+++ b/app/api/todos/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { applyTodoRateLimit, parseOptionalDate, requireTodoSession, todoErrorResponse } from '@/app/lib/todos/api';
+import { requireSessionWorkspace, type RequestWorkspaceSession } from '@/app/lib/workspaces/request';
 import {
   TODO_PRIORITIES,
   TODO_SOURCE_TYPES,
@@ -13,6 +14,7 @@ import {
   type TodoSourceType,
   type TodoStatus,
 } from '@/app/lib/todos/store';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
 
 function parseStatus(value: string | null): ListTodosOptions['status'] {
   if (!value) return undefined;
@@ -42,6 +44,25 @@ function parseFileLinks(value: unknown): TodoFileLinkInput[] | undefined {
   return Array.isArray(value) ? value as TodoFileLinkInput[] : undefined;
 }
 
+function todoWorkspaceScope(workspace: WorkspaceContext | null) {
+  if (!workspace || workspace.workspaceType !== 'team') {
+    return { workspaceType: 'personal' as const };
+  }
+  return {
+    workspaceType: 'team' as const,
+    organizationId: workspace.organizationId,
+    workspaceId: workspace.workspaceId,
+  };
+}
+
+async function resolveRequestedWorkspace(
+  session: RequestWorkspaceSession,
+  workspaceId: string | null | undefined,
+) {
+  if (!workspaceId) return { workspace: null, response: null };
+  return requireSessionWorkspace(session, { workspaceId });
+}
+
 export async function GET(request: NextRequest) {
   const { session, response } = await requireTodoSession(request);
   if (!session || response) {
@@ -54,11 +75,17 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url);
+  const workspaceResult = await resolveRequestedWorkspace(session, searchParams.get('workspaceId'));
+  if (workspaceResult.response) {
+    return workspaceResult.response;
+  }
   const limit = Number(searchParams.get('limit') || 100);
   const todos = await listTodos(session.user.id, {
+    ...todoWorkspaceScope(workspaceResult.workspace),
     status: parseStatus(searchParams.get('status')),
     categoryId: searchParams.get('categoryId') || undefined,
     sourceType: parseSourceType(searchParams.get('sourceType')),
+    assigneeUserId: searchParams.get('assigneeUserId') || undefined,
     due: parseDue(searchParams.get('due')),
     limit: Number.isFinite(limit) ? limit : undefined,
   });
@@ -79,13 +106,22 @@ export async function POST(request: NextRequest) {
 
   try {
     const payload = await request.json();
+    const workspaceResult = await resolveRequestedWorkspace(
+      session,
+      typeof payload?.workspaceId === 'string' ? payload.workspaceId : null,
+    );
+    if (workspaceResult.response) {
+      return workspaceResult.response;
+    }
     const todo = await createTodo(session.user.id, {
+      ...todoWorkspaceScope(workspaceResult.workspace),
       title: String(payload?.title ?? ''),
       description: typeof payload?.description === 'string' ? payload.description : null,
       categoryId: typeof payload?.categoryId === 'string' ? payload.categoryId : null,
       categoryName: typeof payload?.categoryName === 'string' ? payload.categoryName : null,
       priority: parsePriority(payload?.priority),
       dueAt: parseOptionalDate(payload?.dueAt) ?? null,
+      assigneeUserId: typeof payload?.assigneeUserId === 'string' ? payload.assigneeUserId : null,
       sourceType: 'user',
       seenAt: new Date(),
       fileLinks: parseFileLinks(payload?.fileLinks),

--- a/app/apps/todos/components/TodosClient.tsx
+++ b/app/apps/todos/components/TodosClient.tsx
@@ -26,6 +26,7 @@ import {
   Search,
   Send,
   Trash2,
+  Users,
   X,
 } from 'lucide-react';
 
@@ -75,12 +76,31 @@ type TodoCategory = {
 
 type TodoFileLink = {
   id: string;
+  workspaceId: string | null;
+  workspaceType: TodoWorkspaceType;
   workspacePath: string;
   label: string | null;
 };
 
+type TodoWorkspaceType = 'personal' | 'team';
+
+type TodoUserSummary = {
+  id: string;
+  name: string | null;
+  email: string | null;
+};
+
+type AssigneeOption = TodoUserSummary & {
+  role?: string | null;
+};
+
 type TodoItem = {
   id: string;
+  createdByUserId: string | null;
+  assigneeUserId: string | null;
+  organizationId: string | null;
+  workspaceId: string | null;
+  workspaceType: TodoWorkspaceType;
   title: string;
   description: string | null;
   status: TodoStatus;
@@ -100,6 +120,8 @@ type TodoItem = {
   updatedAt: string;
   category: TodoCategory | null;
   fileLinks: TodoFileLink[];
+  createdBy: TodoUserSummary | null;
+  assignee: TodoUserSummary | null;
 };
 
 type WorkspaceFileEntry = {
@@ -114,6 +136,17 @@ type ApiResponse<T> = {
   error?: string;
 };
 
+type WorkspaceOption = {
+  id: string;
+  type: TodoWorkspaceType | 'project';
+  name: string;
+  organizationId: string | null;
+  permissions?: {
+    canRead?: boolean;
+    canWrite?: boolean;
+  };
+};
+
 type TodoFollowUpResponse = {
   todo: TodoItem;
   sessionId: string;
@@ -125,6 +158,7 @@ type TodoFormState = {
   categoryId: string;
   priority: TodoPriority;
   dueAt: string;
+  assigneeUserId: string;
   fileLinks: Array<{ workspacePath: string; label: string | null }>;
 };
 
@@ -137,6 +171,7 @@ const emptyForm: TodoFormState = {
   categoryId: '',
   priority: 'normal',
   dueAt: '',
+  assigneeUserId: '',
   fileLinks: [],
 };
 
@@ -179,6 +214,7 @@ function todoToForm(todo: TodoItem): TodoFormState {
     categoryId: todo.category?.id ?? '',
     priority: todo.priority,
     dueAt: toDateInput(todo.dueAt),
+    assigneeUserId: todo.assigneeUserId ?? '',
     fileLinks: todo.fileLinks.map((link) => ({
       workspacePath: link.workspacePath,
       label: link.label,
@@ -186,8 +222,14 @@ function todoToForm(todo: TodoItem): TodoFormState {
   };
 }
 
-function fileLinkHref(workspacePath: string) {
-  return `/files?path=${encodeURIComponent(workspacePath)}`;
+function fileLinkHref(link: Pick<TodoFileLink, 'workspacePath' | 'workspaceId'>) {
+  const params = new URLSearchParams({ path: link.workspacePath });
+  if (link.workspaceId) params.set('workspaceId', link.workspaceId);
+  return `/files?${params.toString()}`;
+}
+
+function formatTodoUser(user: TodoUserSummary | null | undefined, fallback: string) {
+  return user?.name || user?.email || user?.id || fallback;
 }
 
 function pushTodoChatState(todo: Pick<TodoItem, 'id' | 'sourceSessionId'>) {
@@ -284,6 +326,18 @@ function TodoDetailPanel({
 
       <div className="grid gap-2 text-sm">
         <div className="flex min-w-0 items-center justify-between gap-3">
+          <span className="shrink-0 text-muted-foreground">{t('fields.workspace')}</span>
+          <span className="min-w-0 truncate text-right font-medium">
+            {todo.workspaceType === 'team' ? t('scope.team') : t('scope.personal')}
+          </span>
+        </div>
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <span className="shrink-0 text-muted-foreground">{t('fields.assignee')}</span>
+          <span className="min-w-0 truncate text-right font-medium">
+            {formatTodoUser(todo.assignee, t('labels.unassigned'))}
+          </span>
+        </div>
+        <div className="flex min-w-0 items-center justify-between gap-3">
           <span className="shrink-0 text-muted-foreground">{t('fields.category')}</span>
           <span className="min-w-0 truncate text-right font-medium">{formatCategoryName(todo.category)}</span>
         </div>
@@ -353,7 +407,7 @@ function TodoDetailPanel({
           <div className="space-y-2">
             {todo.fileLinks.map((link) => (
               <Button key={link.id} asChild variant="outline" className="h-auto w-full min-w-0 justify-start overflow-hidden whitespace-normal py-2 text-left">
-                <Link href={fileLinkHref(link.workspacePath)}>
+                <Link href={fileLinkHref(link)}>
                   <FileText className="h-4 w-4" />
                   <span className="min-w-0 flex-1 truncate">{link.label || link.workspacePath}</span>
                 </Link>
@@ -450,6 +504,9 @@ export function TodosClient({ title }: { title: string }) {
   const pendingTodoParamRef = useRef<string | null>(null);
   const [todos, setTodos] = useState<TodoItem[]>([]);
   const [categories, setCategories] = useState<TodoCategory[]>([]);
+  const [workspaces, setWorkspaces] = useState<WorkspaceOption[]>([]);
+  const [assignees, setAssignees] = useState<AssigneeOption[]>([]);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState('');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('open');
   const [categoryFilter, setCategoryFilter] = useState<string>('');
   const [selectedTodoId, setSelectedTodoId] = useState<string | null>(null);
@@ -513,6 +570,15 @@ export function TodosClient({ title }: { title: string }) {
 
   const openCount = useMemo(() => todos.filter((todo) => todo.status === 'open').length, [todos]);
   const doneCount = useMemo(() => todos.filter((todo) => todo.status === 'done').length, [todos]);
+  const teamWorkspaces = useMemo(
+    () => workspaces.filter((workspace) => workspace.type === 'team' && workspace.permissions?.canRead !== false),
+    [workspaces],
+  );
+  const selectedWorkspace = useMemo(
+    () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? null,
+    [selectedWorkspaceId, workspaces],
+  );
+  const selectedWorkspaceLabel = selectedWorkspace?.name || t('scope.personal');
 
   const formatCategoryName = useCallback((category: Pick<TodoCategory, 'name' | 'icon'> | null | undefined) => {
     if (!category) return t('filters.noCategory');
@@ -527,9 +593,24 @@ export function TodosClient({ title }: { title: string }) {
   }, [categories, categoryFilter, formatCategoryName, t]);
 
   const filterSummary = useMemo(
-    () => `${t(`filters.status.${statusFilter}`)} · ${selectedCategoryName}`,
-    [selectedCategoryName, statusFilter, t],
+    () => `${selectedWorkspaceLabel} · ${t(`filters.status.${statusFilter}`)} · ${selectedCategoryName}`,
+    [selectedCategoryName, selectedWorkspaceLabel, statusFilter, t],
   );
+
+  const loadWorkspaces = useCallback(async () => {
+    const response = await fetch('/api/workspaces', { credentials: 'include', cache: 'no-store' });
+    const payload = await response.json().catch(() => null) as { success?: boolean; workspaces?: WorkspaceOption[] } | null;
+    if (!response.ok || !payload?.success) {
+      setWorkspaces([]);
+      return [];
+    }
+    const readable = (payload.workspaces ?? []).filter((workspace) => workspace.type === 'personal' || workspace.type === 'team');
+    setWorkspaces(readable as WorkspaceOption[]);
+    setSelectedWorkspaceId((current) => (
+      current && readable.some((workspace) => workspace.id === current) ? current : ''
+    ));
+    return readable;
+  }, []);
 
   const loadCategories = useCallback(async () => {
     const response = await fetch('/api/todo-categories', { credentials: 'include', cache: 'no-store' });
@@ -538,9 +619,27 @@ export function TodosClient({ title }: { title: string }) {
     return data;
   }, []);
 
+  const loadAssignees = useCallback(async () => {
+    const params = new URLSearchParams();
+    if (selectedWorkspaceId) params.set('workspaceId', selectedWorkspaceId);
+    const response = await fetch(`/api/todos/assignees?${params.toString()}`, {
+      credentials: 'include',
+      cache: 'no-store',
+    });
+    const data = await readApiData<AssigneeOption[]>(response);
+    setAssignees(data);
+    setForm((current) => (
+      current.assigneeUserId && !data.some((candidate) => candidate.id === current.assigneeUserId)
+        ? { ...current, assigneeUserId: '' }
+        : current
+    ));
+    return data;
+  }, [selectedWorkspaceId]);
+
   const loadTodos = useCallback(async () => {
     const params = new URLSearchParams({ status: statusFilter });
     if (categoryFilter) params.set('categoryId', categoryFilter);
+    if (selectedWorkspaceId) params.set('workspaceId', selectedWorkspaceId);
     const response = await fetch(`/api/todos?${params.toString()}`, {
       credentials: 'include',
       cache: 'no-store',
@@ -549,25 +648,25 @@ export function TodosClient({ title }: { title: string }) {
     setTodos(data);
     setSelectedTodoId((current) => (current && data.some((todo) => todo.id === current) ? current : null));
     return data;
-  }, [categoryFilter, statusFilter]);
+  }, [categoryFilter, selectedWorkspaceId, statusFilter]);
 
   const refreshAll = useCallback(async () => {
     setIsLoading(true);
     try {
-      await Promise.all([loadCategories(), loadTodos()]);
+      await Promise.all([loadAssignees(), loadCategories(), loadTodos(), loadWorkspaces()]);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : t('errors.loadFailed'));
     } finally {
       setIsLoading(false);
     }
-  }, [loadCategories, loadTodos, t]);
+  }, [loadAssignees, loadCategories, loadTodos, loadWorkspaces, t]);
 
   useEffect(() => {
     let cancelled = false;
 
     async function loadInitialData() {
       try {
-        await Promise.all([loadCategories(), loadTodos()]);
+        await Promise.all([loadAssignees(), loadCategories(), loadTodos(), loadWorkspaces()]);
       } catch (error) {
         toast.error(error instanceof Error ? error.message : t('errors.loadFailed'));
       } finally {
@@ -581,7 +680,7 @@ export function TodosClient({ title }: { title: string }) {
     return () => {
       cancelled = true;
     };
-  }, [loadCategories, loadTodos, t]);
+  }, [loadAssignees, loadCategories, loadTodos, loadWorkspaces, t]);
 
   useEffect(() => {
     if (!editorOpen) return;
@@ -590,7 +689,9 @@ export function TodosClient({ title }: { title: string }) {
     const handle = window.setTimeout(async () => {
       setIsFileSearching(true);
       try {
-        const response = await fetch(`/api/files/list?q=${encodeURIComponent(fileQuery)}&limit=20`, {
+        const params = new URLSearchParams({ q: fileQuery, limit: '20' });
+        if (selectedWorkspaceId) params.set('workspaceId', selectedWorkspaceId);
+        const response = await fetch(`/api/files/list?${params.toString()}`, {
           credentials: 'include',
           cache: 'no-store',
           signal: controller.signal,
@@ -612,7 +713,7 @@ export function TodosClient({ title }: { title: string }) {
       window.clearTimeout(handle);
       controller.abort();
     };
-  }, [editorOpen, fileQuery]);
+  }, [editorOpen, fileQuery, selectedWorkspaceId]);
 
   const updateTodo = useCallback(async (todoId: string, payload: Record<string, unknown>) => {
     setIsMutating(true);
@@ -746,7 +847,9 @@ export function TodosClient({ title }: { title: string }) {
         categoryId: form.categoryId || null,
         priority: form.priority,
         dueAt: form.dueAt || null,
+        assigneeUserId: form.assigneeUserId || null,
         fileLinks: form.fileLinks,
+        ...(!editingTodoId && selectedWorkspaceId ? { workspaceId: selectedWorkspaceId } : {}),
       };
       const response = await fetch(editingTodoId ? `/api/todos/${encodeURIComponent(editingTodoId)}` : '/api/todos', {
         method: editingTodoId ? 'PATCH' : 'POST',
@@ -765,7 +868,7 @@ export function TodosClient({ title }: { title: string }) {
     } finally {
       setIsMutating(false);
     }
-  }, [editingTodoId, form, loadTodos, t]);
+  }, [editingTodoId, form, loadTodos, selectedWorkspaceId, t]);
 
   const archiveTodo = useCallback(async (todo: TodoItem) => {
     setIsMutating(true);
@@ -956,6 +1059,48 @@ export function TodosClient({ title }: { title: string }) {
     </div>
   );
 
+  const renderWorkspaceFilters = (closeOnSelect = false) => (
+    <div className="grid grid-cols-2 gap-1 md:grid-cols-1">
+      <button
+        type="button"
+        className={cn(
+          'flex h-9 min-w-0 items-center gap-2 rounded-md px-3 text-sm transition-colors',
+          !selectedWorkspaceId
+            ? 'bg-primary text-primary-foreground'
+            : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+        )}
+        onClick={() => {
+          setSelectedWorkspaceId('');
+          setSelectedTodoId(null);
+          if (closeOnSelect) setFilterSheetOpen(false);
+        }}
+      >
+        <Circle className="h-3.5 w-3.5 shrink-0" />
+        <span className="min-w-0 truncate">{t('scope.personal')}</span>
+      </button>
+      {teamWorkspaces.map((workspace) => (
+        <button
+          key={workspace.id}
+          type="button"
+          className={cn(
+            'flex h-9 min-w-0 items-center gap-2 rounded-md px-3 text-sm transition-colors',
+            selectedWorkspaceId === workspace.id
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+          )}
+          onClick={() => {
+            setSelectedWorkspaceId(workspace.id);
+            setSelectedTodoId(null);
+            if (closeOnSelect) setFilterSheetOpen(false);
+          }}
+        >
+          <Users className="h-3.5 w-3.5 shrink-0" />
+          <span className="min-w-0 truncate">{workspace.name || t('scope.team')}</span>
+        </button>
+      ))}
+    </div>
+  );
+
   const renderCategoryFilters = (closeOnSelect = false) => (
     <div className="flex min-w-0 flex-col gap-1">
       <button
@@ -1075,6 +1220,13 @@ export function TodosClient({ title }: { title: string }) {
         </div>
 
         <aside className="hidden min-w-0 space-y-4 md:block">
+          <section className="space-y-3">
+            <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              {t('sections.workspace')}
+            </h3>
+            {renderWorkspaceFilters()}
+          </section>
+
           <section className="space-y-3">
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
@@ -1283,10 +1435,17 @@ export function TodosClient({ title }: { title: string }) {
             <SheetDescription>{filterSummary}</SheetDescription>
           </SheetHeader>
           <div className="min-h-0 overflow-y-auto px-4 py-4">
-            <section className="space-y-3">
-              <div className="flex items-center justify-between gap-2">
+              <section className="space-y-3">
                 <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                  {t('sections.status')}
+                  {t('sections.workspace')}
+                </h3>
+                {renderWorkspaceFilters(true)}
+              </section>
+
+              <section className="mt-5 space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                  <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                    {t('sections.status')}
                 </h3>
                 <Badge variant="outline">{visibleUnreadCount > 99 ? '99+' : visibleUnreadCount}</Badge>
               </div>
@@ -1382,6 +1541,22 @@ export function TodosClient({ title }: { title: string }) {
                     />
                   </div>
                 </div>
+                <label className="space-y-2 text-sm">
+                  <span className="font-medium">{t('fields.assignee')}</span>
+                  <select
+                    id="todo-assignee"
+                    className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                    value={form.assigneeUserId}
+                    onChange={(event) => setForm((current) => ({ ...current, assigneeUserId: event.target.value }))}
+                  >
+                    <option value="">{t('labels.unassigned')}</option>
+                    {assignees.map((candidate) => (
+                      <option key={candidate.id} value={candidate.id}>
+                        {formatTodoUser(candidate, candidate.id)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
               </div>
 
               <div className="space-y-3">

--- a/app/apps/todos/components/TodosClient.tsx
+++ b/app/apps/todos/components/TodosClient.tsx
@@ -662,11 +662,23 @@ export function TodosClient({ title }: { title: string }) {
   }, [loadAssignees, loadCategories, loadTodos, loadWorkspaces, t]);
 
   useEffect(() => {
+    async function loadStaticData() {
+      try {
+        await Promise.all([loadCategories(), loadWorkspaces()]);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : t('errors.loadFailed'));
+      }
+    }
+
+    void loadStaticData();
+  }, [loadCategories, loadWorkspaces, t]);
+
+  useEffect(() => {
     let cancelled = false;
 
-    async function loadInitialData() {
+    async function loadScopedData() {
       try {
-        await Promise.all([loadAssignees(), loadCategories(), loadTodos(), loadWorkspaces()]);
+        await Promise.all([loadAssignees(), loadTodos()]);
       } catch (error) {
         toast.error(error instanceof Error ? error.message : t('errors.loadFailed'));
       } finally {
@@ -676,11 +688,11 @@ export function TodosClient({ title }: { title: string }) {
       }
     }
 
-    void loadInitialData();
+    void loadScopedData();
     return () => {
       cancelled = true;
     };
-  }, [loadAssignees, loadCategories, loadTodos, loadWorkspaces, t]);
+  }, [loadAssignees, loadTodos, t]);
 
   useEffect(() => {
     if (!editorOpen) return;

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -248,6 +248,11 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS todo_items (
       id TEXT PRIMARY KEY NOT NULL,
       user_id TEXT NOT NULL,
+      created_by_user_id TEXT,
+      assignee_user_id TEXT,
+      organization_id TEXT,
+      workspace_id TEXT,
+      workspace_type TEXT NOT NULL DEFAULT 'personal',
       category_id TEXT,
       title TEXT NOT NULL,
       description TEXT,
@@ -268,6 +273,10 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
       FOREIGN KEY (user_id) REFERENCES user(id),
+      FOREIGN KEY (created_by_user_id) REFERENCES user(id),
+      FOREIGN KEY (assignee_user_id) REFERENCES user(id),
+      FOREIGN KEY (organization_id) REFERENCES canvas_organization_settings(organization_id) ON DELETE CASCADE,
+      FOREIGN KEY (workspace_id) REFERENCES canvas_workspaces(id) ON DELETE SET NULL,
       FOREIGN KEY (category_id) REFERENCES todo_categories(id)
     );
 
@@ -275,11 +284,16 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       id TEXT PRIMARY KEY NOT NULL,
       todo_id TEXT NOT NULL,
       user_id TEXT NOT NULL,
+      organization_id TEXT,
+      workspace_id TEXT,
+      workspace_type TEXT NOT NULL DEFAULT 'personal',
       workspace_path TEXT NOT NULL,
       label TEXT,
       created_at INTEGER NOT NULL,
       FOREIGN KEY (todo_id) REFERENCES todo_items(id),
-      FOREIGN KEY (user_id) REFERENCES user(id)
+      FOREIGN KEY (user_id) REFERENCES user(id),
+      FOREIGN KEY (organization_id) REFERENCES canvas_organization_settings(organization_id) ON DELETE CASCADE,
+      FOREIGN KEY (workspace_id) REFERENCES canvas_workspaces(id) ON DELETE SET NULL
     );
 
     CREATE TABLE IF NOT EXISTS todo_email_reply_watchers (
@@ -731,9 +745,28 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     next_run_at: 'INTEGER',
   });
 
-    addColumns(sqlite, 'studio_generations', {
-      studio_preset_name: 'TEXT',
-    });
+  addColumns(sqlite, 'studio_generations', {
+    studio_preset_name: 'TEXT',
+  });
+
+  addColumns(sqlite, 'todo_items', {
+    created_by_user_id: 'TEXT',
+    assignee_user_id: 'TEXT',
+    organization_id: 'TEXT',
+    workspace_id: 'TEXT',
+    workspace_type: "TEXT NOT NULL DEFAULT 'personal'",
+    completion_comment: 'TEXT',
+    follow_up_sent_at: 'INTEGER',
+    follow_up_error: 'TEXT',
+    email_notification_sent_at: 'INTEGER',
+    email_notification_error: 'TEXT',
+  });
+
+  addColumns(sqlite, 'todo_file_links', {
+    organization_id: 'TEXT',
+    workspace_id: 'TEXT',
+    workspace_type: "TEXT NOT NULL DEFAULT 'personal'",
+  });
 
   sqlite.exec(`
     UPDATE email_accounts
@@ -880,9 +913,12 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_todo_items_user_due ON todo_items (user_id, due_at);
     CREATE INDEX IF NOT EXISTS idx_todo_items_user_seen ON todo_items (user_id, seen_at);
     CREATE INDEX IF NOT EXISTS idx_todo_items_source_session ON todo_items (user_id, source_session_id);
+    CREATE INDEX IF NOT EXISTS idx_todo_items_org_workspace_status ON todo_items (organization_id, workspace_id, status, updated_at);
+    CREATE INDEX IF NOT EXISTS idx_todo_items_assignee_status ON todo_items (assignee_user_id, status, updated_at);
     CREATE INDEX IF NOT EXISTS idx_todo_items_category ON todo_items (category_id);
     CREATE INDEX IF NOT EXISTS idx_todo_file_links_todo ON todo_file_links (todo_id);
     CREATE INDEX IF NOT EXISTS idx_todo_file_links_user_path ON todo_file_links (user_id, workspace_path);
+    CREATE INDEX IF NOT EXISTS idx_todo_file_links_workspace_path ON todo_file_links (organization_id, workspace_id, workspace_path);
     CREATE INDEX IF NOT EXISTS idx_todo_email_reply_watchers_status_checked ON todo_email_reply_watchers (status, last_checked_at);
     CREATE INDEX IF NOT EXISTS idx_todo_email_reply_watchers_todo ON todo_email_reply_watchers (todo_id);
     CREATE INDEX IF NOT EXISTS idx_todo_email_reply_watchers_user_status ON todo_email_reply_watchers (user_id, status);
@@ -950,13 +986,11 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     attachments_json: "TEXT NOT NULL DEFAULT '[]'",
   });
 
-  addColumns(sqlite, 'todo_items', {
-    completion_comment: 'TEXT',
-    follow_up_sent_at: 'INTEGER',
-    follow_up_error: 'TEXT',
-    email_notification_sent_at: 'INTEGER',
-    email_notification_error: 'TEXT',
-  });
+  sqlite.exec(`
+    UPDATE todo_items
+    SET created_by_user_id = user_id
+    WHERE created_by_user_id IS NULL;
+  `);
 
   addColumns(sqlite, 'automation_runs', {
     target_output_path: 'TEXT',

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -282,6 +282,11 @@ export const todoCategories = sqliteTable("todo_categories", {
 export const todoItems = sqliteTable("todo_items", {
   id: text("id").primaryKey(),
   userId: text("user_id").notNull().references(() => user.id),
+  createdByUserId: text("created_by_user_id").references(() => user.id),
+  assigneeUserId: text("assignee_user_id").references(() => user.id),
+  organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  workspaceId: text("workspace_id").references(() => canvasWorkspaces.id, { onDelete: 'set null' }),
+  workspaceType: text("workspace_type").notNull().default("personal"),
   categoryId: text("category_id").references(() => todoCategories.id),
   title: text("title").notNull(),
   description: text("description"),
@@ -306,6 +311,8 @@ export const todoItems = sqliteTable("todo_items", {
   userDueIdx: index("idx_todo_items_user_due").on(table.userId, table.dueAt),
   userSeenIdx: index("idx_todo_items_user_seen").on(table.userId, table.seenAt),
   sourceSessionIdx: index("idx_todo_items_source_session").on(table.userId, table.sourceSessionId),
+  orgWorkspaceStatusIdx: index("idx_todo_items_org_workspace_status").on(table.organizationId, table.workspaceId, table.status, table.updatedAt),
+  assigneeStatusIdx: index("idx_todo_items_assignee_status").on(table.assigneeUserId, table.status, table.updatedAt),
   categoryIdx: index("idx_todo_items_category").on(table.categoryId),
 }));
 
@@ -313,12 +320,16 @@ export const todoFileLinks = sqliteTable("todo_file_links", {
   id: text("id").primaryKey(),
   todoId: text("todo_id").notNull().references(() => todoItems.id),
   userId: text("user_id").notNull().references(() => user.id),
+  organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  workspaceId: text("workspace_id").references(() => canvasWorkspaces.id, { onDelete: 'set null' }),
+  workspaceType: text("workspace_type").notNull().default("personal"),
   workspacePath: text("workspace_path").notNull(),
   label: text("label"),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   todoIdx: index("idx_todo_file_links_todo").on(table.todoId),
   userPathIdx: index("idx_todo_file_links_user_path").on(table.userId, table.workspacePath),
+  workspacePathIdx: index("idx_todo_file_links_workspace_path").on(table.organizationId, table.workspaceId, table.workspacePath),
 }));
 
 export const todoEmailReplyWatchers = sqliteTable("todo_email_reply_watchers", {

--- a/app/lib/pi/human-todo-tool.ts
+++ b/app/lib/pi/human-todo-tool.ts
@@ -7,6 +7,7 @@ import {
   type TodoPriority,
 } from '@/app/lib/todos/store';
 import { normalizeManagedAgentId } from '@/app/lib/agents/registry';
+import { getAgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
 
 function parseDueAt(value: unknown): Date | null {
   if (value === undefined || value === null || value === '') {
@@ -62,6 +63,7 @@ export function createHumanTodoTool(deps: { userId?: string; agentId?: string | 
         description: 'Optional workspace-relative file paths relevant to the task. Absolute paths, URLs, and traversal are rejected.',
         maxItems: 20,
       })),
+      assigneeUserId: Type.Optional(Type.String({ description: 'Optional user ID to assign the to-do to. For team workspace to-dos the assignee must be a member of the organization.' })),
       sourceSessionId: Type.Optional(Type.String({ description: 'Optional Canvas Agent session ID. Usually set automatically by Canvas when this tool runs inside a chat session.' })),
     }),
     execute: async (_toolCallId, params) => {
@@ -71,12 +73,22 @@ export function createHumanTodoTool(deps: { userId?: string; agentId?: string | 
         }
 
         const input = params as Record<string, unknown>;
+        const executionContext = getAgentExecutionContext();
+        const workspaceScope = executionContext?.workspaceType === 'team'
+          ? {
+              workspaceType: 'team' as const,
+              organizationId: executionContext.organizationId,
+              workspaceId: executionContext.workspaceId,
+            }
+          : { workspaceType: 'personal' as const };
         const todo = await createTodo(deps.userId, {
+          ...workspaceScope,
           title: String(input.title ?? ''),
           description: typeof input.description === 'string' ? input.description : null,
           categoryName: typeof input.categoryName === 'string' ? input.categoryName : null,
           priority: normalizePriority(input.priority),
           dueAt: parseDueAt(input.dueAt),
+          assigneeUserId: typeof input.assigneeUserId === 'string' ? input.assigneeUserId : null,
           sourceType: 'agent',
           sourceAgentId,
           sourceSessionId: sourceSessionId || (typeof input.sourceSessionId === 'string' ? input.sourceSessionId : null),
@@ -90,8 +102,10 @@ export function createHumanTodoTool(deps: { userId?: string; agentId?: string | 
           `Title: ${todo.title}`,
           `Category: ${todo.category?.name ?? 'To-do'}`,
           `Priority: ${todo.priority}`,
+          `Workspace: ${todo.workspaceType === 'team' ? 'Team' : 'Personal'}`,
+          todo.assignee ? `Assignee: ${todo.assignee.name || todo.assignee.email || todo.assignee.id}` : null,
           `Visible in UI: /todos`,
-        ];
+        ].filter((line): line is string => Boolean(line));
 
         if (todo.fileLinks.length > 0) {
           lines.push('Linked files:');

--- a/app/lib/todos/api.ts
+++ b/app/lib/todos/api.ts
@@ -29,7 +29,11 @@ export function applyTodoRateLimit(request: NextRequest, keyPrefix: string, limi
 
 export function todoErrorResponse(error: unknown, fallback: string) {
   if (error instanceof TodoStoreError) {
-    const status = error.code === 'TODO_NOT_FOUND' || error.code === 'CATEGORY_NOT_FOUND' ? 404 : 400;
+    const status = error.code === 'TODO_NOT_FOUND' || error.code === 'CATEGORY_NOT_FOUND'
+      ? 404
+      : error.code === 'ORGANIZATION_ACCESS_DENIED'
+        ? 403
+        : 400;
     return NextResponse.json({ success: false, error: error.message, code: error.code }, { status });
   }
 

--- a/app/lib/todos/store.ts
+++ b/app/lib/todos/store.ts
@@ -215,10 +215,23 @@ async function assertAssignableUser(organizationId: string, assigneeUserId: stri
   }
 }
 
+async function assertTeamWorkspaceInOrganization(organizationId: string, workspaceId: string): Promise<void> {
+  const workspace = await db.query.canvasWorkspaces.findFirst({
+    where: and(
+      eq(canvasWorkspaces.id, workspaceId),
+      eq(canvasWorkspaces.organizationId, organizationId),
+      eq(canvasWorkspaces.type, 'team'),
+    ),
+  });
+  if (!workspace) {
+    throw new TodoStoreError('Team workspace not found.', 'INVALID_INPUT');
+  }
+}
+
 async function resolveTodoScope(userId: string, input: Pick<CreateTodoInput, 'organizationId' | 'workspaceId' | 'workspaceType'>): Promise<TodoScope> {
   const workspaceType = normalizeWorkspaceType(input.workspaceType);
   if (workspaceType === 'personal') {
-    return { organizationId: null, workspaceId: normalizeOptionalId(input.workspaceId), workspaceType };
+    return { organizationId: null, workspaceId: null, workspaceType };
   }
 
   const organizationId = normalizeOptionalId(input.organizationId);
@@ -229,16 +242,7 @@ async function resolveTodoScope(userId: string, input: Pick<CreateTodoInput, 'or
 
   const workspaceId = normalizeOptionalId(input.workspaceId);
   if (workspaceId) {
-    const workspace = await db.query.canvasWorkspaces.findFirst({
-      where: and(
-        eq(canvasWorkspaces.id, workspaceId),
-        eq(canvasWorkspaces.organizationId, organizationId),
-        eq(canvasWorkspaces.type, 'team'),
-      ),
-    });
-    if (!workspace) {
-      throw new TodoStoreError('Team workspace not found.', 'INVALID_INPUT');
-    }
+    await assertTeamWorkspaceInOrganization(organizationId, workspaceId);
   }
 
   return { organizationId, workspaceId, workspaceType };
@@ -583,8 +587,10 @@ export async function listTodos(userId: string, options: ListTodosOptions = {}):
     }
     await assertOrganizationMember(organizationId, userId);
     conditions.push(eq(todoItems.organizationId, organizationId), eq(todoItems.workspaceType, 'team'));
-    if (options.workspaceId) {
-      conditions.push(eq(todoItems.workspaceId, options.workspaceId));
+    const workspaceId = normalizeOptionalId(options.workspaceId);
+    if (workspaceId) {
+      await assertTeamWorkspaceInOrganization(organizationId, workspaceId);
+      conditions.push(eq(todoItems.workspaceId, workspaceId));
     }
   } else if (workspaceType === 'all') {
     const organizationId = normalizeOptionalId(options.organizationId);

--- a/app/lib/todos/store.ts
+++ b/app/lib/todos/store.ts
@@ -209,6 +209,26 @@ async function assertOrganizationMember(organizationId: string, userId: string):
   }
 }
 
+async function isOrganizationWorkspaceWriter(organizationId: string, userId: string): Promise<boolean> {
+  const permission = await db.query.organizationUserPermissions.findFirst({
+    where: and(
+      eq(organizationUserPermissions.organizationId, organizationId),
+      eq(organizationUserPermissions.userId, userId),
+      ne(organizationUserPermissions.role, 'external'),
+    ),
+  });
+  return Boolean(
+    permission
+    && (permission.role === 'owner' || permission.role === 'admin' || permission.canWriteTeamWorkspace),
+  );
+}
+
+async function assertOrganizationWorkspaceWriter(organizationId: string, userId: string): Promise<void> {
+  if (!(await isOrganizationWorkspaceWriter(organizationId, userId))) {
+    throw new TodoStoreError('User cannot write to this team workspace.', 'ORGANIZATION_ACCESS_DENIED');
+  }
+}
+
 async function assertAssignableUser(organizationId: string, assigneeUserId: string): Promise<void> {
   if (!(await isOrganizationMember(organizationId, assigneeUserId))) {
     throw new TodoStoreError('Assignee is not a member of this organization.', 'ASSIGNEE_NOT_FOUND');
@@ -258,6 +278,21 @@ async function assertCanReadTodo(userId: string, todo: TodoItem): Promise<void> 
   if (!(await canReadTodo(userId, todo))) {
     throw new TodoStoreError('Todo not found', 'TODO_NOT_FOUND');
   }
+}
+
+async function assertCanWriteTodo(userId: string, todo: TodoItem): Promise<void> {
+  const workspaceType = normalizeWorkspaceType((todo.workspaceType as TodoWorkspaceType | null) ?? 'personal');
+  if (workspaceType === 'personal') {
+    if (todo.userId !== userId) {
+      throw new TodoStoreError('Todo not found', 'TODO_NOT_FOUND');
+    }
+    return;
+  }
+
+  if (!todo.organizationId) {
+    throw new TodoStoreError('Team todo is missing organization scope.', 'INVALID_INPUT');
+  }
+  await assertOrganizationWorkspaceWriter(todo.organizationId, userId);
 }
 
 function normalizeDate(value: Date | null | undefined): Date | null {
@@ -481,8 +516,11 @@ export async function createTodo(userId: string, input: CreateTodoInput): Promis
   const now = new Date();
   const scope = await resolveTodoScope(userId, input);
   const assigneeUserId = normalizeOptionalId(input.assigneeUserId);
-  if (scope.workspaceType === 'team' && assigneeUserId) {
-    await assertAssignableUser(scope.organizationId!, assigneeUserId);
+  if (scope.workspaceType === 'team') {
+    await assertOrganizationWorkspaceWriter(scope.organizationId!, userId);
+    if (assigneeUserId) {
+      await assertAssignableUser(scope.organizationId!, assigneeUserId);
+    }
   } else if (scope.workspaceType === 'personal' && assigneeUserId && assigneeUserId !== userId) {
     throw new TodoStoreError('Personal to-dos can only be assigned to the current user.', 'ASSIGNEE_NOT_FOUND');
   }
@@ -654,6 +692,7 @@ export async function updateTodo(userId: string, todoId: string, input: UpdateTo
   });
   if (!current) return null;
   await assertCanReadTodo(userId, current);
+  await assertCanWriteTodo(userId, current);
 
   const now = new Date();
   const updates: Partial<typeof todoItems.$inferInsert> = {

--- a/app/lib/todos/store.ts
+++ b/app/lib/todos/store.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
-import { and, asc, desc, eq, inArray, ne, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, ne, or, sql } from 'drizzle-orm';
 
 import { db } from '@/app/lib/db';
-import { todoCategories, todoFileLinks, todoItems } from '@/app/lib/db/schema';
+import { canvasWorkspaces, organizationUserPermissions, todoCategories, todoFileLinks, todoItems, user } from '@/app/lib/db/schema';
 import { validatePath } from '@/app/lib/filesystem/workspace-files';
 import {
   DEFAULT_TODO_CATEGORIES,
@@ -27,6 +27,9 @@ export type TodoPriority = typeof TODO_PRIORITIES[number];
 export const TODO_SOURCE_TYPES = ['user', 'agent'] as const;
 export type TodoSourceType = typeof TODO_SOURCE_TYPES[number];
 
+export const TODO_WORKSPACE_TYPES = ['personal', 'team'] as const;
+export type TodoWorkspaceType = typeof TODO_WORKSPACE_TYPES[number];
+
 const TITLE_MAX_LENGTH = 180;
 const DESCRIPTION_MAX_LENGTH = 5000;
 const CATEGORY_NAME_MAX_LENGTH = 80;
@@ -40,7 +43,9 @@ export class TodoStoreError extends Error {
       | 'INVALID_INPUT'
       | 'INVALID_WORKSPACE_PATH'
       | 'CATEGORY_NOT_FOUND'
-      | 'TODO_NOT_FOUND',
+      | 'TODO_NOT_FOUND'
+      | 'ORGANIZATION_ACCESS_DENIED'
+      | 'ASSIGNEE_NOT_FOUND',
   ) {
     super(message);
     this.name = 'TodoStoreError';
@@ -54,6 +59,8 @@ export type TodoFileLink = typeof todoFileLinks.$inferSelect;
 export type TodoWithRelations = TodoItem & {
   category: TodoCategory | null;
   fileLinks: TodoFileLink[];
+  createdBy: TodoUserSummary | null;
+  assignee: TodoUserSummary | null;
 };
 
 export type TodoFileLinkInput = string | {
@@ -71,6 +78,10 @@ export type CreateTodoInput = {
   sourceType?: TodoSourceType;
   sourceAgentId?: string | null;
   sourceSessionId?: string | null;
+  organizationId?: string | null;
+  workspaceId?: string | null;
+  workspaceType?: TodoWorkspaceType | null;
+  assigneeUserId?: string | null;
   seenAt?: Date | null;
   fileLinks?: TodoFileLinkInput[];
 };
@@ -86,6 +97,7 @@ export type UpdateTodoInput = {
   completionComment?: string | null;
   followUpSentAt?: Date | null;
   followUpError?: string | null;
+  assigneeUserId?: string | null;
   fileLinks?: TodoFileLinkInput[];
 };
 
@@ -93,8 +105,24 @@ export type ListTodosOptions = {
   status?: TodoStatus | 'active' | 'all';
   categoryId?: string | null;
   sourceType?: TodoSourceType;
+  workspaceType?: TodoWorkspaceType | 'all';
+  organizationId?: string | null;
+  workspaceId?: string | null;
+  assigneeUserId?: string | 'me' | 'unassigned' | null;
   due?: 'overdue' | 'today' | 'upcoming';
   limit?: number;
+};
+
+export type TodoUserSummary = {
+  id: string;
+  name: string | null;
+  email: string | null;
+};
+
+type TodoScope = {
+  organizationId: string | null;
+  workspaceId: string | null;
+  workspaceType: TodoWorkspaceType;
 };
 
 async function sendTodoCreatedEmailNotificationIfNeeded(userId: string, todo: TodoWithRelations): Promise<void> {
@@ -148,6 +176,84 @@ function normalizeTodoSourceType(value: TodoSourceType | undefined): TodoSourceT
     throw new TodoStoreError('Invalid todo source type', 'INVALID_INPUT');
   }
   return value;
+}
+
+function normalizeWorkspaceType(value: TodoWorkspaceType | null | undefined): TodoWorkspaceType {
+  if (!value) return 'personal';
+  if (!TODO_WORKSPACE_TYPES.includes(value)) {
+    throw new TodoStoreError('Invalid todo workspace type', 'INVALID_INPUT');
+  }
+  return value;
+}
+
+function normalizeOptionalId(value: string | null | undefined, maxLength = 160): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized ? normalized.slice(0, maxLength) : null;
+}
+
+async function isOrganizationMember(organizationId: string, userId: string): Promise<boolean> {
+  const permission = await db.query.organizationUserPermissions.findFirst({
+    where: and(
+      eq(organizationUserPermissions.organizationId, organizationId),
+      eq(organizationUserPermissions.userId, userId),
+      ne(organizationUserPermissions.role, 'external'),
+    ),
+  });
+  return Boolean(permission);
+}
+
+async function assertOrganizationMember(organizationId: string, userId: string): Promise<void> {
+  if (!(await isOrganizationMember(organizationId, userId))) {
+    throw new TodoStoreError('User is not a member of this organization.', 'ORGANIZATION_ACCESS_DENIED');
+  }
+}
+
+async function assertAssignableUser(organizationId: string, assigneeUserId: string): Promise<void> {
+  if (!(await isOrganizationMember(organizationId, assigneeUserId))) {
+    throw new TodoStoreError('Assignee is not a member of this organization.', 'ASSIGNEE_NOT_FOUND');
+  }
+}
+
+async function resolveTodoScope(userId: string, input: Pick<CreateTodoInput, 'organizationId' | 'workspaceId' | 'workspaceType'>): Promise<TodoScope> {
+  const workspaceType = normalizeWorkspaceType(input.workspaceType);
+  if (workspaceType === 'personal') {
+    return { organizationId: null, workspaceId: normalizeOptionalId(input.workspaceId), workspaceType };
+  }
+
+  const organizationId = normalizeOptionalId(input.organizationId);
+  if (!organizationId) {
+    throw new TodoStoreError('organizationId is required for team to-dos.', 'INVALID_INPUT');
+  }
+  await assertOrganizationMember(organizationId, userId);
+
+  const workspaceId = normalizeOptionalId(input.workspaceId);
+  if (workspaceId) {
+    const workspace = await db.query.canvasWorkspaces.findFirst({
+      where: and(
+        eq(canvasWorkspaces.id, workspaceId),
+        eq(canvasWorkspaces.organizationId, organizationId),
+        eq(canvasWorkspaces.type, 'team'),
+      ),
+    });
+    if (!workspace) {
+      throw new TodoStoreError('Team workspace not found.', 'INVALID_INPUT');
+    }
+  }
+
+  return { organizationId, workspaceId, workspaceType };
+}
+
+async function canReadTodo(userId: string, todo: TodoItem): Promise<boolean> {
+  const workspaceType = normalizeWorkspaceType((todo.workspaceType as TodoWorkspaceType | null) ?? 'personal');
+  if (workspaceType === 'personal') return todo.userId === userId;
+  return Boolean(todo.organizationId && await isOrganizationMember(todo.organizationId, userId));
+}
+
+async function assertCanReadTodo(userId: string, todo: TodoItem): Promise<void> {
+  if (!(await canReadTodo(userId, todo))) {
+    throw new TodoStoreError('Todo not found', 'TODO_NOT_FOUND');
+  }
 }
 
 function normalizeDate(value: Date | null | undefined): Date | null {
@@ -339,7 +445,13 @@ async function resolveCategoryId(userId: string, input: Pick<CreateTodoInput, 'c
   return matched?.id ?? null;
 }
 
-async function replaceFileLinks(todoId: string, userId: string, links: Array<{ workspacePath: string; label: string | null }>, now: Date) {
+async function replaceFileLinks(
+  todoId: string,
+  userId: string,
+  scope: TodoScope,
+  links: Array<{ workspacePath: string; label: string | null }>,
+  now: Date,
+) {
   await db.delete(todoFileLinks).where(and(eq(todoFileLinks.todoId, todoId), eq(todoFileLinks.userId, userId)));
 
   if (links.length === 0) {
@@ -351,6 +463,9 @@ async function replaceFileLinks(todoId: string, userId: string, links: Array<{ w
       id: randomUUID(),
       todoId,
       userId,
+      organizationId: scope.organizationId,
+      workspaceId: scope.workspaceId,
+      workspaceType: scope.workspaceType,
       workspacePath: link.workspacePath,
       label: link.label,
       createdAt: now,
@@ -360,11 +475,23 @@ async function replaceFileLinks(todoId: string, userId: string, links: Array<{ w
 
 export async function createTodo(userId: string, input: CreateTodoInput): Promise<TodoWithRelations> {
   const now = new Date();
+  const scope = await resolveTodoScope(userId, input);
+  const assigneeUserId = normalizeOptionalId(input.assigneeUserId);
+  if (scope.workspaceType === 'team' && assigneeUserId) {
+    await assertAssignableUser(scope.organizationId!, assigneeUserId);
+  } else if (scope.workspaceType === 'personal' && assigneeUserId && assigneeUserId !== userId) {
+    throw new TodoStoreError('Personal to-dos can only be assigned to the current user.', 'ASSIGNEE_NOT_FOUND');
+  }
   const categoryId = await resolveCategoryId(userId, input);
   const fileLinks = normalizeFileLinks(input.fileLinks);
   const [created] = await db.insert(todoItems).values({
     id: randomUUID(),
     userId,
+    createdByUserId: userId,
+    assigneeUserId: assigneeUserId || null,
+    organizationId: scope.organizationId,
+    workspaceId: scope.workspaceId,
+    workspaceType: scope.workspaceType,
     categoryId,
     title: normalizeRequiredText(input.title, 'Title', TITLE_MAX_LENGTH),
     description: normalizeOptionalText(input.description, DESCRIPTION_MAX_LENGTH),
@@ -386,7 +513,7 @@ export async function createTodo(userId: string, input: CreateTodoInput): Promis
     updatedAt: now,
   }).returning();
 
-  await replaceFileLinks(created.id, userId, fileLinks, now);
+  await replaceFileLinks(created.id, userId, scope, fileLinks, now);
   const hydrated = await getTodo(userId, created.id);
   if (!hydrated) {
     throw new TodoStoreError('Todo not found after creation', 'TODO_NOT_FOUND');
@@ -416,25 +543,62 @@ async function hydrateTodos(rows: TodoItem[]): Promise<TodoWithRelations[]> {
     linksByTodoId.set(link.todoId, current);
   }
 
+  const userIds = Array.from(new Set(rows.flatMap((row) => [
+    row.createdByUserId || row.userId,
+    row.assigneeUserId,
+  ]).filter(Boolean))) as string[];
+  const users = userIds.length
+    ? await db.select({ id: user.id, name: user.name, email: user.email }).from(user).where(inArray(user.id, userIds))
+    : [];
+  const userById = new Map(users.map((entry) => [entry.id, entry]));
+
   return rows.map((row) => ({
     ...row,
     category: row.categoryId ? categoryById.get(row.categoryId) ?? null : null,
     fileLinks: linksByTodoId.get(row.id) ?? [],
+    createdBy: userById.get(row.createdByUserId || row.userId) ?? null,
+    assignee: row.assigneeUserId ? userById.get(row.assigneeUserId) ?? null : null,
   }));
 }
 
 export async function getTodo(userId: string, todoId: string): Promise<TodoWithRelations | null> {
   const todo = await db.query.todoItems.findFirst({
-    where: and(eq(todoItems.id, todoId), eq(todoItems.userId, userId)),
+    where: eq(todoItems.id, todoId),
   });
   if (!todo) return null;
+  await assertCanReadTodo(userId, todo);
   const [hydrated] = await hydrateTodos([todo]);
   return hydrated;
 }
 
 export async function listTodos(userId: string, options: ListTodosOptions = {}): Promise<TodoWithRelations[]> {
   const limit = Math.min(Math.max(options.limit ?? 100, 1), 200);
-  const conditions = [eq(todoItems.userId, userId)];
+  const workspaceType = options.workspaceType || 'personal';
+  const conditions = [];
+
+  if (workspaceType === 'team') {
+    const organizationId = normalizeOptionalId(options.organizationId);
+    if (!organizationId) {
+      throw new TodoStoreError('organizationId is required for team to-dos.', 'INVALID_INPUT');
+    }
+    await assertOrganizationMember(organizationId, userId);
+    conditions.push(eq(todoItems.organizationId, organizationId), eq(todoItems.workspaceType, 'team'));
+    if (options.workspaceId) {
+      conditions.push(eq(todoItems.workspaceId, options.workspaceId));
+    }
+  } else if (workspaceType === 'all') {
+    const organizationId = normalizeOptionalId(options.organizationId);
+    if (organizationId && await isOrganizationMember(organizationId, userId)) {
+      conditions.push(or(
+        and(eq(todoItems.userId, userId), eq(todoItems.workspaceType, 'personal')),
+        and(eq(todoItems.organizationId, organizationId), eq(todoItems.workspaceType, 'team')),
+      )!);
+    } else {
+      conditions.push(eq(todoItems.userId, userId), eq(todoItems.workspaceType, 'personal'));
+    }
+  } else {
+    conditions.push(eq(todoItems.userId, userId), eq(todoItems.workspaceType, 'personal'));
+  }
 
   if (options.status && options.status !== 'all' && options.status !== 'active') {
     conditions.push(eq(todoItems.status, options.status));
@@ -447,6 +611,13 @@ export async function listTodos(userId: string, options: ListTodosOptions = {}):
   }
   if (options.sourceType) {
     conditions.push(eq(todoItems.sourceType, normalizeTodoSourceType(options.sourceType)));
+  }
+  if (options.assigneeUserId === 'me') {
+    conditions.push(eq(todoItems.assigneeUserId, userId));
+  } else if (options.assigneeUserId === 'unassigned') {
+    conditions.push(sql`${todoItems.assigneeUserId} IS NULL`);
+  } else if (typeof options.assigneeUserId === 'string' && options.assigneeUserId.trim()) {
+    conditions.push(eq(todoItems.assigneeUserId, options.assigneeUserId.trim()));
   }
   if (options.due) {
     const now = new Date();
@@ -473,9 +644,10 @@ export async function listTodos(userId: string, options: ListTodosOptions = {}):
 
 export async function updateTodo(userId: string, todoId: string, input: UpdateTodoInput): Promise<TodoWithRelations | null> {
   const current = await db.query.todoItems.findFirst({
-    where: and(eq(todoItems.id, todoId), eq(todoItems.userId, userId)),
+    where: eq(todoItems.id, todoId),
   });
   if (!current) return null;
+  await assertCanReadTodo(userId, current);
 
   const now = new Date();
   const updates: Partial<typeof todoItems.$inferInsert> = {
@@ -511,6 +683,17 @@ export async function updateTodo(userId: string, todoId: string, input: UpdateTo
   if (input.followUpError !== undefined) {
     updates.followUpError = normalizeOptionalText(input.followUpError, 1000);
   }
+  if (input.assigneeUserId !== undefined) {
+    const assigneeUserId = normalizeOptionalId(input.assigneeUserId);
+    const workspaceType = normalizeWorkspaceType((current.workspaceType as TodoWorkspaceType | null) ?? 'personal');
+    if (workspaceType === 'team' && assigneeUserId) {
+      if (!current.organizationId) throw new TodoStoreError('Team todo is missing organization scope.', 'INVALID_INPUT');
+      await assertAssignableUser(current.organizationId, assigneeUserId);
+    } else if (workspaceType === 'personal' && assigneeUserId && assigneeUserId !== userId) {
+      throw new TodoStoreError('Personal to-dos can only be assigned to the current user.', 'ASSIGNEE_NOT_FOUND');
+    }
+    updates.assigneeUserId = assigneeUserId;
+  }
   if (input.status !== undefined) {
     const nextStatus = normalizeTodoStatus(input.status);
     updates.status = nextStatus;
@@ -528,10 +711,14 @@ export async function updateTodo(userId: string, todoId: string, input: UpdateTo
   await db
     .update(todoItems)
     .set(updates)
-    .where(and(eq(todoItems.id, todoId), eq(todoItems.userId, userId)));
+    .where(eq(todoItems.id, todoId));
 
   if (input.fileLinks !== undefined) {
-    await replaceFileLinks(todoId, userId, normalizeFileLinks(input.fileLinks), now);
+    await replaceFileLinks(todoId, current.userId, {
+      organizationId: current.organizationId,
+      workspaceId: current.workspaceId,
+      workspaceType: normalizeWorkspaceType((current.workspaceType as TodoWorkspaceType | null) ?? 'personal'),
+    }, normalizeFileLinks(input.fileLinks), now);
   }
 
   return getTodo(userId, todoId);

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -327,8 +327,25 @@
     {
       "id": 20,
       "title": "To-do-Management mit Organization-Scope, User-Zuweisung und Status-Tracking bauen",
-      "status": "pending",
-      "repo": "canvasstudios-notebook"
+      "status": "completed",
+      "repo": "canvasstudios-notebook",
+      "planningArtifacts": [
+        "docs/architecture/canvas-notebook/team-workspace/05-actor-audit-retention.md",
+        "docs/architecture/canvas-notebook/team-workspace/06-workspace-switching-ux.md",
+        "docs/architecture/canvas-notebook/team-workspace/10-agent-tool-execution-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/db/schema.ts",
+        "app/lib/db/migrate.ts",
+        "app/lib/todos/store.ts",
+        "app/api/todos/route.ts",
+        "app/api/todos/[id]/route.ts",
+        "app/api/todos/assignees/route.ts",
+        "app/apps/todos/components/TodosClient.tsx",
+        "app/lib/pi/human-todo-tool.ts",
+        "scripts/todo-store-test.ts",
+        "scripts/todo-email-notification-test.ts"
+      ]
     },
     {
       "id": 21,

--- a/messages/de.json
+++ b/messages/de.json
@@ -1458,11 +1458,16 @@
     "eyebrow": "Human-in-the-loop",
     "summary": "{open} offen · {done} erledigt · {unread} ungelesen",
     "sections": {
+      "workspace": "Workspace",
       "status": "Status",
       "categories": "Kategorien",
       "files": "Dateien",
       "session": "Session",
       "emailNotification": "E-Mail-Benachrichtigung"
+    },
+    "scope": {
+      "personal": "Persönlich",
+      "team": "Team"
     },
     "filters": {
       "allCategories": "Alle Kategorien",
@@ -1524,6 +1529,8 @@
       "title": "Titel",
       "description": "Beschreibung",
       "category": "Kategorie",
+      "workspace": "Workspace",
+      "assignee": "Zugewiesen an",
       "priority": "Priorität",
       "dueAt": "Fällig",
       "noDueAt": "Kein Datum",
@@ -1549,6 +1556,7 @@
     },
     "labels": {
       "unread": "Ungelesen",
+      "unassigned": "Nicht zugewiesen",
       "followUpSentAt": "Zuletzt an den Agenten gesendet: {date}",
       "emailNotificationSentAt": "E-Mail-Benachrichtigung gesendet: {date}",
       "emailNotificationBlocked": "E-Mail-Benachrichtigung nicht gesendet"

--- a/messages/en.json
+++ b/messages/en.json
@@ -1459,11 +1459,16 @@
     "eyebrow": "Human in the loop",
     "summary": "{open} open · {done} done · {unread} unread",
     "sections": {
+      "workspace": "Workspace",
       "status": "Status",
       "categories": "Categories",
       "files": "Files",
       "session": "Session",
       "emailNotification": "Email notification"
+    },
+    "scope": {
+      "personal": "Personal",
+      "team": "Team"
     },
     "filters": {
       "allCategories": "All categories",
@@ -1525,6 +1530,8 @@
       "title": "Title",
       "description": "Description",
       "category": "Category",
+      "workspace": "Workspace",
+      "assignee": "Assignee",
       "priority": "Priority",
       "dueAt": "Due",
       "noDueAt": "No date",
@@ -1550,6 +1557,7 @@
     },
     "labels": {
       "unread": "Unread",
+      "unassigned": "Unassigned",
       "followUpSentAt": "Last sent to the agent: {date}",
       "emailNotificationSentAt": "Email notification sent: {date}",
       "emailNotificationBlocked": "Email notification not sent"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "test:channels:media": "tsx scripts/channel-media-directives-test.ts",
     "test:channels:db": "tsx --conditions react-server scripts/channel-db-test.ts",
     "test:sessions:read-state": "tsx scripts/session-read-state-test.ts",
-    "test:todos:store": "tsx scripts/todo-store-test.ts",
+    "test:todos:store": "tsx --conditions react-server scripts/todo-store-test.ts",
     "test:todos:api": "node scripts/todo-api-test.mjs",
     "test:todos:tool": "tsx --conditions react-server scripts/human-todo-tool-test.ts",
     "test:todos:email": "tsx --conditions react-server scripts/todo-email-notification-test.ts",

--- a/scripts/todo-email-notification-test.ts
+++ b/scripts/todo-email-notification-test.ts
@@ -126,11 +126,16 @@ async function main() {
     createdAt: now,
     updatedAt: now,
   }).returning();
+  const todoRelations = {
+    category: null,
+    fileLinks: [],
+    createdBy: { id: userId, name: 'Todo Email User', email: 'owner@example.test' },
+    assignee: null,
+  };
 
   const result = await sendTodoCreatedEmailNotification(userId, {
     ...agentTodo,
-    category: null,
-    fileLinks: [],
+    ...todoRelations,
   });
 
   assert.equal(result.status, 'sent');
@@ -183,8 +188,7 @@ async function main() {
 
   const englishResult = await sendTodoCreatedEmailNotification(userId, {
     ...englishTodo,
-    category: null,
-    fileLinks: [],
+    ...todoRelations,
   });
 
   assert.equal(englishResult.status, 'sent');
@@ -212,8 +216,7 @@ async function main() {
 
   const skipped = await sendTodoCreatedEmailNotification(userId, {
     ...skippedTodo,
-    category: null,
-    fileLinks: [],
+    ...todoRelations,
   });
 
   assert.equal(skipped.status, 'skipped');
@@ -242,8 +245,7 @@ async function main() {
 
   const policyAllowed = await sendTodoCreatedEmailNotification(userId, {
     ...policyTodo,
-    category: null,
-    fileLinks: [],
+    ...todoRelations,
   });
 
   assert.equal(policyAllowed.status, 'sent');

--- a/scripts/todo-store-test.ts
+++ b/scripts/todo-store-test.ts
@@ -155,6 +155,7 @@ async function main() {
     sourceType: 'agent',
     sourceAgentId: 'canvas-agent',
     sourceSessionId: 'sess-test',
+    workspaceId: 'team-workspace',
     fileLinks: [
       { workspacePath: './docs/brief.md', label: 'Brief' },
       'docs/brief.md',
@@ -166,8 +167,11 @@ async function main() {
   assert.equal(created.sourceType, 'agent');
   assert.equal(created.category?.name, 'Review');
   assert.equal(getDefaultTodoCategoryKey(created.category), 'review');
+  assert.equal(created.workspaceType, 'personal');
+  assert.equal(created.workspaceId, null);
   assert.equal(created.fileLinks.length, 1);
   assert.equal(created.fileLinks[0].workspacePath, 'docs/brief.md');
+  assert.equal(created.fileLinks[0].workspaceId, null);
 
   const todos = await listTodos('todo-user');
   assert.equal(todos.length, 1);
@@ -215,6 +219,16 @@ async function main() {
       workspaceId: 'team-workspace',
     }),
     (error) => error instanceof TodoStoreError && error.code === 'ORGANIZATION_ACCESS_DENIED',
+  );
+
+  await assert.rejects(
+    () => listTodos('todo-user', {
+      status: 'all',
+      workspaceType: 'team',
+      organizationId: 'org-test',
+      workspaceId: 'missing-team-workspace',
+    }),
+    (error) => error instanceof TodoStoreError && error.code === 'INVALID_INPUT',
   );
 
   await assert.rejects(

--- a/scripts/todo-store-test.ts
+++ b/scripts/todo-store-test.ts
@@ -13,7 +13,12 @@ async function main() {
   writeFileSync(path.join(workspaceDir, 'docs', 'brief.md'), '# Brief');
 
   const { db } = await import('../app/lib/db');
-  const { user } = await import('../app/lib/db/schema');
+  const {
+    canvasOrganizationSettings,
+    canvasWorkspaces,
+    organizationUserPermissions,
+    user,
+  } = await import('../app/lib/db/schema');
   const {
     DEFAULT_TODO_CATEGORY_NAME,
     getDefaultTodoCategoryKey,
@@ -47,6 +52,92 @@ async function main() {
       emailVerified: true,
       image: null,
       role: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: 'external-user',
+      name: 'External User',
+      email: 'external-todo-user@example.test',
+      emailVerified: true,
+      image: null,
+      role: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+  ]);
+
+  await db.insert(canvasOrganizationSettings).values({
+    organizationId: 'org-test',
+    ownerUserId: 'todo-user',
+    deploymentMode: 'team',
+    teamFeaturesEnabled: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(canvasWorkspaces).values({
+    id: 'team-workspace',
+    organizationId: 'org-test',
+    type: 'team',
+    ownerUserId: null,
+    rootRelativePath: 'organizations/org-test/team',
+    displayName: 'Team Workspace',
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(organizationUserPermissions).values([
+    {
+      organizationId: 'org-test',
+      userId: 'todo-user',
+      role: 'owner',
+      canWriteTeamWorkspace: true,
+      canCreatePublicLinks: true,
+      canCreateTeamAutomations: true,
+      canSharePluginsAndSkills: true,
+      canExport: true,
+      canDeleteTeamFiles: true,
+      canDeleteStudioAssets: true,
+      canManageBackups: true,
+      canMigrateDatabase: true,
+      canEnableKnowledge: true,
+      canRecoverWorkspaces: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      organizationId: 'org-test',
+      userId: 'other-user',
+      role: 'member',
+      canWriteTeamWorkspace: true,
+      canCreatePublicLinks: true,
+      canCreateTeamAutomations: false,
+      canSharePluginsAndSkills: false,
+      canExport: false,
+      canDeleteTeamFiles: true,
+      canDeleteStudioAssets: true,
+      canManageBackups: false,
+      canMigrateDatabase: false,
+      canEnableKnowledge: false,
+      canRecoverWorkspaces: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      organizationId: 'org-test',
+      userId: 'external-user',
+      role: 'external',
+      canWriteTeamWorkspace: false,
+      canCreatePublicLinks: false,
+      canCreateTeamAutomations: false,
+      canSharePluginsAndSkills: false,
+      canExport: false,
+      canDeleteTeamFiles: false,
+      canDeleteStudioAssets: false,
+      canManageBackups: false,
+      canMigrateDatabase: false,
+      canEnableKnowledge: false,
+      canRecoverWorkspaces: false,
       createdAt: now,
       updatedAt: now,
     },
@@ -84,6 +175,52 @@ async function main() {
 
   const otherUserTodos = await listTodos('other-user', { status: 'all' });
   assert.equal(otherUserTodos.length, 0);
+
+  const teamTodo = await createTodo('todo-user', {
+    title: 'Team handoff',
+    description: 'Shared org task',
+    workspaceType: 'team',
+    organizationId: 'org-test',
+    workspaceId: 'team-workspace',
+    assigneeUserId: 'other-user',
+    fileLinks: ['docs/brief.md'],
+  });
+  assert.equal(teamTodo.workspaceType, 'team');
+  assert.equal(teamTodo.organizationId, 'org-test');
+  assert.equal(teamTodo.workspaceId, 'team-workspace');
+  assert.equal(teamTodo.createdBy?.id, 'todo-user');
+  assert.equal(teamTodo.assignee?.id, 'other-user');
+  assert.equal(teamTodo.fileLinks[0].workspaceType, 'team');
+  assert.equal(teamTodo.fileLinks[0].workspaceId, 'team-workspace');
+
+  const memberTeamTodos = await listTodos('other-user', {
+    status: 'all',
+    workspaceType: 'team',
+    organizationId: 'org-test',
+    workspaceId: 'team-workspace',
+  });
+  assert.deepEqual(memberTeamTodos.map((todo) => todo.id), [teamTodo.id]);
+
+  const personalStillPrivate = await listTodos('other-user', {
+    status: 'all',
+    workspaceType: 'personal',
+  });
+  assert.equal(personalStillPrivate.length, 0);
+
+  await assert.rejects(
+    () => listTodos('external-user', {
+      status: 'all',
+      workspaceType: 'team',
+      organizationId: 'org-test',
+      workspaceId: 'team-workspace',
+    }),
+    (error) => error instanceof TodoStoreError && error.code === 'ORGANIZATION_ACCESS_DENIED',
+  );
+
+  await assert.rejects(
+    () => updateTodo('todo-user', teamTodo.id, { assigneeUserId: 'external-user' }),
+    (error) => error instanceof TodoStoreError && error.code === 'ASSIGNEE_NOT_FOUND',
+  );
 
   const seen = await markTodoSeen('todo-user', created.id, new Date('2026-05-31T12:05:00.000Z'));
   assert.equal(seen?.seenAt?.toISOString(), '2026-05-31T12:05:00.000Z');

--- a/scripts/todo-store-test.ts
+++ b/scripts/todo-store-test.ts
@@ -65,6 +65,16 @@ async function main() {
       createdAt: now,
       updatedAt: now,
     },
+    {
+      id: 'readonly-user',
+      name: 'Readonly User',
+      email: 'readonly-todo-user@example.test',
+      emailVerified: true,
+      image: null,
+      role: null,
+      createdAt: now,
+      updatedAt: now,
+    },
   ]);
 
   await db.insert(canvasOrganizationSettings).values({
@@ -141,6 +151,24 @@ async function main() {
       createdAt: now,
       updatedAt: now,
     },
+    {
+      organizationId: 'org-test',
+      userId: 'readonly-user',
+      role: 'member',
+      canWriteTeamWorkspace: false,
+      canCreatePublicLinks: true,
+      canCreateTeamAutomations: false,
+      canSharePluginsAndSkills: false,
+      canExport: false,
+      canDeleteTeamFiles: false,
+      canDeleteStudioAssets: true,
+      canManageBackups: false,
+      canMigrateDatabase: false,
+      canEnableKnowledge: false,
+      canRecoverWorkspaces: false,
+      createdAt: now,
+      updatedAt: now,
+    },
   ]);
 
   const categories = await ensureTodoCategories('todo-user');
@@ -205,6 +233,14 @@ async function main() {
   });
   assert.deepEqual(memberTeamTodos.map((todo) => todo.id), [teamTodo.id]);
 
+  const readonlyTeamTodos = await listTodos('readonly-user', {
+    status: 'all',
+    workspaceType: 'team',
+    organizationId: 'org-test',
+    workspaceId: 'team-workspace',
+  });
+  assert.deepEqual(readonlyTeamTodos.map((todo) => todo.id), [teamTodo.id]);
+
   const personalStillPrivate = await listTodos('other-user', {
     status: 'all',
     workspaceType: 'personal',
@@ -229,6 +265,21 @@ async function main() {
       workspaceId: 'missing-team-workspace',
     }),
     (error) => error instanceof TodoStoreError && error.code === 'INVALID_INPUT',
+  );
+
+  await assert.rejects(
+    () => createTodo('readonly-user', {
+      title: 'Read-only cannot create',
+      workspaceType: 'team',
+      organizationId: 'org-test',
+      workspaceId: 'team-workspace',
+    }),
+    (error) => error instanceof TodoStoreError && error.code === 'ORGANIZATION_ACCESS_DENIED',
+  );
+
+  await assert.rejects(
+    () => updateTodo('readonly-user', teamTodo.id, { status: 'done' }),
+    (error) => error instanceof TodoStoreError && error.code === 'ORGANIZATION_ACCESS_DENIED',
   );
 
   await assert.rejects(


### PR DESCRIPTION
## Summary
- add organization/workspace scope, assignee fields, and indexes to todo items and file links
- enforce personal-vs-team todo access in the store and API, including scoped agent-created todos
- add scoped assignee lookup API and workspace/assignee controls in the todos UI
- mark task 20 complete in the architecture todo list

## Verification
- npm run test:todos:store
- npm run test:todos:tool
- npm run test:todos:email
- npm run lint
- npm run build

Greptile score: 5/5 (reviewed a89718ec)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds organization/workspace scoping to todo items and file links — introducing team vs. personal todo isolation, an `assigneeUserId` field, org-membership guards at the store layer, and a scoped assignees lookup API and workspace switcher in the UI.

- **Schema & migration**: `todo_items` and `todo_file_links` gain `organization_id`, `workspace_id`, `workspace_type`, `created_by_user_id`, and `assignee_user_id` columns with FK constraints and covering indexes; existing rows are backfilled via `UPDATE … WHERE created_by_user_id IS NULL`.
- **Store authorization**: `createTodo`/`updateTodo` now call `assertOrganizationWorkspaceWriter` for team todos; `listTodos` gates team queries behind `assertOrganizationMember`; `getTodo` drops its `userId = ?` WHERE clause in favour of `assertCanReadTodo`/`assertCanWriteTodo` helpers.
- **API & UI**: The POST route correctly requires `canWrite`; PATCH/DELETE pre-fetch the todo and call `requireTodoWriteWorkspace`; a new `/api/todos/assignees` endpoint returns non-external org members; `TodosClient` splits static and workspace-scoped data loads into separate effects.

<h3>Confidence Score: 5/5</h3>

Safe to merge — authorization changes are well-layered (API + store) and covered by new test cases; no regressions found in the personal-todo path.

The write-permission and org-membership guards work correctly end-to-end. The only findings are an inconsistent silent-fallback in the unused `workspaceType: 'all'` branch and a redundant DB query in the team create path — neither affects correctness or security of the shipped paths.

app/lib/todos/store.ts — the `listTodos` `'all'` branch and the `resolveTodoScope` redundancy are worth a second look before that code path is wired up to the API.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/lib/todos/store.ts | Core store refactored with team/personal scoping, org membership guards, and write-permission checks; `listTodos` 'all' branch silently swallows unauthorised org access instead of throwing |
| app/api/todos/route.ts | POST now passes `canWrite` permission; GET passes `canRead`; workspace scope correctly resolved via `todoWorkspaceScope` |
| app/api/todos/[id]/route.ts | PATCH and DELETE now pre-fetch todo then gate on `requireTodoWriteWorkspace`; error handling wrapped in try/catch throughout |
| app/api/todos/assignees/route.ts | New endpoint; correctly gates on `canRead` permission, returns only non-external org members for team workspaces |
| app/lib/db/migrate.ts | New columns added via idempotent `addColumns`; previously-separate completion columns consolidated into single block; backfill of `created_by_user_id` correct |
| app/lib/db/schema.ts | Schema extended with org/workspace/assignee fields and appropriate FK constraints and indexes |
| app/apps/todos/components/TodosClient.tsx | Workspace switcher, assignee dropdown, and scoped todo/file-link loading added; static vs scoped data load effects correctly split |
| app/lib/pi/human-todo-tool.ts | Agent tool now picks up execution context for workspace scoping and supports optional `assigneeUserId` |
| scripts/todo-store-test.ts | Comprehensive new test cases cover team todo creation, org membership gates, read-only member access, and assignee validation |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `app/api/todos/route.ts`, line 124-130 ([link](https://github.com/canvascoding/canvas-notebook/blob/fef5ad4398324e4a56afb07a0bbed5b387f81139/app/api/todos/route.ts#L124-L130)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing write-permission check for team workspace**

   `resolveRequestedWorkspace` calls `requireSessionWorkspace` without a `permissions` argument, so `assertWorkspacePermissions` runs an empty loop and grants access to anyone whose session can resolve the workspace. A user with `canWrite: false` on the team workspace can reach `createTodo` and pass the store's `assertOrganizationMember` gate (which only blocks `external` roles), then successfully insert a team todo. Compare the assignees endpoint which explicitly passes `permissions: 'canRead'`. The POST path should pass `permissions: 'canWrite'` so users without write access are rejected at the API layer before touching the store.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Forg-scoped-todos%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Forg-scoped-todos%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fapi%2Ftodos%2Froute.ts%0ALine%3A%20124-130%0A%0AComment%3A%0A**Missing%20write-permission%20check%20for%20team%20workspace**%0A%0A%60resolveRequestedWorkspace%60%20calls%20%60requireSessionWorkspace%60%20without%20a%20%60permissions%60%20argument%2C%20so%20%60assertWorkspacePermissions%60%20runs%20an%20empty%20loop%20and%20grants%20access%20to%20anyone%20whose%20session%20can%20resolve%20the%20workspace.%20A%20user%20with%20%60canWrite%3A%20false%60%20on%20the%20team%20workspace%20can%20reach%20%60createTodo%60%20and%20pass%20the%20store's%20%60assertOrganizationMember%60%20gate%20%28which%20only%20blocks%20%60external%60%20roles%29%2C%20then%20successfully%20insert%20a%20team%20todo.%20Compare%20the%20assignees%20endpoint%20which%20explicitly%20passes%20%60permissions%3A%20'canRead'%60.%20The%20POST%20path%20should%20pass%20%60permissions%3A%20'canWrite'%60%20so%20users%20without%20write%20access%20are%20rejected%20at%20the%20API%20layer%20before%20touching%20the%20store.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=22&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `app/lib/todos/store.ts`, line 922-926 ([link](https://github.com/canvascoding/canvas-notebook/blob/fef5ad4398324e4a56afb07a0bbed5b387f81139/app/lib/todos/store.ts#L922-L926)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Personal-scope `workspaceId` stored without ownership verification**

   When `workspaceType` is `'personal'`, `resolveTodoScope` stores whichever `workspaceId` is passed in without verifying that the `workspaceId` actually belongs to the caller. The API routes avoid this by having `todoWorkspaceScope` strip `workspaceId` from the personal branch, but any direct call to `createTodo` (e.g. future internal callers or tests) with a personal scope and an arbitrary `workspaceId` will silently persist the value. Consider setting `workspaceId: null` unconditionally for personal todos to keep the invariant clear.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Forg-scoped-todos%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Forg-scoped-todos%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Ftodos%2Fstore.ts%0ALine%3A%20922-926%0A%0AComment%3A%0A**Personal-scope%20%60workspaceId%60%20stored%20without%20ownership%20verification**%0A%0AWhen%20%60workspaceType%60%20is%20%60'personal'%60%2C%20%60resolveTodoScope%60%20stores%20whichever%20%60workspaceId%60%20is%20passed%20in%20without%20verifying%20that%20the%20%60workspaceId%60%20actually%20belongs%20to%20the%20caller.%20The%20API%20routes%20avoid%20this%20by%20having%20%60todoWorkspaceScope%60%20strip%20%60workspaceId%60%20from%20the%20personal%20branch%2C%20but%20any%20direct%20call%20to%20%60createTodo%60%20%28e.g.%20future%20internal%20callers%20or%20tests%29%20with%20a%20personal%20scope%20and%20an%20arbitrary%20%60workspaceId%60%20will%20silently%20persist%20the%20value.%20Consider%20setting%20%60workspaceId%3A%20null%60%20unconditionally%20for%20personal%20todos%20to%20keep%20the%20invariant%20clear.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=22&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

3. `app/apps/todos/components/TodosClient.tsx`, line 418 ([link](https://github.com/canvascoding/canvas-notebook/blob/fef5ad4398324e4a56afb07a0bbed5b387f81139/app/apps/todos/components/TodosClient.tsx#L418)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Full data reload triggered on every workspace switch**

   `loadAssignees` captures `selectedWorkspaceId` in its closure, so every time the selected workspace changes, React recreates the `loadAssignees` callback. Because the initial-load `useEffect` lists `loadAssignees` as a dependency, it fires again — re-fetching workspaces, categories, and todos in addition to assignees. `loadWorkspaces` and `loadCategories` are workspace-agnostic and don't need to re-run when `selectedWorkspaceId` changes. A dedicated `useEffect` that only calls `loadAssignees` and `loadTodos` when `selectedWorkspaceId` changes would avoid the redundant network requests.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Forg-scoped-todos%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Forg-scoped-todos%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fapps%2Ftodos%2Fcomponents%2FTodosClient.tsx%0ALine%3A%20418%0A%0AComment%3A%0A**Full%20data%20reload%20triggered%20on%20every%20workspace%20switch**%0A%0A%60loadAssignees%60%20captures%20%60selectedWorkspaceId%60%20in%20its%20closure%2C%20so%20every%20time%20the%20selected%20workspace%20changes%2C%20React%20recreates%20the%20%60loadAssignees%60%20callback.%20Because%20the%20initial-load%20%60useEffect%60%20lists%20%60loadAssignees%60%20as%20a%20dependency%2C%20it%20fires%20again%20%E2%80%94%20re-fetching%20workspaces%2C%20categories%2C%20and%20todos%20in%20addition%20to%20assignees.%20%60loadWorkspaces%60%20and%20%60loadCategories%60%20are%20workspace-agnostic%20and%20don't%20need%20to%20re-run%20when%20%60selectedWorkspaceId%60%20changes.%20A%20dedicated%20%60useEffect%60%20that%20only%20calls%20%60loadAssignees%60%20and%20%60loadTodos%60%20when%20%60selectedWorkspaceId%60%20changes%20would%20avoid%20the%20redundant%20network%20requests.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=22&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Forg-scoped-todos%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Forg-scoped-todos%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Flib%2Ftodos%2Fstore.ts%3A621-640%0A**%60'all'%60%20workspace%20type%20silently%20degrades%20instead%20of%20rejecting%20non-members**%0A%0AWhen%20%60workspaceType%20%3D%3D%3D%20'all'%60%20and%20%60organizationId%60%20is%20supplied%20but%20the%20caller%20is%20not%20a%20member%2C%20the%20code%20silently%20falls%20through%20to%20returning%20only%20the%20caller's%20personal%20todos.%20The%20%60'team'%60%20branch%20in%20the%20same%20function%20throws%20%60ORGANIZATION_ACCESS_DENIED%60%20under%20the%20same%20condition.%20A%20caller%20that%20passes%20%60workspaceType%3A%20'all'%60%20with%20an%20explicit%20%60organizationId%60%20has%20no%20way%20to%20distinguish%20%22you're%20not%20a%20member%22%20from%20%22there%20are%20genuinely%20no%20team%20todos%22%20%E2%80%94%20it%20just%20gets%20a%20quietly%20narrowed%20result%20set.%20Throwing%20an%20error%20here%20%28matching%20the%20%60'team'%60%20path%29%20would%20make%20the%20contract%20consistent%20and%20surface%20bugs%20early.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Flib%2Ftodos%2Fstore.ts%3A251-268%0A**Redundant%20membership%20check%20before%20write-permission%20check%20in%20team%20create%20path**%0A%0AFor%20team%20todos%2C%20%60resolveTodoScope%60%20calls%20%60assertOrganizationMember%60%20%28a%20DB%20query%20with%20%60ne%28role%2C%20'external'%29%60%29%2C%20and%20then%20%60createTodo%60%20immediately%20calls%20%60assertOrganizationWorkspaceWriter%60%2C%20which%20issues%20the%20same%20query%20and%20additionally%20checks%20%60role%20%3D%3D%3D%20'owner'%20%7C%7C%20role%20%3D%3D%3D%20'admin'%20%7C%7C%20canWriteTeamWorkspace%60.%20The%20write%20check%20fully%20subsumes%20the%20membership%20check%2C%20so%20the%20%60assertOrganizationMember%60%20call%20in%20%60resolveTodoScope%60%20for%20the%20team%20path%20is%20an%20unconditional%20extra%20round-trip%20that%20never%20blocks%20a%20request%20the%20write%20check%20wouldn't%20also%20block.%20Removing%20it%20from%20%60resolveTodoScope%60%20%28while%20keeping%20it%20in%20%60listTodos%60%20where%20no%20write%20check%20follows%29%20would%20eliminate%20the%20duplicate%20query.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=22&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["Handle todo route authorization errors"](https://github.com/canvascoding/canvas-notebook/commit/a89718ecb6f7ba438f556bb33676980f476ad1a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38828499)</sub>

<!-- /greptile_comment -->