### PR TITLE
Add scoped usage and automation jobs

### DIFF
--- a/app/lib/automations/store.ts
+++ b/app/lib/automations/store.ts
@@ -82,6 +82,41 @@ function resolveAutomationRunActor(
   };
 }
 
+function normalizeJobScopePart(value: string | null | undefined, fallback: string): string {
+  const normalized = value?.trim();
+  return (normalized || fallback).replace(/[:\s]+/g, '_');
+}
+
+function buildAutomationJobScope(input: {
+  scope: AutomationScope;
+  organizationId?: string | null;
+  workspaceId?: string | null;
+  workspaceType?: string | null;
+  ownerUserId?: string | null;
+  responsibleUserId?: string | null;
+  createdByUserId?: string | null;
+  actorUserId?: string | null;
+}): string {
+  const workspacePart = normalizeJobScopePart(input.workspaceId || input.workspaceType, 'legacy');
+  if (input.scope === 'organization') {
+    return `organization:${normalizeJobScopePart(input.organizationId, 'legacy')}:${workspacePart}`;
+  }
+
+  return `personal:${normalizeJobScopePart(input.ownerUserId || input.responsibleUserId || input.actorUserId || input.createdByUserId, 'unknown')}:${workspacePart}`;
+}
+
+function resolveStoredJobScope(job: typeof automationJobs.$inferSelect, scope = normalizeAutomationScope(job.scope)): string {
+  return job.jobScope || buildAutomationJobScope({
+    scope,
+    organizationId: job.organizationId ?? null,
+    workspaceId: job.workspaceId ?? null,
+    workspaceType: job.workspaceType ?? null,
+    ownerUserId: job.ownerUserId ?? null,
+    responsibleUserId: job.responsibleUserId ?? null,
+    createdByUserId: job.createdByUserId,
+  });
+}
+
 function stripLeadingPathDecorators(value: string): string {
   let next = value;
   while (next.startsWith('/')) {
@@ -297,6 +332,7 @@ function mapJobRow(
     name: row.name,
     status: row.status as AutomationJobRecord['status'],
     scope: normalizeAutomationScope(row.scope),
+    jobScope: resolveStoredJobScope(row),
     organizationId: row.organizationId ?? null,
     workspaceId: row.workspaceId ?? null,
     workspaceType: normalizeAutomationWorkspaceType(row.workspaceType),
@@ -349,6 +385,7 @@ function mapRunRow(
     jobId: row.jobId,
     status: row.status as AutomationRunRecord['status'],
     scope: normalizeAutomationScope(row.scope),
+    jobScope: row.jobScope,
     organizationId: row.organizationId ?? null,
     workspaceId: row.workspaceId ?? null,
     workspaceType: normalizeAutomationWorkspaceType(row.workspaceType),
@@ -489,6 +526,7 @@ export async function listAutomationRuns(jobId: string): Promise<AutomationRunRe
       jobId: automationRuns.jobId,
       status: automationRuns.status,
       scope: automationRuns.scope,
+      jobScope: automationRuns.jobScope,
       organizationId: automationRuns.organizationId,
       workspaceId: automationRuns.workspaceId,
       workspaceType: automationRuns.workspaceType,
@@ -527,6 +565,7 @@ export async function getAutomationRun(runId: string): Promise<AutomationRunReco
       jobId: automationRuns.jobId,
       status: automationRuns.status,
       scope: automationRuns.scope,
+      jobScope: automationRuns.jobScope,
       organizationId: automationRuns.organizationId,
       workspaceId: automationRuns.workspaceId,
       workspaceType: automationRuns.workspaceType,
@@ -621,6 +660,7 @@ export async function createAutomationJob(input: CreateAutomationJobInput, user:
   }
 
   const automationScope = await resolveAutomationScopeForCreate(input, policyUser);
+  const jobScope = buildAutomationJobScope({ ...automationScope, createdByUserId: userId });
   const now = new Date();
   const nextRunAt = input.status === 'paused' ? null : computeNextRunAt(schedule, { from: now });
   const id = `job-${randomUUID()}`;
@@ -632,6 +672,7 @@ export async function createAutomationJob(input: CreateAutomationJobInput, user:
       name,
       status: input.status || 'active',
       scope: automationScope.scope,
+      jobScope,
       organizationId: automationScope.organizationId,
       workspaceId: automationScope.workspaceId,
       workspaceType: automationScope.workspaceType,
@@ -686,6 +727,7 @@ export async function createWebhookAutomationJob(input: CreateWebhookAutomationJ
   const id = `job-${randomUUID()}`;
   const preferredTimeZone = await getUserPreferredTimeZone(userId);
   const automationScope = await resolveAutomationScopeForCreate(input, policyUser);
+  const jobScope = buildAutomationJobScope({ ...automationScope, createdByUserId: userId });
   const schedule: FriendlySchedule = {
     kind: 'webhook',
     timeZone: preferredTimeZone,
@@ -698,6 +740,7 @@ export async function createWebhookAutomationJob(input: CreateWebhookAutomationJ
       name,
       status: input.status || 'active',
       scope: automationScope.scope,
+      jobScope,
       organizationId: automationScope.organizationId,
       workspaceId: automationScope.workspaceId,
       workspaceType: automationScope.workspaceType,
@@ -759,6 +802,7 @@ export async function createCustomWebhookAutomationJob(
   const secret = generateAutomationWebhookSecret();
   const preferredTimeZone = await getUserPreferredTimeZone(userId);
   const automationScope = await resolveAutomationScopeForCreate(input, policyUser);
+  const jobScope = buildAutomationJobScope({ ...automationScope, createdByUserId: userId });
   const schedule: FriendlySchedule = {
     kind: 'webhook',
     timeZone: preferredTimeZone,
@@ -772,6 +816,7 @@ export async function createCustomWebhookAutomationJob(
         name,
         status: input.status || 'active',
         scope: automationScope.scope,
+        jobScope,
         organizationId: automationScope.organizationId,
         workspaceId: automationScope.workspaceId,
         workspaceType: automationScope.workspaceType,
@@ -928,6 +973,7 @@ export async function createPendingAutomationRun(
 
     const now = new Date();
     const jobScope = normalizeAutomationScope(job.scope);
+    const storedJobScope = resolveStoredJobScope(job, jobScope);
     const runActor = resolveAutomationRunActor(job, jobScope, options);
     const [inserted] = tx
       .insert(automationRuns)
@@ -936,6 +982,7 @@ export async function createPendingAutomationRun(
         jobId,
         status: 'pending',
         scope: jobScope,
+        jobScope: storedJobScope,
         organizationId: job.organizationId ?? null,
         workspaceId: job.workspaceId ?? null,
         workspaceType: normalizeAutomationWorkspaceType(job.workspaceType),
@@ -1314,6 +1361,7 @@ export async function scheduleAutomationJobRun(
 
     const now = new Date();
     const jobScope = normalizeAutomationScope(job.scope);
+    const storedJobScope = resolveStoredJobScope(job, jobScope);
     const runActor = resolveAutomationRunActor(job, jobScope, options);
     const [inserted] = tx
       .insert(automationRuns)
@@ -1322,6 +1370,7 @@ export async function scheduleAutomationJobRun(
         jobId,
         status: 'pending',
         scope: jobScope,
+        jobScope: storedJobScope,
         organizationId: job.organizationId ?? null,
         workspaceId: job.workspaceId ?? null,
         workspaceType: normalizeAutomationWorkspaceType(job.workspaceType),
@@ -1587,6 +1636,14 @@ export async function upsertHeartbeatJob(data: {
       .update(automationJobs)
       .set({
         status,
+        jobScope: existing.jobScope || buildAutomationJobScope({
+          scope: 'personal',
+          ownerUserId: data.userId,
+          responsibleUserId: data.userId,
+          createdByUserId: data.userId,
+          workspaceId: existing.workspaceId,
+          workspaceType: existing.workspaceType,
+        }),
         scheduleKind: schedule.kind,
         scheduleConfigJson: JSON.stringify(schedule),
         timeZone: schedule.timeZone,
@@ -1615,6 +1672,13 @@ export async function upsertHeartbeatJob(data: {
       name: 'Heartbeat',
       status,
       scope: 'personal',
+      jobScope: buildAutomationJobScope({
+        scope: 'personal',
+        ownerUserId: data.userId,
+        responsibleUserId: data.userId,
+        createdByUserId: data.userId,
+        workspaceType: 'personal',
+      }),
       workspaceType: 'personal',
       ownerUserId: data.userId,
       responsibleUserId: data.userId,

--- a/app/lib/automations/types.ts
+++ b/app/lib/automations/types.ts
@@ -59,6 +59,7 @@ export type AutomationJobRecord = {
   name: string;
   status: AutomationJobStatus;
   scope: AutomationScope;
+  jobScope: string;
   organizationId: string | null;
   workspaceId: string | null;
   workspaceType: AutomationWorkspaceType;
@@ -106,6 +107,7 @@ export type AutomationRunRecord = {
   jobId: string;
   status: AutomationRunStatus;
   scope: AutomationScope;
+  jobScope: string;
   organizationId: string | null;
   workspaceId: string | null;
   workspaceType: AutomationWorkspaceType;

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -1501,14 +1501,14 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
         ORDER BY s.updated_at DESC
         LIMIT 1
       )),
-      agent_id = COALESCE(NULLIF(agent_id, ''), (
-        SELECT s.agent_id
+      agent_id = COALESCE((
+        SELECT NULLIF(s.agent_id, '')
         FROM pi_sessions s
         WHERE s.session_id = pi_usage_events.session_id
           AND s.user_id = pi_usage_events.user_id
         ORDER BY s.updated_at DESC
         LIMIT 1
-      ), 'canvas-agent')
+      ), NULLIF(agent_id, ''), 'canvas-agent')
     WHERE organization_id IS NULL
       OR workspace_id IS NULL
       OR workspace_type IS NULL

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -202,6 +202,10 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
       fingerprint TEXT NOT NULL,
       user_id TEXT NOT NULL,
+      organization_id TEXT,
+      workspace_id TEXT,
+      workspace_type TEXT,
+      agent_id TEXT NOT NULL DEFAULT 'canvas-agent',
       session_id TEXT NOT NULL,
       provider TEXT NOT NULL,
       model TEXT NOT NULL,
@@ -451,6 +455,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       name TEXT NOT NULL,
       status TEXT NOT NULL,
       scope TEXT NOT NULL DEFAULT 'personal',
+      job_scope TEXT NOT NULL DEFAULT 'personal:legacy:legacy',
       organization_id TEXT,
       workspace_id TEXT,
       workspace_type TEXT NOT NULL DEFAULT 'personal',
@@ -500,6 +505,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       job_id TEXT NOT NULL,
       status TEXT NOT NULL,
       scope TEXT NOT NULL DEFAULT 'personal',
+      job_scope TEXT NOT NULL DEFAULT 'personal:legacy:legacy',
       organization_id TEXT,
       workspace_id TEXT,
       workspace_type TEXT NOT NULL DEFAULT 'personal',
@@ -1363,8 +1369,16 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     workspace_root_relative_path: 'TEXT',
   });
 
+  addColumns(sqlite, 'pi_usage_events', {
+    organization_id: 'TEXT',
+    workspace_id: 'TEXT',
+    workspace_type: 'TEXT',
+    agent_id: "TEXT NOT NULL DEFAULT 'canvas-agent'",
+  });
+
   addColumns(sqlite, 'automation_jobs', {
     scope: "TEXT NOT NULL DEFAULT 'personal'",
+    job_scope: "TEXT NOT NULL DEFAULT 'personal:legacy:legacy'",
     organization_id: 'TEXT',
     workspace_id: 'TEXT',
     workspace_type: "TEXT NOT NULL DEFAULT 'personal'",
@@ -1391,6 +1405,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
 
   addColumns(sqlite, 'automation_runs', {
     scope: "TEXT NOT NULL DEFAULT 'personal'",
+    job_scope: "TEXT NOT NULL DEFAULT 'personal:legacy:legacy'",
     organization_id: 'TEXT',
     workspace_id: 'TEXT',
     workspace_type: "TEXT NOT NULL DEFAULT 'personal'",
@@ -1406,26 +1421,46 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       responsible_user_id = COALESCE(responsible_user_id, created_by_user_id),
       last_edited_by_user_id = COALESCE(last_edited_by_user_id, created_by_user_id),
       scope = COALESCE(NULLIF(scope, ''), 'personal'),
-      workspace_type = COALESCE(NULLIF(workspace_type, ''), 'personal')
+      workspace_type = COALESCE(NULLIF(workspace_type, ''), 'personal'),
+      job_scope = CASE
+        WHEN COALESCE(NULLIF(scope, ''), 'personal') = 'organization'
+          THEN 'organization:' || COALESCE(NULLIF(organization_id, ''), 'legacy') || ':' || COALESCE(NULLIF(workspace_id, ''), NULLIF(workspace_type, ''), 'legacy')
+        ELSE 'personal:' || COALESCE(NULLIF(owner_user_id, ''), NULLIF(responsible_user_id, ''), NULLIF(created_by_user_id, ''), 'unknown') || ':' || COALESCE(NULLIF(workspace_id, ''), NULLIF(workspace_type, ''), 'legacy')
+      END
     WHERE owner_user_id IS NULL
       OR responsible_user_id IS NULL
       OR last_edited_by_user_id IS NULL
       OR scope IS NULL
       OR scope = ''
       OR workspace_type IS NULL
-      OR workspace_type = '';
+      OR workspace_type = ''
+      OR job_scope IS NULL
+      OR job_scope = ''
+      OR job_scope = 'personal:legacy:legacy';
 
     UPDATE automation_runs
     SET
       scope = COALESCE(NULLIF(scope, ''), 'personal'),
       workspace_type = COALESCE(NULLIF(workspace_type, ''), 'personal'),
-      actor_type = COALESCE(NULLIF(actor_type, ''), 'user')
+      actor_type = COALESCE(NULLIF(actor_type, ''), 'user'),
+      job_scope = COALESCE((
+        SELECT NULLIF(j.job_scope, '')
+        FROM automation_jobs j
+        WHERE j.id = automation_runs.job_id
+      ), CASE
+        WHEN COALESCE(NULLIF(scope, ''), 'personal') = 'organization'
+          THEN 'organization:' || COALESCE(NULLIF(organization_id, ''), 'legacy') || ':' || COALESCE(NULLIF(workspace_id, ''), NULLIF(workspace_type, ''), 'legacy')
+        ELSE 'personal:' || COALESCE(NULLIF(actor_user_id, ''), 'unknown') || ':' || COALESCE(NULLIF(workspace_id, ''), NULLIF(workspace_type, ''), 'legacy')
+      END)
     WHERE scope IS NULL
       OR scope = ''
       OR workspace_type IS NULL
       OR workspace_type = ''
       OR actor_type IS NULL
-      OR actor_type = '';
+      OR actor_type = ''
+      OR job_scope IS NULL
+      OR job_scope = ''
+      OR job_scope = 'personal:legacy:legacy';
 
     UPDATE automation_runs
     SET actor_user_id = (
@@ -1439,6 +1474,47 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
         FROM automation_jobs j
         WHERE j.id = automation_runs.job_id
       );
+
+    UPDATE pi_usage_events
+    SET
+      organization_id = COALESCE(organization_id, (
+        SELECT s.organization_id
+        FROM pi_sessions s
+        WHERE s.session_id = pi_usage_events.session_id
+          AND s.user_id = pi_usage_events.user_id
+        ORDER BY s.updated_at DESC
+        LIMIT 1
+      )),
+      workspace_id = COALESCE(workspace_id, (
+        SELECT s.workspace_id
+        FROM pi_sessions s
+        WHERE s.session_id = pi_usage_events.session_id
+          AND s.user_id = pi_usage_events.user_id
+        ORDER BY s.updated_at DESC
+        LIMIT 1
+      )),
+      workspace_type = COALESCE(NULLIF(workspace_type, ''), (
+        SELECT s.workspace_type
+        FROM pi_sessions s
+        WHERE s.session_id = pi_usage_events.session_id
+          AND s.user_id = pi_usage_events.user_id
+        ORDER BY s.updated_at DESC
+        LIMIT 1
+      )),
+      agent_id = COALESCE(NULLIF(agent_id, ''), (
+        SELECT s.agent_id
+        FROM pi_sessions s
+        WHERE s.session_id = pi_usage_events.session_id
+          AND s.user_id = pi_usage_events.user_id
+        ORDER BY s.updated_at DESC
+        LIMIT 1
+      ), 'canvas-agent')
+    WHERE organization_id IS NULL
+      OR workspace_id IS NULL
+      OR workspace_type IS NULL
+      OR workspace_type = ''
+      OR agent_id IS NULL
+      OR agent_id = '';
   `);
 
   // ── Deferred indexes on columns added via ALTER TABLE ──────────────────────
@@ -1462,6 +1538,11 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_channel ON pi_sessions (channel_id, channel_session_key);
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_workspace ON pi_sessions (workspace_id);
     CREATE INDEX IF NOT EXISTS idx_pi_sessions_user_workspace_created ON pi_sessions (user_id, workspace_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_pi_usage_events_org_workspace ON pi_usage_events (organization_id, workspace_id, assistant_timestamp);
+    CREATE INDEX IF NOT EXISTS idx_pi_usage_events_user_workspace ON pi_usage_events (user_id, workspace_id, assistant_timestamp);
+    CREATE INDEX IF NOT EXISTS idx_pi_usage_events_agent ON pi_usage_events (agent_id, assistant_timestamp);
+    CREATE INDEX IF NOT EXISTS idx_automation_jobs_job_scope_status ON automation_jobs (job_scope, status, next_run_at);
+    CREATE INDEX IF NOT EXISTS idx_automation_runs_job_scope_status ON automation_runs (job_scope, status, scheduled_for);
   `);
 
   sqlite.exec(`

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -252,6 +252,10 @@ export const piUsageEvents = sqliteTable("pi_usage_events", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   fingerprint: text("fingerprint").notNull().unique(),
   userId: text("user_id").notNull().references(() => user.id),
+  organizationId: text("organization_id"),
+  workspaceId: text("workspace_id"),
+  workspaceType: text("workspace_type"),
+  agentId: text("agent_id").notNull().default('canvas-agent'),
   sessionId: text("session_id").notNull(),
   provider: text("provider").notNull(),
   model: text("model").notNull(),
@@ -269,7 +273,19 @@ export const piUsageEvents = sqliteTable("pi_usage_events", {
   cacheWriteCost: real("cache_write_cost").notNull(),
   totalCost: real("total_cost").notNull(),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
-});
+}, (table) => ({
+  userCreatedIdx: index("idx_pi_usage_events_user_created_at").on(table.userId, table.createdAt),
+  sessionCreatedIdx: index("idx_pi_usage_events_session_created_at").on(table.sessionId, table.createdAt),
+  providerCreatedIdx: index("idx_pi_usage_events_provider_created_at").on(table.provider, table.createdAt),
+  modelCreatedIdx: index("idx_pi_usage_events_model_created_at").on(table.model, table.createdAt),
+  userAssistantTimestampIdx: index("idx_pi_usage_events_user_assistant_timestamp").on(table.userId, table.assistantTimestamp),
+  sessionAssistantTimestampIdx: index("idx_pi_usage_events_session_assistant_timestamp").on(table.sessionId, table.assistantTimestamp),
+  providerAssistantTimestampIdx: index("idx_pi_usage_events_provider_assistant_timestamp").on(table.provider, table.assistantTimestamp),
+  modelAssistantTimestampIdx: index("idx_pi_usage_events_model_assistant_timestamp").on(table.model, table.assistantTimestamp),
+  organizationWorkspaceIdx: index("idx_pi_usage_events_org_workspace").on(table.organizationId, table.workspaceId, table.assistantTimestamp),
+  userWorkspaceIdx: index("idx_pi_usage_events_user_workspace").on(table.userId, table.workspaceId, table.assistantTimestamp),
+  agentIdx: index("idx_pi_usage_events_agent").on(table.agentId, table.assistantTimestamp),
+}));
 
 export const todoCategories = sqliteTable("todo_categories", {
   id: text("id").primaryKey(),
@@ -536,6 +552,7 @@ export const automationJobs = sqliteTable("automation_jobs", {
   name: text("name").notNull(),
   status: text("status").notNull(),
   scope: text("scope").notNull().default('personal'),
+  jobScope: text("job_scope").notNull().default('personal:legacy:legacy'),
   organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
   workspaceId: text("workspace_id").references(() => canvasWorkspaces.id, { onDelete: 'set null' }),
   workspaceType: text("workspace_type").notNull().default('personal'),
@@ -574,6 +591,7 @@ export const automationJobs = sqliteTable("automation_jobs", {
 }, (table) => ({
   ownerScopeIdx: index("idx_automation_jobs_owner_scope").on(table.ownerUserId, table.scope),
   organizationWorkspaceIdx: index("idx_automation_jobs_org_workspace").on(table.organizationId, table.workspaceId),
+  jobScopeStatusIdx: index("idx_automation_jobs_job_scope_status").on(table.jobScope, table.status, table.nextRunAt),
   composioTriggerIdx: uniqueIndex("idx_automation_jobs_composio_trigger_id").on(table.composioTriggerId),
 }));
 
@@ -674,6 +692,7 @@ export const automationRuns = sqliteTable("automation_runs", {
   jobId: text("job_id").notNull().references(() => automationJobs.id),
   status: text("status").notNull(),
   scope: text("scope").notNull().default('personal'),
+  jobScope: text("job_scope").notNull().default('personal:legacy:legacy'),
   organizationId: text("organization_id").references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
   workspaceId: text("workspace_id").references(() => canvasWorkspaces.id, { onDelete: 'set null' }),
   workspaceType: text("workspace_type").notNull().default('personal'),
@@ -699,6 +718,7 @@ export const automationRuns = sqliteTable("automation_runs", {
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
 }, (table) => ({
   workspaceCreatedIdx: index("idx_automation_runs_workspace_created").on(table.workspaceId, table.createdAt),
+  jobScopeStatusIdx: index("idx_automation_runs_job_scope_status").on(table.jobScope, table.status, table.scheduledFor),
 }));
 
 export const studioProducts = sqliteTable("studio_products", {

--- a/app/lib/pi/usage-events.ts
+++ b/app/lib/pi/usage-events.ts
@@ -15,6 +15,14 @@ type PersistPiUsageEventsParams = {
 
 export type PiUsageEventRow = typeof piUsageEvents.$inferSelect;
 
+type PiUsageSessionContext = {
+  sessionTitleSnapshot: string | null;
+  organizationId: string | null;
+  workspaceId: string | null;
+  workspaceType: string | null;
+  agentId: string;
+};
+
 function isAssistantMessage(message: AgentMessage): message is AssistantMessage {
   return message.role === 'assistant';
 }
@@ -49,6 +57,10 @@ export function extractPiUsageEventValues(params: {
   sessionId: string;
   userId: string;
   sessionTitleSnapshot?: string | null;
+  organizationId?: string | null;
+  workspaceId?: string | null;
+  workspaceType?: string | null;
+  agentId?: string | null;
   messages: AgentMessage[];
 }) {
   return params.messages
@@ -57,6 +69,10 @@ export function extractPiUsageEventValues(params: {
     .map((message) => ({
       fingerprint: buildPiUsageFingerprint(params.sessionId, message),
       userId: params.userId,
+      organizationId: params.organizationId ?? null,
+      workspaceId: params.workspaceId ?? null,
+      workspaceType: params.workspaceType ?? null,
+      agentId: params.agentId ?? 'canvas-agent',
       sessionId: params.sessionId,
       provider: message.provider,
       model: message.model,
@@ -77,15 +93,25 @@ export function extractPiUsageEventValues(params: {
     }));
 }
 
-async function loadSessionTitleSnapshot(sessionId: string, userId: string): Promise<string | null> {
+async function loadSessionUsageContext(sessionId: string, userId: string): Promise<PiUsageSessionContext> {
   const session = await db.query.piSessions.findFirst({
     columns: {
       title: true,
+      organizationId: true,
+      workspaceId: true,
+      workspaceType: true,
+      agentId: true,
     },
     where: and(eq(piSessions.sessionId, sessionId), eq(piSessions.userId, userId)),
   });
 
-  return session?.title ?? null;
+  return {
+    sessionTitleSnapshot: session?.title ?? null,
+    organizationId: session?.organizationId ?? null,
+    workspaceId: session?.workspaceId ?? null,
+    workspaceType: session?.workspaceType ?? null,
+    agentId: session?.agentId ?? 'canvas-agent',
+  };
 }
 
 export async function persistPiUsageEvents({
@@ -97,11 +123,11 @@ export async function persistPiUsageEvents({
     return 0;
   }
 
-  const sessionTitleSnapshot = await loadSessionTitleSnapshot(sessionId, userId);
+  const sessionContext = await loadSessionUsageContext(sessionId, userId);
   const values = extractPiUsageEventValues({
     sessionId,
     userId,
-    sessionTitleSnapshot,
+    ...sessionContext,
     messages,
   });
 

--- a/app/lib/pi/usage-reporting.ts
+++ b/app/lib/pi/usage-reporting.ts
@@ -64,6 +64,9 @@ function parseGroupBy(value: string | null): UsageSummaryGroupBy {
   switch (value) {
     case 'provider':
     case 'model':
+    case 'organization':
+    case 'workspace':
+    case 'agent':
     case 'user':
     case 'session':
       return value;
@@ -85,6 +88,10 @@ export function parseUsageFilters(searchParams: URLSearchParams): UsageFilters {
     sessionId: normalizeOptionalString(searchParams.get('sessionId')),
     sessionQuery: normalizeOptionalString(searchParams.get('sessionQuery')),
     stopReason: normalizeOptionalString(searchParams.get('stopReason')),
+    organizationId: normalizeOptionalString(searchParams.get('organizationId')),
+    workspaceId: normalizeOptionalString(searchParams.get('workspaceId')),
+    workspaceType: normalizeOptionalString(searchParams.get('workspaceType')),
+    agentId: normalizeOptionalString(searchParams.get('agentId')),
     groupBy: parseGroupBy(searchParams.get('groupBy')),
     userId: normalizeOptionalString(searchParams.get('userId')),
   };
@@ -121,6 +128,10 @@ function serializeUsageFilters(filters: UsageFilters, access: UsageAccess): Seri
     sessionId: filters.sessionId ?? null,
     sessionQuery: filters.sessionQuery ?? null,
     stopReason: filters.stopReason ?? null,
+    organizationId: filters.organizationId ?? null,
+    workspaceId: filters.workspaceId ?? null,
+    workspaceType: filters.workspaceType ?? null,
+    agentId: filters.agentId ?? null,
     groupBy: filters.groupBy,
     userId: access.effectiveUserId ?? null,
   };
@@ -170,6 +181,22 @@ function buildWhere(filters: UsageFilters, access: UsageAccess) {
 
   if (filters.stopReason) {
     conditions.push(eq(piUsageEvents.stopReason, filters.stopReason));
+  }
+
+  if (filters.organizationId) {
+    conditions.push(eq(piUsageEvents.organizationId, filters.organizationId));
+  }
+
+  if (filters.workspaceId) {
+    conditions.push(eq(piUsageEvents.workspaceId, filters.workspaceId));
+  }
+
+  if (filters.workspaceType) {
+    conditions.push(eq(piUsageEvents.workspaceType, filters.workspaceType));
+  }
+
+  if (filters.agentId) {
+    conditions.push(eq(piUsageEvents.agentId, filters.agentId));
   }
 
   if (filters.sessionQuery) {
@@ -237,6 +264,24 @@ function getGrouping(filters: UsageFilters) {
       return {
         groupKey: piUsageEvents.userId,
         label: sql<string>`coalesce(${user.name}, ${user.email}, ${piUsageEvents.userId})`,
+        orderBy: desc(sql<number>`coalesce(sum(${piUsageEvents.totalCost}), 0)`),
+      };
+    case 'organization':
+      return {
+        groupKey: sql<string>`coalesce(${piUsageEvents.organizationId}, 'unscoped')`,
+        label: sql<string>`coalesce(${piUsageEvents.organizationId}, 'Unscoped organization')`,
+        orderBy: desc(sql<number>`coalesce(sum(${piUsageEvents.totalCost}), 0)`),
+      };
+    case 'workspace':
+      return {
+        groupKey: sql<string>`coalesce(${piUsageEvents.workspaceId}, 'legacy')`,
+        label: sql<string>`coalesce(${piUsageEvents.workspaceId}, 'Legacy workspace')`,
+        orderBy: desc(sql<number>`coalesce(sum(${piUsageEvents.totalCost}), 0)`),
+      };
+    case 'agent':
+      return {
+        groupKey: sql<string>`${piUsageEvents.agentId}`,
+        label: sql<string>`${piUsageEvents.agentId}`,
         orderBy: desc(sql<number>`coalesce(sum(${piUsageEvents.totalCost}), 0)`),
       };
     case 'session':
@@ -328,6 +373,10 @@ export async function getUsageEvents(
       id: piUsageEvents.id,
       userId: piUsageEvents.userId,
       userLabel: sql<string>`coalesce(${user.name}, ${user.email}, ${piUsageEvents.userId})`,
+      organizationId: piUsageEvents.organizationId,
+      workspaceId: piUsageEvents.workspaceId,
+      workspaceType: piUsageEvents.workspaceType,
+      agentId: piUsageEvents.agentId,
       sessionId: piUsageEvents.sessionId,
       sessionTitleSnapshot: piUsageEvents.sessionTitleSnapshot,
       provider: piUsageEvents.provider,
@@ -356,6 +405,10 @@ export async function getUsageEvents(
       id: row.id,
       userId: row.userId,
       userLabel: row.userLabel,
+      organizationId: row.organizationId ?? null,
+      workspaceId: row.workspaceId ?? null,
+      workspaceType: row.workspaceType ?? null,
+      agentId: row.agentId,
       sessionId: row.sessionId,
       sessionTitleSnapshot: row.sessionTitleSnapshot,
       provider: row.provider,

--- a/app/lib/pi/usage-types.ts
+++ b/app/lib/pi/usage-types.ts
@@ -1,4 +1,4 @@
-export type UsageSummaryGroupBy = 'day' | 'provider' | 'model' | 'user' | 'session';
+export type UsageSummaryGroupBy = 'day' | 'provider' | 'model' | 'user' | 'session' | 'organization' | 'workspace' | 'agent';
 
 export type UsageFilters = {
   from: Date;
@@ -8,6 +8,10 @@ export type UsageFilters = {
   sessionId?: string;
   sessionQuery?: string;
   stopReason?: string;
+  organizationId?: string;
+  workspaceId?: string;
+  workspaceType?: string;
+  agentId?: string;
   groupBy: UsageSummaryGroupBy;
   userId?: string;
 };
@@ -42,6 +46,10 @@ export type SerializedUsageFilters = {
   sessionId: string | null;
   sessionQuery: string | null;
   stopReason: string | null;
+  organizationId: string | null;
+  workspaceId: string | null;
+  workspaceType: string | null;
+  agentId: string | null;
   groupBy: UsageSummaryGroupBy;
   userId: string | null;
 };
@@ -56,6 +64,10 @@ export type UsageEventRow = {
   id: number;
   userId: string;
   userLabel: string;
+  organizationId: string | null;
+  workspaceId: string | null;
+  workspaceType: string | null;
+  agentId: string;
   sessionId: string;
   sessionTitleSnapshot: string | null;
   provider: string;

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -436,7 +436,7 @@
     {
       "id": 26,
       "title": "Background Jobs und Usage mit userId, organizationId, workspaceId und Job-Scope versehen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/05-actor-audit-retention.md",

--- a/scripts/automation-delivery-test.ts
+++ b/scripts/automation-delivery-test.ts
@@ -43,6 +43,7 @@ async function main() {
     name: 'Delivery Test',
     status: 'active',
     scope: 'personal',
+    jobScope: `personal:${userId}:personal`,
     organizationId: null,
     workspaceId: null,
     workspaceType: 'personal',

--- a/scripts/automation-workspace-scope-test.ts
+++ b/scripts/automation-workspace-scope-test.ts
@@ -123,6 +123,7 @@ async function main() {
     assert.equal(memberPersonalJob.workspaceType, 'personal');
     assert.equal(memberPersonalJob.ownerUserId, 'user-member');
     assert.equal(memberPersonalJob.responsibleUserId, 'user-member');
+    assert.equal(memberPersonalJob.jobScope, `personal:user-member:${memberPersonalWorkspace.id}`);
 
     await assert.rejects(
       () => createAutomationJob({
@@ -158,6 +159,7 @@ async function main() {
     assert.equal(memberOrganizationJob.scope, 'organization');
     assert.equal(memberOrganizationJob.createdByUserId, 'user-member');
     assert.equal(memberOrganizationJob.ownerUserId, null);
+    assert.equal(memberOrganizationJob.jobScope, `organization:${organizationId}:${teamWorkspace.id}`);
     const memberJobsWithOrgAccess = await listAutomationJobs('user-member');
     assert.ok(memberJobsWithOrgAccess.some((job) => job.id === memberOrganizationJob.id));
 
@@ -177,6 +179,7 @@ async function main() {
     assert.equal(ownerOrganizationJob.ownerUserId, null);
     assert.equal(ownerOrganizationJob.responsibleUserId, 'user-owner');
     assert.equal(ownerOrganizationJob.approvedByUserId, 'user-owner');
+    assert.equal(ownerOrganizationJob.jobScope, `organization:${organizationId}:${teamWorkspace.id}`);
     assert.ok(ownerOrganizationJob.serviceActorId?.startsWith('org-service:'));
 
     const memberJobs = await listAutomationJobs('user-member');
@@ -192,6 +195,7 @@ async function main() {
     assert.equal(run.scope, 'organization');
     assert.equal(run.workspaceId, teamWorkspace.id);
     assert.equal(run.workspaceType, 'team');
+    assert.equal(run.jobScope, ownerOrganizationJob.jobScope);
     assert.equal(run.actorType, 'user');
     assert.equal(run.actorUserId, 'user-owner');
     assert.equal(run.serviceActorId, null);
@@ -199,6 +203,7 @@ async function main() {
     const loadedRun = await getAutomationRun(run.id);
     assert.equal(loadedRun?.workspaceId, teamWorkspace.id);
     assert.equal(loadedRun?.scope, 'organization');
+    assert.equal(loadedRun?.jobScope, ownerOrganizationJob.jobScope);
 
     const heartbeatJob = await upsertHeartbeatJob({
       userId: 'user-member',
@@ -211,6 +216,7 @@ async function main() {
     assert.equal(heartbeatJob.ownerUserId, 'user-member');
     assert.equal(heartbeatJob.responsibleUserId, 'user-member');
     assert.equal(heartbeatJob.lastEditedByUserId, 'user-member');
+    assert.equal(heartbeatJob.jobScope, 'personal:user-member:personal');
   } finally {
     if (sqlite.open) {
       sqlite.close();

--- a/scripts/db-migration-legacy-test.ts
+++ b/scripts/db-migration-legacy-test.ts
@@ -28,6 +28,7 @@ try {
       user_id TEXT NOT NULL,
       provider TEXT NOT NULL,
       model TEXT NOT NULL,
+      agent_id TEXT NOT NULL DEFAULT 'canvas-agent',
       title TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
@@ -44,6 +45,31 @@ try {
       content TEXT NOT NULL,
       timestamp INTEGER NOT NULL,
       FOREIGN KEY (pi_session_db_id) REFERENCES pi_sessions(id)
+    );
+
+    CREATE TABLE pi_usage_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      fingerprint TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      assistant_timestamp TEXT NOT NULL,
+      session_title_snapshot TEXT,
+      input_tokens INTEGER NOT NULL,
+      output_tokens INTEGER NOT NULL,
+      total_tokens INTEGER NOT NULL,
+      cache_read_tokens INTEGER NOT NULL,
+      cache_write_tokens INTEGER NOT NULL,
+      reasoning_tokens INTEGER NOT NULL,
+      stop_reason TEXT,
+      input_cost REAL NOT NULL,
+      output_cost REAL NOT NULL,
+      cache_read_cost REAL NOT NULL,
+      cache_write_cost REAL NOT NULL,
+      total_cost REAL NOT NULL,
+      created_at INTEGER NOT NULL
     );
 
     CREATE TABLE channel_active_sessions (
@@ -63,15 +89,64 @@ try {
     INSERT INTO user (id, name, email, email_verified, image, role, created_at, updated_at)
     VALUES ('user-migration', 'Migration User', 'migration@example.test', 1, NULL, NULL, 1700000000, 1700000000);
 
-    INSERT INTO pi_sessions (id, session_id, user_id, provider, model, title, created_at, updated_at)
+    INSERT INTO pi_sessions (id, session_id, user_id, provider, model, agent_id, title, created_at, updated_at)
     VALUES
-      (1, 'sess-migration', 'user-migration', 'test-provider', 'test-model', 'Migration Session', 1700000000, 1700000000),
-      (2, 'sess-migration-old', 'user-migration', 'test-provider', 'test-model', 'Old Migration Session', 1699990000, 1699990000);
+      (1, 'sess-migration', 'user-migration', 'test-provider', 'test-model', 'agent-legacy', 'Migration Session', 1700000000, 1700000000),
+      (2, 'sess-migration-old', 'user-migration', 'test-provider', 'test-model', 'canvas-agent', 'Old Migration Session', 1699990000, 1699990000);
 
     INSERT INTO pi_messages (id, pi_session_db_id, role, content, timestamp)
     VALUES
       (10, 1, 'user', '{"role":"user","content":"first","timestamp":2000}', 2000),
       (20, 1, 'user', '{"role":"user","content":"second","timestamp":1000}', 1000);
+
+    INSERT INTO pi_usage_events (
+      id,
+      fingerprint,
+      user_id,
+      session_id,
+      provider,
+      model,
+      message_id,
+      assistant_timestamp,
+      session_title_snapshot,
+      input_tokens,
+      output_tokens,
+      total_tokens,
+      cache_read_tokens,
+      cache_write_tokens,
+      reasoning_tokens,
+      stop_reason,
+      input_cost,
+      output_cost,
+      cache_read_cost,
+      cache_write_cost,
+      total_cost,
+      created_at
+    )
+    VALUES (
+      1,
+      'legacy-fingerprint',
+      'user-migration',
+      'sess-migration',
+      'test-provider',
+      'test-model',
+      'msg-legacy',
+      '2026-01-01T00:00:00.000Z',
+      'Migration Session',
+      10,
+      20,
+      30,
+      0,
+      0,
+      0,
+      NULL,
+      0.01,
+      0.02,
+      0,
+      0,
+      0.03,
+      1700000000
+    );
 
     INSERT INTO channel_active_sessions (user_id, channel_id, channel_session_key, channel_thread_key, session_id, updated_at)
     VALUES ('user-migration', 'web', 'web:user:user-migration', '', 'sess-migration', 1700000100);
@@ -135,6 +210,21 @@ try {
       .map((index) => (index as { name: string }).name),
   );
   assert.ok(messageIndexes.has('idx_pi_messages_session_sequence'));
+
+  const migratedUsage = sqlite.prepare(`
+    SELECT agent_id AS agentId, organization_id AS organizationId, workspace_id AS workspaceId, workspace_type AS workspaceType
+    FROM pi_usage_events
+    WHERE id = 1
+  `).get() as {
+    agentId: string;
+    organizationId: string | null;
+    workspaceId: string | null;
+    workspaceType: string | null;
+  };
+  assert.equal(migratedUsage.agentId, 'agent-legacy');
+  assert.equal(migratedUsage.organizationId, null);
+  assert.equal(migratedUsage.workspaceId, null);
+  assert.equal(migratedUsage.workspaceType, null);
 
   sqlite.close();
   console.log('legacy db migration tests passed');

--- a/scripts/pi-usage-test.ts
+++ b/scripts/pi-usage-test.ts
@@ -50,6 +50,9 @@ async function main() {
   const alphaSessionId = 'sess-alpha';
   const budgetSessionId = 'sess-budget';
   const otherSessionId = 'sess-other';
+  const organizationId = 'org-usage';
+  const personalWorkspaceId = 'ws-personal-usage';
+  const teamWorkspaceId = 'ws-team-usage';
   const now = new Date('2026-03-16T12:00:00.000Z');
 
   try {
@@ -93,6 +96,10 @@ async function main() {
         provider: 'openai',
         model: 'gpt-4o',
         title: 'Alpha Session',
+        agentId: 'agent-alpha',
+        organizationId,
+        workspaceId: personalWorkspaceId,
+        workspaceType: 'personal',
         createdAt: now,
         updatedAt: now,
       },
@@ -102,6 +109,10 @@ async function main() {
         provider: 'ollama',
         model: 'llama3.2',
         title: 'Budget Session',
+        agentId: 'agent-budget',
+        organizationId,
+        workspaceId: teamWorkspaceId,
+        workspaceType: 'team',
         createdAt: now,
         updatedAt: now,
       },
@@ -111,6 +122,10 @@ async function main() {
         provider: 'anthropic',
         model: 'claude-sonnet-4',
         title: 'Other Session',
+        agentId: 'agent-other',
+        organizationId: 'org-other',
+        workspaceId: 'ws-other',
+        workspaceType: 'personal',
         createdAt: now,
         updatedAt: now,
       },
@@ -217,6 +232,10 @@ async function main() {
       sessionId: alphaSessionId,
       userId,
       sessionTitleSnapshot: 'Alpha Session',
+      organizationId,
+      workspaceId: personalWorkspaceId,
+      workspaceType: 'personal',
+      agentId: 'agent-alpha',
       messages: [
         {
           role: 'user',
@@ -232,6 +251,10 @@ async function main() {
     assert.equal(extractionRows.length, 2);
     assert.equal(extractionRows[0]?.sessionTitleSnapshot, 'Alpha Session');
     assert.equal(extractionRows[0]?.provider, 'openai');
+    assert.equal(extractionRows[0]?.organizationId, organizationId);
+    assert.equal(extractionRows[0]?.workspaceId, personalWorkspaceId);
+    assert.equal(extractionRows[0]?.workspaceType, 'personal');
+    assert.equal(extractionRows[0]?.agentId, 'agent-alpha');
     assert.equal(extractionRows[0]?.totalTokens, 210);
     assert.equal(extractionRows[1]?.provider, 'ollama');
     assert.equal(extractionRows[1]?.totalCost, 0);
@@ -272,6 +295,40 @@ async function main() {
       .from(piUsageEvents);
 
     assert.equal(Number(countRow?.count ?? 0), 3);
+
+    const persistedUsageRows = await db
+      .select({
+        sessionId: piUsageEvents.sessionId,
+        organizationId: piUsageEvents.organizationId,
+        workspaceId: piUsageEvents.workspaceId,
+        workspaceType: piUsageEvents.workspaceType,
+        agentId: piUsageEvents.agentId,
+      })
+      .from(piUsageEvents)
+      .orderBy(piUsageEvents.sessionId);
+    assert.deepEqual(persistedUsageRows, [
+      {
+        sessionId: alphaSessionId,
+        organizationId,
+        workspaceId: personalWorkspaceId,
+        workspaceType: 'personal',
+        agentId: 'agent-alpha',
+      },
+      {
+        sessionId: budgetSessionId,
+        organizationId,
+        workspaceId: teamWorkspaceId,
+        workspaceType: 'team',
+        agentId: 'agent-budget',
+      },
+      {
+        sessionId: otherSessionId,
+        organizationId: 'org-other',
+        workspaceId: 'ws-other',
+        workspaceType: 'personal',
+        agentId: 'agent-other',
+      },
+    ]);
 
     const defaultFilters = parseUsageFilters(new URLSearchParams());
     assert.equal(defaultFilters.groupBy, 'day');
@@ -334,6 +391,29 @@ async function main() {
       sessionSummary.rows.map((row) => row.label).sort(),
       ['Alpha Session', 'Budget Session'],
     );
+
+    const workspaceSummary = await getUsageSummary(
+      {
+        from: new Date('2026-03-01T00:00:00.000Z'),
+        to: new Date('2026-03-31T23:59:59.999Z'),
+        groupBy: 'workspace',
+        workspaceId: teamWorkspaceId,
+      },
+      { id: userId, role: 'user' },
+    );
+    assert.deepEqual(workspaceSummary.rows.map((row) => row.groupKey), [teamWorkspaceId]);
+    assert.equal(workspaceSummary.totals.totalTokens, 50);
+
+    const agentSummary = await getUsageSummary(
+      {
+        from: new Date('2026-03-01T00:00:00.000Z'),
+        to: new Date('2026-03-31T23:59:59.999Z'),
+        groupBy: 'agent',
+        agentId: 'agent-alpha',
+      },
+      { id: userId, role: 'user' },
+    );
+    assert.deepEqual(agentSummary.rows.map((row) => row.groupKey), ['agent-alpha']);
 
     const adminUserSummary = await getUsageSummary(
       {
@@ -417,6 +497,10 @@ async function main() {
 
     assert.equal(filteredEvents.rows.length, 1);
     assert.equal(filteredEvents.rows[0]?.sessionId, alphaSessionId);
+    assert.equal(filteredEvents.rows[0]?.organizationId, organizationId);
+    assert.equal(filteredEvents.rows[0]?.workspaceId, personalWorkspaceId);
+    assert.equal(filteredEvents.rows[0]?.workspaceType, 'personal');
+    assert.equal(filteredEvents.rows[0]?.agentId, 'agent-alpha');
     assert.match(filteredEvents.rows[0]?.assistantTimestamp || '', /^2026-03-10T10:15:00/);
 
     assert.equal(hasRenderableUsage(alphaAssistant.usage), true);


### PR DESCRIPTION
## Summary
- add organization/workspace/agent scope metadata to PI usage events and reporting filters/groupings
- add deterministic job_scope metadata to automation jobs/runs for queue isolation and backpressure groundwork
- backfill legacy SQLite records from sessions/jobs and mark Task 26 completed in the architecture todo list

## Verification
- npm run test:pi:usage
- tsx --conditions react-server scripts/db-migration-legacy-test.ts
- tsx --conditions react-server scripts/automation-workspace-scope-test.ts
- tsx --conditions react-server scripts/automation-delivery-test.ts
- npm run lint
- git diff --check origin/main...HEAD
- npm run build

## Greptile
- Score: pending automatic review

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds org/workspace/agent scope metadata to PI usage events (new columns on `pi_usage_events`, backfill from `pi_sessions`, new `organization`/`workspace`/`agent` groupBy and filter options in usage reporting) and deterministic `job_scope` strings to automation jobs and runs for future queue isolation and backpressure. Legacy SQLite rows are backfilled in a single migration exec block; the jobs backfill runs before the runs backfill so runs correctly inherit properly-computed job scope values.

- New `organizationId`, `workspaceId`, `workspaceType`, and `agentId` columns on `pi_usage_events` are populated at event-persist time from the associated `pi_session` and backfilled for all pre-existing rows via a correlated subquery; the COALESCE order correctly prioritises the session lookup over the column default.
- A deterministic `job_scope` string (`personal:<userId>:<workspaceId>` or `organization:<orgId>:<workspaceId>`) is computed at job-creation time via `buildAutomationJobScope`, stored on both jobs and runs, and indexed for efficient queue-scoped queries.
- Task 26 in the architecture todo list is marked completed.

<h3>Confidence Score: 5/5</h3>

Safe to merge; migration backfill logic is structurally sound and the new scope fields are well-tested by the accompanying script suite.

The migration correctly sequences the jobs backfill before the runs backfill in a single exec block, ensuring runs inherit properly-computed job scope values. The COALESCE ordering in the pi_usage_events agent_id backfill places the session subquery first, so legacy events correctly pick up the session stored agent_id rather than the column default. Access control for the new reporting filters correctly falls through to the existing effectiveUserId restriction. The two observations noted are limited in scope and do not affect correctness on realistic data.

app/lib/db/migrate.ts for the SQL normalization gap; app/lib/automations/store.ts for the resolveStoredJobScope sentinel handling.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/db/migrate.ts | Adds four new columns to pi_usage_events and job_scope to automation_jobs/runs; backfill logic is correct — session subquery is first in COALESCE so agent_id is properly resolved — but the SQL CASE expression does not normalise colons/spaces in embedded ID values the way normalizeJobScopePart does. |
| app/lib/automations/store.ts | Introduces buildAutomationJobScope and resolveStoredJobScope; the || fallback to buildAutomationJobScope is unreachable given the NOT NULL default, and mapRunRow uses row.jobScope directly while mapJobRow goes through resolveStoredJobScope. |
| app/lib/db/schema.ts | Adds organizationId/workspaceId/workspaceType/agentId to piUsageEvents and jobScope to automationJobs/automationRuns; deferred indexes match the CREATE INDEX statements in migrate.ts. |
| app/lib/pi/usage-events.ts | Replaces loadSessionTitleSnapshot with loadSessionUsageContext that also fetches scope fields; spread into extractPiUsageEventValues cleanly. |
| app/lib/pi/usage-reporting.ts | Adds organization/workspace/agent groupBy cases and filter conditions; non-admins remain restricted to their own data via the existing effectiveUserId guard. |
| app/lib/pi/usage-types.ts | Extends UsageSummaryGroupBy, UsageFilters, SerializedUsageFilters, and UsageEventRow with the new scope fields; consistent with implementation. |
| app/lib/automations/types.ts | Adds jobScope: string to AutomationJobRecord and AutomationRunRecord; straightforward type additions. |
| scripts/automation-workspace-scope-test.ts | Adds jobScope assertions for personal/organization jobs and run propagation; covers all create paths and heartbeat upsert. |
| scripts/db-migration-legacy-test.ts | Extends legacy migration test with pi_usage_events and asserts agent_id is backfilled from the session correctly. |
| scripts/pi-usage-test.ts | Adds scope field assertions to extraction, persistence, and workspace/agent summary grouping tests. |
| scripts/automation-delivery-test.ts | Adds jobScope to the job fixture; minor update aligned with the new required field. |
| docs/architecture/canvas-notebook/todo.json | Marks Task 26 as completed; documentation-only change. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fjob-usage-scope%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fjob-usage-scope%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Flib%2Fautomations%2Fstore.ts%3A108-118%0AThe%20%60%7C%7C%60%20fallback%20to%20%60buildAutomationJobScope%60%20is%20unreachable%20in%20practice.%20%60job.jobScope%60%20is%20declared%20%60NOT%20NULL%20DEFAULT%20'personal%3Alegacy%3Alegacy'%60%20in%20both%20the%20schema%20and%20migration%2C%20so%20it%20is%20never%20an%20empty%20or%20falsy%20string%20%E2%80%94%20the%20right-hand%20side%20of%20%60%7C%7C%60%20will%20never%20be%20evaluated.%20Replacing%20the%20%60%7C%7C%60%20with%20an%20explicit%20sentinel%20check%20makes%20the%20actual%20semantics%20clear%20and%20activates%20the%20fallback%20for%20jobs%20still%20carrying%20the%20placeholder.%0A%0A%60%60%60suggestion%0Afunction%20resolveStoredJobScope%28job%3A%20typeof%20automationJobs.%24inferSelect%2C%20scope%20%3D%20normalizeAutomationScope%28job.scope%29%29%3A%20string%20%7B%0A%20%20const%20stored%20%3D%20job.jobScope%3B%0A%20%20if%20%28stored%20%26%26%20stored%20!%3D%3D%20'personal%3Alegacy%3Alegacy'%29%20%7B%0A%20%20%20%20return%20stored%3B%0A%20%20%7D%0A%20%20return%20buildAutomationJobScope%28%7B%0A%20%20%20%20scope%2C%0A%20%20%20%20organizationId%3A%20job.organizationId%20%3F%3F%20null%2C%0A%20%20%20%20workspaceId%3A%20job.workspaceId%20%3F%3F%20null%2C%0A%20%20%20%20workspaceType%3A%20job.workspaceType%20%3F%3F%20null%2C%0A%20%20%20%20ownerUserId%3A%20job.ownerUserId%20%3F%3F%20null%2C%0A%20%20%20%20responsibleUserId%3A%20job.responsibleUserId%20%3F%3F%20null%2C%0A%20%20%20%20createdByUserId%3A%20job.createdByUserId%2C%0A%20%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Flib%2Fdb%2Fmigrate.ts%3A1425-1429%0A**SQL%20backfill%20skips%20colon%2Fwhitespace%20normalization%20that%20TypeScript%20applies**%0A%0A%60normalizeJobScopePart%60%20replaces%20%60%5B%3A%5Cs%5D%2B%60%20with%20%60_%60%20before%20embedding%20a%20value%20into%20the%20scope%20string%20%28e.g.%20an%20%60organization_id%60%20of%20%60%22org%3Ateam%22%60%20becomes%20%60%22org_team%22%60%29.%20The%20SQL%20CASE%20expression%20concatenates%20raw%20column%20values%20without%20this%20sanitisation%2C%20so%20a%20legacy%20row%20whose%20%60organization_id%60%20or%20%60workspace_id%60%20contains%20a%20colon%20or%20space%20would%20produce%20a%20differently-formatted%20%60job_scope%60%20than%20the%20same%20job%20computed%20at%20runtime%20via%20TypeScript.%20If%20the%20%60job_scope%60%20value%20is%20ever%20parsed%20or%20compared%20structurally%20for%20queue%20routing%2C%20the%20mismatch%20could%20cause%20incorrect%20bucketing.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Fix usage agent backfill"](https://github.com/canvascoding/canvas-notebook/commit/e06350653420e57db494eda451f3db2f8d670285) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38893854)</sub>

<!-- /greptile_comment -->