### PR TITLE
Add organization user offboarding flow

### DIFF
--- a/app/api/admin/organization/users/[userId]/offboarding/route.ts
+++ b/app/api/admin/organization/users/[userId]/offboarding/route.ts
@@ -79,7 +79,14 @@ export async function POST(request: NextRequest, context: RouteContext) {
       reason: typeof body.reason === 'string' ? body.reason : null,
       acknowledgeWarnings: body.acknowledgeWarnings === true,
     });
-    return NextResponse.json({ success: true, data: result });
+    return NextResponse.json({
+      success: true,
+      data: {
+        preflight: result.preflight,
+        appliedAt: result.appliedAt,
+        actions: result.actions,
+      },
+    });
   } catch (error) {
     return errorResponse(error);
   }

--- a/app/api/admin/organization/users/[userId]/offboarding/route.ts
+++ b/app/api/admin/organization/users/[userId]/offboarding/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  createOffboardingPreflight,
+  offboardUser,
+  OffboardingError,
+} from '@/app/lib/organization/offboarding';
+import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+type RouteContext = {
+  params: Promise<{
+    userId: string;
+  }>;
+};
+
+function errorResponse(error: unknown) {
+  if (error instanceof OffboardingError) {
+    return NextResponse.json({
+      success: false,
+      code: error.code,
+      error: error.message,
+      preflight: error.preflight,
+    }, { status: error.status });
+  }
+
+  console.error('[admin/organization/users/offboarding] Request failed:', error);
+  return NextResponse.json({
+    success: false,
+    code: 'INTERNAL_ERROR',
+    error: 'Could not process offboarding request.',
+  }, { status: 500 });
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const guard = await requireOrganizationPermission(request, 'canRecoverWorkspaces', {
+    errorMessage: 'Only owners or administrators with recovery permission can run offboarding preflight checks.',
+  });
+  if (!guard.ok) return guard.response;
+
+  const limited = rateLimit(request, {
+    limit: 30,
+    windowMs: 60_000,
+    keyPrefix: 'admin-user-offboarding-preflight',
+  });
+  if (!limited.ok) return limited.response;
+
+  try {
+    const { userId } = await context.params;
+    const preflight = await createOffboardingPreflight(userId, guard.session.user.id);
+    return NextResponse.json({ success: true, data: preflight });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const guard = await requireOrganizationPermission(request, 'canRecoverWorkspaces', {
+    errorMessage: 'Only owners or administrators with recovery permission can offboard users.',
+  });
+  if (!guard.ok) return guard.response;
+
+  const limited = rateLimit(request, {
+    limit: 10,
+    windowMs: 60_000,
+    keyPrefix: 'admin-user-offboarding-apply',
+  });
+  if (!limited.ok) return limited.response;
+
+  try {
+    const { userId } = await context.params;
+    const body = await request.json().catch(() => ({})) as {
+      reason?: unknown;
+      acknowledgeWarnings?: unknown;
+    };
+    const result = await offboardUser({
+      targetUserId: userId,
+      requestedByUserId: guard.session.user.id,
+      reason: typeof body.reason === 'string' ? body.reason : null,
+      acknowledgeWarnings: body.acknowledgeWarnings === true,
+    });
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/app/api/todos/assignees/route.ts
+++ b/app/api/todos/assignees/route.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, ne } from 'drizzle-orm';
+import { and, asc, eq, ne, sql } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { db } from '@/app/lib/db';
@@ -61,6 +61,8 @@ export async function GET(request: NextRequest) {
     .where(and(
       eq(organizationUserPermissions.organizationId, workspace.organizationId),
       ne(organizationUserPermissions.role, 'external'),
+      eq(organizationUserPermissions.status, 'active'),
+      sql`COALESCE(${user.banned}, 0) != 1`,
     ))
     .orderBy(asc(user.name), asc(user.email));
 

--- a/app/components/settings/UserManagementPanel.tsx
+++ b/app/components/settings/UserManagementPanel.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
-import { Ban, CheckCircle2, KeyRound, Loader2, Plus, RefreshCw, Search, Shield, Trash2, UserCog } from 'lucide-react';
+import { AlertTriangle, Ban, CheckCircle2, KeyRound, Loader2, Plus, RefreshCw, Search, Shield, UserCog, UserMinus } from 'lucide-react';
 
 import { authClient } from '@/app/lib/auth-client';
 import {
@@ -69,6 +69,27 @@ type CreateUserDraft = {
 type RoleChangeTarget = {
   user: ManagedUser;
   nextRole: 'admin' | 'user';
+};
+
+type OffboardingFinding = {
+  severity: 'blocker' | 'warning' | 'info';
+  category: string;
+  message: string;
+  count?: number;
+  action?: string;
+};
+
+type OffboardingPreflight = {
+  canApply: boolean;
+  blockers: OffboardingFinding[];
+  warnings: OffboardingFinding[];
+  info: OffboardingFinding[];
+  counts: Record<string, number>;
+  personalWorkspace: {
+    id: string;
+    status: string;
+    rootRelativePath: string;
+  } | null;
 };
 
 function unwrapAuthResult<T>(result: unknown, fallbackMessage: string): T {
@@ -163,7 +184,11 @@ export function UserManagementPanel({
   const [roleTarget, setRoleTarget] = useState<RoleChangeTarget | null>(null);
   const [banTarget, setBanTarget] = useState<ManagedUser | null>(null);
   const [banReason, setBanReason] = useState('');
-  const [deleteTarget, setDeleteTarget] = useState<ManagedUser | null>(null);
+  const [offboardingTarget, setOffboardingTarget] = useState<ManagedUser | null>(null);
+  const [offboardingPreflight, setOffboardingPreflight] = useState<OffboardingPreflight | null>(null);
+  const [isOffboardingPreflightLoading, setIsOffboardingPreflightLoading] = useState(false);
+  const [offboardingAcknowledge, setOffboardingAcknowledge] = useState(false);
+  const [offboardingReason, setOffboardingReason] = useState('');
 
   const page = Math.floor(offset / PAGE_SIZE) + 1;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -342,24 +367,106 @@ export function UserManagementPanel({
     );
   };
 
-  const deleteUser = async () => {
-    if (!deleteTarget) return;
-    const user = deleteTarget;
+  const loadOffboardingPreflight = async (user: ManagedUser) => {
+    setIsOffboardingPreflightLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/admin/organization/users/${encodeURIComponent(user.id)}/offboarding`, {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        const preflight = payload.preflight || payload.data;
+        if (preflight) {
+          setOffboardingPreflight(preflight as OffboardingPreflight);
+        }
+        throw new Error(payload.error || t('errors.offboardingPreflight'));
+      }
+      setOffboardingPreflight(payload.data as OffboardingPreflight);
+    } catch (preflightError) {
+      setError(preflightError instanceof Error ? preflightError.message : t('errors.offboardingPreflight'));
+    } finally {
+      setIsOffboardingPreflightLoading(false);
+    }
+  };
+
+  const openOffboardingDialog = (user: ManagedUser) => {
+    setOffboardingTarget(user);
+    setOffboardingPreflight(null);
+    setOffboardingAcknowledge(false);
+    setOffboardingReason('');
+    resetTransientState();
+    void loadOffboardingPreflight(user);
+  };
+
+  const offboardUser = async () => {
+    if (!offboardingTarget) return;
+    const user = offboardingTarget;
     await runAction(
-      `delete:${user.id}`,
+      `offboard:${user.id}`,
       async () => {
-        unwrapAuthResult<unknown>(
-          await authClient.admin.removeUser({ userId: user.id }),
-          t('errors.delete'),
-        );
-        setDeleteTarget(null);
+        const response = await fetch(`/api/admin/organization/users/${encodeURIComponent(user.id)}/offboarding`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            reason: offboardingReason.trim() || undefined,
+            acknowledgeWarnings: offboardingAcknowledge,
+          }),
+        });
+        const payload = await response.json();
+        if (!response.ok || !payload.success) {
+          const preflight = payload.preflight || payload.data;
+          if (preflight) {
+            setOffboardingPreflight(preflight as OffboardingPreflight);
+          }
+          throw new Error(payload.error || t('errors.offboarding'));
+        }
+        setOffboardingTarget(null);
+        setOffboardingPreflight(null);
+        setOffboardingAcknowledge(false);
+        setOffboardingReason('');
       },
-      t('messages.deleted', { email: user.email }),
+      t('messages.offboarded', { email: user.email }),
     );
   };
 
   const userRows = useMemo(() => users, [users]);
   const roleDialogCopy = getRoleDialogCopy(locale, roleTarget);
+  const renderOffboardingFindings = (title: string, findings: OffboardingFinding[], tone: 'blocker' | 'warning' | 'info') => {
+    if (findings.length === 0) return null;
+    const toneClassName = tone === 'blocker'
+      ? 'border-destructive/40 bg-destructive/10 text-destructive'
+      : tone === 'warning'
+        ? 'border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-200'
+        : 'border-border bg-muted/40 text-muted-foreground';
+
+    return (
+      <div className={`rounded-md border p-3 ${toneClassName}`}>
+        <p className="text-sm font-medium">{title}</p>
+        <ul className="mt-2 space-y-1 text-sm">
+          {findings.map((finding, index) => (
+            <li key={`${finding.category}:${index}`} className="flex gap-2">
+              <span aria-hidden="true">-</span>
+              <span>
+                {finding.message}
+                {typeof finding.count === 'number' ? ` (${finding.count})` : ''}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
+  const offboardingHasWarnings = Boolean(offboardingPreflight && offboardingPreflight.warnings.length > 0);
+  const offboardingCanSubmit = Boolean(
+    offboardingTarget &&
+    offboardingPreflight?.canApply &&
+    !isOffboardingPreflightLoading &&
+    !activeAction?.startsWith('offboard:') &&
+    (!offboardingHasWarnings || offboardingAcknowledge),
+  );
 
   const renderUserActions = (user: ManagedUser, options: { compact?: boolean } = {}) => {
     const role = normalizeRole(user.role);
@@ -436,14 +543,11 @@ export function UserManagementPanel({
           variant="destructive"
           size="sm"
           className={buttonClassName}
-          onClick={() => {
-            setDeleteTarget(user);
-            resetTransientState();
-          }}
+          onClick={() => openOffboardingDialog(user)}
           disabled={isSelf || isRowBusy || activeAction !== null}
         >
-          <Trash2 data-icon="inline-start" />
-          {t('actions.delete')}
+          <UserMinus data-icon="inline-start" />
+          {t('actions.offboard')}
         </Button>
       </div>
     );
@@ -799,22 +903,116 @@ export function UserManagementPanel({
         </DialogContent>
       </Dialog>
 
-      <AlertDialog open={Boolean(deleteTarget)} onOpenChange={(open) => !open && setDeleteTarget(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('deleteDialog.title')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteTarget ? t('deleteDialog.description', { email: deleteTarget.email }) : ''}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={activeAction?.startsWith('delete:')}>{t('cancel')}</AlertDialogCancel>
-            <AlertDialogAction variant="destructive" disabled={activeAction?.startsWith('delete:')} onClick={() => void deleteUser()}>
-              {t('deleteDialog.submit')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <Dialog
+        open={Boolean(offboardingTarget)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setOffboardingTarget(null);
+            setOffboardingPreflight(null);
+            setOffboardingAcknowledge(false);
+            setOffboardingReason('');
+          }
+        }}
+      >
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{t('offboardingDialog.title')}</DialogTitle>
+            <DialogDescription>
+              {offboardingTarget ? t('offboardingDialog.description', { email: offboardingTarget.email }) : ''}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto pr-1">
+            {isOffboardingPreflightLoading ? (
+              <div className="rounded-md border px-3 py-6 text-center text-sm text-muted-foreground">
+                <span className="inline-flex items-center gap-2">
+                  <Loader2 className="animate-spin" />
+                  {t('offboardingDialog.loading')}
+                </span>
+              </div>
+            ) : offboardingPreflight ? (
+              <>
+                <div className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
+                  <p className="font-medium text-foreground">{t('offboardingDialog.summaryTitle')}</p>
+                  <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                    <span>{t('offboardingDialog.summary.sessions', { count: offboardingPreflight.counts.activeSessions || 0 })}</span>
+                    <span>{t('offboardingDialog.summary.automations', {
+                      count: (offboardingPreflight.counts.personalAutomations || 0)
+                        + (offboardingPreflight.counts.organizationResponsibleAutomations || 0)
+                        + (offboardingPreflight.counts.organizationReviewAutomations || 0),
+                    })}</span>
+                    <span>{t('offboardingDialog.summary.todos', { count: offboardingPreflight.counts.openAssignedTodos || 0 })}</span>
+                    <span>{t('offboardingDialog.summary.credentials', {
+                      count: (offboardingPreflight.counts.authAccounts || 0) + (offboardingPreflight.counts.activeEmailAccounts || 0),
+                    })}</span>
+                  </div>
+                </div>
+
+                {renderOffboardingFindings(t('offboardingDialog.blockers'), offboardingPreflight.blockers, 'blocker')}
+                {renderOffboardingFindings(t('offboardingDialog.warnings'), offboardingPreflight.warnings, 'warning')}
+                {renderOffboardingFindings(t('offboardingDialog.info'), offboardingPreflight.info, 'info')}
+
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="user-offboarding-reason">{t('offboardingDialog.reason')}</Label>
+                  <Input
+                    id="user-offboarding-reason"
+                    value={offboardingReason}
+                    onChange={(event) => setOffboardingReason(event.target.value)}
+                    placeholder={t('offboardingDialog.reasonPlaceholder')}
+                    disabled={activeAction?.startsWith('offboard:')}
+                  />
+                </div>
+
+                {offboardingHasWarnings && (
+                  <label className="flex items-start gap-3 rounded-md border p-3 text-sm">
+                    <input
+                      type="checkbox"
+                      className="mt-1"
+                      checked={offboardingAcknowledge}
+                      onChange={(event) => setOffboardingAcknowledge(event.target.checked)}
+                      disabled={activeAction?.startsWith('offboard:')}
+                    />
+                    <span className="text-muted-foreground">
+                      {t('offboardingDialog.acknowledgeWarnings')}
+                    </span>
+                  </label>
+                )}
+
+                {!offboardingPreflight.canApply && (
+                  <div className="inline-flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>{t('offboardingDialog.blockedHint')}</span>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="rounded-md border px-3 py-6 text-center text-sm text-muted-foreground">
+                {t('offboardingDialog.empty')}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOffboardingTarget(null)}
+              disabled={activeAction?.startsWith('offboard:')}
+            >
+              {t('cancel')}
+            </Button>
+            {offboardingTarget && (
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={() => void offboardUser()}
+                disabled={!offboardingCanSubmit}
+              >
+                {activeAction?.startsWith('offboard:') ? <Loader2 data-icon="inline-start" className="animate-spin" /> : <UserMinus data-icon="inline-start" />}
+                {t('offboardingDialog.submit')}
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/app/components/settings/UserManagementPanel.tsx
+++ b/app/components/settings/UserManagementPanel.tsx
@@ -84,7 +84,9 @@ type OffboardingPreflight = {
   blockers: OffboardingFinding[];
   warnings: OffboardingFinding[];
   info: OffboardingFinding[];
-  counts: Record<string, number>;
+  counts: Record<string, number> & {
+    affectedAutomations?: number;
+  };
   personalWorkspace: {
     id: string;
     status: string;
@@ -936,9 +938,7 @@ export function UserManagementPanel({
                   <div className="mt-2 grid gap-2 sm:grid-cols-2">
                     <span>{t('offboardingDialog.summary.sessions', { count: offboardingPreflight.counts.activeSessions || 0 })}</span>
                     <span>{t('offboardingDialog.summary.automations', {
-                      count: (offboardingPreflight.counts.personalAutomations || 0)
-                        + (offboardingPreflight.counts.organizationResponsibleAutomations || 0)
-                        + (offboardingPreflight.counts.organizationReviewAutomations || 0),
+                      count: offboardingPreflight.counts.affectedAutomations || 0,
                     })}</span>
                     <span>{t('offboardingDialog.summary.todos', { count: offboardingPreflight.counts.openAssignedTodos || 0 })}</span>
                     <span>{t('offboardingDialog.summary.credentials', {

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -133,6 +133,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       organization_id TEXT NOT NULL,
       user_id TEXT NOT NULL,
       role TEXT NOT NULL DEFAULT 'member',
+      status TEXT NOT NULL DEFAULT 'active',
       can_write_team_workspace INTEGER NOT NULL DEFAULT 0,
       can_create_public_links INTEGER NOT NULL DEFAULT 1,
       can_create_team_automations INTEGER NOT NULL DEFAULT 0,
@@ -144,11 +145,17 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       can_migrate_database INTEGER NOT NULL DEFAULT 0,
       can_enable_knowledge INTEGER NOT NULL DEFAULT 0,
       can_recover_workspaces INTEGER NOT NULL DEFAULT 0,
+      disabled_at INTEGER,
+      archived_at INTEGER,
+      offboarded_by_user_id TEXT,
+      offboarding_reason TEXT,
+      offboarding_report_json TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
       PRIMARY KEY (organization_id, user_id),
       FOREIGN KEY (organization_id) REFERENCES canvas_organization_settings(organization_id) ON DELETE CASCADE,
-      FOREIGN KEY (user_id) REFERENCES user(id)
+      FOREIGN KEY (user_id) REFERENCES user(id),
+      FOREIGN KEY (offboarded_by_user_id) REFERENCES user(id)
     );
 
     CREATE TABLE IF NOT EXISTS pi_sessions (
@@ -770,6 +777,15 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     next_run_at: 'INTEGER',
   });
 
+  addColumns(sqlite, 'organization_user_permissions', {
+    status: "TEXT NOT NULL DEFAULT 'active'",
+    disabled_at: 'INTEGER',
+    archived_at: 'INTEGER',
+    offboarded_by_user_id: 'TEXT',
+    offboarding_reason: 'TEXT',
+    offboarding_report_json: 'TEXT',
+  });
+
   addColumns(sqlite, 'studio_generations', {
     studio_preset_name: 'TEXT',
   });
@@ -1154,6 +1170,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE UNIQUE INDEX IF NOT EXISTS idx_canvas_workspaces_team_organization ON canvas_workspaces (organization_id) WHERE type = 'team';
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_user ON organization_user_permissions (user_id);
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_role ON organization_user_permissions (organization_id, role);
+    CREATE INDEX IF NOT EXISTS idx_org_user_permissions_status ON organization_user_permissions (organization_id, status);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_org_user_permissions_single_owner ON organization_user_permissions (organization_id) WHERE role = 'owner';
 
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_last_message ON pi_sessions (last_message_at);

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -129,6 +129,7 @@ export const organizationUserPermissions = sqliteTable("organization_user_permis
   organizationId: text("organization_id").notNull().references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
   userId: text("user_id").notNull().references(() => user.id),
   role: text("role").notNull().default("member"),
+  status: text("status").notNull().default("active"),
   canWriteTeamWorkspace: integer("can_write_team_workspace", { mode: "boolean" }).notNull().default(false),
   canCreatePublicLinks: integer("can_create_public_links", { mode: "boolean" }).notNull().default(true),
   canCreateTeamAutomations: integer("can_create_team_automations", { mode: "boolean" }).notNull().default(false),
@@ -140,12 +141,18 @@ export const organizationUserPermissions = sqliteTable("organization_user_permis
   canMigrateDatabase: integer("can_migrate_database", { mode: "boolean" }).notNull().default(false),
   canEnableKnowledge: integer("can_enable_knowledge", { mode: "boolean" }).notNull().default(false),
   canRecoverWorkspaces: integer("can_recover_workspaces", { mode: "boolean" }).notNull().default(false),
+  disabledAt: integer("disabled_at", { mode: "timestamp" }),
+  archivedAt: integer("archived_at", { mode: "timestamp" }),
+  offboardedByUserId: text("offboarded_by_user_id").references(() => user.id),
+  offboardingReason: text("offboarding_reason"),
+  offboardingReportJson: text("offboarding_report_json"),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   pk: primaryKey(table.organizationId, table.userId),
   userIdx: index("idx_org_user_permissions_user").on(table.userId),
   roleIdx: index("idx_org_user_permissions_role").on(table.organizationId, table.role),
+  statusIdx: index("idx_org_user_permissions_status").on(table.organizationId, table.status),
   singleOwnerIdx: uniqueIndex("idx_org_user_permissions_single_owner").on(table.organizationId).where(sql`${table.role} = 'owner'`),
 }));
 

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -32,9 +32,11 @@ import { resolveWorkspaceDataRoot } from '@/app/lib/workspaces/context';
 export const LOCAL_ORGANIZATION_ID_PREFIX = 'org_';
 
 export type OrganizationRole = 'owner' | 'admin' | 'member' | 'external';
+export type OrganizationUserStatus = 'active' | 'disabled' | 'archived' | 'recovery_locked';
 
 export type OrganizationPermissionSnapshot = {
   role: OrganizationRole;
+  status: OrganizationUserStatus;
   canWriteTeamWorkspace: boolean;
   canCreatePublicLinks: boolean;
   canCreateTeamAutomations: boolean;
@@ -95,6 +97,7 @@ type OrganizationRow = {
 
 type PermissionRow = {
   role: string;
+  status: string | null;
   can_write_team_workspace: number;
   can_create_public_links: number;
   can_create_team_automations: number;
@@ -121,6 +124,11 @@ export class OrganizationBootstrapError extends Error {
 function normalizeRole(role: string | null | undefined): OrganizationRole {
   if (role === 'owner' || role === 'admin' || role === 'external') return role;
   return 'member';
+}
+
+function normalizeUserStatus(status: string | null | undefined): OrganizationUserStatus {
+  if (status === 'disabled' || status === 'archived' || status === 'recovery_locked') return status;
+  return 'active';
 }
 
 function isTruthyEnv(value: string | undefined): boolean {
@@ -280,6 +288,7 @@ function permissionDefaults(role: OrganizationRole): OrganizationPermissionSnaps
   const isInternal = role !== 'external';
   return {
     role,
+    status: 'active',
     canWriteTeamWorkspace: isAdminLike,
     canCreatePublicLinks: isInternal,
     canCreateTeamAutomations: isAdminLike,
@@ -349,7 +358,7 @@ function getPermissionRow(
   userId: string,
 ): OrganizationPermissionSnapshot | null {
   const row = sqlite.prepare(`
-    SELECT role, can_write_team_workspace, can_create_public_links, can_create_team_automations,
+    SELECT role, status, can_write_team_workspace, can_create_public_links, can_create_team_automations,
       can_share_plugins_and_skills, can_export, can_delete_team_files, can_delete_studio_assets,
       can_manage_backups, can_migrate_database, can_enable_knowledge, can_recover_workspaces
     FROM organization_user_permissions
@@ -358,20 +367,23 @@ function getPermissionRow(
   `).get(organizationId, userId) as PermissionRow | undefined;
 
   if (!row) return null;
+  const status = normalizeUserStatus(row.status);
+  const enabled = status === 'active';
 
   return {
     role: normalizeRole(row.role),
-    canWriteTeamWorkspace: booleanFromDb(row.can_write_team_workspace),
-    canCreatePublicLinks: booleanFromDb(row.can_create_public_links),
-    canCreateTeamAutomations: booleanFromDb(row.can_create_team_automations),
-    canSharePluginsAndSkills: booleanFromDb(row.can_share_plugins_and_skills),
-    canExport: booleanFromDb(row.can_export),
-    canDeleteTeamFiles: booleanFromDb(row.can_delete_team_files),
-    canDeleteStudioAssets: booleanFromDb(row.can_delete_studio_assets),
-    canManageBackups: booleanFromDb(row.can_manage_backups),
-    canMigrateDatabase: booleanFromDb(row.can_migrate_database),
-    canEnableKnowledge: booleanFromDb(row.can_enable_knowledge),
-    canRecoverWorkspaces: booleanFromDb(row.can_recover_workspaces),
+    status,
+    canWriteTeamWorkspace: enabled && booleanFromDb(row.can_write_team_workspace),
+    canCreatePublicLinks: enabled && booleanFromDb(row.can_create_public_links),
+    canCreateTeamAutomations: enabled && booleanFromDb(row.can_create_team_automations),
+    canSharePluginsAndSkills: enabled && booleanFromDb(row.can_share_plugins_and_skills),
+    canExport: enabled && booleanFromDb(row.can_export),
+    canDeleteTeamFiles: enabled && booleanFromDb(row.can_delete_team_files),
+    canDeleteStudioAssets: enabled && booleanFromDb(row.can_delete_studio_assets),
+    canManageBackups: enabled && booleanFromDb(row.can_manage_backups),
+    canMigrateDatabase: enabled && booleanFromDb(row.can_migrate_database),
+    canEnableKnowledge: enabled && booleanFromDb(row.can_enable_knowledge),
+    canRecoverWorkspaces: enabled && booleanFromDb(row.can_recover_workspaces),
   };
 }
 

--- a/app/lib/organization/offboarding.ts
+++ b/app/lib/organization/offboarding.ts
@@ -1,0 +1,805 @@
+import 'server-only';
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type Database from 'better-sqlite3';
+
+import {
+  resolveUserAgentsDir,
+  resolveUserMailDir,
+  resolveUserMcpDir,
+  resolveUserPluginsDir,
+  resolveUserSecretsDir,
+  resolveUserSettingsDir,
+  resolveUserSkillsDir,
+} from '@/app/lib/runtime-data-paths';
+
+import { openOrganizationBootstrapDatabase } from './bootstrap';
+
+type Sqlite = Database.Database;
+
+export type OffboardingFindingSeverity = 'blocker' | 'warning' | 'info';
+export type OffboardingFindingCategory =
+  | 'user'
+  | 'permissions'
+  | 'sessions'
+  | 'automations'
+  | 'todos'
+  | 'credentials'
+  | 'channels'
+  | 'workspace'
+  | 'public_links'
+  | 'studio_assets';
+
+export type OffboardingFinding = {
+  severity: OffboardingFindingSeverity;
+  category: OffboardingFindingCategory;
+  message: string;
+  count?: number;
+  action?: string;
+};
+
+export type OffboardingPreflight = {
+  targetUser: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    role: string | null;
+    banned: boolean;
+    organizationRole: string | null;
+    organizationStatus: string | null;
+  };
+  requestedByUserId: string;
+  organizationId: string;
+  generatedAt: string;
+  canApply: boolean;
+  blockers: OffboardingFinding[];
+  warnings: OffboardingFinding[];
+  info: OffboardingFinding[];
+  counts: {
+    activeRecoveryAdminsRemaining: number;
+    activeSessions: number;
+    authAccounts: number;
+    activeEmailAccounts: number;
+    activeChannelBindings: number;
+    personalAutomations: number;
+    organizationResponsibleAutomations: number;
+    organizationReviewAutomations: number;
+    inFlightAutomationRuns: number;
+    openAssignedTodos: number;
+    openCreatedTodos: number;
+    activePublicShares: number;
+    studioGenerations: number;
+  };
+  personalWorkspace: {
+    id: string;
+    status: string;
+    rootRelativePath: string;
+  } | null;
+  scopedStorage: {
+    userSettings: boolean;
+    userSecrets: boolean;
+    userMcp: boolean;
+    userMail: boolean;
+    userAgents: boolean;
+    userSkills: boolean;
+    userPlugins: boolean;
+  };
+};
+
+export type OffboardingApplyResult = {
+  preflight: OffboardingPreflight;
+  appliedAt: string;
+  actions: Record<string, number>;
+  manifestPath: string;
+};
+
+type TargetUserRow = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  role: string | null;
+  banned: number | null;
+  organization_role: string | null;
+  organization_status: string | null;
+};
+
+type OrganizationRow = {
+  organization_id: string;
+  owner_user_id: string;
+};
+
+type PersonalWorkspaceRow = {
+  id: string;
+  status: string;
+  root_relative_path: string;
+};
+
+export class OffboardingError extends Error {
+  constructor(
+    public readonly code: 'NOT_FOUND' | 'FORBIDDEN' | 'BLOCKED' | 'ACKNOWLEDGEMENT_REQUIRED' | 'DATABASE_ERROR',
+    message: string,
+    public readonly status = 400,
+    public readonly preflight?: OffboardingPreflight,
+  ) {
+    super(message);
+    this.name = 'OffboardingError';
+  }
+}
+
+function count(sqlite: Sqlite, sql: string, params: unknown[] = []): number {
+  const row = sqlite.prepare(sql).get(...params) as { count: number } | undefined;
+  return Number(row?.count || 0);
+}
+
+async function directoryExists(targetPath: string): Promise<boolean> {
+  return fs.stat(targetPath).then((stat) => stat.isDirectory()).catch(() => false);
+}
+
+function addFinding(findings: OffboardingFinding[], finding: OffboardingFinding): void {
+  findings.push(finding);
+}
+
+function getOrganization(sqlite: Sqlite): OrganizationRow {
+  const organization = sqlite.prepare(`
+    SELECT organization_id, owner_user_id
+    FROM canvas_organization_settings
+    ORDER BY created_at ASC
+    LIMIT 1
+  `).get() as OrganizationRow | undefined;
+
+  if (!organization) {
+    throw new OffboardingError('NOT_FOUND', 'Organization is not configured.', 409);
+  }
+
+  return organization;
+}
+
+function getTargetUser(sqlite: Sqlite, organizationId: string, targetUserId: string): TargetUserRow {
+  const target = sqlite.prepare(`
+    SELECT
+      u.id,
+      u.name,
+      u.email,
+      u.role,
+      u.banned,
+      p.role AS organization_role,
+      COALESCE(p.status, 'active') AS organization_status
+    FROM user u
+    LEFT JOIN organization_user_permissions p
+      ON p.user_id = u.id
+      AND p.organization_id = ?
+    WHERE u.id = ?
+    LIMIT 1
+  `).get(organizationId, targetUserId) as TargetUserRow | undefined;
+
+  if (!target) {
+    throw new OffboardingError('NOT_FOUND', 'User not found.', 404);
+  }
+
+  return target;
+}
+
+function getPersonalWorkspace(sqlite: Sqlite, targetUserId: string): PersonalWorkspaceRow | null {
+  return sqlite.prepare(`
+    SELECT id, status, root_relative_path
+    FROM canvas_workspaces
+    WHERE owner_user_id = ?
+      AND type = 'personal'
+    LIMIT 1
+  `).get(targetUserId) as PersonalWorkspaceRow | undefined || null;
+}
+
+async function getScopedStorageState(targetUserId: string): Promise<OffboardingPreflight['scopedStorage']> {
+  const [
+    userSettings,
+    userSecrets,
+    userMcp,
+    userMail,
+    userAgents,
+    userSkills,
+    userPlugins,
+  ] = await Promise.all([
+    directoryExists(resolveUserSettingsDir(targetUserId)),
+    directoryExists(resolveUserSecretsDir(targetUserId)),
+    directoryExists(resolveUserMcpDir(targetUserId)),
+    directoryExists(resolveUserMailDir(targetUserId)),
+    directoryExists(resolveUserAgentsDir(targetUserId)),
+    directoryExists(resolveUserSkillsDir(targetUserId)),
+    directoryExists(resolveUserPluginsDir(targetUserId)),
+  ]);
+
+  return {
+    userSettings,
+    userSecrets,
+    userMcp,
+    userMail,
+    userAgents,
+    userSkills,
+    userPlugins,
+  };
+}
+
+function buildAutomationAffectedWhere(): string {
+  return `
+    status = 'active'
+    AND (
+      (
+        COALESCE(scope, 'personal') != 'organization'
+        AND (
+          owner_user_id = @targetUserId
+          OR (owner_user_id IS NULL AND created_by_user_id = @targetUserId)
+        )
+      )
+      OR (
+        scope = 'organization'
+        AND (
+          responsible_user_id = @targetUserId
+          OR created_by_user_id = @targetUserId
+          OR approved_by_user_id = @targetUserId
+          OR last_edited_by_user_id = @targetUserId
+        )
+      )
+    )
+  `;
+}
+
+async function buildPreflight(
+  sqlite: Sqlite,
+  targetUserId: string,
+  requestedByUserId: string,
+): Promise<OffboardingPreflight> {
+  const organization = getOrganization(sqlite);
+  const target = getTargetUser(sqlite, organization.organization_id, targetUserId);
+  const personalWorkspace = getPersonalWorkspace(sqlite, targetUserId);
+  const blockers: OffboardingFinding[] = [];
+  const warnings: OffboardingFinding[] = [];
+  const info: OffboardingFinding[] = [];
+  const activeRecoveryAdminsRemaining = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM organization_user_permissions p
+    INNER JOIN user u ON u.id = p.user_id
+    WHERE p.organization_id = ?
+      AND p.user_id != ?
+      AND COALESCE(p.status, 'active') = 'active'
+      AND p.role IN ('owner', 'admin')
+      AND p.can_recover_workspaces = 1
+      AND COALESCE(u.banned, 0) != 1
+  `, [organization.organization_id, targetUserId]);
+
+  if (targetUserId === requestedByUserId) {
+    addFinding(blockers, {
+      severity: 'blocker',
+      category: 'user',
+      message: 'Users cannot offboard their own account.',
+    });
+  }
+
+  if (!target.organization_role) {
+    addFinding(blockers, {
+      severity: 'blocker',
+      category: 'permissions',
+      message: 'User is not a member of this organization.',
+    });
+  }
+
+  if (target.organization_status && target.organization_status !== 'active') {
+    addFinding(blockers, {
+      severity: 'blocker',
+      category: 'permissions',
+      message: `User is already ${target.organization_status}.`,
+    });
+  }
+
+  if (organization.owner_user_id === targetUserId || target.organization_role === 'owner') {
+    addFinding(blockers, {
+      severity: 'blocker',
+      category: 'permissions',
+      message: 'The organization owner must be transferred before offboarding.',
+    });
+  } else if (target.organization_role === 'admin' && activeRecoveryAdminsRemaining < 1) {
+    addFinding(blockers, {
+      severity: 'blocker',
+      category: 'permissions',
+      message: 'At least one active owner/admin with recovery permission must remain.',
+    });
+  }
+
+  const activeSessions = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM session
+    WHERE user_id = ?
+      AND expires_at > ?
+  `, [targetUserId, Date.now()]);
+  const authAccounts = count(sqlite, 'SELECT COUNT(*) AS count FROM account WHERE user_id = ?', [targetUserId]);
+  const activeEmailAccounts = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM email_accounts
+    WHERE user_id = ?
+      AND status = 'active'
+  `, [targetUserId]);
+  const activeChannelBindings = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM channel_user_bindings
+    WHERE user_id = ?
+      AND enabled = 1
+  `, [targetUserId]);
+  const personalAutomations = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM automation_jobs
+    WHERE status = 'active'
+      AND COALESCE(scope, 'personal') != 'organization'
+      AND (
+        owner_user_id = ?
+        OR (owner_user_id IS NULL AND created_by_user_id = ?)
+      )
+  `, [targetUserId, targetUserId]);
+  const organizationResponsibleAutomations = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM automation_jobs
+    WHERE status = 'active'
+      AND scope = 'organization'
+      AND responsible_user_id = ?
+  `, [targetUserId]);
+  const organizationReviewAutomations = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM automation_jobs
+    WHERE status = 'active'
+      AND scope = 'organization'
+      AND (
+        created_by_user_id = ?
+        OR approved_by_user_id = ?
+        OR last_edited_by_user_id = ?
+      )
+  `, [targetUserId, targetUserId, targetUserId]);
+  const inFlightAutomationRuns = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM automation_runs r
+    LEFT JOIN automation_jobs j ON j.id = r.job_id
+    WHERE r.status IN ('pending', 'running', 'retry_scheduled')
+      AND (
+        r.actor_user_id = ?
+        OR j.owner_user_id = ?
+        OR j.responsible_user_id = ?
+        OR j.created_by_user_id = ?
+      )
+  `, [targetUserId, targetUserId, targetUserId, targetUserId]);
+  const openAssignedTodos = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM todo_items
+    WHERE assignee_user_id = ?
+      AND status = 'open'
+      AND archived_at IS NULL
+  `, [targetUserId]);
+  const openCreatedTodos = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM todo_items
+    WHERE created_by_user_id = ?
+      AND status = 'open'
+      AND archived_at IS NULL
+  `, [targetUserId]);
+  const activePublicShares = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM public_file_shares
+    WHERE created_by_user_id = ?
+      AND status = 'active'
+  `, [targetUserId]);
+  const studioGenerations = count(sqlite, 'SELECT COUNT(*) AS count FROM studio_generations WHERE user_id = ?', [targetUserId]);
+  const scopedStorage = await getScopedStorageState(targetUserId);
+
+  if (activeSessions > 0) {
+    addFinding(warnings, {
+      severity: 'warning',
+      category: 'sessions',
+      message: 'Active sessions will be revoked.',
+      count: activeSessions,
+      action: 'delete_sessions',
+    });
+  }
+
+  if (authAccounts > 0 || activeEmailAccounts > 0 || scopedStorage.userSecrets || scopedStorage.userMcp) {
+    addFinding(warnings, {
+      severity: 'warning',
+      category: 'credentials',
+      message: 'User login accounts, email accounts, MCP state, and user-scoped secrets will be disabled or marked for reconnect.',
+      count: authAccounts + activeEmailAccounts,
+      action: 'revoke_user_credentials',
+    });
+  }
+
+  const automationCount = personalAutomations + organizationResponsibleAutomations + organizationReviewAutomations;
+  if (automationCount > 0) {
+    addFinding(warnings, {
+      severity: 'warning',
+      category: 'automations',
+      message: 'Affected automations will be paused and require admin review before reactivation.',
+      count: automationCount,
+      action: 'pause_automations',
+    });
+  }
+
+  if (inFlightAutomationRuns > 0) {
+    addFinding(warnings, {
+      severity: 'warning',
+      category: 'automations',
+      message: 'Pending or running automation runs will be marked failed.',
+      count: inFlightAutomationRuns,
+      action: 'stop_automation_runs',
+    });
+  }
+
+  if (openAssignedTodos > 0) {
+    addFinding(warnings, {
+      severity: 'warning',
+      category: 'todos',
+      message: 'Open to-dos assigned to this user will become unassigned; they will not be silently assigned to the admin.',
+      count: openAssignedTodos,
+      action: 'unassign_todos',
+    });
+  }
+
+  if (openCreatedTodos > 0) {
+    addFinding(warnings, {
+      severity: 'warning',
+      category: 'todos',
+      message: 'Open to-dos created by this user keep their creator reference for history.',
+      count: openCreatedTodos,
+      action: 'preserve_creator_references',
+    });
+  }
+
+  if (activeChannelBindings > 0) {
+    addFinding(warnings, {
+      severity: 'warning',
+      category: 'channels',
+      message: 'User channel bindings will be disabled.',
+      count: activeChannelBindings,
+      action: 'disable_channels',
+    });
+  }
+
+  if (personalWorkspace) {
+    addFinding(warnings, {
+      severity: 'warning',
+      category: 'workspace',
+      message: 'The personal workspace will be locked for recovery-only access.',
+      count: 1,
+      action: 'lock_personal_workspace',
+    });
+  }
+
+  if (activePublicShares > 0) {
+    addFinding(warnings, {
+      severity: 'warning',
+      category: 'public_links',
+      message: 'Active public links created by this user remain visible and must be reviewed separately.',
+      count: activePublicShares,
+      action: 'manual_public_link_review',
+    });
+  }
+
+  if (studioGenerations > 0) {
+    addFinding(info, {
+      severity: 'info',
+      category: 'studio_assets',
+      message: 'Studio generations remain visible with the archived creator reference.',
+      count: studioGenerations,
+      action: 'preserve_studio_assets',
+    });
+  }
+
+  if (warnings.length === 0 && blockers.length === 0) {
+    addFinding(info, {
+      severity: 'info',
+      category: 'user',
+      message: 'No dependent resources require manual review.',
+    });
+  }
+
+  return {
+    targetUser: {
+      id: target.id,
+      name: target.name,
+      email: target.email,
+      role: target.role,
+      banned: target.banned === 1,
+      organizationRole: target.organization_role,
+      organizationStatus: target.organization_status || 'active',
+    },
+    requestedByUserId,
+    organizationId: organization.organization_id,
+    generatedAt: new Date().toISOString(),
+    canApply: blockers.length === 0,
+    blockers,
+    warnings,
+    info,
+    counts: {
+      activeRecoveryAdminsRemaining,
+      activeSessions,
+      authAccounts,
+      activeEmailAccounts,
+      activeChannelBindings,
+      personalAutomations,
+      organizationResponsibleAutomations,
+      organizationReviewAutomations,
+      inFlightAutomationRuns,
+      openAssignedTodos,
+      openCreatedTodos,
+      activePublicShares,
+      studioGenerations,
+    },
+    personalWorkspace: personalWorkspace ? {
+      id: personalWorkspace.id,
+      status: personalWorkspace.status,
+      rootRelativePath: personalWorkspace.root_relative_path,
+    } : null,
+    scopedStorage,
+  };
+}
+
+function run(sqlite: Sqlite, sql: string, params: unknown[] = []): number {
+  return sqlite.prepare(sql).run(...params).changes;
+}
+
+function affectedAutomationJobIds(sqlite: Sqlite, targetUserId: string): string[] {
+  return (sqlite.prepare(`
+    SELECT id
+    FROM automation_jobs
+    WHERE ${buildAutomationAffectedWhere()}
+  `).all({ targetUserId }) as Array<{ id: string }>).map((row) => row.id);
+}
+
+function placeholders(values: unknown[]): string {
+  return values.map(() => '?').join(', ');
+}
+
+async function writeOffboardingManifest(result: Omit<OffboardingApplyResult, 'manifestPath'>): Promise<string> {
+  const settingsDir = resolveUserSettingsDir(result.preflight.targetUser.id);
+  await fs.mkdir(settingsDir, { recursive: true });
+  const manifestPath = path.join(settingsDir, 'offboarding.json');
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify({
+      version: 1,
+      ...result,
+    }, null, 2),
+    { encoding: 'utf8', mode: 0o600 },
+  );
+  return manifestPath;
+}
+
+export async function createOffboardingPreflight(
+  targetUserId: string,
+  requestedByUserId: string,
+): Promise<OffboardingPreflight> {
+  const sqlite = openOrganizationBootstrapDatabase();
+  try {
+    return await buildPreflight(sqlite, targetUserId, requestedByUserId);
+  } finally {
+    sqlite.close();
+  }
+}
+
+export async function offboardUser(options: {
+  targetUserId: string;
+  requestedByUserId: string;
+  reason?: string | null;
+  acknowledgeWarnings?: boolean;
+}): Promise<OffboardingApplyResult> {
+  const sqlite = openOrganizationBootstrapDatabase();
+  let resultWithoutManifest: Omit<OffboardingApplyResult, 'manifestPath'> | null = null;
+
+  try {
+    sqlite.exec('BEGIN IMMEDIATE');
+    const preflight = await buildPreflight(sqlite, options.targetUserId, options.requestedByUserId);
+    if (preflight.blockers.length > 0) {
+      throw new OffboardingError('BLOCKED', 'Offboarding is blocked by preflight findings.', 409, preflight);
+    }
+    if (preflight.warnings.length > 0 && !options.acknowledgeWarnings) {
+      throw new OffboardingError('ACKNOWLEDGEMENT_REQUIRED', 'Offboarding warnings must be acknowledged.', 428, preflight);
+    }
+
+    const now = Date.now();
+    const nowIso = new Date(now).toISOString();
+    const reason = (options.reason || '').trim() || 'Offboarded by administrator';
+    const affectedJobs = affectedAutomationJobIds(sqlite, options.targetUserId);
+    const actions: Record<string, number> = {};
+
+    actions.userBanned = run(sqlite, `
+      UPDATE user
+      SET banned = 1, ban_reason = ?, ban_expires = NULL, updated_at = ?
+      WHERE id = ?
+    `, [`Offboarded: ${reason}`, now, options.targetUserId]);
+    actions.sessionsRevoked = run(sqlite, 'DELETE FROM session WHERE user_id = ?', [options.targetUserId]);
+    actions.authAccountsRevoked = run(sqlite, `
+      UPDATE account
+      SET access_token = NULL,
+          refresh_token = NULL,
+          id_token = NULL,
+          password = NULL,
+          updated_at = ?
+      WHERE user_id = ?
+    `, [now, options.targetUserId]);
+    actions.emailAccountsRevoked = run(sqlite, `
+      UPDATE email_accounts
+      SET status = 'revoked',
+          is_primary = 0,
+          updated_at = ?
+      WHERE user_id = ?
+        AND status != 'revoked'
+    `, [now, options.targetUserId]);
+    actions.todoEmailWatchersDisabled = run(sqlite, `
+      UPDATE todo_email_reply_watchers
+      SET status = 'disabled',
+          error = ?,
+          updated_at = ?
+      WHERE user_id = ?
+        AND status = 'active'
+    `, ['User was offboarded.', now, options.targetUserId]);
+    actions.channelBindingsDisabled = run(sqlite, `
+      UPDATE channel_user_bindings
+      SET enabled = 0
+      WHERE user_id = ?
+        AND enabled = 1
+    `, [options.targetUserId]);
+    actions.channelActiveSessionsDeleted = run(sqlite, 'DELETE FROM channel_active_sessions WHERE user_id = ?', [options.targetUserId]);
+    actions.telegramActiveSessionsDeleted = run(sqlite, 'DELETE FROM telegram_active_session WHERE user_id = ?', [options.targetUserId]);
+    actions.channelLinkTokensDeleted = run(sqlite, 'DELETE FROM channel_link_tokens WHERE user_id = ?', [options.targetUserId]);
+
+    actions.automationsPaused = run(sqlite, `
+      UPDATE automation_jobs
+      SET status = 'paused',
+          next_run_at = NULL,
+          last_edited_by_user_id = ?,
+          updated_at = ?
+      WHERE status = 'active'
+        AND (
+          (
+            COALESCE(scope, 'personal') != 'organization'
+            AND (
+              owner_user_id = ?
+              OR (owner_user_id IS NULL AND created_by_user_id = ?)
+            )
+          )
+          OR (
+            scope = 'organization'
+            AND (
+              responsible_user_id = ?
+              OR created_by_user_id = ?
+              OR approved_by_user_id = ?
+              OR last_edited_by_user_id = ?
+            )
+          )
+        )
+    `, [
+      options.requestedByUserId,
+      now,
+      options.targetUserId,
+      options.targetUserId,
+      options.targetUserId,
+      options.targetUserId,
+      options.targetUserId,
+      options.targetUserId,
+    ]);
+    if (affectedJobs.length > 0) {
+      actions.webhookTriggersPaused = run(sqlite, `
+        UPDATE automation_webhook_triggers
+        SET status = 'paused',
+            updated_at = ?
+        WHERE job_id IN (${placeholders(affectedJobs)})
+      `, [now, ...affectedJobs]);
+      actions.automationRunsStopped = run(sqlite, `
+        UPDATE automation_runs
+        SET status = 'failed',
+            finished_at = COALESCE(finished_at, ?),
+            error_message = COALESCE(error_message, ?)
+        WHERE status IN ('pending', 'running', 'retry_scheduled')
+          AND (
+            actor_user_id = ?
+            OR job_id IN (${placeholders(affectedJobs)})
+          )
+      `, [now, 'User was offboarded before the run completed.', options.targetUserId, ...affectedJobs]);
+    } else {
+      actions.webhookTriggersPaused = 0;
+      actions.automationRunsStopped = run(sqlite, `
+        UPDATE automation_runs
+        SET status = 'failed',
+            finished_at = COALESCE(finished_at, ?),
+            error_message = COALESCE(error_message, ?)
+        WHERE status IN ('pending', 'running', 'retry_scheduled')
+          AND actor_user_id = ?
+      `, [now, 'User was offboarded before the run completed.', options.targetUserId]);
+    }
+
+    actions.todosUnassigned = run(sqlite, `
+      UPDATE todo_items
+      SET assignee_user_id = NULL,
+          updated_at = ?
+      WHERE assignee_user_id = ?
+        AND status = 'open'
+        AND archived_at IS NULL
+    `, [now, options.targetUserId]);
+    actions.personalWorkspacesLocked = run(sqlite, `
+      UPDATE canvas_workspaces
+      SET status = 'recovery_locked',
+          updated_at = ?
+      WHERE owner_user_id = ?
+        AND type = 'personal'
+        AND status != 'recovery_locked'
+    `, [now, options.targetUserId]);
+
+    const reportJson = JSON.stringify({
+      generatedAt: nowIso,
+      requestedByUserId: options.requestedByUserId,
+      reason,
+      preflight,
+      actions,
+    });
+    actions.permissionArchived = run(sqlite, `
+      UPDATE organization_user_permissions
+      SET status = 'archived',
+          disabled_at = COALESCE(disabled_at, ?),
+          archived_at = ?,
+          offboarded_by_user_id = ?,
+          offboarding_reason = ?,
+          offboarding_report_json = ?,
+          can_write_team_workspace = 0,
+          can_create_public_links = 0,
+          can_create_team_automations = 0,
+          can_share_plugins_and_skills = 0,
+          can_export = 0,
+          can_delete_team_files = 0,
+          can_delete_studio_assets = 0,
+          can_manage_backups = 0,
+          can_migrate_database = 0,
+          can_enable_knowledge = 0,
+          can_recover_workspaces = 0,
+          updated_at = ?
+      WHERE organization_id = ?
+        AND user_id = ?
+    `, [
+      now,
+      now,
+      options.requestedByUserId,
+      reason,
+      reportJson,
+      now,
+      preflight.organizationId,
+      options.targetUserId,
+    ]);
+
+    resultWithoutManifest = {
+      preflight,
+      appliedAt: nowIso,
+      actions,
+    };
+    sqlite.exec('COMMIT');
+  } catch (error) {
+    if (sqlite.inTransaction) {
+      sqlite.exec('ROLLBACK');
+    }
+    if (error instanceof OffboardingError) {
+      throw error;
+    }
+    throw new OffboardingError('DATABASE_ERROR', 'Could not offboard user.', 500);
+  } finally {
+    sqlite.close();
+  }
+
+  if (!resultWithoutManifest) {
+    throw new OffboardingError('DATABASE_ERROR', 'Could not offboard user.', 500);
+  }
+
+  const manifestPath = await writeOffboardingManifest(resultWithoutManifest);
+  console.warn('[OrganizationOffboarding] User offboarded.', {
+    targetUserId: options.targetUserId,
+    requestedByUserId: options.requestedByUserId,
+    actions: resultWithoutManifest.actions,
+  });
+
+  return {
+    ...resultWithoutManifest,
+    manifestPath,
+  };
+}

--- a/app/lib/organization/offboarding.ts
+++ b/app/lib/organization/offboarding.ts
@@ -66,6 +66,7 @@ export type OffboardingPreflight = {
     personalAutomations: number;
     organizationResponsibleAutomations: number;
     organizationReviewAutomations: number;
+    affectedAutomations: number;
     inFlightAutomationRuns: number;
     openAssignedTodos: number;
     openCreatedTodos: number;
@@ -245,11 +246,12 @@ function buildAutomationAffectedWhere(): string {
   `;
 }
 
-async function buildPreflight(
+function buildPreflightFromScopedStorage(
   sqlite: Sqlite,
   targetUserId: string,
   requestedByUserId: string,
-): Promise<OffboardingPreflight> {
+  scopedStorage: OffboardingPreflight['scopedStorage'],
+): OffboardingPreflight {
   const organization = getOrganization(sqlite);
   const target = getTargetUser(sqlite, organization.organization_id, targetUserId);
   const personalWorkspace = getPersonalWorkspace(sqlite, targetUserId);
@@ -353,6 +355,12 @@ async function buildPreflight(
         OR last_edited_by_user_id = ?
       )
   `, [targetUserId, targetUserId, targetUserId]);
+  const affectedAutomations = count(sqlite, `
+    SELECT COUNT(*) AS count
+    FROM automation_jobs
+    WHERE status = 'active'
+      AND ${buildAutomationAffectedWhere()}
+  `, [{ targetUserId }]);
   const inFlightAutomationRuns = count(sqlite, `
     SELECT COUNT(*) AS count
     FROM automation_runs r
@@ -386,7 +394,6 @@ async function buildPreflight(
       AND status = 'active'
   `, [targetUserId]);
   const studioGenerations = count(sqlite, 'SELECT COUNT(*) AS count FROM studio_generations WHERE user_id = ?', [targetUserId]);
-  const scopedStorage = await getScopedStorageState(targetUserId);
 
   if (activeSessions > 0) {
     addFinding(warnings, {
@@ -408,7 +415,7 @@ async function buildPreflight(
     });
   }
 
-  const automationCount = personalAutomations + organizationResponsibleAutomations + organizationReviewAutomations;
+  const automationCount = affectedAutomations;
   if (automationCount > 0) {
     addFinding(warnings, {
       severity: 'warning',
@@ -523,6 +530,7 @@ async function buildPreflight(
       personalAutomations,
       organizationResponsibleAutomations,
       organizationReviewAutomations,
+      affectedAutomations,
       inFlightAutomationRuns,
       openAssignedTodos,
       openCreatedTodos,
@@ -536,6 +544,15 @@ async function buildPreflight(
     } : null,
     scopedStorage,
   };
+}
+
+async function buildPreflight(
+  sqlite: Sqlite,
+  targetUserId: string,
+  requestedByUserId: string,
+): Promise<OffboardingPreflight> {
+  const scopedStorage = await getScopedStorageState(targetUserId);
+  return buildPreflightFromScopedStorage(sqlite, targetUserId, requestedByUserId, scopedStorage);
 }
 
 function run(sqlite: Sqlite, sql: string, params: unknown[] = []): number {
@@ -591,8 +608,14 @@ export async function offboardUser(options: {
   let resultWithoutManifest: Omit<OffboardingApplyResult, 'manifestPath'> | null = null;
 
   try {
+    const scopedStorage = await getScopedStorageState(options.targetUserId);
     sqlite.exec('BEGIN IMMEDIATE');
-    const preflight = await buildPreflight(sqlite, options.targetUserId, options.requestedByUserId);
+    const preflight = buildPreflightFromScopedStorage(
+      sqlite,
+      options.targetUserId,
+      options.requestedByUserId,
+      scopedStorage,
+    );
     if (preflight.blockers.length > 0) {
       throw new OffboardingError('BLOCKED', 'Offboarding is blocked by preflight findings.', 409, preflight);
     }
@@ -782,6 +805,7 @@ export async function offboardUser(options: {
     if (error instanceof OffboardingError) {
       throw error;
     }
+    console.error('[OrganizationOffboarding] Unexpected error during offboarding:', error);
     throw new OffboardingError('DATABASE_ERROR', 'Could not offboard user.', 500);
   } finally {
     sqlite.close();

--- a/app/lib/organization/permissions.ts
+++ b/app/lib/organization/permissions.ts
@@ -11,7 +11,7 @@ import {
   type OrganizationPermissionState,
 } from '@/app/lib/organization/bootstrap';
 
-export type OrganizationPermissionKey = Exclude<keyof OrganizationPermissionSnapshot, 'role'>;
+export type OrganizationPermissionKey = Exclude<keyof OrganizationPermissionSnapshot, 'role' | 'status'>;
 
 export type OrganizationPermissionGuardResult =
   | {
@@ -36,6 +36,7 @@ type PermissionUserCandidate = AdminUserCandidate & {
 
 const LEGACY_ADMIN_PERMISSION: OrganizationPermissionSnapshot = {
   role: 'admin',
+  status: 'active',
   canWriteTeamWorkspace: true,
   canCreatePublicLinks: true,
   canCreateTeamAutomations: true,
@@ -78,7 +79,7 @@ export function hasOrganizationPermission(
   permission: OrganizationPermissionSnapshot | null | undefined,
   key: OrganizationPermissionKey,
 ): boolean {
-  return permission?.[key] === true;
+  return permission?.status === 'active' && permission?.[key] === true;
 }
 
 export function assertOrganizationPermission(
@@ -195,5 +196,5 @@ export async function requireOrganizationPermission(
 }
 
 export function isOrganizationAdminLike(permission: OrganizationPermissionSnapshot | null | undefined): boolean {
-  return permission?.role === 'owner' || permission?.role === 'admin';
+  return permission?.status === 'active' && (permission?.role === 'owner' || permission?.role === 'admin');
 }

--- a/app/lib/todos/store.ts
+++ b/app/lib/todos/store.ts
@@ -197,6 +197,7 @@ async function isOrganizationMember(organizationId: string, userId: string): Pro
     where: and(
       eq(organizationUserPermissions.organizationId, organizationId),
       eq(organizationUserPermissions.userId, userId),
+      eq(organizationUserPermissions.status, 'active'),
       ne(organizationUserPermissions.role, 'external'),
     ),
   });
@@ -214,6 +215,7 @@ async function isOrganizationWorkspaceWriter(organizationId: string, userId: str
     where: and(
       eq(organizationUserPermissions.organizationId, organizationId),
       eq(organizationUserPermissions.userId, userId),
+      eq(organizationUserPermissions.status, 'active'),
       ne(organizationUserPermissions.role, 'external'),
     ),
   });

--- a/app/lib/workspaces/client-types.ts
+++ b/app/lib/workspaces/client-types.ts
@@ -1,6 +1,6 @@
 export type ClientWorkspaceType = 'personal' | 'team' | 'project';
 
-export type ClientWorkspaceStatus = 'active' | 'archived' | 'disabled';
+export type ClientWorkspaceStatus = 'active' | 'archived' | 'disabled' | 'recovery_locked';
 
 export interface ClientWorkspacePermissions {
   canRead: boolean;

--- a/app/lib/workspaces/service.ts
+++ b/app/lib/workspaces/service.ts
@@ -40,6 +40,7 @@ type WorkspaceRow = {
 
 type PermissionRow = {
   role: string;
+  status: string;
   can_write_team_workspace: number;
   can_create_public_links: number;
 };
@@ -50,7 +51,7 @@ function normalizeWorkspaceType(value: string): WorkspaceType {
 }
 
 function normalizeWorkspaceStatus(value: string): WorkspaceStatus {
-  if (value === 'archived' || value === 'disabled') return value;
+  if (value === 'archived' || value === 'disabled' || value === 'recovery_locked') return value;
   return 'active';
 }
 
@@ -229,7 +230,7 @@ export function ensureDefaultWorkspaceRecords(
 
 function getPermissionRow(sqlite: Database.Database, organizationId: string, userId: string): PermissionRow | null {
   return sqlite.prepare(`
-    SELECT role, can_write_team_workspace, can_create_public_links
+    SELECT role, COALESCE(status, 'active') AS status, can_write_team_workspace, can_create_public_links
     FROM organization_user_permissions
     WHERE organization_id = ? AND user_id = ?
     LIMIT 1
@@ -239,7 +240,7 @@ function getPermissionRow(sqlite: Database.Database, organizationId: string, use
 function canReadWorkspace(record: WorkspaceRecord, actor: WorkspaceActor, permission: PermissionRow | null): boolean {
   if (record.status !== 'active') return false;
   if (record.type === 'personal') return record.ownerUserId === actor.userId;
-  if (record.type === 'team') return Boolean(permission && permission.role !== 'external');
+  if (record.type === 'team') return Boolean(permission && permission.status === 'active' && permission.role !== 'external');
   return false;
 }
 
@@ -250,11 +251,14 @@ export function workspaceContextFromRecord(
 ): WorkspaceContext {
   const role = actor.role;
   const ownsPersonalWorkspace = record.type === 'personal' && record.ownerUserId === actor.userId;
-  const canAccessTeamWorkspace = record.type === 'team' && Boolean(permission && permission.role !== 'external');
+  const canAccessTeamWorkspace = record.type === 'team' && Boolean(permission && permission.status === 'active' && permission.role !== 'external');
   const canWriteTeamWorkspace = record.type === 'team' && (
-    role === 'owner' ||
-    role === 'admin' ||
-    permission?.can_write_team_workspace === 1
+    permission?.status === 'active' &&
+    (
+      role === 'owner' ||
+      role === 'admin' ||
+      permission?.can_write_team_workspace === 1
+    )
   );
 
   return {

--- a/app/lib/workspaces/types.ts
+++ b/app/lib/workspaces/types.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 export type WorkspaceType = 'personal' | 'team' | 'project';
 
-export type WorkspaceStatus = 'active' | 'archived' | 'disabled';
+export type WorkspaceStatus = 'active' | 'archived' | 'disabled' | 'recovery_locked';
 
 export type WorkspaceUserRole = 'owner' | 'admin' | 'member' | 'external';
 

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -370,13 +370,23 @@
     {
       "id": 22,
       "title": "Offboarding-Flow fuer User mit Workspace-Sicherung, Automation-Review, To-do-Behandlung und Credential-Revocation bauen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/08-user-scoped-secrets-runtime.md",
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md",
         "docs/architecture/canvas-notebook/team-workspace/11-automation-execution-model.md",
         "docs/architecture/canvas-notebook/team-workspace/16-offboarding-and-recovery-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/organization/offboarding.ts",
+        "app/api/admin/organization/users/[userId]/offboarding/route.ts",
+        "app/components/settings/UserManagementPanel.tsx",
+        "app/lib/organization/bootstrap.ts",
+        "app/lib/organization/permissions.ts",
+        "app/lib/workspaces/service.ts",
+        "app/api/todos/assignees/route.ts",
+        "scripts/organization-offboarding-test.ts"
       ]
     },
     {

--- a/messages/de.json
+++ b/messages/de.json
@@ -1676,7 +1676,8 @@
         "password": "Passwort",
         "ban": "Sperren",
         "unban": "Entsperren",
-        "delete": "Löschen"
+        "delete": "Löschen",
+        "offboard": "Offboarden"
       },
       "fields": {
         "name": "Name",
@@ -1713,13 +1714,35 @@
         "description": "{email} wird dauerhaft mit Sitzungen und Login-Konten gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
         "submit": "Dauerhaft löschen"
       },
+      "offboardingDialog": {
+        "title": "Benutzer offboarden",
+        "description": "{email} wird archiviert statt gelöscht. Sessions und Credentials werden widerrufen, Automations pausiert und der persönliche Workspace wird nur noch über Recovery zugänglich.",
+        "loading": "Offboarding-Preflight läuft...",
+        "empty": "Es ist kein Preflight-Ergebnis verfügbar.",
+        "summaryTitle": "Preflight-Zusammenfassung",
+        "blockers": "Blocker",
+        "warnings": "Warnungen",
+        "info": "Hinweise",
+        "reason": "Grund",
+        "reasonPlaceholder": "Optionaler Offboarding-Grund",
+        "acknowledgeWarnings": "Ich habe die Warnungen geprüft und verstehe, dass betroffene Automations, Credentials, To-dos und Workspaces geändert werden.",
+        "blockedHint": "Alle Blocker müssen behoben werden, bevor dieser Benutzer offboarded werden kann.",
+        "submit": "Archivieren und Zugriff widerrufen",
+        "summary": {
+          "sessions": "{count} aktive Sessions",
+          "automations": "{count} betroffene Automations",
+          "todos": "{count} offene zugewiesene To-dos",
+          "credentials": "{count} Login- oder E-Mail-Credentials"
+        }
+      },
       "messages": {
         "created": "{email} wurde angelegt.",
         "roleUpdated": "Rolle für {email} wurde aktualisiert.",
         "passwordUpdated": "Passwort für {email} wurde aktualisiert.",
         "banned": "{email} wurde gesperrt.",
         "unbanned": "{email} wurde entsperrt.",
-        "deleted": "{email} wurde gelöscht."
+        "deleted": "{email} wurde gelöscht.",
+        "offboarded": "{email} wurde offboarded und archiviert."
       },
       "errors": {
         "load": "Benutzer konnten nicht geladen werden.",
@@ -1732,7 +1755,9 @@
         "passwordLength": "Das Passwort muss mindestens 8 Zeichen lang sein.",
         "ban": "Benutzer konnte nicht gesperrt werden.",
         "unban": "Benutzer konnte nicht entsperrt werden.",
-        "delete": "Benutzer konnte nicht gelöscht werden."
+        "delete": "Benutzer konnte nicht gelöscht werden.",
+        "offboardingPreflight": "Offboarding-Preflight konnte nicht geladen werden.",
+        "offboarding": "Benutzer konnte nicht offboarded werden."
       }
     },
     "scopes": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1677,7 +1677,8 @@
         "password": "Password",
         "ban": "Ban",
         "unban": "Unban",
-        "delete": "Delete"
+        "delete": "Delete",
+        "offboard": "Offboard"
       },
       "fields": {
         "name": "Name",
@@ -1714,13 +1715,35 @@
         "description": "{email} will be permanently deleted with sessions and login accounts. This cannot be undone.",
         "submit": "Delete permanently"
       },
+      "offboardingDialog": {
+        "title": "Offboard user",
+        "description": "{email} will be archived instead of deleted. Sessions and credentials are revoked, automations are paused, and the personal workspace is locked for recovery-only access.",
+        "loading": "Running offboarding preflight...",
+        "empty": "No preflight result is available.",
+        "summaryTitle": "Preflight summary",
+        "blockers": "Blockers",
+        "warnings": "Warnings",
+        "info": "Notes",
+        "reason": "Reason",
+        "reasonPlaceholder": "Optional offboarding reason",
+        "acknowledgeWarnings": "I reviewed the warnings and understand that affected automations, credentials, to-dos, and workspaces will be changed.",
+        "blockedHint": "Resolve all blockers before this user can be offboarded.",
+        "submit": "Archive and revoke access",
+        "summary": {
+          "sessions": "{count} active sessions",
+          "automations": "{count} affected automations",
+          "todos": "{count} assigned open to-dos",
+          "credentials": "{count} login or email credentials"
+        }
+      },
       "messages": {
         "created": "{email} was created.",
         "roleUpdated": "Role for {email} was updated.",
         "passwordUpdated": "Password for {email} was updated.",
         "banned": "{email} was banned.",
         "unbanned": "{email} was unbanned.",
-        "deleted": "{email} was deleted."
+        "deleted": "{email} was deleted.",
+        "offboarded": "{email} was offboarded and archived."
       },
       "errors": {
         "load": "Could not load users.",
@@ -1733,7 +1756,9 @@
         "passwordLength": "Password must be at least 8 characters.",
         "ban": "Could not ban user.",
         "unban": "Could not unban user.",
-        "delete": "Could not delete user."
+        "delete": "Could not delete user.",
+        "offboardingPreflight": "Could not load offboarding preflight.",
+        "offboarding": "Could not offboard user."
       }
     },
     "scopes": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:composio:user-scope": "tsx scripts/composio-user-scope-test.ts",
     "test:auth:setup": "tsx --conditions react-server scripts/auth-setup-test.ts",
     "test:organization:permissions": "tsx --conditions react-server scripts/organization-permission-guards-test.ts",
+    "test:organization:offboarding": "tsx --conditions react-server scripts/organization-offboarding-test.ts",
     "test:license": "tsx --conditions react-server scripts/license-security-test.ts",
     "test:cli:admin": "bash scripts/cli-admin-command-test.sh",
     "test:channels": "tsx scripts/channel-architecture-test.ts",

--- a/scripts/organization-offboarding-test.ts
+++ b/scripts/organization-offboarding-test.ts
@@ -239,6 +239,8 @@ async function main() {
     assert.equal(memberPreflight.counts.activeEmailAccounts, 1);
     assert.equal(memberPreflight.counts.personalAutomations, 1);
     assert.equal(memberPreflight.counts.organizationResponsibleAutomations, 1);
+    assert.equal(memberPreflight.counts.organizationReviewAutomations, 1);
+    assert.equal(memberPreflight.counts.affectedAutomations, 2);
     assert.equal(memberPreflight.counts.openAssignedTodos, 1);
     assert.ok(memberPreflight.warnings.length >= 4);
 

--- a/scripts/organization-offboarding-test.ts
+++ b/scripts/organization-offboarding-test.ts
@@ -1,0 +1,308 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../app/lib/db/migrate';
+import { ensureOrganizationBootstrapForUser } from '../app/lib/organization/bootstrap';
+import { ensureDefaultWorkspaceRecords } from '../app/lib/workspaces/service';
+
+type WorkspaceRow = {
+  id: string;
+  type: string;
+  owner_user_id: string | null;
+};
+
+function getRequiredRow<T>(sqlite: Database.Database, sql: string, ...params: unknown[]): T {
+  const row = sqlite.prepare(sql).get(...params) as T | undefined;
+  assert.ok(row);
+  return row;
+}
+
+function insertUser(sqlite: Database.Database, id: string, name: string, email: string, role: string) {
+  const now = Date.now();
+  sqlite.prepare(`
+    INSERT INTO user (id, name, email, email_verified, role, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(id, name, email, 1, role, now, now);
+}
+
+function insertPermission(sqlite: Database.Database, organizationId: string, userId: string, role: string, adminLike = false) {
+  const now = Date.now();
+  sqlite.prepare(`
+    INSERT INTO organization_user_permissions (
+      organization_id, user_id, role,
+      can_write_team_workspace, can_create_public_links, can_create_team_automations,
+      can_share_plugins_and_skills, can_export, can_delete_team_files, can_delete_studio_assets,
+      can_manage_backups, can_migrate_database, can_enable_knowledge, can_recover_workspaces,
+      created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    organizationId,
+    userId,
+    role,
+    adminLike ? 1 : 0,
+    1,
+    adminLike ? 1 : 0,
+    adminLike ? 1 : 0,
+    adminLike ? 1 : 0,
+    adminLike ? 1 : 0,
+    1,
+    adminLike ? 1 : 0,
+    adminLike ? 1 : 0,
+    adminLike ? 1 : 0,
+    adminLike ? 1 : 0,
+    now,
+    now,
+  );
+}
+
+function insertAutomation(
+  sqlite: Database.Database,
+  input: {
+    id: string;
+    name: string;
+    scope: 'personal' | 'organization';
+    organizationId: string;
+    workspaceId: string;
+    workspaceType: 'personal' | 'team';
+    ownerUserId: string | null;
+    responsibleUserId: string | null;
+    createdByUserId: string;
+    approvedByUserId?: string | null;
+    lastEditedByUserId?: string | null;
+  },
+) {
+  const now = Date.now();
+  sqlite.prepare(`
+    INSERT INTO automation_jobs (
+      id, name, status, scope, organization_id, workspace_id, workspace_type,
+      owner_user_id, responsible_user_id, service_actor_id, approved_by_user_id,
+      last_edited_by_user_id, prompt, preferred_skill, workspace_context_paths_json,
+      target_output_path, schedule_kind, schedule_config_json, time_zone, next_run_at,
+      last_run_at, last_run_status, created_by_user_id, agent_id, delivery_mode,
+      delivery_session_mode, created_at, updated_at, job_type
+    ) VALUES (?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'default')
+  `).run(
+    input.id,
+    input.name,
+    input.scope,
+    input.organizationId,
+    input.workspaceId,
+    input.workspaceType,
+    input.ownerUserId,
+    input.responsibleUserId,
+    input.scope === 'organization' ? `org-service:${input.organizationId}` : null,
+    input.approvedByUserId ?? null,
+    input.lastEditedByUserId ?? input.createdByUserId,
+    'Test automation prompt.',
+    'auto',
+    '[]',
+    null,
+    'daily',
+    JSON.stringify({ kind: 'daily', times: ['09:00'], timeZone: 'UTC' }),
+    'UTC',
+    now + 60_000,
+    null,
+    null,
+    input.createdByUserId,
+    'canvas-agent',
+    'web',
+    'new_session',
+    now,
+    now,
+  );
+}
+
+async function main() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-offboarding-'));
+  const dataRoot = path.join(tempRoot, 'data');
+  const dbPath = path.join(dataRoot, 'sqlite.db');
+  process.env.DATA = dataRoot;
+  process.env.CANVAS_DEPLOYMENT_MODE = 'managed-team';
+  process.env.CANVAS_DATABASE_PROVIDER = 'postgres';
+
+  await fs.mkdir(dataRoot, { recursive: true });
+  const sqlite = new Database(dbPath);
+
+  try {
+    runMigrations(sqlite);
+    insertUser(sqlite, 'user-owner', 'Owner', 'owner@example.test', 'admin');
+    insertUser(sqlite, 'user-admin', 'Admin', 'admin@example.test', 'admin');
+    insertUser(sqlite, 'user-member', 'Member', 'member@example.test', 'user');
+
+    sqlite.exec('BEGIN IMMEDIATE');
+    const ownerStatus = ensureOrganizationBootstrapForUser(sqlite, 'user-owner');
+    sqlite.exec('COMMIT');
+    assert.ok(ownerStatus.organizationId);
+    const organizationId = ownerStatus.organizationId;
+
+    insertPermission(sqlite, organizationId, 'user-admin', 'admin', true);
+    insertPermission(sqlite, organizationId, 'user-member', 'member', false);
+    ensureDefaultWorkspaceRecords(sqlite, { organizationId, userId: 'user-admin', teamFeaturesEnabled: true });
+    ensureDefaultWorkspaceRecords(sqlite, { organizationId, userId: 'user-member', teamFeaturesEnabled: true });
+
+    const workspaces = sqlite.prepare(`
+      SELECT id, type, owner_user_id
+      FROM canvas_workspaces
+      ORDER BY created_at ASC
+    `).all() as WorkspaceRow[];
+    const memberWorkspace = workspaces.find((workspace) => workspace.type === 'personal' && workspace.owner_user_id === 'user-member');
+    const teamWorkspace = workspaces.find((workspace) => workspace.type === 'team');
+    assert.ok(memberWorkspace?.id);
+    assert.ok(teamWorkspace?.id);
+
+    const now = Date.now();
+    sqlite.prepare(`
+      INSERT INTO session (id, expires_at, token, created_at, updated_at, user_id)
+      VALUES ('session-member', ?, 'token-member', ?, ?, 'user-member')
+    `).run(now + 60_000, now, now);
+    sqlite.prepare(`
+      INSERT INTO account (id, account_id, provider_id, user_id, access_token, refresh_token, id_token, password, created_at, updated_at)
+      VALUES ('account-member', 'member-login', 'credential', 'user-member', 'access', 'refresh', 'id-token', 'password', ?, ?)
+    `).run(now, now);
+    sqlite.prepare(`
+      INSERT INTO email_accounts (
+        id, user_id, provider, auth_type, email_address, status, policy_json, secret_ref, is_primary, created_at, updated_at
+      ) VALUES ('email-member', 'user-member', 'google', 'oauth', 'member@example.test', 'active', '{}', 'secret-ref', 1, ?, ?)
+    `).run(now, now);
+    sqlite.prepare(`
+      INSERT INTO todo_items (
+        id, user_id, created_by_user_id, assignee_user_id, organization_id, workspace_id, workspace_type,
+        title, status, priority, source_type, created_at, updated_at
+      ) VALUES ('todo-member', 'user-owner', 'user-owner', 'user-member', ?, ?, 'team', 'Assigned todo', 'open', 'normal', 'user', ?, ?)
+    `).run(organizationId, teamWorkspace.id, now, now);
+    sqlite.prepare(`
+      INSERT INTO channel_user_bindings (user_id, channel_id, channel_user_id, enabled, created_at)
+      VALUES ('user-member', 'telegram', '12345', 1, ?)
+    `).run(now);
+
+    insertAutomation(sqlite, {
+      id: 'job-personal-member',
+      name: 'Personal member automation',
+      scope: 'personal',
+      organizationId,
+      workspaceId: memberWorkspace.id,
+      workspaceType: 'personal',
+      ownerUserId: 'user-member',
+      responsibleUserId: 'user-member',
+      createdByUserId: 'user-member',
+    });
+    insertAutomation(sqlite, {
+      id: 'job-team-member',
+      name: 'Team member automation',
+      scope: 'organization',
+      organizationId,
+      workspaceId: teamWorkspace.id,
+      workspaceType: 'team',
+      ownerUserId: null,
+      responsibleUserId: 'user-member',
+      createdByUserId: 'user-admin',
+      approvedByUserId: 'user-admin',
+      lastEditedByUserId: 'user-member',
+    });
+    sqlite.prepare(`
+      INSERT INTO automation_webhook_triggers (id, job_id, secret_hash, secret_preview, status, created_at, updated_at)
+      VALUES ('wh-member', 'job-team-member', 'hash', 'prev', 'active', ?, ?)
+    `).run(now, now);
+    sqlite.prepare(`
+      INSERT INTO automation_runs (
+        id, job_id, status, scope, organization_id, workspace_id, workspace_type, actor_type,
+        actor_user_id, trigger_type, attempt_number, created_at
+      ) VALUES ('run-member', 'job-team-member', 'pending', 'organization', ?, ?, 'team', 'user', 'user-member', 'manual', 1, ?)
+    `).run(organizationId, teamWorkspace.id, now);
+
+    const userSettingsDir = path.join(dataRoot, 'users', 'user-member', 'settings');
+    const userSecretsDir = path.join(dataRoot, 'users', 'user-member', 'secrets');
+    await fs.mkdir(userSettingsDir, { recursive: true });
+    await fs.mkdir(userSecretsDir, { recursive: true });
+
+    const {
+      createOffboardingPreflight,
+      offboardUser,
+      OffboardingError,
+    } = await import('../app/lib/organization/offboarding');
+    const {
+      hasOrganizationPermission,
+      readOrganizationPermissionForUser,
+    } = await import('../app/lib/organization/permissions');
+
+    const ownerPreflight = await createOffboardingPreflight('user-owner', 'user-admin');
+    assert.equal(ownerPreflight.canApply, false);
+    assert.ok(ownerPreflight.blockers.some((finding) => finding.category === 'permissions'));
+
+    const memberPreflight = await createOffboardingPreflight('user-member', 'user-admin');
+    assert.equal(memberPreflight.canApply, true);
+    assert.equal(memberPreflight.counts.activeSessions, 1);
+    assert.equal(memberPreflight.counts.activeEmailAccounts, 1);
+    assert.equal(memberPreflight.counts.personalAutomations, 1);
+    assert.equal(memberPreflight.counts.organizationResponsibleAutomations, 1);
+    assert.equal(memberPreflight.counts.openAssignedTodos, 1);
+    assert.ok(memberPreflight.warnings.length >= 4);
+
+    await assert.rejects(
+      () => offboardUser({ targetUserId: 'user-member', requestedByUserId: 'user-admin' }),
+      (error) => error instanceof OffboardingError && error.code === 'ACKNOWLEDGEMENT_REQUIRED',
+    );
+
+    const result = await offboardUser({
+      targetUserId: 'user-member',
+      requestedByUserId: 'user-admin',
+      reason: 'Contract ended',
+      acknowledgeWarnings: true,
+    });
+    assert.equal(result.actions.userBanned, 1);
+    assert.equal(result.actions.sessionsRevoked, 1);
+    assert.equal(result.actions.emailAccountsRevoked, 1);
+    assert.equal(result.actions.automationsPaused, 2);
+    assert.equal(result.actions.todosUnassigned, 1);
+    assert.equal(result.actions.personalWorkspacesLocked, 1);
+    assert.equal(await fs.stat(result.manifestPath).then((stat) => stat.isFile()), true);
+
+    const member = getRequiredRow<{ banned: number; ban_reason: string }>(sqlite, `
+      SELECT banned, ban_reason FROM user WHERE id = 'user-member'
+    `);
+    assert.equal(member.banned, 1);
+    assert.match(member.ban_reason, /Contract ended/);
+    const sessionCount = getRequiredRow<{ count: number }>(
+      sqlite,
+      'SELECT COUNT(*) AS count FROM session WHERE user_id = ?',
+      'user-member',
+    );
+    assert.equal(sessionCount.count, 0);
+    const account = getRequiredRow<Record<string, string | null>>(sqlite, `
+      SELECT access_token, refresh_token, id_token, password FROM account WHERE id = 'account-member'
+    `);
+    assert.equal(account.access_token, null);
+    assert.equal(account.refresh_token, null);
+    assert.equal(account.id_token, null);
+    assert.equal(account.password, null);
+    assert.equal(getRequiredRow<{ status: string; is_primary: number }>(sqlite, 'SELECT status, is_primary FROM email_accounts WHERE id = ?', 'email-member').status, 'revoked');
+    assert.equal(getRequiredRow<{ assignee_user_id: string | null }>(sqlite, 'SELECT assignee_user_id FROM todo_items WHERE id = ?', 'todo-member').assignee_user_id, null);
+    assert.equal(getRequiredRow<{ status: string }>(sqlite, 'SELECT status FROM canvas_workspaces WHERE id = ?', memberWorkspace.id).status, 'recovery_locked');
+    assert.equal(getRequiredRow<{ status: string }>(sqlite, 'SELECT status FROM automation_jobs WHERE id = ?', 'job-personal-member').status, 'paused');
+    assert.equal(getRequiredRow<{ status: string }>(sqlite, 'SELECT status FROM automation_jobs WHERE id = ?', 'job-team-member').status, 'paused');
+    assert.equal(getRequiredRow<{ status: string }>(sqlite, 'SELECT status FROM automation_webhook_triggers WHERE id = ?', 'wh-member').status, 'paused');
+    assert.equal(getRequiredRow<{ status: string }>(sqlite, 'SELECT status FROM automation_runs WHERE id = ?', 'run-member').status, 'failed');
+    assert.equal(getRequiredRow<{ enabled: number }>(sqlite, 'SELECT enabled FROM channel_user_bindings WHERE user_id = ?', 'user-member').enabled, 0);
+
+    const permission = readOrganizationPermissionForUser('user-member').permission;
+    assert.equal(permission?.status, 'archived');
+    assert.equal(hasOrganizationPermission(permission, 'canCreatePublicLinks'), false);
+    assert.equal(hasOrganizationPermission(permission, 'canDeleteStudioAssets'), false);
+  } finally {
+    if (sqlite.open) {
+      sqlite.close();
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+
+  console.log('organization-offboarding-test: ok');
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Adds an organization user offboarding preflight/apply service and admin API.
- Archives organization membership instead of deleting users, revokes sessions/login/email credentials, pauses affected automations/webhooks/runs, unassigns open to-dos, and locks personal workspaces as recovery-only.
- Replaces the destructive delete action in User Management with an offboarding review dialog.
- Marks Task 22 completed in the architecture todo file and adds a targeted offboarding regression test.

## Verification
- `npm run test:organization:offboarding`
- `npm run test:organization:permissions`
- `npm run test:automation:workspace-scope`
- `npm run test:todos:store`
- `npm run test:workspace:model`
- `npm run lint`
- `npm run build`

## Greptile
Greptile returned **4/5** on commit `96f65382`. Actionable feedback was reviewed and fixed in follow-up commit `b087cab8`:
- removed `manifestPath` from the admin API response
- moved user-scoped filesystem preflight scanning outside the SQLite write transaction
- logged unexpected offboarding apply errors before wrapping them
- added a deduplicated affected automation count for the UI summary

No additional Greptile review was triggered after the fix commit per maintainer instruction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a complete organization user offboarding flow: a preflight/apply service that archives the membership row, revokes sessions/auth/email credentials, pauses automations and webhook triggers, fails in-flight runs, unassigns open to-dos, and locks the personal workspace. It also wires up a review dialog in the User Management panel that replaces the previous destructive delete action.

- **Database**: `organization_user_permissions` gains a `status` column (with idempotent migration) and five offboarding audit columns; `bootstrap.ts` forces all capability booleans to `false` when `status != 'active'`, so archived users are cleanly blocked from exercising any permissions.
- **Offboarding service** (`offboarding.ts`): the `offboardUser` function opens a `BEGIN IMMEDIATE` write transaction and then `await`s `getScopedStorageState` (7 async `fs.stat` calls) inside that same transaction, blocking all concurrent DB writes for the duration of the FS scan (flagged in a previous review and still present). The `catch` block also silently discards the original exception before wrapping it in `OffboardingError('DATABASE_ERROR')`, making production SQLite errors invisible (also flagged previously, still present).
- **UI**: the automation summary shown in the dialog sums `organizationResponsibleAutomations + organizationReviewAutomations`, which double-counts automations where the user appears in both columns (flagged in a previous review and still present).

<h3>Confidence Score: 4/5</h3>

Safe to merge with the two open issues in offboarding.ts addressed first.

Two issues from the previous review round remain in offboarding.ts: the async filesystem scan inside a SQLite IMMEDIATE write lock blocks all concurrent DB writes for the duration of the FS scan on every offboarding apply, and a real database error during apply produces a generic 500 with no server-side trace of the original cause.

app/lib/organization/offboarding.ts — the BEGIN IMMEDIATE / async FS interaction and the silent error-swallowing catch block need attention before this ships.

<details open><summary><h3>Security Review</h3></summary>

- **Server filesystem path disclosure**: `offboardUser` returns an `OffboardingApplyResult` that includes `manifestPath` and the route returns it verbatim in the JSON response body. Any admin browser that completes an offboarding action receives the server data-root layout. The field is unused by the client and should be stripped before the response is sent.
- No injection, CSRF, or privilege-escalation issues identified. Auth is enforced at the route level via `requireOrganizationPermission('canRecoverWorkspaces')` before any user data is read.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/lib/organization/offboarding.ts | Core offboarding service with two unresolved issues: async FS I/O inside a BEGIN IMMEDIATE transaction blocks all concurrent DB writes, and the catch block silently discards the original error before wrapping it in OffboardingError. |
| app/api/admin/organization/users/[userId]/offboarding/route.ts | New admin route with correct auth (canRecoverWorkspaces) and rate limiting. The manifestPath (absolute server FS path) is included in the POST response body unnecessarily. |
| app/components/settings/UserManagementPanel.tsx | Delete action replaced with a well-structured offboarding review dialog. The automation summary count may be inflated by double-counting automations where the user is both responsible_user_id and created_by_user_id. |
| app/lib/db/migrate.ts | Correctly adds new columns via idempotent addColumns, with matching index creation. |
| app/lib/db/schema.ts | Drizzle schema updated to match migration: status, archived/disabled timestamps, and offboarding audit columns added. |
| app/lib/organization/bootstrap.ts | getPermissionRow now forces all capability booleans to false when status != 'active', cleanly blocking archived users from exercising any permissions. |
| app/lib/todos/store.ts | isOrganizationMember now filters status = 'active', preventing offboarded users from being re-assigned to todos. |
| app/api/todos/assignees/route.ts | Assignee list query now correctly excludes archived and banned users from the suggester. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `app/lib/organization/offboarding.ts`, line 1391-1399 ([link](https://github.com/canvascoding/canvas-notebook/blob/96f6538220e568ccf2510f4e6a62007ae1631a54/app/lib/organization/offboarding.ts#L1391-L1399)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Original error silently discarded on database failure**

   The catch block wraps any non-`OffboardingError` into a new `OffboardingError('DATABASE_ERROR')` without logging or preserving the original exception. The route's `errorResponse` only emits a `console.error` for errors that are *not* an `OffboardingError` instance — so a real SQLite constraint violation, busy error, or schema mismatch will produce a generic 500 response with zero server-side trace to diagnose it.

   The original error should be logged before re-throwing: `console.error('[OrganizationOffboarding] Unexpected error during offboarding:', error);`

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-offboarding-flow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-offboarding-flow%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Forganization%2Foffboarding.ts%0ALine%3A%201391-1399%0A%0AComment%3A%0A**Original%20error%20silently%20discarded%20on%20database%20failure**%0A%0AThe%20catch%20block%20wraps%20any%20non-%60OffboardingError%60%20into%20a%20new%20%60OffboardingError%28'DATABASE_ERROR'%29%60%20without%20logging%20or%20preserving%20the%20original%20exception.%20The%20route's%20%60errorResponse%60%20only%20emits%20a%20%60console.error%60%20for%20errors%20that%20are%20*not*%20an%20%60OffboardingError%60%20instance%20%E2%80%94%20so%20a%20real%20SQLite%20constraint%20violation%2C%20busy%20error%2C%20or%20schema%20mismatch%20will%20produce%20a%20generic%20500%20response%20with%20zero%20server-side%20trace%20to%20diagnose%20it.%0A%0AThe%20original%20error%20should%20be%20logged%20before%20re-throwing%3A%20%60console.error%28'%5BOrganizationOffboarding%5D%20Unexpected%20error%20during%20offboarding%3A'%2C%20error%29%3B%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=24&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `app/lib/organization/offboarding.ts`, line 1203-1209 ([link](https://github.com/canvascoding/canvas-notebook/blob/96f6538220e568ccf2510f4e6a62007ae1631a54/app/lib/organization/offboarding.ts#L1203-L1209)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Async filesystem I/O held inside an IMMEDIATE write transaction**

   `buildPreflight` is an async function that awaits `getScopedStorageState`, which calls `fs.stat` on up to seven directories. These async filesystem operations occur while the `BEGIN IMMEDIATE` write lock is already held on the SQLite database. Any concurrent admin write operation (role change, ban, another preflight-apply) is blocked for the entire duration of the FS scan. Consider running `buildPreflight` before starting the transaction and passing the result in.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-offboarding-flow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-offboarding-flow%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Forganization%2Foffboarding.ts%0ALine%3A%201203-1209%0A%0AComment%3A%0A**Async%20filesystem%20I%2FO%20held%20inside%20an%20IMMEDIATE%20write%20transaction**%0A%0A%60buildPreflight%60%20is%20an%20async%20function%20that%20awaits%20%60getScopedStorageState%60%2C%20which%20calls%20%60fs.stat%60%20on%20up%20to%20seven%20directories.%20These%20async%20filesystem%20operations%20occur%20while%20the%20%60BEGIN%20IMMEDIATE%60%20write%20lock%20is%20already%20held%20on%20the%20SQLite%20database.%20Any%20concurrent%20admin%20write%20operation%20%28role%20change%2C%20ban%2C%20another%20preflight-apply%29%20is%20blocked%20for%20the%20entire%20duration%20of%20the%20FS%20scan.%20Consider%20running%20%60buildPreflight%60%20before%20starting%20the%20transaction%20and%20passing%20the%20result%20in.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=24&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

3. `app/components/settings/UserManagementPanel.tsx`, line 353-358 ([link](https://github.com/canvascoding/canvas-notebook/blob/96f6538220e568ccf2510f4e6a62007ae1631a54/app/components/settings/UserManagementPanel.tsx#L353-L358)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Automation count in preflight summary can be double-counted**

   `organizationResponsibleAutomations` and `organizationReviewAutomations` are produced by separate SQL queries with overlapping predicates. An organization-scope automation where the user is simultaneously `responsible_user_id` **and** `created_by_user_id` (or `approved_by_user_id`, etc.) is counted in both queries. Adding the two values together inflates the displayed automation total. The actual pausing step uses a unified `OR` clause (`buildAutomationAffectedWhere`) that de-duplicates correctly, so only the user-facing count is wrong.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-offboarding-flow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-offboarding-flow%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fcomponents%2Fsettings%2FUserManagementPanel.tsx%0ALine%3A%20353-358%0A%0AComment%3A%0A**Automation%20count%20in%20preflight%20summary%20can%20be%20double-counted**%0A%0A%60organizationResponsibleAutomations%60%20and%20%60organizationReviewAutomations%60%20are%20produced%20by%20separate%20SQL%20queries%20with%20overlapping%20predicates.%20An%20organization-scope%20automation%20where%20the%20user%20is%20simultaneously%20%60responsible_user_id%60%20**and**%20%60created_by_user_id%60%20%28or%20%60approved_by_user_id%60%2C%20etc.%29%20is%20counted%20in%20both%20queries.%20Adding%20the%20two%20values%20together%20inflates%20the%20displayed%20automation%20total.%20The%20actual%20pausing%20step%20uses%20a%20unified%20%60OR%60%20clause%20%28%60buildAutomationAffectedWhere%60%29%20that%20de-duplicates%20correctly%2C%20so%20only%20the%20user-facing%20count%20is%20wrong.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=24&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fuser-offboarding-flow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fuser-offboarding-flow%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fapi%2Fadmin%2Forganization%2Fusers%2F%5BuserId%5D%2Foffboarding%2Froute.ts%3A82%0A**Server%20filesystem%20path%20leaked%20to%20browser%20client**%0A%0A%60offboardUser%60%20returns%20an%20%60OffboardingApplyResult%60%20that%20contains%20%60manifestPath%60%20%E2%80%94%20an%20absolute%20server-side%20path%20such%20as%20%60%2Fdata%2Fusers%2F%3Cid%3E%2Fsettings%2Foffboarding.json%60.%20Returning%20it%20verbatim%20exposes%20the%20server's%20data-root%20layout%20to%20every%20admin%20browser%20that%20completes%20an%20offboarding.%20The%20field%20is%20unused%20by%20the%20client.%20Strip%20it%20before%20sending%20the%20response.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=24&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Add organization user offboarding flow"](https://github.com/canvascoding/canvas-notebook/commit/96f6538220e568ccf2510f4e6a62007ae1631a54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38847076)</sub>

<!-- /greptile_comment -->
