### PR TITLE
Scope Studio assets to organization

### DIFF
--- a/app/api/studio/generations/[id]/outputs/[outId]/route.ts
+++ b/app/api/studio/generations/[id]/outputs/[outId]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { auth } from '@/app/lib/auth';
 import { db } from '@/app/lib/db';
-import { studioGenerationOutputs } from '@/app/lib/db/schema';
+import { studioGenerationOutputs, studioGenerations } from '@/app/lib/db/schema';
 import { deleteStudioOutput, getStudioOutputForUser } from '@/app/lib/integrations/studio-generation-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 
@@ -53,6 +53,21 @@ export async function PATCH(
     const existing = await getStudioOutputForUser(outId, session.user.id);
 
     if (!existing || existing.generationId !== id) {
+      return NextResponse.json({ success: false, error: 'Output not found' }, { status: 404 });
+    }
+
+    const [ownedOutput] = await db
+      .select({ id: studioGenerationOutputs.id })
+      .from(studioGenerationOutputs)
+      .innerJoin(studioGenerations, eq(studioGenerationOutputs.generationId, studioGenerations.id))
+      .where(and(
+        eq(studioGenerationOutputs.id, outId),
+        eq(studioGenerations.id, id),
+        eq(studioGenerations.userId, session.user.id),
+      ))
+      .limit(1);
+
+    if (!ownedOutput) {
       return NextResponse.json({ success: false, error: 'Output not found' }, { status: 404 });
     }
 

--- a/app/api/studio/generations/[id]/outputs/[outId]/route.ts
+++ b/app/api/studio/generations/[id]/outputs/[outId]/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { auth } from '@/app/lib/auth';
 import { db } from '@/app/lib/db';
-import { studioGenerationOutputs, studioGenerations } from '@/app/lib/db/schema';
-import { deleteStudioOutput } from '@/app/lib/integrations/studio-generation-service';
+import { studioGenerationOutputs } from '@/app/lib/db/schema';
+import { deleteStudioOutput, getStudioOutputForUser } from '@/app/lib/integrations/studio-generation-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 
 export async function DELETE(
@@ -50,18 +50,9 @@ export async function PATCH(
   }
 
   try {
-    const [existing] = await db
-      .select({ id: studioGenerationOutputs.id })
-      .from(studioGenerationOutputs)
-      .innerJoin(studioGenerations, eq(studioGenerationOutputs.generationId, studioGenerations.id))
-      .where(and(
-        eq(studioGenerationOutputs.id, outId),
-        eq(studioGenerationOutputs.generationId, id),
-        eq(studioGenerations.userId, session.user.id),
-      ))
-      .limit(1);
+    const existing = await getStudioOutputForUser(outId, session.user.id);
 
-    if (!existing) {
+    if (!existing || existing.generationId !== id) {
       return NextResponse.json({ success: false, error: 'Output not found' }, { status: 404 });
     }
 

--- a/app/api/studio/generations/route.ts
+++ b/app/api/studio/generations/route.ts
@@ -22,7 +22,8 @@ export async function GET(request: NextRequest) {
   try {
     const limit = Math.min(parsePositiveInt(request.nextUrl.searchParams.get('limit'), DEFAULT_LIMIT), MAX_LIMIT);
     const offset = parsePositiveInt(request.nextUrl.searchParams.get('offset'), 0);
-    const result = await listStudioGenerations(session.user.id, { limit, offset });
+    const creatorUserId = request.nextUrl.searchParams.get('creatorUserId');
+    const result = await listStudioGenerations(session.user.id, { limit, offset, creatorUserId });
     return NextResponse.json({ success: true, ...result });
   } catch (error) {
     console.error('[Studio Generations] Error:', error);

--- a/app/api/studio/library/route.ts
+++ b/app/api/studio/library/route.ts
@@ -6,6 +6,7 @@ import { listStudioGenerations } from '@/app/lib/integrations/studio-generation-
 import { db } from '@/app/lib/db';
 import { studioPresets } from '@/app/lib/db/schema';
 import { eq, or } from 'drizzle-orm';
+import { resolveStudioScope } from '@/app/lib/integrations/studio-scope';
 
 export async function GET(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
@@ -20,6 +21,11 @@ export async function GET(request: NextRequest) {
       listStudioGenerations(session.user.id),
     ]);
 
+    const scope = resolveStudioScope(session.user.id);
+    const presetVisibility = scope.organizationWide && scope.organizationId
+      ? or(eq(studioPresets.userId, session.user.id), eq(studioPresets.organizationId, scope.organizationId), eq(studioPresets.isDefault, true))
+      : or(eq(studioPresets.userId, session.user.id), eq(studioPresets.isDefault, true));
+
     const presets = await db.select({
       id: studioPresets.id,
       name: studioPresets.name,
@@ -28,7 +34,7 @@ export async function GET(request: NextRequest) {
       isDefault: studioPresets.isDefault,
     })
       .from(studioPresets)
-      .where(or(eq(studioPresets.userId, session.user.id), eq(studioPresets.isDefault, true)));
+      .where(presetVisibility);
 
     return NextResponse.json({
       success: true,
@@ -36,6 +42,7 @@ export async function GET(request: NextRequest) {
       personas,
       presets,
       generations: generationResult.generations,
+      creators: generationResult.creators,
     });
   } catch (error) {
     console.error('[Studio Library] Error:', error);

--- a/app/api/studio/media/[...path]/route.ts
+++ b/app/api/studio/media/[...path]/route.ts
@@ -9,6 +9,7 @@ import {
   resolveValidatedStudioOutputPath,
   resolveValidatedUserUploadStudioRefPath
 } from '@/app/lib/integrations/studio-paths';
+import { canReadStudioOutputPath } from '@/app/lib/integrations/studio-generation-service';
 
 const MEDIA_TYPES: Record<string, string> = {
   pdf: 'application/pdf',
@@ -84,6 +85,9 @@ export async function GET(
 
   const { path: pathParts } = await context.params;
   const encodedPath = pathParts.map((p) => decodeURIComponent(p)).join('/');
+  if (encodedPath.startsWith('studio/outputs/') && !(await canReadStudioOutputPath(encodedPath, session.user.id))) {
+    return NextResponse.json({ success: false, error: 'File not found or unreadable' }, { status: 404 });
+  }
   const fullPath = resolveStudioPath(encodedPath);
 
   if (!fullPath) {

--- a/app/api/studio/media/preview/[...path]/route.ts
+++ b/app/api/studio/media/preview/[...path]/route.ts
@@ -16,6 +16,7 @@ import {
   HTML_PREVIEW_CSP,
   isHtmlFile,
 } from '@/app/lib/html-preview';
+import { canReadStudioOutputPath } from '@/app/lib/integrations/studio-generation-service';
 
 const STUDIO_HTML_PREVIEW_PREFIX = '/api/studio/media/preview';
 
@@ -62,6 +63,9 @@ export async function GET(
 
   const { path: pathParts } = await context.params;
   const encodedPath = pathParts.map((p) => decodeURIComponent(p)).join('/');
+  if (encodedPath.startsWith('studio/outputs/') && !(await canReadStudioOutputPath(encodedPath, session.user.id))) {
+    return NextResponse.json({ success: false, error: 'File not found or unreadable' }, { status: 404 });
+  }
   const fullPath = resolveStudioPath(encodedPath);
 
   if (!fullPath) {

--- a/app/api/studio/outputs/save-to-workspace/route.ts
+++ b/app/api/studio/outputs/save-to-workspace/route.ts
@@ -90,7 +90,7 @@ export async function POST(request: NextRequest) {
     const reservedPaths = new Set<string>();
 
     for (const id of uniqueOutputIds) {
-      // Verify output belongs to user before reading the studio output file.
+      // Verify the output is visible to the actor before reading the studio output file.
       const output = await getStudioOutputForUser(id, session.user.id);
 
       if (!output) {

--- a/app/api/studio/references/assets/route.ts
+++ b/app/api/studio/references/assets/route.ts
@@ -7,13 +7,14 @@ import fs from 'node:fs/promises';
 import { auth } from '@/app/lib/auth';
 import type { FileNode } from '@/app/lib/filesystem/workspace-files';
 import { buildGenericFileTree } from '@/app/lib/filesystem/workspace-files';
-import { getStudioEditsRoot, getStudioOutputsRoot } from '@/app/lib/integrations/studio-workspace';
+import { getStudioEditsRoot } from '@/app/lib/integrations/studio-workspace';
 import { getUserUploadsStudioRefRoot } from '@/app/lib/runtime-data-paths';
 import { toMediaUrl, toPreviewUrl } from '@/app/lib/utils/media-url';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 import { db } from '@/app/lib/db';
 import { studioGenerationOutputs, studioGenerations } from '@/app/lib/db/schema';
 import { and, desc, eq } from 'drizzle-orm';
+import { resolveStudioScope, studioVisibilityCondition } from '@/app/lib/integrations/studio-scope';
 
 const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'webp', 'bmp', 'tif', 'tiff', 'gif']);
 const VIDEO_EXTENSIONS = new Set(['mp4', 'mov']);
@@ -124,6 +125,11 @@ export async function GET(request: NextRequest) {
     const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(limitRaw, 500)) : 300;
     const depthRaw = Number(searchParams.get('depth') || '8');
     const depth = Number.isFinite(depthRaw) ? Math.max(1, Math.min(depthRaw, 12)) : 8;
+    const studioVisibility = studioVisibilityCondition(resolveStudioScope(session.user.id), {
+      userId: studioGenerations.userId,
+      organizationId: studioGenerations.organizationId,
+      createdByUserId: studioGenerations.createdByUserId,
+    });
 
     if (veoOnly) {
       if (requestedKind !== 'video') {
@@ -143,7 +149,7 @@ export async function GET(request: NextRequest) {
         .from(studioGenerationOutputs)
         .innerJoin(studioGenerations, eq(studioGenerationOutputs.generationId, studioGenerations.id))
         .where(and(
-          eq(studioGenerations.userId, session.user.id),
+          studioVisibility,
           eq(studioGenerationOutputs.type, 'video'),
         ))
         .orderBy(desc(studioGenerationOutputs.createdAt))
@@ -169,17 +175,34 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Scan studio outputs (data/studio/outputs)
-    const outputsTree = await safeBuildGenericFileTree(getStudioOutputsRoot(), depth);
+    const outputType = requestedKind === 'audio' ? 'sound' : requestedKind;
+    const outputRows = await db.select({
+      filePath: studioGenerationOutputs.filePath,
+      fileName: studioGenerationOutputs.fileName,
+      fileSize: studioGenerationOutputs.fileSize,
+      createdAt: studioGenerationOutputs.createdAt,
+      type: studioGenerationOutputs.type,
+    })
+      .from(studioGenerationOutputs)
+      .innerJoin(studioGenerations, eq(studioGenerationOutputs.generationId, studioGenerations.id))
+      .where(and(
+        studioVisibility,
+        eq(studioGenerationOutputs.type, outputType),
+      ))
+      .orderBy(desc(studioGenerationOutputs.createdAt))
+      .limit(limit);
     // Scan aspect-ratio edits (data/studio/edits)
     const editsTree = await safeBuildGenericFileTree(getStudioEditsRoot(), depth);
     // Scan user-uploaded studio references (data/user-uploads/studio-references)
     const uploadsTree = await safeBuildGenericFileTree(getUserUploadsStudioRefRoot(), depth);
 
     const allFiles = [
-      ...walkFiles(outputsTree).map((n) => ({
-        ...n,
-        path: n.path.startsWith('studio/') ? n.path : `studio/outputs/${n.path}`,
+      ...outputRows.map((row): FileNode => ({
+        type: 'file',
+        name: row.fileName || row.filePath.split('/').pop() || row.filePath,
+        path: row.filePath.startsWith('studio/') ? row.filePath : `studio/outputs/${row.filePath}`,
+        size: row.fileSize ?? undefined,
+        modified: row.createdAt ? Math.floor(row.createdAt.getTime() / 1000) : undefined,
       })),
       ...walkFiles(editsTree).map((n) => ({
         ...n,

--- a/app/apps/studio/components/create/CreateView.tsx
+++ b/app/apps/studio/components/create/CreateView.tsx
@@ -326,7 +326,8 @@ export function CreateView({ initialProviderConfig = EMPTY_STUDIO_PROVIDER_CONFI
   const router = useRouter();
   const searchParams = useSearchParams();
   const setChatContext = useSetStudioChatContext();
-  const generationHook = useStudioGeneration();
+  const [creatorFilter, setCreatorFilter] = useState<string | null>(null);
+  const generationHook = useStudioGeneration(creatorFilter);
   const productsHook = useStudioProducts();
   const personasHook = useStudioPersonas();
   const stylesHook = useStudioStyles();
@@ -335,6 +336,7 @@ export function CreateView({ initialProviderConfig = EMPTY_STUDIO_PROVIDER_CONFI
   const {
     fetchGenerations,
     generations,
+    creators,
     recentlyCompletedIds,
     hasMoreGenerations,
     loadingMore,
@@ -845,7 +847,7 @@ export function CreateView({ initialProviderConfig = EMPTY_STUDIO_PROVIDER_CONFI
     )),
     [generations],
   );
-  const hasActiveOutputFilters = mediaFilter !== 'all' || dateFilter !== 'all';
+  const hasActiveOutputFilters = mediaFilter !== 'all' || dateFilter !== 'all' || creatorFilter !== null;
   const hasNoMatchingVisibleOutputs = visibleOutputList.length === 0;
   const shouldShowInspiration = (
     !startingPointsLoading &&
@@ -942,6 +944,9 @@ export function CreateView({ initialProviderConfig = EMPTY_STUDIO_PROVIDER_CONFI
               onDateFilterChange={setDateFilter}
               sortOrder={sortOrder}
               onSortOrderChange={setSortOrder}
+              creatorFilter={creatorFilter}
+              onCreatorFilterChange={setCreatorFilter}
+              creators={creators}
               selectionEnabled={selectionEnabled}
               onToggleSelection={() => {
                 setSelectionEnabled((current) => {

--- a/app/apps/studio/components/create/FilterBar.tsx
+++ b/app/apps/studio/components/create/FilterBar.tsx
@@ -5,6 +5,7 @@ import { ArrowDownUp, CheckSquare, Download, Filter, SlidersHorizontal, Star, Tr
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
 import { Badge } from '@/components/ui/badge';
+import type { StudioCreator } from '../../types/generation';
 import type { OutputMediaFilter, OutputDateFilter, OutputSortOrder } from './OutputGrid';
 
 const MEDIA_OPTIONS: { value: OutputMediaFilter; label: string }[] = [
@@ -33,6 +34,9 @@ interface FilterBarProps {
   onDateFilterChange: (value: OutputDateFilter) => void;
   sortOrder: OutputSortOrder;
   onSortOrderChange: (value: OutputSortOrder) => void;
+  creatorFilter: string | null;
+  onCreatorFilterChange: (value: string | null) => void;
+  creators: StudioCreator[];
   selectionEnabled: boolean;
   onToggleSelection: () => void;
   selectedCount: number;
@@ -72,12 +76,20 @@ function FilterContent({
   onMediaFilterChange,
   dateFilter,
   onDateFilterChange,
+  creatorFilter,
+  onCreatorFilterChange,
+  creators,
 }: {
   mediaFilter: OutputMediaFilter;
   onMediaFilterChange: (value: OutputMediaFilter) => void;
   dateFilter: OutputDateFilter;
   onDateFilterChange: (value: OutputDateFilter) => void;
+  creatorFilter: string | null;
+  onCreatorFilterChange: (value: string | null) => void;
+  creators: StudioCreator[];
 }) {
+  const hasCreatorOptions = creators.length > 1 || creatorFilter !== null;
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center gap-2">
@@ -107,6 +119,26 @@ function FilterContent({
           </PillButton>
         ))}
       </div>
+
+      {hasCreatorOptions ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+            Creator
+          </span>
+          <select
+            value={creatorFilter ?? ''}
+            onChange={(event) => onCreatorFilterChange(event.target.value || null)}
+            className="h-9 rounded-full border border-border bg-card/80 px-3 text-sm text-foreground outline-none transition hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="">All creators</option>
+            {creators.map((creator) => (
+              <option key={creator.id} value={creator.id}>
+                {creator.name || creator.email || creator.id}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -118,6 +150,9 @@ export function FilterBar({
   onDateFilterChange,
   sortOrder,
   onSortOrderChange,
+  creatorFilter,
+  onCreatorFilterChange,
+  creators,
   selectionEnabled,
   onToggleSelection,
   selectedCount,
@@ -134,8 +169,9 @@ export function FilterBar({
     let count = 0;
     if (mediaFilter !== 'all') count++;
     if (dateFilter !== 'all') count++;
+    if (creatorFilter !== null) count++;
     return count;
-  }, [mediaFilter, dateFilter]);
+  }, [mediaFilter, dateFilter, creatorFilter]);
 
   const activeChips = useMemo(() => {
     const chips: { label: string; onRemove: () => void }[] = [];
@@ -147,8 +183,15 @@ export function FilterBar({
       const opt = DATE_OPTIONS.find((o) => o.value === dateFilter);
       if (opt) chips.push({ label: opt.label, onRemove: () => onDateFilterChange('all') });
     }
+    if (creatorFilter !== null) {
+      const creator = creators.find((item) => item.id === creatorFilter);
+      chips.push({
+        label: creator?.name || creator?.email || 'Creator',
+        onRemove: () => onCreatorFilterChange(null),
+      });
+    }
     return chips;
-  }, [mediaFilter, dateFilter, onMediaFilterChange, onDateFilterChange]);
+  }, [mediaFilter, dateFilter, creatorFilter, creators, onMediaFilterChange, onDateFilterChange, onCreatorFilterChange]);
 
   return (
     <>
@@ -214,6 +257,9 @@ export function FilterBar({
                 onMediaFilterChange={(v) => { onMediaFilterChange(v); }}
                 dateFilter={dateFilter}
                 onDateFilterChange={(v) => { onDateFilterChange(v); }}
+                creatorFilter={creatorFilter}
+                onCreatorFilterChange={onCreatorFilterChange}
+                creators={creators}
               />
             </div>
           </CollapsibleContent>
@@ -400,6 +446,9 @@ export function FilterBar({
               onDateFilterChange={(v) => {
                 onDateFilterChange(v);
               }}
+              creatorFilter={creatorFilter}
+              onCreatorFilterChange={onCreatorFilterChange}
+              creators={creators}
             />
           </div>
         </SheetContent>

--- a/app/apps/studio/hooks/useStudioGeneration.ts
+++ b/app/apps/studio/hooks/useStudioGeneration.ts
@@ -177,6 +177,12 @@ function buildGenerationsUrl(limit: number, offset: number, creatorFilter?: stri
   return `/api/studio/generations?${params.toString()}`;
 }
 
+function decrementLoadedServerGenerationCount() {
+  useStudioGenerationsCacheStore.setState((state) => ({
+    loadedServerGenerationCount: Math.max(0, state.loadedServerGenerationCount - 1),
+  }));
+}
+
 export function useStudioGeneration(creatorFilter?: string | null): UseStudioGenerationReturn {
   const generations = useStudioGenerationsCacheStore((state) => state.generations);
   const currentGeneration = useStudioGenerationsCacheStore((state) => state.currentGeneration);
@@ -268,6 +274,7 @@ export function useStudioGeneration(creatorFilter?: string | null): UseStudioGen
       setGenerationsState((current) => preserveActiveGenerations(current, nextGenerations));
       useStudioGenerationsCacheStore.setState({
         hasMoreGenerations: Boolean(data.hasMore),
+        loadedServerGenerationCount: nextGenerations.length,
         creators: (data.creators ?? []) as StudioCreator[],
       });
       setCurrentGenerationState((current) => {
@@ -288,20 +295,20 @@ export function useStudioGeneration(creatorFilter?: string | null): UseStudioGen
   }, [creatorFilter]);
 
   const loadMoreGenerations = useCallback(async () => {
-    const { generations, hasMoreGenerations, loadingMore } = useStudioGenerationsCacheStore.getState();
+    const { hasMoreGenerations, loadedServerGenerationCount, loadingMore } = useStudioGenerationsCacheStore.getState();
     if (loadingMore || !hasMoreGenerations) {
       return;
     }
 
     useStudioGenerationsCacheStore.setState({ loadingMore: true, error: null });
     try {
-      const loadedServerGenerationCount = generations.filter((generation) => !generation.id.startsWith('temp-')).length;
       const response = await fetch(buildGenerationsUrl(GENERATIONS_PAGE_SIZE, loadedServerGenerationCount, creatorFilter));
       const data = await parseJsonResponse(response);
       const nextGenerations = (data.generations ?? []) as StudioGeneration[];
       setGenerationsState((current) => mergeGenerationPages(current, nextGenerations));
       useStudioGenerationsCacheStore.setState({
         hasMoreGenerations: Boolean(data.hasMore),
+        loadedServerGenerationCount: loadedServerGenerationCount + nextGenerations.length,
         creators: (data.creators ?? []) as StudioCreator[],
       });
     } catch (err) {
@@ -387,7 +394,11 @@ export function useStudioGeneration(creatorFilter?: string | null): UseStudioGen
     try {
       const response = await fetch(`/api/studio/generations/${id}`, { method: 'DELETE' });
       await parseJsonResponse(response);
+      const existed = useStudioGenerationsCacheStore.getState().generations.some((generation) => generation.id === id);
       setGenerationsState((current) => current.filter((generation) => generation.id !== id));
+      if (existed && !id.startsWith('temp-')) {
+        decrementLoadedServerGenerationCount();
+      }
       setCurrentGenerationState((current) => (current?.id === id ? null : current));
       if (activeGenerationId === id) {
         stopPolling();
@@ -407,7 +418,11 @@ export function useStudioGeneration(creatorFilter?: string | null): UseStudioGen
       const generationDeleted = data.generationDeleted === true;
 
       if (generationDeleted) {
+        const existed = useStudioGenerationsCacheStore.getState().generations.some((g) => g.id === generationId);
         setGenerationsState((current) => current.filter((g) => g.id !== generationId));
+        if (existed && !generationId.startsWith('temp-')) {
+          decrementLoadedServerGenerationCount();
+        }
         setCurrentGenerationState((current) => (current?.id === generationId ? null : current));
         if (activeGenerationId === generationId) {
           stopPolling();

--- a/app/apps/studio/hooks/useStudioGeneration.ts
+++ b/app/apps/studio/hooks/useStudioGeneration.ts
@@ -6,6 +6,7 @@ import { useStudioGenerationsCacheStore } from '@/app/store/studio-generations-c
 import type {
   StudioGeneratePayload,
   StudioGenerateResponse,
+  StudioCreator,
   StudioGeneration,
   StudioGenerationMode,
   StudioGenerationOutput,
@@ -26,6 +27,7 @@ interface UseStudioGenerationReturn {
   activeGenerationId: string | null;
   recentlyCompletedIds: Set<string>;
   hasMoreGenerations: boolean;
+  creators: StudioCreator[];
   fetchGenerations: () => Promise<void>;
   loadMoreGenerations: () => Promise<void>;
   fetchGeneration: (id: string, options?: { silent?: boolean }) => Promise<StudioGeneration | null>;
@@ -164,7 +166,18 @@ function preserveActiveGenerations(
   return mergeGenerationPages(optimistic, nextGenerations);
 }
 
-export function useStudioGeneration(): UseStudioGenerationReturn {
+function buildGenerationsUrl(limit: number, offset: number, creatorFilter?: string | null): string {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  });
+  if (creatorFilter) {
+    params.set('creatorUserId', creatorFilter);
+  }
+  return `/api/studio/generations?${params.toString()}`;
+}
+
+export function useStudioGeneration(creatorFilter?: string | null): UseStudioGenerationReturn {
   const generations = useStudioGenerationsCacheStore((state) => state.generations);
   const currentGeneration = useStudioGenerationsCacheStore((state) => state.currentGeneration);
   const loading = useStudioGenerationsCacheStore((state) => state.loading);
@@ -173,6 +186,7 @@ export function useStudioGeneration(): UseStudioGenerationReturn {
   const activeGenerationId = useStudioGenerationsCacheStore((state) => state.activeGenerationId);
   const recentlyCompletedIds = useStudioGenerationsCacheStore((state) => state.recentlyCompletedIds);
   const hasMoreGenerations = useStudioGenerationsCacheStore((state) => state.hasMoreGenerations);
+  const creators = useStudioGenerationsCacheStore((state) => state.creators);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const stopPolling = useCallback(() => {
@@ -248,11 +262,14 @@ export function useStudioGeneration(): UseStudioGenerationReturn {
   const fetchGenerations = useCallback(async () => {
     useStudioGenerationsCacheStore.setState({ loading: true, error: null });
     try {
-      const response = await fetch(`/api/studio/generations?limit=${GENERATIONS_PAGE_SIZE}&offset=0`);
+      const response = await fetch(buildGenerationsUrl(GENERATIONS_PAGE_SIZE, 0, creatorFilter));
       const data = await parseJsonResponse(response);
       const nextGenerations = (data.generations ?? []) as StudioGeneration[];
       setGenerationsState((current) => preserveActiveGenerations(current, nextGenerations));
-      useStudioGenerationsCacheStore.setState({ hasMoreGenerations: Boolean(data.hasMore) });
+      useStudioGenerationsCacheStore.setState({
+        hasMoreGenerations: Boolean(data.hasMore),
+        creators: (data.creators ?? []) as StudioCreator[],
+      });
       setCurrentGenerationState((current) => {
         const latestGenerations = preserveActiveGenerations(
           useStudioGenerationsCacheStore.getState().generations,
@@ -268,7 +285,7 @@ export function useStudioGeneration(): UseStudioGenerationReturn {
     } finally {
       useStudioGenerationsCacheStore.setState({ loading: false });
     }
-  }, []);
+  }, [creatorFilter]);
 
   const loadMoreGenerations = useCallback(async () => {
     const { generations, hasMoreGenerations, loadingMore } = useStudioGenerationsCacheStore.getState();
@@ -279,17 +296,20 @@ export function useStudioGeneration(): UseStudioGenerationReturn {
     useStudioGenerationsCacheStore.setState({ loadingMore: true, error: null });
     try {
       const loadedServerGenerationCount = generations.filter((generation) => !generation.id.startsWith('temp-')).length;
-      const response = await fetch(`/api/studio/generations?limit=${GENERATIONS_PAGE_SIZE}&offset=${loadedServerGenerationCount}`);
+      const response = await fetch(buildGenerationsUrl(GENERATIONS_PAGE_SIZE, loadedServerGenerationCount, creatorFilter));
       const data = await parseJsonResponse(response);
       const nextGenerations = (data.generations ?? []) as StudioGeneration[];
       setGenerationsState((current) => mergeGenerationPages(current, nextGenerations));
-      useStudioGenerationsCacheStore.setState({ hasMoreGenerations: Boolean(data.hasMore) });
+      useStudioGenerationsCacheStore.setState({
+        hasMoreGenerations: Boolean(data.hasMore),
+        creators: (data.creators ?? []) as StudioCreator[],
+      });
     } catch (err) {
       useStudioGenerationsCacheStore.setState({ error: toErrorMessage(err, 'Failed to load more generations') });
     } finally {
       useStudioGenerationsCacheStore.setState({ loadingMore: false });
     }
-  }, []);
+  }, [creatorFilter]);
 
   const watchGeneration = useCallback((id: string) => {
     useStudioGenerationsCacheStore.setState({ activeGenerationId: id });
@@ -524,6 +544,7 @@ export function useStudioGeneration(): UseStudioGenerationReturn {
     activeGenerationId,
     recentlyCompletedIds,
     hasMoreGenerations,
+    creators,
     fetchGenerations,
     loadMoreGenerations,
     fetchGeneration,

--- a/app/apps/studio/types/generation.ts
+++ b/app/apps/studio/types/generation.ts
@@ -3,6 +3,12 @@ import type { StudioPreset } from './presets';
 export type StudioGenerationMode = 'image' | 'video' | 'sound';
 export type StudioGenerationStatus = 'pending' | 'generating' | 'completed' | 'failed';
 
+export interface StudioCreator {
+  id: string;
+  name: string;
+  email: string | null;
+}
+
 export interface StudioGenerationOutput {
   id: string;
   generationId: string;
@@ -23,6 +29,9 @@ export interface StudioGenerationOutput {
 export interface StudioGeneration {
   id: string;
   userId: string;
+  organizationId?: string | null;
+  createdByUserId?: string | null;
+  workspaceId?: string | null;
   mode: StudioGenerationMode;
   prompt: string | null;
   rawPrompt: string | null;

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -581,6 +581,9 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS studio_products (
       id TEXT PRIMARY KEY NOT NULL,
       user_id TEXT NOT NULL,
+      organization_id TEXT,
+      created_by_user_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'organization',
       name TEXT NOT NULL,
       description TEXT,
       thumbnail_path TEXT,
@@ -609,6 +612,9 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS studio_personas (
       id TEXT PRIMARY KEY NOT NULL,
       user_id TEXT NOT NULL,
+      organization_id TEXT,
+      created_by_user_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'organization',
       name TEXT NOT NULL,
       description TEXT,
       thumbnail_path TEXT,
@@ -637,6 +643,9 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS studio_styles (
       id TEXT PRIMARY KEY NOT NULL,
       user_id TEXT NOT NULL,
+      organization_id TEXT,
+      created_by_user_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'organization',
       name TEXT NOT NULL,
       description TEXT,
       thumbnail_path TEXT,
@@ -665,6 +674,9 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS studio_presets (
       id TEXT PRIMARY KEY NOT NULL,
       user_id TEXT,
+      organization_id TEXT,
+      created_by_user_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'user',
       is_default INTEGER NOT NULL DEFAULT 0,
       name TEXT NOT NULL,
       description TEXT,
@@ -680,6 +692,9 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS studio_generations (
       id TEXT PRIMARY KEY NOT NULL,
       user_id TEXT NOT NULL,
+      organization_id TEXT,
+      created_by_user_id TEXT,
+      workspace_id TEXT,
       mode TEXT NOT NULL,
       prompt TEXT,
       raw_prompt TEXT,
@@ -702,6 +717,9 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS studio_generation_outputs (
       id TEXT PRIMARY KEY NOT NULL,
       generation_id TEXT NOT NULL,
+      organization_id TEXT,
+      created_by_user_id TEXT,
+      workspace_id TEXT,
       variation_index INTEGER NOT NULL DEFAULT 0,
       type TEXT NOT NULL DEFAULT 'image',
       file_path TEXT NOT NULL,
@@ -744,6 +762,9 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS studio_bulk_jobs (
       id TEXT PRIMARY KEY NOT NULL,
       user_id TEXT NOT NULL,
+      organization_id TEXT,
+      created_by_user_id TEXT,
+      workspace_id TEXT,
       name TEXT,
       studio_preset_id TEXT,
       additional_prompt TEXT,
@@ -797,6 +818,45 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
 
   addColumns(sqlite, 'studio_generations', {
     studio_preset_name: 'TEXT',
+    organization_id: 'TEXT',
+    created_by_user_id: 'TEXT',
+    workspace_id: 'TEXT',
+  });
+
+  addColumns(sqlite, 'studio_products', {
+    organization_id: 'TEXT',
+    created_by_user_id: 'TEXT',
+    visibility: "TEXT NOT NULL DEFAULT 'organization'",
+  });
+
+  addColumns(sqlite, 'studio_personas', {
+    organization_id: 'TEXT',
+    created_by_user_id: 'TEXT',
+    visibility: "TEXT NOT NULL DEFAULT 'organization'",
+  });
+
+  addColumns(sqlite, 'studio_styles', {
+    organization_id: 'TEXT',
+    created_by_user_id: 'TEXT',
+    visibility: "TEXT NOT NULL DEFAULT 'organization'",
+  });
+
+  addColumns(sqlite, 'studio_presets', {
+    organization_id: 'TEXT',
+    created_by_user_id: 'TEXT',
+    visibility: "TEXT NOT NULL DEFAULT 'user'",
+  });
+
+  addColumns(sqlite, 'studio_generation_outputs', {
+    organization_id: 'TEXT',
+    created_by_user_id: 'TEXT',
+    workspace_id: 'TEXT',
+  });
+
+  addColumns(sqlite, 'studio_bulk_jobs', {
+    organization_id: 'TEXT',
+    created_by_user_id: 'TEXT',
+    workspace_id: 'TEXT',
   });
 
   addColumns(sqlite, 'todo_items', {
@@ -819,6 +879,119 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
   });
 
   sqlite.exec(`
+    WITH primary_org AS (
+      SELECT organization_id
+      FROM canvas_organization_settings
+      ORDER BY created_at ASC
+      LIMIT 1
+    )
+    UPDATE studio_products
+    SET
+      created_by_user_id = COALESCE(created_by_user_id, user_id),
+      organization_id = COALESCE(organization_id, (SELECT organization_id FROM primary_org)),
+      visibility = CASE
+        WHEN COALESCE(organization_id, (SELECT organization_id FROM primary_org)) IS NULL THEN 'user'
+        ELSE COALESCE(visibility, 'organization')
+      END
+    WHERE created_by_user_id IS NULL OR organization_id IS NULL OR visibility IS NULL;
+
+    WITH primary_org AS (
+      SELECT organization_id
+      FROM canvas_organization_settings
+      ORDER BY created_at ASC
+      LIMIT 1
+    )
+    UPDATE studio_personas
+    SET
+      created_by_user_id = COALESCE(created_by_user_id, user_id),
+      organization_id = COALESCE(organization_id, (SELECT organization_id FROM primary_org)),
+      visibility = CASE
+        WHEN COALESCE(organization_id, (SELECT organization_id FROM primary_org)) IS NULL THEN 'user'
+        ELSE COALESCE(visibility, 'organization')
+      END
+    WHERE created_by_user_id IS NULL OR organization_id IS NULL OR visibility IS NULL;
+
+    WITH primary_org AS (
+      SELECT organization_id
+      FROM canvas_organization_settings
+      ORDER BY created_at ASC
+      LIMIT 1
+    )
+    UPDATE studio_styles
+    SET
+      created_by_user_id = COALESCE(created_by_user_id, user_id),
+      organization_id = COALESCE(organization_id, (SELECT organization_id FROM primary_org)),
+      visibility = CASE
+        WHEN COALESCE(organization_id, (SELECT organization_id FROM primary_org)) IS NULL THEN 'user'
+        ELSE COALESCE(visibility, 'organization')
+      END
+    WHERE created_by_user_id IS NULL OR organization_id IS NULL OR visibility IS NULL;
+
+    WITH primary_org AS (
+      SELECT organization_id
+      FROM canvas_organization_settings
+      ORDER BY created_at ASC
+      LIMIT 1
+    )
+    UPDATE studio_presets
+    SET
+      created_by_user_id = COALESCE(created_by_user_id, user_id),
+      organization_id = COALESCE(organization_id, (SELECT organization_id FROM primary_org)),
+      visibility = COALESCE(visibility, CASE WHEN user_id IS NULL THEN 'default' ELSE 'user' END)
+    WHERE created_by_user_id IS NULL OR organization_id IS NULL OR visibility IS NULL;
+
+    WITH primary_org AS (
+      SELECT organization_id
+      FROM canvas_organization_settings
+      ORDER BY created_at ASC
+      LIMIT 1
+    )
+    UPDATE studio_generations
+    SET
+      created_by_user_id = COALESCE(created_by_user_id, user_id),
+      organization_id = COALESCE(organization_id, (SELECT organization_id FROM primary_org))
+    WHERE created_by_user_id IS NULL OR organization_id IS NULL;
+
+    UPDATE studio_generation_outputs
+    SET
+      created_by_user_id = COALESCE(
+        created_by_user_id,
+        (
+          SELECT COALESCE(studio_generations.created_by_user_id, studio_generations.user_id)
+          FROM studio_generations
+          WHERE studio_generations.id = studio_generation_outputs.generation_id
+        )
+      ),
+      organization_id = COALESCE(
+        organization_id,
+        (
+          SELECT studio_generations.organization_id
+          FROM studio_generations
+          WHERE studio_generations.id = studio_generation_outputs.generation_id
+        )
+      ),
+      workspace_id = COALESCE(
+        workspace_id,
+        (
+          SELECT studio_generations.workspace_id
+          FROM studio_generations
+          WHERE studio_generations.id = studio_generation_outputs.generation_id
+        )
+      )
+    WHERE created_by_user_id IS NULL OR organization_id IS NULL OR workspace_id IS NULL;
+
+    WITH primary_org AS (
+      SELECT organization_id
+      FROM canvas_organization_settings
+      ORDER BY created_at ASC
+      LIMIT 1
+    )
+    UPDATE studio_bulk_jobs
+    SET
+      created_by_user_id = COALESCE(created_by_user_id, user_id),
+      organization_id = COALESCE(organization_id, (SELECT organization_id FROM primary_org))
+    WHERE created_by_user_id IS NULL OR organization_id IS NULL;
+
     UPDATE email_accounts
     SET is_primary = 0
     WHERE status != 'active';
@@ -931,21 +1104,35 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE UNIQUE INDEX IF NOT EXISTS idx_license_public_keys_fingerprint ON license_public_keys (fingerprint);
     CREATE INDEX IF NOT EXISTS idx_license_public_keys_fetched_at ON license_public_keys (fetched_at);
     CREATE INDEX IF NOT EXISTS idx_studio_products_user ON studio_products (user_id);
+    CREATE INDEX IF NOT EXISTS idx_studio_products_organization ON studio_products (organization_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_products_creator ON studio_products (created_by_user_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_products_created ON studio_products (created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_product_images_product ON studio_product_images (product_id);
     CREATE INDEX IF NOT EXISTS idx_studio_personas_user ON studio_personas (user_id);
+    CREATE INDEX IF NOT EXISTS idx_studio_personas_organization ON studio_personas (organization_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_personas_creator ON studio_personas (created_by_user_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_personas_created ON studio_personas (created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_persona_images_persona ON studio_persona_images (persona_id);
     CREATE INDEX IF NOT EXISTS idx_studio_styles_user ON studio_styles (user_id);
+    CREATE INDEX IF NOT EXISTS idx_studio_styles_organization ON studio_styles (organization_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_styles_creator ON studio_styles (created_by_user_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_styles_created ON studio_styles (created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_style_images_style ON studio_style_images (style_id);
     CREATE INDEX IF NOT EXISTS idx_studio_presets_user ON studio_presets (user_id);
+    CREATE INDEX IF NOT EXISTS idx_studio_presets_organization ON studio_presets (organization_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_presets_creator ON studio_presets (created_by_user_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_presets_category ON studio_presets (category);
     CREATE INDEX IF NOT EXISTS idx_studio_presets_created ON studio_presets (created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_generations_user ON studio_generations (user_id);
+    CREATE INDEX IF NOT EXISTS idx_studio_generations_organization ON studio_generations (organization_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_generations_creator ON studio_generations (created_by_user_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_generations_workspace ON studio_generations (workspace_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_generations_status ON studio_generations (status);
     CREATE INDEX IF NOT EXISTS idx_studio_generations_created ON studio_generations (created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_gen_outputs_generation ON studio_generation_outputs (generation_id);
+    CREATE INDEX IF NOT EXISTS idx_studio_gen_outputs_organization ON studio_generation_outputs (organization_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_gen_outputs_creator ON studio_generation_outputs (created_by_user_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_gen_outputs_workspace ON studio_generation_outputs (workspace_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_gen_outputs_created ON studio_generation_outputs (created_at);
     CREATE INDEX IF NOT EXISTS idx_gen_products_generation ON studio_generation_products (generation_id);
     CREATE INDEX IF NOT EXISTS idx_gen_products_product ON studio_generation_products (product_id);
@@ -954,6 +1141,9 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_gen_styles_generation ON studio_generation_styles (generation_id);
     CREATE INDEX IF NOT EXISTS idx_gen_styles_style ON studio_generation_styles (style_id);
     CREATE INDEX IF NOT EXISTS idx_studio_bulk_jobs_user ON studio_bulk_jobs (user_id);
+    CREATE INDEX IF NOT EXISTS idx_studio_bulk_jobs_organization ON studio_bulk_jobs (organization_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_bulk_jobs_creator ON studio_bulk_jobs (created_by_user_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_studio_bulk_jobs_workspace ON studio_bulk_jobs (workspace_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_bulk_jobs_status ON studio_bulk_jobs (status);
     CREATE INDEX IF NOT EXISTS idx_studio_bulk_jobs_created ON studio_bulk_jobs (created_at);
     CREATE INDEX IF NOT EXISTS idx_studio_bulk_job_line_items_bulk_job ON studio_bulk_job_line_items (bulk_job_id);

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -639,6 +639,9 @@ export const automationRuns = sqliteTable("automation_runs", {
 export const studioProducts = sqliteTable("studio_products", {
   id: text("id").primaryKey(),
   userId: text("user_id").notNull().references(() => user.id),
+  organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: 'set null' }),
+  visibility: text("visibility").notNull().default('organization'),
   name: text("name").notNull(),
   description: text("description"),
   thumbnailPath: text("thumbnail_path"),
@@ -647,6 +650,8 @@ export const studioProducts = sqliteTable("studio_products", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   userIdx: index("idx_studio_products_user").on(table.userId),
+  organizationIdx: index("idx_studio_products_organization").on(table.organizationId, table.createdAt),
+  creatorIdx: index("idx_studio_products_creator").on(table.createdByUserId, table.createdAt),
   createdIdx: index("idx_studio_products_created").on(table.createdAt),
 }));
 
@@ -670,6 +675,9 @@ export const studioProductImages = sqliteTable("studio_product_images", {
 export const studioPersonas = sqliteTable("studio_personas", {
   id: text("id").primaryKey(),
   userId: text("user_id").notNull().references(() => user.id),
+  organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: 'set null' }),
+  visibility: text("visibility").notNull().default('organization'),
   name: text("name").notNull(),
   description: text("description"),
   thumbnailPath: text("thumbnail_path"),
@@ -678,6 +686,8 @@ export const studioPersonas = sqliteTable("studio_personas", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   userIdx: index("idx_studio_personas_user").on(table.userId),
+  organizationIdx: index("idx_studio_personas_organization").on(table.organizationId, table.createdAt),
+  creatorIdx: index("idx_studio_personas_creator").on(table.createdByUserId, table.createdAt),
   createdIdx: index("idx_studio_personas_created").on(table.createdAt),
 }));
 
@@ -701,6 +711,9 @@ export const studioPersonaImages = sqliteTable("studio_persona_images", {
 export const studioStyles = sqliteTable("studio_styles", {
   id: text("id").primaryKey(),
   userId: text("user_id").notNull().references(() => user.id),
+  organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: 'set null' }),
+  visibility: text("visibility").notNull().default('organization'),
   name: text("name").notNull(),
   description: text("description"),
   thumbnailPath: text("thumbnail_path"),
@@ -709,6 +722,8 @@ export const studioStyles = sqliteTable("studio_styles", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   userIdx: index("idx_studio_styles_user").on(table.userId),
+  organizationIdx: index("idx_studio_styles_organization").on(table.organizationId, table.createdAt),
+  creatorIdx: index("idx_studio_styles_creator").on(table.createdByUserId, table.createdAt),
   createdIdx: index("idx_studio_styles_created").on(table.createdAt),
 }));
 
@@ -732,6 +747,9 @@ export const studioStyleImages = sqliteTable("studio_style_images", {
 export const studioPresets = sqliteTable("studio_presets", {
   id: text("id").primaryKey(),
   userId: text("user_id").references(() => user.id, { onDelete: 'cascade' }),
+  organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: 'set null' }),
+  visibility: text("visibility").notNull().default('user'),
   isDefault: integer("is_default", { mode: "boolean" }).notNull().default(false),
   name: text("name").notNull(),
   description: text("description"),
@@ -743,6 +761,8 @@ export const studioPresets = sqliteTable("studio_presets", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   userIdx: index("idx_studio_presets_user").on(table.userId),
+  organizationIdx: index("idx_studio_presets_organization").on(table.organizationId, table.createdAt),
+  creatorIdx: index("idx_studio_presets_creator").on(table.createdByUserId, table.createdAt),
   categoryIdx: index("idx_studio_presets_category").on(table.category),
   createdIdx: index("idx_studio_presets_created").on(table.createdAt),
 }));
@@ -750,6 +770,9 @@ export const studioPresets = sqliteTable("studio_presets", {
 export const studioGenerations = sqliteTable("studio_generations", {
   id: text("id").primaryKey(),
   userId: text("user_id").notNull().references(() => user.id),
+  organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: 'set null' }),
+  workspaceId: text("workspace_id").references(() => canvasWorkspaces.id, { onDelete: 'set null' }),
   mode: text("mode").notNull(),
   prompt: text("prompt"),
   rawPrompt: text("raw_prompt"),
@@ -766,6 +789,9 @@ export const studioGenerations = sqliteTable("studio_generations", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   userIdx: index("idx_studio_generations_user").on(table.userId),
+  organizationIdx: index("idx_studio_generations_organization").on(table.organizationId, table.createdAt),
+  creatorIdx: index("idx_studio_generations_creator").on(table.createdByUserId, table.createdAt),
+  workspaceIdx: index("idx_studio_generations_workspace").on(table.workspaceId, table.createdAt),
   statusIdx: index("idx_studio_generations_status").on(table.status),
   createdIdx: index("idx_studio_generations_created").on(table.createdAt),
 }));
@@ -773,6 +799,9 @@ export const studioGenerations = sqliteTable("studio_generations", {
 export const studioGenerationOutputs = sqliteTable("studio_generation_outputs", {
   id: text("id").primaryKey(),
   generationId: text("generation_id").notNull().references(() => studioGenerations.id, { onDelete: 'cascade' }),
+  organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: 'set null' }),
+  workspaceId: text("workspace_id").references(() => canvasWorkspaces.id, { onDelete: 'set null' }),
   variationIndex: integer("variation_index").notNull(),
   type: text("type").notNull(),
   filePath: text("file_path").notNull(),
@@ -787,6 +816,9 @@ export const studioGenerationOutputs = sqliteTable("studio_generation_outputs", 
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   generationIdx: index("idx_studio_gen_outputs_generation").on(table.generationId),
+  organizationIdx: index("idx_studio_gen_outputs_organization").on(table.organizationId, table.createdAt),
+  creatorIdx: index("idx_studio_gen_outputs_creator").on(table.createdByUserId, table.createdAt),
+  workspaceIdx: index("idx_studio_gen_outputs_workspace").on(table.workspaceId, table.createdAt),
   createdIdx: index("idx_studio_gen_outputs_created").on(table.createdAt),
 }));
 
@@ -820,6 +852,9 @@ export const studioGenerationStyles = sqliteTable("studio_generation_styles", {
 export const studioBulkJobs = sqliteTable("studio_bulk_jobs", {
   id: text("id").primaryKey(),
   userId: text("user_id").notNull().references(() => user.id),
+  organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: 'set null' }),
+  workspaceId: text("workspace_id").references(() => canvasWorkspaces.id, { onDelete: 'set null' }),
   name: text("name"),
   studioPresetId: text("studio_preset_id").references(() => studioPresets.id, { onDelete: 'set null' }),
   additionalPrompt: text("additional_prompt"),
@@ -833,6 +868,9 @@ export const studioBulkJobs = sqliteTable("studio_bulk_jobs", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   userIdx: index("idx_studio_bulk_jobs_user").on(table.userId),
+  organizationIdx: index("idx_studio_bulk_jobs_organization").on(table.organizationId, table.createdAt),
+  creatorIdx: index("idx_studio_bulk_jobs_creator").on(table.createdByUserId, table.createdAt),
+  workspaceIdx: index("idx_studio_bulk_jobs_workspace").on(table.workspaceId, table.createdAt),
   statusIdx: index("idx_studio_bulk_jobs_status").on(table.status),
   createdIdx: index("idx_studio_bulk_jobs_created").on(table.createdAt),
 }));

--- a/app/lib/integrations/studio-generation-service.ts
+++ b/app/lib/integrations/studio-generation-service.ts
@@ -1600,7 +1600,8 @@ async function listStudioGenerationCreators(userId: string) {
     createdByUserId: studioGenerations.createdByUserId,
   })
     .from(studioGenerations)
-    .where(generationVisibilityCondition(userId));
+    .where(generationVisibilityCondition(userId))
+    .groupBy(studioGenerations.userId, studioGenerations.createdByUserId);
 
   const creatorIds = [...new Set(
     rows
@@ -1644,11 +1645,12 @@ export async function listStudioGenerations(userId: string, options: ListStudioG
     query = query.offset(offset);
   }
 
-  const [generations, totalResult] = await Promise.all([
+  const [generations, totalResult, creators] = await Promise.all([
     query,
     db.select({ count: count() })
       .from(studioGenerations)
       .where(visibility),
+    listStudioGenerationCreators(userId),
   ]);
 
   const results = await Promise.all(generations.map(async (gen) => {
@@ -1682,7 +1684,7 @@ export async function listStudioGenerations(userId: string, options: ListStudioG
 
   return {
     generations: results,
-    creators: await listStudioGenerationCreators(userId),
+    creators,
     total: totalResult[0]?.count ?? results.length,
     limit: limit ?? null,
     offset: offset ?? 0,
@@ -1733,7 +1735,7 @@ export async function deleteStudioOutput(outputId: string, userId: string): Prom
   })
     .from(studioGenerationOutputs)
     .innerJoin(studioGenerations, eq(studioGenerationOutputs.generationId, studioGenerations.id))
-    .where(and(eq(studioGenerationOutputs.id, outputId), generationVisibilityCondition(userId)))
+    .where(and(eq(studioGenerationOutputs.id, outputId), eq(studioGenerations.userId, userId)))
     .limit(1);
 
   if (!outputRow) {
@@ -1766,7 +1768,7 @@ export async function deleteStudioOutput(outputId: string, userId: string): Prom
 export async function deleteStudioGeneration(generationId: string, userId: string) {
   const [generation] = await db.select()
     .from(studioGenerations)
-    .where(and(eq(studioGenerations.id, generationId), generationVisibilityCondition(userId)));
+    .where(and(eq(studioGenerations.id, generationId), eq(studioGenerations.userId, userId)));
 
   if (!generation) {
     throw new StudioServiceError('Generation not found', 'Generierung nicht gefunden', 'NOT_FOUND');

--- a/app/lib/integrations/studio-generation-service.ts
+++ b/app/lib/integrations/studio-generation-service.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { db } from '@/app/lib/db';
 import {
+  user,
   studioProducts,
   studioProductImages,
   studioPersonas,
@@ -17,7 +18,7 @@ import {
   studioGenerationPersonas,
   studioGenerationStyles,
 } from '@/app/lib/db/schema';
-import { eq, and, desc, count, asc } from 'drizzle-orm';
+import { eq, and, desc, count, asc, inArray, or } from 'drizzle-orm';
 import { getImageGenerationProvider } from '@/app/lib/integrations/image-generation-providers';
 import { StudioServiceError } from '@/app/lib/integrations/studio-errors';
 import {
@@ -46,6 +47,7 @@ import {
   normalizeGeminiImageModelId,
 } from '@/app/lib/integrations/image-generation-constants';
 import type { EnvStorageScope } from '@/app/lib/integrations/env-config';
+import { resolveStudioScope, studioInsertScope, studioVisibilityCondition } from '@/app/lib/integrations/studio-scope';
 
 type ProviderReferenceImage = { imageBytes: string; mimeType: string };
 type ProviderReferenceMedia = { imageBytes: string; mimeType: string; fileName?: string };
@@ -120,6 +122,38 @@ const MAX_IMAGE_COUNT = 4;
 const PRESET_BLOCK_ORDER = ['lighting', 'camera', 'background', 'props', 'subject'];
 const MAX_PROMPT_LENGTH = 4000;
 
+function generationVisibilityCondition(userId: string, creatorUserId?: string | null) {
+  return studioVisibilityCondition(resolveStudioScope(userId), {
+    userId: studioGenerations.userId,
+    organizationId: studioGenerations.organizationId,
+    createdByUserId: studioGenerations.createdByUserId,
+  }, creatorUserId);
+}
+
+function productVisibilityCondition(userId: string) {
+  return studioVisibilityCondition(resolveStudioScope(userId), {
+    userId: studioProducts.userId,
+    organizationId: studioProducts.organizationId,
+    createdByUserId: studioProducts.createdByUserId,
+  });
+}
+
+function personaVisibilityCondition(userId: string) {
+  return studioVisibilityCondition(resolveStudioScope(userId), {
+    userId: studioPersonas.userId,
+    organizationId: studioPersonas.organizationId,
+    createdByUserId: studioPersonas.createdByUserId,
+  });
+}
+
+function styleVisibilityCondition(userId: string) {
+  return studioVisibilityCondition(resolveStudioScope(userId), {
+    userId: studioStyles.userId,
+    organizationId: studioStyles.organizationId,
+    createdByUserId: studioStyles.createdByUserId,
+  });
+}
+
 const MIME_EXTENSION: Record<string, string> = {
   'image/png': 'png',
   'image/jpeg': 'jpg',
@@ -155,7 +189,7 @@ async function loadProductImages(userId: string, productIds: string[]): Promise<
   for (const productId of productIds) {
     const [product] = await db.select({ id: studioProducts.id, name: studioProducts.name, description: studioProducts.description })
       .from(studioProducts)
-      .where(and(eq(studioProducts.id, productId), eq(studioProducts.userId, userId)));
+      .where(and(eq(studioProducts.id, productId), productVisibilityCondition(userId)));
 
     if (!product) {
       throw new StudioServiceError(
@@ -207,7 +241,7 @@ async function loadPersonaImages(userId: string, personaIds: string[]): Promise<
   for (const personaId of personaIds) {
     const [persona] = await db.select({ id: studioPersonas.id, name: studioPersonas.name, description: studioPersonas.description })
       .from(studioPersonas)
-      .where(and(eq(studioPersonas.id, personaId), eq(studioPersonas.userId, userId)));
+      .where(and(eq(studioPersonas.id, personaId), personaVisibilityCondition(userId)));
 
     if (!persona) {
       throw new StudioServiceError(
@@ -259,7 +293,7 @@ async function loadStyleImages(userId: string, styleIds: string[]): Promise<Load
   for (const styleId of styleIds) {
     const [style] = await db.select({ id: studioStyles.id, name: studioStyles.name, description: studioStyles.description })
       .from(studioStyles)
-      .where(and(eq(studioStyles.id, styleId), eq(studioStyles.userId, userId)));
+      .where(and(eq(studioStyles.id, styleId), styleVisibilityCondition(userId)));
 
     if (!style) {
       throw new StudioServiceError(
@@ -319,10 +353,30 @@ export async function getStudioOutputForUser(outputId: string, userId: string) {
   })
     .from(studioGenerationOutputs)
     .innerJoin(studioGenerations, eq(studioGenerationOutputs.generationId, studioGenerations.id))
-    .where(and(eq(studioGenerationOutputs.id, outputId), eq(studioGenerations.userId, userId)))
+    .where(and(eq(studioGenerationOutputs.id, outputId), generationVisibilityCondition(userId)))
     .limit(1);
 
   return output ?? null;
+}
+
+export async function canReadStudioOutputPath(inputPath: string, userId: string): Promise<boolean> {
+  const normalizedPath = inputPath.startsWith('studio/outputs/')
+    ? inputPath.slice('studio/outputs/'.length)
+    : inputPath;
+
+  const [output] = await db.select({ id: studioGenerationOutputs.id })
+    .from(studioGenerationOutputs)
+    .innerJoin(studioGenerations, eq(studioGenerationOutputs.generationId, studioGenerations.id))
+    .where(and(
+      or(
+        eq(studioGenerationOutputs.filePath, normalizedPath),
+        eq(studioGenerationOutputs.filePath, `studio/outputs/${normalizedPath}`),
+      )!,
+      generationVisibilityCondition(userId),
+    ))
+    .limit(1);
+
+  return Boolean(output);
 }
 
 function isVeoGenerationOutput(output: {
@@ -391,7 +445,7 @@ async function getVeoVideoOutputByPathForUser(inputPath: string, userId: string)
     })
       .from(studioGenerationOutputs)
       .innerJoin(studioGenerations, eq(studioGenerationOutputs.generationId, studioGenerations.id))
-      .where(and(eq(studioGenerationOutputs.filePath, candidate), eq(studioGenerations.userId, userId)))
+      .where(and(eq(studioGenerationOutputs.filePath, candidate), generationVisibilityCondition(userId)))
       .limit(1);
 
     if (output) {
@@ -478,7 +532,7 @@ async function loadSourceOutputReferences(userId: string, sourceGenerationId: st
 }> {
   const [generation] = await db.select({ id: studioGenerations.id })
     .from(studioGenerations)
-    .where(and(eq(studioGenerations.id, sourceGenerationId), eq(studioGenerations.userId, userId)))
+    .where(and(eq(studioGenerations.id, sourceGenerationId), generationVisibilityCondition(userId)))
     .limit(1);
 
   if (!generation) {
@@ -676,6 +730,7 @@ export async function createStudioGeneration(
 
   const generationId = randomUUID();
   const now = new Date();
+  const scope = studioInsertScope(userId);
   let sourceGenerationId: string | null = null;
 
   const defaultModel = providerId === 'openai' ? 'gpt-image-2' : GEMINI_FLASH_IMAGE_MODEL_ID;
@@ -751,6 +806,9 @@ export async function createStudioGeneration(
   await db.insert(studioGenerations).values({
     id: generationId,
     userId,
+    organizationId: scope.organizationId,
+    createdByUserId: scope.createdByUserId,
+    workspaceId: null,
     mode,
     prompt: rawPrompt,
     rawPrompt: request.prompt,
@@ -867,6 +925,29 @@ interface GenerationRow {
   aspectRatio: string;
   prompt: string | null;
   metadata: string | null;
+}
+
+type StudioOutputInsert = typeof studioGenerationOutputs.$inferInsert;
+
+async function insertStudioGenerationOutput(
+  values: Omit<StudioOutputInsert, 'organizationId' | 'createdByUserId' | 'workspaceId'>,
+) {
+  const [scope] = await db.select({
+    userId: studioGenerations.userId,
+    organizationId: studioGenerations.organizationId,
+    createdByUserId: studioGenerations.createdByUserId,
+    workspaceId: studioGenerations.workspaceId,
+  })
+    .from(studioGenerations)
+    .where(eq(studioGenerations.id, values.generationId))
+    .limit(1);
+
+  await db.insert(studioGenerationOutputs).values({
+    ...values,
+    organizationId: scope?.organizationId ?? null,
+    createdByUserId: scope?.createdByUserId ?? scope?.userId ?? null,
+    workspaceId: scope?.workspaceId ?? null,
+  });
 }
 
 async function executeStudioGenerationProcessing(
@@ -1101,7 +1182,7 @@ async function generateStudioImages(
         imageSize: options?.imageSize,
         usage: result.usage,
       };
-      await db.insert(studioGenerationOutputs).values({
+      await insertStudioGenerationOutput({
         id: outputId,
         generationId,
         variationIndex: index,
@@ -1133,7 +1214,7 @@ async function generateStudioImages(
       console.error(`[Studio Generation] Image ${index + 1}/${count} failed: ${errorMsg}`, error instanceof Error ? error.stack : error);
       const errorOutputId = randomUUID();
       const now = new Date();
-      await db.insert(studioGenerationOutputs).values({
+      await insertStudioGenerationOutput({
         id: errorOutputId,
         generationId,
         variationIndex: index,
@@ -1215,7 +1296,7 @@ async function generateStudioSound(
 
   const outputId = randomUUID();
   const now = new Date();
-  await db.insert(studioGenerationOutputs).values({
+  await insertStudioGenerationOutput({
     id: outputId,
     generationId,
     variationIndex: 0,
@@ -1349,7 +1430,7 @@ async function generateStudioVideo(
   const outputId = randomUUID();
   const now = new Date();
 
-  await db.insert(studioGenerationOutputs).values({
+  await insertStudioGenerationOutput({
     id: outputId,
     generationId,
     variationIndex: 0,
@@ -1479,7 +1560,7 @@ async function generateStudioSeedanceVideo(
 
   const outputId = randomUUID();
   const now = new Date();
-  await db.insert(studioGenerationOutputs).values({
+  await insertStudioGenerationOutput({
     id: outputId,
     generationId,
     variationIndex: 0,
@@ -1510,15 +1591,49 @@ async function generateStudioSeedanceVideo(
 export interface ListStudioGenerationsOptions {
   limit?: number;
   offset?: number;
+  creatorUserId?: string | null;
+}
+
+async function listStudioGenerationCreators(userId: string) {
+  const rows = await db.select({
+    userId: studioGenerations.userId,
+    createdByUserId: studioGenerations.createdByUserId,
+  })
+    .from(studioGenerations)
+    .where(generationVisibilityCondition(userId));
+
+  const creatorIds = [...new Set(
+    rows
+      .map((row) => row.createdByUserId ?? row.userId)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0),
+  )];
+
+  if (creatorIds.length === 0) return [];
+
+  const users = await db.select({
+    id: user.id,
+    name: user.name,
+    email: user.email,
+  })
+    .from(user)
+    .where(inArray(user.id, creatorIds));
+  const usersById = new Map(users.map((row) => [row.id, row]));
+
+  return creatorIds.map((id) => ({
+    id,
+    name: usersById.get(id)?.name ?? usersById.get(id)?.email ?? id,
+    email: usersById.get(id)?.email ?? null,
+  }));
 }
 
 export async function listStudioGenerations(userId: string, options: ListStudioGenerationsOptions = {}) {
   const limit = options.limit && options.limit > 0 ? options.limit : undefined;
   const offset = options.offset && options.offset > 0 ? options.offset : undefined;
+  const visibility = generationVisibilityCondition(userId, options.creatorUserId);
 
   let query = db.select()
     .from(studioGenerations)
-    .where(eq(studioGenerations.userId, userId))
+    .where(visibility)
     .orderBy(desc(studioGenerations.createdAt))
     .$dynamic();
 
@@ -1533,7 +1648,7 @@ export async function listStudioGenerations(userId: string, options: ListStudioG
     query,
     db.select({ count: count() })
       .from(studioGenerations)
-      .where(eq(studioGenerations.userId, userId)),
+      .where(visibility),
   ]);
 
   const results = await Promise.all(generations.map(async (gen) => {
@@ -1567,6 +1682,7 @@ export async function listStudioGenerations(userId: string, options: ListStudioG
 
   return {
     generations: results,
+    creators: await listStudioGenerationCreators(userId),
     total: totalResult[0]?.count ?? results.length,
     limit: limit ?? null,
     offset: offset ?? 0,
@@ -1577,7 +1693,7 @@ export async function listStudioGenerations(userId: string, options: ListStudioG
 export async function getStudioGeneration(generationId: string, userId: string) {
   const [generation] = await db.select()
     .from(studioGenerations)
-    .where(and(eq(studioGenerations.id, generationId), eq(studioGenerations.userId, userId)));
+    .where(and(eq(studioGenerations.id, generationId), generationVisibilityCondition(userId)));
 
   if (!generation) return null;
 
@@ -1617,7 +1733,7 @@ export async function deleteStudioOutput(outputId: string, userId: string): Prom
   })
     .from(studioGenerationOutputs)
     .innerJoin(studioGenerations, eq(studioGenerationOutputs.generationId, studioGenerations.id))
-    .where(and(eq(studioGenerationOutputs.id, outputId), eq(studioGenerations.userId, userId)))
+    .where(and(eq(studioGenerationOutputs.id, outputId), generationVisibilityCondition(userId)))
     .limit(1);
 
   if (!outputRow) {
@@ -1650,7 +1766,7 @@ export async function deleteStudioOutput(outputId: string, userId: string): Prom
 export async function deleteStudioGeneration(generationId: string, userId: string) {
   const [generation] = await db.select()
     .from(studioGenerations)
-    .where(and(eq(studioGenerations.id, generationId), eq(studioGenerations.userId, userId)));
+    .where(and(eq(studioGenerations.id, generationId), generationVisibilityCondition(userId)));
 
   if (!generation) {
     throw new StudioServiceError('Generation not found', 'Generierung nicht gefunden', 'NOT_FOUND');

--- a/app/lib/integrations/studio-persona-service.ts
+++ b/app/lib/integrations/studio-persona-service.ts
@@ -289,7 +289,7 @@ export async function reorderPersonaImages(personaId: string, userId: string, im
 }
 
 export async function deletePersona(personaId: string, userId: string) {
-  const persona = await getVisiblePersona(personaId, userId);
+  const persona = await getOwnedPersona(personaId, userId);
   if (!persona) {
     throw new StudioServiceError('Persona not found', 'Persona nicht gefunden', 'NOT_FOUND');
   }

--- a/app/lib/integrations/studio-persona-service.ts
+++ b/app/lib/integrations/studio-persona-service.ts
@@ -11,6 +11,7 @@ import {
   ensureStudioAssetsWorkspace,
 } from '@/app/lib/integrations/studio-workspace';
 import { StudioServiceError } from '@/app/lib/integrations/studio-errors';
+import { resolveStudioScope, studioInsertScope, studioVisibilityCondition } from '@/app/lib/integrations/studio-scope';
 
 const MAX_IMAGES_PER_PERSONA = 10;
 
@@ -21,6 +22,21 @@ async function getOwnedPersona(personaId: string, userId: string) {
   return persona ?? null;
 }
 
+async function getVisiblePersona(personaId: string, userId: string) {
+  const scope = resolveStudioScope(userId);
+  const [persona] = await db.select()
+    .from(studioPersonas)
+    .where(and(
+      eq(studioPersonas.id, personaId),
+      studioVisibilityCondition(scope, {
+        userId: studioPersonas.userId,
+        organizationId: studioPersonas.organizationId,
+        createdByUserId: studioPersonas.createdByUserId,
+      }),
+    ));
+  return persona ?? null;
+}
+
 export async function createPersona(
   userId: string,
   data: { name: string; description?: string }
@@ -28,9 +44,13 @@ export async function createPersona(
   await ensureStudioAssetsWorkspace();
   const id = randomUUID();
   const now = new Date();
+  const scope = studioInsertScope(userId);
   const [inserted] = await db.insert(studioPersonas).values({
     id,
     userId,
+    organizationId: scope.organizationId,
+    createdByUserId: scope.createdByUserId,
+    visibility: scope.visibility,
     name: data.name,
     description: data.description ?? null,
     thumbnailPath: null,
@@ -42,7 +62,7 @@ export async function createPersona(
 }
 
 export async function getPersona(personaId: string, userId: string) {
-  const persona = await getOwnedPersona(personaId, userId);
+  const persona = await getVisiblePersona(personaId, userId);
   if (!persona) return null;
   const images = await db.select().from(studioPersonaImages)
     .where(eq(studioPersonaImages.personaId, personaId))
@@ -51,7 +71,12 @@ export async function getPersona(personaId: string, userId: string) {
 }
 
 export async function listPersonas(userId: string, search?: string) {
-  const conditions = [eq(studioPersonas.userId, userId)];
+  const scope = resolveStudioScope(userId);
+  const conditions = [studioVisibilityCondition(scope, {
+    userId: studioPersonas.userId,
+    organizationId: studioPersonas.organizationId,
+    createdByUserId: studioPersonas.createdByUserId,
+  })];
   if (search) {
     conditions.push(like(studioPersonas.name, `%${search}%`));
   }
@@ -147,7 +172,7 @@ export async function addPersonaImage(
 }
 
 export async function deletePersonaImage(personaId: string, userId: string, imageId: string) {
-  const persona = await getOwnedPersona(personaId, userId);
+  const persona = await getVisiblePersona(personaId, userId);
   if (!persona) {
     throw new StudioServiceError('Persona not found', 'Persona nicht gefunden', 'NOT_FOUND');
   }
@@ -171,7 +196,7 @@ export async function deletePersonaImage(personaId: string, userId: string, imag
     await db.update(studioPersonas).set({
       thumbnailPath: nextImage?.filePath ?? null,
       updatedAt: now,
-    }).where(and(eq(studioPersonas.id, personaId), eq(studioPersonas.userId, userId)));
+    }).where(eq(studioPersonas.id, personaId));
   }
 }
 
@@ -215,7 +240,7 @@ export async function replacePersonaImage(
 }
 
 export async function getPersonaImageBuffer(personaId: string, userId: string, imageId: string) {
-  const persona = await getOwnedPersona(personaId, userId);
+  const persona = await getVisiblePersona(personaId, userId);
   if (!persona) {
     throw new StudioServiceError('Persona not found', 'Persona nicht gefunden', 'NOT_FOUND');
   }
@@ -264,7 +289,7 @@ export async function reorderPersonaImages(personaId: string, userId: string, im
 }
 
 export async function deletePersona(personaId: string, userId: string) {
-  const persona = await getOwnedPersona(personaId, userId);
+  const persona = await getVisiblePersona(personaId, userId);
   if (!persona) {
     throw new StudioServiceError('Persona not found', 'Persona nicht gefunden', 'NOT_FOUND');
   }
@@ -287,6 +312,6 @@ export async function deletePersona(personaId: string, userId: string) {
   } catch (err) {
     console.warn(`Failed to delete persona directory personas/${personaId}/:`, err);
   }
-  await db.delete(studioPersonas).where(and(eq(studioPersonas.id, personaId), eq(studioPersonas.userId, userId)));
+  await db.delete(studioPersonas).where(eq(studioPersonas.id, personaId));
   return { success: true, warnings };
 }

--- a/app/lib/integrations/studio-product-service.ts
+++ b/app/lib/integrations/studio-product-service.ts
@@ -11,6 +11,7 @@ import {
   ensureStudioAssetsWorkspace,
 } from '@/app/lib/integrations/studio-workspace';
 import { StudioServiceError } from '@/app/lib/integrations/studio-errors';
+import { resolveStudioScope, studioInsertScope, studioVisibilityCondition } from '@/app/lib/integrations/studio-scope';
 
 const MAX_IMAGES_PER_PRODUCT = 10;
 
@@ -21,6 +22,21 @@ async function getOwnedProduct(productId: string, userId: string) {
   return product ?? null;
 }
 
+async function getVisibleProduct(productId: string, userId: string) {
+  const scope = resolveStudioScope(userId);
+  const [product] = await db.select()
+    .from(studioProducts)
+    .where(and(
+      eq(studioProducts.id, productId),
+      studioVisibilityCondition(scope, {
+        userId: studioProducts.userId,
+        organizationId: studioProducts.organizationId,
+        createdByUserId: studioProducts.createdByUserId,
+      }),
+    ));
+  return product ?? null;
+}
+
 export async function createProduct(
   userId: string,
   data: { name: string; description?: string }
@@ -28,9 +44,13 @@ export async function createProduct(
   await ensureStudioAssetsWorkspace();
   const id = randomUUID();
   const now = new Date();
+  const scope = studioInsertScope(userId);
   const [inserted] = await db.insert(studioProducts).values({
     id,
     userId,
+    organizationId: scope.organizationId,
+    createdByUserId: scope.createdByUserId,
+    visibility: scope.visibility,
     name: data.name,
     description: data.description ?? null,
     thumbnailPath: null,
@@ -42,7 +62,7 @@ export async function createProduct(
 }
 
 export async function getProduct(productId: string, userId: string) {
-  const product = await getOwnedProduct(productId, userId);
+  const product = await getVisibleProduct(productId, userId);
   if (!product) return null;
   const images = await db.select().from(studioProductImages)
     .where(eq(studioProductImages.productId, productId))
@@ -51,7 +71,12 @@ export async function getProduct(productId: string, userId: string) {
 }
 
 export async function listProducts(userId: string, search?: string) {
-  const conditions = [eq(studioProducts.userId, userId)];
+  const scope = resolveStudioScope(userId);
+  const conditions = [studioVisibilityCondition(scope, {
+    userId: studioProducts.userId,
+    organizationId: studioProducts.organizationId,
+    createdByUserId: studioProducts.createdByUserId,
+  })];
   if (search) {
     conditions.push(like(studioProducts.name, `%${search}%`));
   }
@@ -147,7 +172,7 @@ export async function addProductImage(
 }
 
 export async function deleteProductImage(productId: string, userId: string, imageId: string) {
-  const product = await getOwnedProduct(productId, userId);
+  const product = await getVisibleProduct(productId, userId);
   if (!product) {
     throw new StudioServiceError('Product not found', 'Produkt nicht gefunden', 'NOT_FOUND');
   }
@@ -171,7 +196,7 @@ export async function deleteProductImage(productId: string, userId: string, imag
     await db.update(studioProducts).set({
       thumbnailPath: nextImage?.filePath ?? null,
       updatedAt: now,
-    }).where(and(eq(studioProducts.id, productId), eq(studioProducts.userId, userId)));
+    }).where(eq(studioProducts.id, productId));
   }
 }
 
@@ -215,7 +240,7 @@ export async function replaceProductImage(
 }
 
 export async function getProductImageBuffer(productId: string, userId: string, imageId: string) {
-  const product = await getOwnedProduct(productId, userId);
+  const product = await getVisibleProduct(productId, userId);
   if (!product) {
     throw new StudioServiceError('Product not found', 'Produkt nicht gefunden', 'NOT_FOUND');
   }
@@ -264,7 +289,7 @@ export async function reorderProductImages(productId: string, userId: string, im
 }
 
 export async function deleteProduct(productId: string, userId: string) {
-  const product = await getOwnedProduct(productId, userId);
+  const product = await getVisibleProduct(productId, userId);
   if (!product) {
     throw new StudioServiceError('Product not found', 'Produkt nicht gefunden', 'NOT_FOUND');
   }
@@ -287,6 +312,6 @@ export async function deleteProduct(productId: string, userId: string) {
   } catch (err) {
     console.warn(`Failed to delete product directory products/${productId}/:`, err);
   }
-  await db.delete(studioProducts).where(and(eq(studioProducts.id, productId), eq(studioProducts.userId, userId)));
+  await db.delete(studioProducts).where(eq(studioProducts.id, productId));
   return { success: true, warnings };
 }

--- a/app/lib/integrations/studio-product-service.ts
+++ b/app/lib/integrations/studio-product-service.ts
@@ -289,7 +289,7 @@ export async function reorderProductImages(productId: string, userId: string, im
 }
 
 export async function deleteProduct(productId: string, userId: string) {
-  const product = await getVisibleProduct(productId, userId);
+  const product = await getOwnedProduct(productId, userId);
   if (!product) {
     throw new StudioServiceError('Product not found', 'Produkt nicht gefunden', 'NOT_FOUND');
   }

--- a/app/lib/integrations/studio-scope.ts
+++ b/app/lib/integrations/studio-scope.ts
@@ -63,6 +63,7 @@ export function studioVisibilityCondition(
 ): SQL {
   if (scope.organizationWide && scope.organizationId) {
     const organizationVisible = withCreator(eq(columns.organizationId, scope.organizationId), columns, creatorUserId);
+    // Rows that could not be backfilled into an organization remain personal-only.
     const ownLegacy = withCreator(and(isNull(columns.organizationId), eq(columns.userId, scope.actorUserId))!, columns, creatorUserId);
     return or(organizationVisible, ownLegacy)!;
   }

--- a/app/lib/integrations/studio-scope.ts
+++ b/app/lib/integrations/studio-scope.ts
@@ -1,0 +1,84 @@
+import 'server-only';
+
+import { and, eq, isNull, or, type SQL } from 'drizzle-orm';
+import type { AnySQLiteColumn } from 'drizzle-orm/sqlite-core';
+
+import { readOrganizationPermissionForUser } from '@/app/lib/organization/permissions';
+import type { OrganizationPermissionSnapshot } from '@/app/lib/organization/bootstrap';
+
+export interface StudioScope {
+  actorUserId: string;
+  organizationId: string | null;
+  organizationWide: boolean;
+  permission: OrganizationPermissionSnapshot | null;
+}
+
+type ScopedColumns = {
+  userId: AnySQLiteColumn;
+  organizationId: AnySQLiteColumn;
+  createdByUserId: AnySQLiteColumn;
+};
+
+function isInternalActivePermission(permission: OrganizationPermissionSnapshot | null): boolean {
+  if (!permission || permission.status !== 'active') return false;
+  return permission.role === 'owner' || permission.role === 'admin' || permission.role === 'member';
+}
+
+export function resolveStudioScope(userId: string): StudioScope {
+  const state = readOrganizationPermissionForUser(userId);
+  const organizationWide = Boolean(
+    state.configured &&
+    state.teamFeaturesEnabled &&
+    state.organizationId &&
+    isInternalActivePermission(state.permission),
+  );
+
+  return {
+    actorUserId: userId,
+    organizationId: organizationWide ? state.organizationId : null,
+    organizationWide,
+    permission: state.permission,
+  };
+}
+
+function creatorMatches(columns: ScopedColumns, creatorUserId?: string | null): SQL | undefined {
+  const normalizedCreatorUserId = creatorUserId?.trim();
+  if (!normalizedCreatorUserId) return undefined;
+
+  return or(
+    eq(columns.createdByUserId, normalizedCreatorUserId),
+    and(isNull(columns.createdByUserId), eq(columns.userId, normalizedCreatorUserId)),
+  );
+}
+
+function withCreator(base: SQL, columns: ScopedColumns, creatorUserId?: string | null): SQL {
+  const creator = creatorMatches(columns, creatorUserId);
+  return creator ? and(base, creator)! : base;
+}
+
+export function studioVisibilityCondition(
+  scope: StudioScope,
+  columns: ScopedColumns,
+  creatorUserId?: string | null,
+): SQL {
+  if (scope.organizationWide && scope.organizationId) {
+    const organizationVisible = withCreator(eq(columns.organizationId, scope.organizationId), columns, creatorUserId);
+    const ownLegacy = withCreator(and(isNull(columns.organizationId), eq(columns.userId, scope.actorUserId))!, columns, creatorUserId);
+    return or(organizationVisible, ownLegacy)!;
+  }
+
+  return withCreator(eq(columns.userId, scope.actorUserId), columns, creatorUserId);
+}
+
+export function studioInsertScope(userId: string): {
+  organizationId: string | null;
+  createdByUserId: string;
+  visibility: 'organization' | 'user';
+} {
+  const scope = resolveStudioScope(userId);
+  return {
+    organizationId: scope.organizationWide ? scope.organizationId : null,
+    createdByUserId: userId,
+    visibility: scope.organizationWide ? 'organization' : 'user',
+  };
+}

--- a/app/lib/integrations/studio-style-service.ts
+++ b/app/lib/integrations/studio-style-service.ts
@@ -289,7 +289,7 @@ export async function reorderStyleImages(styleId: string, userId: string, imageO
 }
 
 export async function deleteStyle(styleId: string, userId: string) {
-  const style = await getVisibleStyle(styleId, userId);
+  const style = await getOwnedStyle(styleId, userId);
   if (!style) {
     throw new StudioServiceError('Style not found', 'Style nicht gefunden', 'NOT_FOUND');
   }

--- a/app/lib/integrations/studio-style-service.ts
+++ b/app/lib/integrations/studio-style-service.ts
@@ -11,6 +11,7 @@ import {
   ensureStudioAssetsWorkspace,
 } from '@/app/lib/integrations/studio-workspace';
 import { StudioServiceError } from '@/app/lib/integrations/studio-errors';
+import { resolveStudioScope, studioInsertScope, studioVisibilityCondition } from '@/app/lib/integrations/studio-scope';
 
 const MAX_IMAGES_PER_STYLE = 10;
 
@@ -21,6 +22,21 @@ async function getOwnedStyle(styleId: string, userId: string) {
   return style ?? null;
 }
 
+async function getVisibleStyle(styleId: string, userId: string) {
+  const scope = resolveStudioScope(userId);
+  const [style] = await db.select()
+    .from(studioStyles)
+    .where(and(
+      eq(studioStyles.id, styleId),
+      studioVisibilityCondition(scope, {
+        userId: studioStyles.userId,
+        organizationId: studioStyles.organizationId,
+        createdByUserId: studioStyles.createdByUserId,
+      }),
+    ));
+  return style ?? null;
+}
+
 export async function createStyle(
   userId: string,
   data: { name: string; description?: string }
@@ -28,9 +44,13 @@ export async function createStyle(
   await ensureStudioAssetsWorkspace();
   const id = randomUUID();
   const now = new Date();
+  const scope = studioInsertScope(userId);
   const [inserted] = await db.insert(studioStyles).values({
     id,
     userId,
+    organizationId: scope.organizationId,
+    createdByUserId: scope.createdByUserId,
+    visibility: scope.visibility,
     name: data.name,
     description: data.description ?? null,
     thumbnailPath: null,
@@ -42,7 +62,7 @@ export async function createStyle(
 }
 
 export async function getStyle(styleId: string, userId: string) {
-  const style = await getOwnedStyle(styleId, userId);
+  const style = await getVisibleStyle(styleId, userId);
   if (!style) return null;
   const images = await db.select().from(studioStyleImages)
     .where(eq(studioStyleImages.styleId, styleId))
@@ -51,7 +71,12 @@ export async function getStyle(styleId: string, userId: string) {
 }
 
 export async function listStyles(userId: string, search?: string) {
-  const conditions = [eq(studioStyles.userId, userId)];
+  const scope = resolveStudioScope(userId);
+  const conditions = [studioVisibilityCondition(scope, {
+    userId: studioStyles.userId,
+    organizationId: studioStyles.organizationId,
+    createdByUserId: studioStyles.createdByUserId,
+  })];
   if (search) {
     conditions.push(like(studioStyles.name, `%${search}%`));
   }
@@ -147,7 +172,7 @@ export async function addStyleImage(
 }
 
 export async function deleteStyleImage(styleId: string, userId: string, imageId: string) {
-  const style = await getOwnedStyle(styleId, userId);
+  const style = await getVisibleStyle(styleId, userId);
   if (!style) {
     throw new StudioServiceError('Style not found', 'Style nicht gefunden', 'NOT_FOUND');
   }
@@ -171,7 +196,7 @@ export async function deleteStyleImage(styleId: string, userId: string, imageId:
     await db.update(studioStyles).set({
       thumbnailPath: nextImage?.filePath ?? null,
       updatedAt: now,
-    }).where(and(eq(studioStyles.id, styleId), eq(studioStyles.userId, userId)));
+    }).where(eq(studioStyles.id, styleId));
   }
 }
 
@@ -215,7 +240,7 @@ export async function replaceStyleImage(
 }
 
 export async function getStyleImageBuffer(styleId: string, userId: string, imageId: string) {
-  const style = await getOwnedStyle(styleId, userId);
+  const style = await getVisibleStyle(styleId, userId);
   if (!style) {
     throw new StudioServiceError('Style not found', 'Style nicht gefunden', 'NOT_FOUND');
   }
@@ -264,7 +289,7 @@ export async function reorderStyleImages(styleId: string, userId: string, imageO
 }
 
 export async function deleteStyle(styleId: string, userId: string) {
-  const style = await getOwnedStyle(styleId, userId);
+  const style = await getVisibleStyle(styleId, userId);
   if (!style) {
     throw new StudioServiceError('Style not found', 'Style nicht gefunden', 'NOT_FOUND');
   }
@@ -287,6 +312,6 @@ export async function deleteStyle(styleId: string, userId: string) {
   } catch (err) {
     console.warn(`Failed to delete style directory styles/${styleId}/:`, err);
   }
-  await db.delete(studioStyles).where(and(eq(studioStyles.id, styleId), eq(studioStyles.userId, userId)));
+  await db.delete(studioStyles).where(eq(studioStyles.id, styleId));
   return { success: true, warnings };
 }

--- a/app/store/studio-generations-cache-store.ts
+++ b/app/store/studio-generations-cache-store.ts
@@ -10,6 +10,7 @@ interface StudioGenerationsCacheState {
   activeGenerationId: string | null;
   recentlyCompletedIds: Set<string>;
   hasMoreGenerations: boolean;
+  loadedServerGenerationCount: number;
   creators: StudioCreator[];
 }
 
@@ -22,5 +23,6 @@ export const useStudioGenerationsCacheStore = create<StudioGenerationsCacheState
   activeGenerationId: null,
   recentlyCompletedIds: new Set<string>(),
   hasMoreGenerations: false,
+  loadedServerGenerationCount: 0,
   creators: [],
 }));

--- a/app/store/studio-generations-cache-store.ts
+++ b/app/store/studio-generations-cache-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { StudioGeneration } from '@/app/apps/studio/types/generation';
+import type { StudioCreator, StudioGeneration } from '@/app/apps/studio/types/generation';
 
 interface StudioGenerationsCacheState {
   generations: StudioGeneration[];
@@ -10,6 +10,7 @@ interface StudioGenerationsCacheState {
   activeGenerationId: string | null;
   recentlyCompletedIds: Set<string>;
   hasMoreGenerations: boolean;
+  creators: StudioCreator[];
 }
 
 export const useStudioGenerationsCacheStore = create<StudioGenerationsCacheState>(() => ({
@@ -21,4 +22,5 @@ export const useStudioGenerationsCacheStore = create<StudioGenerationsCacheState
   activeGenerationId: null,
   recentlyCompletedIds: new Set<string>(),
   hasMoreGenerations: false,
+  creators: [],
 }));

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -413,7 +413,7 @@
     {
       "id": 24,
       "title": "Studio Route auf Organization-geteilte Bibliotheken und user-filterbare Asset-Sammlung umbauen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/06-workspace-switching-ux.md",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:mcp:icons": "tsx scripts/mcp-icons-test.ts",
     "test:studio:seedance": "tsx scripts/seedance-generation-test.ts",
     "test:studio:veo": "tsx scripts/veo-generation-test.ts",
+    "test:studio:organization-scope": "tsx --conditions react-server scripts/studio-organization-scope-test.ts",
     "test:skills:runtime": "tsx scripts/skills-runtime-test.ts",
     "test:skills:seed-bootstrap": "tsx scripts/default-seed-skills-test.ts",
     "test:plugins:seed-bootstrap": "tsx scripts/default-seed-plugins-test.ts",

--- a/scripts/studio-organization-scope-test.ts
+++ b/scripts/studio-organization-scope-test.ts
@@ -52,6 +52,10 @@ function insertGeneration(sqlite: Database.Database, id: string, userId: string,
   `).run(`out-${id}`, id, organizationId, userId, `${id}.png`, `${id}.png`, `/api/studio/media/studio/outputs/${id}.png`, now);
 }
 
+function readCount(sqlite: Database.Database, statement: string, id: string) {
+  return (sqlite.prepare(statement).get(id) as { count: number }).count;
+}
+
 async function main() {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-studio-organization-scope-'));
   const dataRoot = path.join(tempRoot, 'data');
@@ -84,11 +88,14 @@ async function main() {
 
     const {
       canReadStudioOutputPath,
+      deleteStudioGeneration,
+      deleteStudioOutput,
       getStudioGeneration,
       getStudioOutputForUser,
       listStudioGenerations,
     } = await import('../app/lib/integrations/studio-generation-service');
-    const { listProducts } = await import('../app/lib/integrations/studio-product-service');
+    const { deleteProduct, listProducts } = await import('../app/lib/integrations/studio-product-service');
+    const { StudioServiceError } = await import('../app/lib/integrations/studio-errors');
 
     const memberProducts = await listProducts('user-member');
     assert.deepEqual(memberProducts.map((product) => product.id).sort(), ['product-member', 'product-owner']);
@@ -110,6 +117,24 @@ async function main() {
     assert.equal(visibleOwnerOutput?.generationId, 'gen-owner');
     assert.equal(await canReadStudioOutputPath('studio/outputs/gen-owner.png', 'user-member'), true);
     assert.equal(await canReadStudioOutputPath('studio/outputs/gen-owner.png', 'user-outsider'), false);
+
+    await assert.rejects(
+      () => deleteProduct('product-owner', 'user-member'),
+      (error) => error instanceof StudioServiceError && error.code === 'NOT_FOUND',
+    );
+    assert.equal(readCount(sqlite, 'SELECT count(*) AS count FROM studio_products WHERE id = ?', 'product-owner'), 1);
+
+    await assert.rejects(
+      () => deleteStudioOutput('out-gen-owner', 'user-member'),
+      (error) => error instanceof StudioServiceError && error.code === 'NOT_FOUND',
+    );
+    assert.equal(readCount(sqlite, 'SELECT count(*) AS count FROM studio_generation_outputs WHERE id = ?', 'out-gen-owner'), 1);
+
+    await assert.rejects(
+      () => deleteStudioGeneration('gen-owner', 'user-member'),
+      (error) => error instanceof StudioServiceError && error.code === 'NOT_FOUND',
+    );
+    assert.equal(readCount(sqlite, 'SELECT count(*) AS count FROM studio_generations WHERE id = ?', 'gen-owner'), 1);
   } finally {
     sqlite.close();
     await fs.rm(tempRoot, { recursive: true, force: true });

--- a/scripts/studio-organization-scope-test.ts
+++ b/scripts/studio-organization-scope-test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../app/lib/db/migrate';
+import { ensureOrganizationBootstrapForUser } from '../app/lib/organization/bootstrap';
+
+function insertUser(sqlite: Database.Database, id: string, name: string, email: string, role: string) {
+  const now = Date.now();
+  sqlite.prepare(`
+    INSERT INTO user (id, name, email, email_verified, role, created_at, updated_at)
+    VALUES (?, ?, ?, 1, ?, ?, ?)
+  `).run(id, name, email, role, now, now);
+}
+
+function insertPermission(sqlite: Database.Database, organizationId: string, userId: string, role: string) {
+  const now = Date.now();
+  sqlite.prepare(`
+    INSERT INTO organization_user_permissions (
+      organization_id, user_id, role, can_write_team_workspace, can_create_public_links,
+      can_delete_team_files, can_delete_studio_assets, created_at, updated_at
+    ) VALUES (?, ?, ?, 0, 1, 1, 1, ?, ?)
+  `).run(organizationId, userId, role, now, now);
+}
+
+function insertProduct(sqlite: Database.Database, id: string, userId: string, organizationId: string, name: string) {
+  const now = Date.now();
+  sqlite.prepare(`
+    INSERT INTO studio_products (
+      id, user_id, organization_id, created_by_user_id, visibility, name, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, 'organization', ?, ?, ?)
+  `).run(id, userId, organizationId, userId, name, now, now);
+}
+
+function insertGeneration(sqlite: Database.Database, id: string, userId: string, organizationId: string, prompt: string) {
+  const now = Date.now();
+  sqlite.prepare(`
+    INSERT INTO studio_generations (
+      id, user_id, organization_id, created_by_user_id, mode, prompt, raw_prompt,
+      aspect_ratio, provider, model, status, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, 'image', ?, ?, '1:1', 'gemini', 'gemini-2.5-flash-image', 'completed', ?, ?)
+  `).run(id, userId, organizationId, userId, prompt, prompt, now, now);
+
+  sqlite.prepare(`
+    INSERT INTO studio_generation_outputs (
+      id, generation_id, organization_id, created_by_user_id, variation_index, type,
+      file_path, file_name, media_url, mime_type, is_favorite, created_at
+    ) VALUES (?, ?, ?, ?, 0, 'image', ?, ?, ?, 'image/png', 0, ?)
+  `).run(`out-${id}`, id, organizationId, userId, `${id}.png`, `${id}.png`, `/api/studio/media/studio/outputs/${id}.png`, now);
+}
+
+async function main() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-studio-organization-scope-'));
+  const dataRoot = path.join(tempRoot, 'data');
+  process.env.DATA = dataRoot;
+  process.env.CANVAS_DEPLOYMENT_MODE = 'managed-team';
+  process.env.CANVAS_DATABASE_PROVIDER = 'postgres';
+
+  await fs.mkdir(dataRoot, { recursive: true });
+  const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+
+  try {
+    runMigrations(sqlite);
+    insertUser(sqlite, 'user-owner', 'Owner User', 'owner@example.test', 'admin');
+    insertUser(sqlite, 'user-member', 'Member User', 'member@example.test', 'member');
+    insertUser(sqlite, 'user-outsider', 'Outside User', 'outside@example.test', 'member');
+
+    sqlite.exec('BEGIN IMMEDIATE');
+    const ownerStatus = ensureOrganizationBootstrapForUser(sqlite, 'user-owner');
+    sqlite.exec('COMMIT');
+    assert.equal(ownerStatus.teamFeaturesEnabled, true);
+    assert.ok(ownerStatus.organizationId);
+    const organizationId = ownerStatus.organizationId;
+
+    insertPermission(sqlite, organizationId, 'user-member', 'member');
+
+    insertProduct(sqlite, 'product-owner', 'user-owner', organizationId, 'Owner Product');
+    insertProduct(sqlite, 'product-member', 'user-member', organizationId, 'Member Product');
+    insertGeneration(sqlite, 'gen-owner', 'user-owner', organizationId, 'Owner generation');
+    insertGeneration(sqlite, 'gen-member', 'user-member', organizationId, 'Member generation');
+
+    const {
+      canReadStudioOutputPath,
+      getStudioGeneration,
+      getStudioOutputForUser,
+      listStudioGenerations,
+    } = await import('../app/lib/integrations/studio-generation-service');
+    const { listProducts } = await import('../app/lib/integrations/studio-product-service');
+
+    const memberProducts = await listProducts('user-member');
+    assert.deepEqual(memberProducts.map((product) => product.id).sort(), ['product-member', 'product-owner']);
+
+    const outsiderProducts = await listProducts('user-outsider');
+    assert.equal(outsiderProducts.length, 0);
+
+    const memberGenerations = await listStudioGenerations('user-member');
+    assert.deepEqual(memberGenerations.generations.map((generation) => generation.id).sort(), ['gen-member', 'gen-owner']);
+    assert.deepEqual(memberGenerations.creators.map((creator) => creator.id).sort(), ['user-member', 'user-owner']);
+
+    const ownerOnlyGenerations = await listStudioGenerations('user-member', { creatorUserId: 'user-owner' });
+    assert.deepEqual(ownerOnlyGenerations.generations.map((generation) => generation.id), ['gen-owner']);
+
+    const visibleOwnerGeneration = await getStudioGeneration('gen-owner', 'user-member');
+    assert.equal(visibleOwnerGeneration?.createdByUserId, 'user-owner');
+
+    const visibleOwnerOutput = await getStudioOutputForUser('out-gen-owner', 'user-member');
+    assert.equal(visibleOwnerOutput?.generationId, 'gen-owner');
+    assert.equal(await canReadStudioOutputPath('studio/outputs/gen-owner.png', 'user-member'), true);
+    assert.equal(await canReadStudioOutputPath('studio/outputs/gen-owner.png', 'user-outsider'), false);
+  } finally {
+    sqlite.close();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+
+  console.log('studio-organization-scope-test: ok');
+}
+
+void main();


### PR DESCRIPTION
## Summary
- Add organization/creator/workspace metadata for Studio libraries, generations, outputs, and bulk jobs with migration backfill
- Make Studio generation/output APIs and media/reference access organization-scope aware while preserving single-user legacy behavior
- Add Studio creator filter UI and server-side creator filtering
- Mark Task 24 completed in the architecture todo list

## Verification
- npm run test:studio:organization-scope
- tsx --conditions react-server scripts/db-migration-legacy-test.ts
- npm run lint
- npm run build

Greptile: awaiting automatic first review.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes Studio assets (generations, outputs, products, personas, styles, presets, bulk jobs) to organizations by adding `organization_id`, `created_by_user_id`, and `visibility` columns with a migration backfill, a new `studio-scope.ts` visibility helper, and a creator filter UI backed by server-side filtering.

- **Schema & migration**: `addColumns` + idempotent backfill for all Studio tables using the primary org from `canvas_organization_settings`; new indexes on `(organization_id, created_at)` and `(created_by_user_id, created_at)` support the new query patterns.
- **API & service layer**: Read operations now use `studioVisibilityCondition` (org-wide or personal legacy fallback); delete operations on generations/outputs retain owner-only guards; media and preview routes add a DB-backed `canReadStudioOutputPath` check for `studio/outputs/` paths.
- **Creator filter**: `GET /api/studio/generations` accepts `creatorUserId`, the hook propagates `creatorFilter` through `buildGenerationsUrl`, and `FilterBar` renders a dropdown hidden when only one creator is present.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one targeted fix: the PATCH route for toggling output favorites now allows any org member to modify another member's row.

The migration and scope logic are solid. The one concrete write-authorization gap introduced is the PATCH route for `isFavorite` — it widened the lookup from owner-only to org-wide but left the UPDATE without a corresponding owner assertion, letting any org member alter another member's favorite state.

app/api/studio/generations/[id]/outputs/[outId]/route.ts — the PATCH handler needs an owner check added back after the visibility lookup.

<details open><summary><h3>Security Review</h3></summary>

- **Cross-member write via broadened authorization** (`app/api/studio/generations/[id]/outputs/[outId]/route.ts`): The `PATCH` route switched from an owner-only check (`eq(studioGenerations.userId, session.user.id)`) to `getStudioOutputForUser`, which uses org-wide visibility. Any org member can now set or clear `isFavorite` on another member's output. Favorites are a per-user property stored on the shared row; the update should require the row owner.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/api/studio/generations/[id]/outputs/[outId]/route.ts | PATCH route now uses org-wide visibility for the authorization check, allowing any org member to toggle another member's output favorite; DELETE still correctly uses owner-only check. |
| app/lib/integrations/studio-scope.ts | New module implementing organization-scoped visibility conditions; logic for personal, org-wide, and legacy-null-org branches looks correct. |
| app/lib/integrations/studio-generation-service.ts | Adds org visibility conditions for reads and new `canReadStudioOutputPath`; delete operations retain owner-only (`userId`) guard. `listStudioGenerationCreators` now uses `groupBy` and runs in the same `Promise.all` as other queries. |
| app/lib/db/migrate.ts | Adds `organization_id`, `created_by_user_id`, `visibility` columns to all Studio tables via `addColumns` + backfill migration using `canvas_organization_settings` primary org; indexes added for org/creator columns. |
| app/api/studio/references/assets/route.ts | Replaces filesystem scan of outputs root with DB-based org-scoped query; correctly maps `audio` → `sound` output type; `requestedKind` is always typed as a valid value. |
| app/apps/studio/hooks/useStudioGeneration.ts | Adds `creatorFilter` parameter to the hook and `creators` to the returned state; offset calculation in `loadMoreGenerations` can drift when a filter change coincides with in-flight active generations. |
| app/apps/studio/components/create/FilterBar.tsx | Adds creator filter UI with correct active-chip tracking and `hasCreatorOptions` guard for single-user context. |
| app/lib/db/schema.ts | Adds `organizationId`, `createdByUserId`, `visibility` columns to Studio table schemas; consistent with migration additions. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/api/studio/generations/[id]/outputs/[outId]/route.ts`, line 52-63 ([link](https://github.com/canvascoding/canvas-notebook/blob/b44dd4d1808b7ab988a70c3770c688da0f2121b5/app/api/studio/generations/[id]/outputs/[outId]/route.ts#L52-L63)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Org-member can favorite-toggle another member's output**

   `getStudioOutputForUser` now resolves using `generationVisibilityCondition` (any org member can read), but the subsequent `UPDATE` uses only `eq(studioGenerationOutputs.id, outId)` with no owner guard. Any org member who can see an output can permanently alter its `isFavorite` flag on another member's row. Favorites are a personal preference stored per-row; the write should be gated on the row's creator — e.g., also asserting `eq(studioGenerationOutputs.createdByUserId, session.user.id)` or falling back to `eq(studioGenerations.userId, session.user.id)` as the old code did.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fstudio-organization-assets%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fstudio-organization-assets%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fapi%2Fstudio%2Fgenerations%2F%5Bid%5D%2Foutputs%2F%5BoutId%5D%2Froute.ts%0ALine%3A%2052-63%0A%0AComment%3A%0A**Org-member%20can%20favorite-toggle%20another%20member's%20output**%0A%0A%60getStudioOutputForUser%60%20now%20resolves%20using%20%60generationVisibilityCondition%60%20%28any%20org%20member%20can%20read%29%2C%20but%20the%20subsequent%20%60UPDATE%60%20uses%20only%20%60eq%28studioGenerationOutputs.id%2C%20outId%29%60%20with%20no%20owner%20guard.%20Any%20org%20member%20who%20can%20see%20an%20output%20can%20permanently%20alter%20its%20%60isFavorite%60%20flag%20on%20another%20member's%20row.%20Favorites%20are%20a%20personal%20preference%20stored%20per-row%3B%20the%20write%20should%20be%20gated%20on%20the%20row's%20creator%20%E2%80%94%20e.g.%2C%20also%20asserting%20%60eq%28studioGenerationOutputs.createdByUserId%2C%20session.user.id%29%60%20or%20falling%20back%20to%20%60eq%28studioGenerations.userId%2C%20session.user.id%29%60%20as%20the%20old%20code%20did.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=26&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fstudio-organization-assets%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fstudio-organization-assets%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fapi%2Fstudio%2Fgenerations%2F%5Bid%5D%2Foutputs%2F%5BoutId%5D%2Froute.ts%3A52-63%0A**Org-member%20can%20favorite-toggle%20another%20member's%20output**%0A%0A%60getStudioOutputForUser%60%20now%20resolves%20using%20%60generationVisibilityCondition%60%20%28any%20org%20member%20can%20read%29%2C%20but%20the%20subsequent%20%60UPDATE%60%20uses%20only%20%60eq%28studioGenerationOutputs.id%2C%20outId%29%60%20with%20no%20owner%20guard.%20Any%20org%20member%20who%20can%20see%20an%20output%20can%20permanently%20alter%20its%20%60isFavorite%60%20flag%20on%20another%20member's%20row.%20Favorites%20are%20a%20personal%20preference%20stored%20per-row%3B%20the%20write%20should%20be%20gated%20on%20the%20row's%20creator%20%E2%80%94%20e.g.%2C%20also%20asserting%20%60eq%28studioGenerationOutputs.createdByUserId%2C%20session.user.id%29%60%20or%20falling%20back%20to%20%60eq%28studioGenerations.userId%2C%20session.user.id%29%60%20as%20the%20old%20code%20did.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fapps%2Fstudio%2Fhooks%2FuseStudioGeneration.ts%3A295-317%0A**%60loadMoreGenerations%60%20offset%20can%20diverge%20when%20active%20generations%20straddle%20a%20filter%20change**%0A%0A%60loadMoreGenerations%60%20calculates%20the%20server-side%20offset%20as%20%60generations.filter%28g%20%3D%3E%20!g.id.startsWith%28'temp-'%29%29.length%60.%20When%20%60creatorFilter%60%20changes%2C%20%60fetchGenerations%60%20%28offset%200%2C%20new%20filter%29%20is%20called%20and%20%60preserveActiveGenerations%60%20merges%20the%20new%20result%20with%20any%20currently-in-progress%20non-temp%20generations%20from%20the%20previous%20filter%20context.%20If%20N%20such%20generations%20are%20preserved%2C%20the%20next%20%22load%20more%22%20request%20sends%20%60offset%20%3D%20filteredResults%20%2B%20N%60%20instead%20of%20just%20%60filteredResults%60%2C%20causing%20the%20server%20to%20skip%20N%20records%20from%20the%20filtered%20result%20set.%20The%20effect%20resolves%20once%20active%20generations%20complete%2C%20but%20users%20would%20see%20a%20gap%20in%20the%20paginated%20history%20during%20that%20window.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=26&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address studio asset review feedback"](https://github.com/canvascoding/canvas-notebook/commit/b44dd4d1808b7ab988a70c3770c688da0f2121b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38888064)</sub>

<!-- /greptile_comment -->