### PR TITLE
Add granular migration export policy

### DIFF
--- a/app/api/migration/export/route.ts
+++ b/app/api/migration/export/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { requireMigrationExportPermission } from '@/app/lib/migration/auth';
-import { createMigrationExportJob, normalizeMigrationComponents } from '@/app/lib/migration/export-service';
+import { createMigrationExportJob, normalizeMigrationExportOptions } from '@/app/lib/migration/export-service';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 
 export async function POST(request: NextRequest) {
@@ -16,9 +16,19 @@ export async function POST(request: NextRequest) {
   if (!limited.ok) return limited.response;
 
   try {
-    const payload = await request.json().catch(() => ({})) as { components?: unknown };
-    const components = normalizeMigrationComponents(payload.components);
-    const job = await createMigrationExportJob({ components });
+    const payload = await request.json().catch(() => ({}));
+    const options = normalizeMigrationExportOptions(payload);
+    const job = await createMigrationExportJob({
+      ...options,
+      source: {
+        organizationId: admin.state.organizationId,
+        databaseProvider: admin.state.databaseProvider,
+        teamFeaturesEnabled: admin.state.teamFeaturesEnabled,
+        createdByUserId: admin.session.user.id,
+        createdByEmail: admin.session.user.email,
+        createdByRole: admin.permission.role,
+      },
+    });
     return NextResponse.json({ success: true, job });
   } catch (error) {
     console.error('[Migration Export] Failed to create export job:', error);

--- a/app/components/settings/WorkspaceSettingsPanel.tsx
+++ b/app/components/settings/WorkspaceSettingsPanel.tsx
@@ -29,6 +29,7 @@ import {
   MIGRATION_COMPONENT_KEYS,
   type MigrationComponentKey,
   type MigrationComponents,
+  type MigrationExportProfile,
   type MigrationExportJob,
   type MigrationInspection,
   type MigrationUploadStatus,
@@ -121,6 +122,8 @@ export function WorkspaceSettingsPanel({ isAdmin = false, organizationPermission
     ...DEFAULT_MIGRATION_COMPONENTS,
     secrets: false,
   }));
+  const [migrationExportProfile, setMigrationExportProfile] = useState<MigrationExportProfile>('standard');
+  const [includePersonalWorkspaces, setIncludePersonalWorkspaces] = useState(false);
   const [migrationError, setMigrationError] = useState<string | null>(null);
   const [migrationMessage, setMigrationMessage] = useState<string | null>(null);
   const [exportJob, setExportJob] = useState<MigrationExportJob | null>(null);
@@ -235,6 +238,13 @@ export function WorkspaceSettingsPanel({ isAdmin = false, organizationPermission
     }));
   };
 
+  const selectMigrationExportProfile = (profile: MigrationExportProfile) => {
+    setMigrationExportProfile(profile);
+    if (profile !== 'full_admin') {
+      setIncludePersonalWorkspaces(false);
+    }
+  };
+
   const createMigrationExport = async () => {
     if (!canExportData) {
       setMigrationError(t('workspacePanel.migration.adminOnly'));
@@ -249,7 +259,11 @@ export function WorkspaceSettingsPanel({ isAdmin = false, organizationPermission
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ components: migrationComponents }),
+        body: JSON.stringify({
+          components: migrationComponents,
+          profile: migrationExportProfile,
+          includePersonalWorkspaces,
+        }),
       });
       const payload = await response.json();
       if (!response.ok || !payload.success) {
@@ -628,6 +642,51 @@ export function WorkspaceSettingsPanel({ isAdmin = false, organizationPermission
             </div>
 
             <div className="grid gap-2 sm:grid-cols-2">
+              {(['standard', 'full_admin'] as const).map((profile) => {
+                const selected = migrationExportProfile === profile;
+                return (
+                  <button
+                    key={profile}
+                    type="button"
+                    disabled={!canExportData}
+                    onClick={() => selectMigrationExportProfile(profile)}
+                    className={`rounded-lg border p-3 text-left text-sm transition ${
+                      selected
+                        ? 'border-primary bg-primary/5 text-foreground'
+                        : 'border-border bg-background text-muted-foreground hover:border-muted-foreground/50'
+                    }`}
+                  >
+                    <span className="block font-medium text-foreground">
+                      {t(`workspacePanel.migration.profiles.${profile}.label`)}
+                    </span>
+                    <span className="mt-1 block text-xs">
+                      {t(`workspacePanel.migration.profiles.${profile}.hint`)}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <label className="flex min-w-0 items-start gap-3 rounded-lg border border-border p-3 text-sm">
+              <input
+                type="checkbox"
+                checked={includePersonalWorkspaces}
+                onChange={() => setIncludePersonalWorkspaces((value) => !value)}
+                disabled={!canExportData || migrationExportProfile !== 'full_admin' || !migrationComponents.workspace}
+                className="mt-0.5 h-4 w-4 accent-primary"
+              />
+              <span className="min-w-0">
+                <span className="block font-medium">{t('workspacePanel.migration.includePersonalWorkspaces.label')}</span>
+                <span className="block text-xs text-muted-foreground">{t('workspacePanel.migration.includePersonalWorkspaces.hint')}</span>
+              </span>
+            </label>
+
+            <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{t('workspacePanel.migration.unencryptedWarning')}</span>
+            </div>
+
+            <div className="grid gap-2 sm:grid-cols-2">
               {MIGRATION_COMPONENT_KEYS.map((key) => {
                 const Icon = COMPONENT_ICONS[key];
                 return (
@@ -650,7 +709,7 @@ export function WorkspaceSettingsPanel({ isAdmin = false, organizationPermission
             </div>
 
             {migrationComponents.secrets ? (
-              <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
+              <div className="flex items-start gap-2 rounded-lg border border-border bg-muted/40 p-3 text-sm text-muted-foreground">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                 <span>{t('workspacePanel.migration.secretsWarning')}</span>
               </div>

--- a/app/lib/migration/component-paths.ts
+++ b/app/lib/migration/component-paths.ts
@@ -10,6 +10,9 @@ export interface MigrationComponentPathMapping {
 
 const COMPONENT_PATH_MAPPINGS: MigrationComponentPathMapping[] = [
   { component: 'workspace', dataPath: ['workspace'], archiveRoot: 'data/workspace' },
+  { component: 'workspace', dataPath: ['workspaces', 'team'], archiveRoot: 'data/workspaces/team' },
+  { component: 'workspace', dataPath: ['workspaces', 'project'], archiveRoot: 'data/workspaces/project' },
+  { component: 'workspace', dataPath: ['workspaces', 'personal'], archiveRoot: 'data/workspaces/personal' },
   { component: 'studioAssets', dataPath: ['studio', 'assets'], archiveRoot: 'data/studio/assets' },
   { component: 'studioOutputs', dataPath: ['studio', 'outputs'], archiveRoot: 'data/studio/outputs' },
   { component: 'studioOutputs', dataPath: ['studio', 'edits'], archiveRoot: 'data/studio/edits' },
@@ -18,11 +21,27 @@ const COMPONENT_PATH_MAPPINGS: MigrationComponentPathMapping[] = [
   { component: 'agents', dataPath: ['settings'], archiveRoot: 'data/settings' },
   { component: 'agents', dataPath: ['canvas-agent'], archiveRoot: 'data/canvas-agent' },
   { component: 'skills', dataPath: ['skills'], archiveRoot: 'data/skills' },
-  { component: 'secrets', dataPath: ['secrets'], archiveRoot: 'data/secrets' },
 ];
+
+const STANDARD_EXPORT_EXCLUDED_PATHS = new Set([
+  'workspaces/personal',
+]);
 
 export function getSelectedMigrationComponentPaths(components: MigrationComponents): MigrationComponentPathMapping[] {
   return COMPONENT_PATH_MAPPINGS.filter((mapping) => components[mapping.component]);
+}
+
+export function getSelectedMigrationExportComponentPaths(
+  components: MigrationComponents,
+  options: { includePersonalWorkspaces?: boolean } = {},
+): MigrationComponentPathMapping[] {
+  return getSelectedMigrationComponentPaths(components).filter((mapping) => {
+    const normalizedPath = mapping.dataPath.join('/');
+    if (!options.includePersonalWorkspaces && STANDARD_EXPORT_EXCLUDED_PATHS.has(normalizedPath)) {
+      return false;
+    }
+    return true;
+  });
 }
 
 export function resolveMigrationDataPath(dataRoot: string, mapping: MigrationComponentPathMapping): string {

--- a/app/lib/migration/export-service.ts
+++ b/app/lib/migration/export-service.ts
@@ -12,11 +12,16 @@ import {
   DEFAULT_MIGRATION_COMPONENTS,
   MIGRATION_BUNDLE_SCHEMA_VERSION,
   MIGRATION_COMPONENT_KEYS,
+  MIGRATION_EXPORT_PROFILES,
   type CanvasMigrationManifest,
   type MigrationComponentKey,
   type MigrationComponents,
   type MigrationExportJob,
   type MigrationExportOptions,
+  type MigrationExportProfile,
+  type MigrationExportSecurity,
+  type MigrationExportSelection,
+  type MigrationExportSource,
   type MigrationFileEntry,
 } from '@/app/lib/migration/types';
 import {
@@ -25,13 +30,15 @@ import {
   getMigrationExportsRoot,
 } from '@/app/lib/migration/paths';
 import {
-  getSelectedMigrationComponentPaths,
+  getSelectedMigrationExportComponentPaths,
   resolveMigrationDataPath,
 } from '@/app/lib/migration/component-paths';
+import { getDatabaseProvider, getDeploymentMode } from '@/app/lib/organization/bootstrap';
 
 const EXPORT_STATUS_FILE = 'status.json';
 const SQLITE_FILE_NAME = 'sqlite.db';
 const EXPORT_WRITE_THROTTLE_MS = 750;
+const RECONNECT_MANIFEST_ARCHIVE_PATH = 'data/reconnect-manifest.json';
 
 type ZipArchive = InstanceType<typeof ZipStream>;
 
@@ -39,10 +46,48 @@ const activeExports = new Map<string, Promise<void>>();
 
 function cloneComponents(components?: Partial<MigrationComponents>): MigrationComponents {
   const next = { ...DEFAULT_MIGRATION_COMPONENTS, ...components };
-  if (!next.secrets) {
-    next.secrets = false;
-  }
+  next.secrets = next.secrets === true;
   return next;
+}
+
+function normalizeMigrationExportProfile(value: unknown): MigrationExportProfile {
+  return MIGRATION_EXPORT_PROFILES.includes(value as MigrationExportProfile)
+    ? value as MigrationExportProfile
+    : 'standard';
+}
+
+function buildExportSelection(params: {
+  profile: MigrationExportProfile;
+  includePersonalWorkspaces?: boolean;
+}): MigrationExportSelection {
+  return {
+    includePersonalWorkspaces: params.profile === 'full_admin' && params.includePersonalWorkspaces === true,
+    includePublicLinks: false,
+    includeRawSecrets: false,
+  };
+}
+
+function buildExportSource(source?: Partial<MigrationExportSource>): MigrationExportSource {
+  return {
+    databaseProvider: source?.databaseProvider || getDatabaseProvider(),
+    deploymentMode: source?.deploymentMode || getDeploymentMode(),
+    teamFeaturesEnabled: source?.teamFeaturesEnabled ?? process.env.CANVAS_TEAM_FEATURES_ENABLED === 'true',
+    managedServicesEnabled: source?.managedServicesEnabled ?? process.env.CANVAS_MANAGED_SERVICES_ENABLED === 'true',
+    organizationId: source?.organizationId ?? (process.env.CANVAS_ORGANIZATION_ID?.trim() || null),
+    createdByUserId: source?.createdByUserId ?? null,
+    createdByEmail: source?.createdByEmail ?? null,
+    createdByRole: source?.createdByRole ?? null,
+  };
+}
+
+function buildExportSecurity(components: MigrationComponents): MigrationExportSecurity {
+  return {
+    publicLinksIncluded: false,
+    publicLinkTokensIncluded: false,
+    rawSecretsIncluded: false,
+    secretsMode: components.secrets ? 'reconnect_manifest' : 'excluded',
+    unencryptedArchive: true,
+  };
 }
 
 function getExportDir(exportId: string): string {
@@ -142,6 +187,201 @@ async function addZipEntry(
   });
 }
 
+function tableExists(sqlite: InstanceType<typeof Database>, tableName: string): boolean {
+  const row = sqlite.prepare(`
+    SELECT 1
+    FROM sqlite_master
+    WHERE type = 'table' AND name = ?
+    LIMIT 1
+  `).get(tableName);
+  return Boolean(row);
+}
+
+function tableColumns(sqlite: InstanceType<typeof Database>, tableName: string): Set<string> {
+  return new Set(
+    sqlite.prepare(`PRAGMA table_info(${tableName})`).all()
+      .map((column) => (column as { name: string }).name),
+  );
+}
+
+function nullColumns(sqlite: InstanceType<typeof Database>, tableName: string, columns: string[]): void {
+  if (!tableExists(sqlite, tableName)) return;
+  const existing = tableColumns(sqlite, tableName);
+  const assignments = columns.filter((column) => existing.has(column)).map((column) => `${column} = NULL`);
+  if (assignments.length === 0) return;
+  sqlite.prepare(`UPDATE ${tableName} SET ${assignments.join(', ')}`).run();
+}
+
+function sanitizeSqliteMigrationSnapshot(snapshotPath: string): void {
+  const snapshot = new Database(snapshotPath);
+  try {
+    const transaction = snapshot.transaction(() => {
+      if (tableExists(snapshot, 'public_file_shares')) {
+        snapshot.prepare('DELETE FROM public_file_shares').run();
+      }
+      if (tableExists(snapshot, 'session')) {
+        snapshot.prepare('DELETE FROM session').run();
+      }
+      if (tableExists(snapshot, 'verification')) {
+        snapshot.prepare('DELETE FROM verification').run();
+      }
+      if (tableExists(snapshot, 'channel_link_tokens')) {
+        snapshot.prepare('DELETE FROM channel_link_tokens').run();
+      }
+      if (tableExists(snapshot, 'oauth_tokens')) {
+        snapshot.prepare('DELETE FROM oauth_tokens').run();
+      }
+      if (tableExists(snapshot, 'todo_email_reply_events')) {
+        snapshot.prepare('DELETE FROM todo_email_reply_events').run();
+      }
+      if (tableExists(snapshot, 'todo_email_reply_watchers')) {
+        snapshot.prepare('DELETE FROM todo_email_reply_watchers').run();
+      }
+      if (tableExists(snapshot, 'composio_webhook_subscriptions')) {
+        const columns = tableColumns(snapshot, 'composio_webhook_subscriptions');
+        const assignments: string[] = [];
+        const values: unknown[] = [];
+        if (columns.has('encrypted_secret')) {
+          assignments.push('encrypted_secret = ?');
+          values.push('redacted');
+        }
+        if (columns.has('secret_preview')) {
+          assignments.push('secret_preview = ?');
+          values.push('redacted');
+        }
+        if (columns.has('status')) {
+          assignments.push('status = ?');
+          values.push('paused');
+        }
+        if (assignments.length > 0) {
+          snapshot.prepare(`UPDATE composio_webhook_subscriptions SET ${assignments.join(', ')}`).run(...values);
+        }
+      }
+      if (tableExists(snapshot, 'automation_webhook_triggers')) {
+        const columns = tableColumns(snapshot, 'automation_webhook_triggers');
+        const assignments: string[] = [];
+        const values: unknown[] = [];
+        if (columns.has('status')) {
+          assignments.push('status = ?');
+          values.push('paused');
+        }
+        if (columns.has('secret_preview')) {
+          assignments.push('secret_preview = ?');
+          values.push('redacted');
+        }
+        if (assignments.length > 0) {
+          snapshot.prepare(`UPDATE automation_webhook_triggers SET ${assignments.join(', ')}`).run(...values);
+        }
+      }
+      nullColumns(snapshot, 'account', [
+        'access_token',
+        'refresh_token',
+        'id_token',
+        'access_token_expires_at',
+        'refresh_token_expires_at',
+        'password',
+      ]);
+    });
+    transaction();
+    snapshot.pragma('wal_checkpoint(TRUNCATE)');
+  } finally {
+    snapshot.close();
+  }
+}
+
+async function maybeStat(pathname: string): Promise<import('fs').Stats | null> {
+  try {
+    return await fs.stat(pathname);
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function extractEnvKeys(raw: string): string[] {
+  const keys = new Set<string>();
+  for (const line of raw.split(/\r?\n/u)) {
+    const match = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/u.exec(line);
+    if (match?.[1]) keys.add(match[1]);
+  }
+  return [...keys].sort((a, b) => a.localeCompare(b));
+}
+
+async function readRedactedEnvKeys(filePath: string): Promise<string[]> {
+  const raw = await fs.readFile(filePath, 'utf8').catch((error) => {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return '';
+    }
+    throw error;
+  });
+  return raw ? extractEnvKeys(raw) : [];
+}
+
+async function buildReconnectManifest(params: {
+  dataRoot: string;
+  job: MigrationExportJob;
+}): Promise<{ content: string; entry: MigrationFileEntry } | null> {
+  if (!params.job.components.secrets) return null;
+
+  const entries: Array<{
+    kind: 'env_file' | 'oauth_store' | 'secret_directory';
+    scope: 'legacy' | 'user' | 'organization' | 'system';
+    path: string;
+    secretNames?: string[];
+    requiresReconnect: true;
+  }> = [];
+
+  const addEnvFile = async (scope: 'legacy' | 'system', relativePath: string) => {
+    const filePath = path.join(params.dataRoot, ...relativePath.split('/'));
+    const secretNames = await readRedactedEnvKeys(filePath);
+    const stat = await maybeStat(filePath);
+    if (secretNames.length === 0 && !stat) return;
+    entries.push({ kind: 'env_file', scope, path: relativePath, secretNames, requiresReconnect: true });
+  };
+
+  const addDirectory = async (
+    kind: 'oauth_store' | 'secret_directory',
+    scope: 'legacy' | 'user' | 'organization' | 'system',
+    relativePath: string,
+  ) => {
+    const stat = await maybeStat(path.join(params.dataRoot, ...relativePath.split('/')));
+    if (!stat?.isDirectory()) return;
+    entries.push({ kind, scope, path: relativePath, requiresReconnect: true });
+  };
+
+  await addEnvFile('legacy', 'secrets/Canvas-Integrations.env');
+  await addEnvFile('legacy', 'secrets/Canvas-Agents.env');
+  await addDirectory('oauth_store', 'legacy', 'settings/mcp-oauth');
+  await addDirectory('oauth_store', 'legacy', 'canvas-agent/mcp-oauth');
+  await addDirectory('oauth_store', 'legacy', 'pi-oauth-states');
+  await addDirectory('oauth_store', 'legacy', 'secrets/email-oauth');
+  await addDirectory('secret_directory', 'user', 'users');
+  await addDirectory('secret_directory', 'organization', 'organizations');
+  await addDirectory('secret_directory', 'system', 'system/secrets');
+
+  const manifest = {
+    format: 'canvas-notebook-reconnect-manifest',
+    generatedAt: new Date().toISOString(),
+    exportId: params.job.id,
+    rawSecretsIncluded: false,
+    note: 'Migration exports never include raw secrets or OAuth tokens. Reconnect these integrations on the target instance.',
+    entries,
+  };
+  const content = `${JSON.stringify(manifest, null, 2)}\n`;
+
+  return {
+    content,
+    entry: {
+      component: 'secrets',
+      archivePath: RECONNECT_MANIFEST_ARCHIVE_PATH,
+      size: Buffer.byteLength(content),
+      modifiedAt: new Date().toISOString(),
+    },
+  };
+}
+
 async function createSqliteSnapshot(dataRoot: string, exportDir: string): Promise<{
   filePath: string;
   entry: MigrationFileEntry;
@@ -156,6 +396,8 @@ async function createSqliteSnapshot(dataRoot: string, exportDir: string): Promis
   } finally {
     source.close();
   }
+
+  sanitizeSqliteMigrationSnapshot(snapshotPath);
 
   const snapshot = new Database(snapshotPath, { readonly: true, fileMustExist: true });
   try {
@@ -181,7 +423,11 @@ async function createSqliteSnapshot(dataRoot: string, exportDir: string): Promis
 
 function buildManifest(params: {
   exportId: string;
+  profile: MigrationExportProfile;
   components: MigrationComponents;
+  selection: MigrationExportSelection;
+  source: MigrationExportSource;
+  security: MigrationExportSecurity;
   files: MigrationFileEntry[];
 }): CanvasMigrationManifest {
   const warnings: string[] = [
@@ -189,8 +435,16 @@ function buildManifest(params: {
     'Automations are paused during restore and must be re-enabled after verification.',
     'OAuth-based integrations may require re-authentication on the target VM.',
     'Target VM license and instance identity are not overwritten during restore.',
+    'Migration exports do not include active public links or public-link tokens.',
+    'This V1 migration archive is stored locally without automatic encryption.',
   ];
 
+  if (params.profile === 'full_admin' && params.selection.includePersonalWorkspaces) {
+    warnings.push('Full Admin export includes selected personal workspace directories. Handle with elevated privacy controls.');
+  }
+  if (!params.selection.includePersonalWorkspaces) {
+    warnings.push('Personal workspace directories are excluded unless Full Admin export explicitly includes them.');
+  }
   if (!params.components.workspace) {
     warnings.push('Workspace files were not included. Existing file references may point to missing files.');
   }
@@ -202,6 +456,8 @@ function buildManifest(params: {
   }
   if (!params.components.secrets) {
     warnings.push('Secrets were not included. API keys and local integration credentials must be configured again.');
+  } else {
+    warnings.push('Only a redacted reconnect manifest is included for secrets; raw secret files and OAuth tokens are excluded.');
   }
 
   return {
@@ -210,7 +466,11 @@ function buildManifest(params: {
     appVersion: getCurrentAppVersion(),
     exportedAt: new Date().toISOString(),
     exportId: params.exportId,
+    exportProfile: params.profile,
     components: params.components,
+    selection: params.selection,
+    source: params.source,
+    security: params.security,
     fileCount: params.files.length,
     totalBytes: params.files.reduce((sum, entry) => sum + entry.size, 0),
     warnings,
@@ -254,11 +514,14 @@ async function runExport(job: MigrationExportJob): Promise<void> {
       files.push(sqliteSnapshot.entry);
     }
 
-    const componentRoots = getSelectedMigrationComponentPaths(job.components).map((mapping) => ({
+    const componentRoots = getSelectedMigrationExportComponentPaths(job.components, {
+      includePersonalWorkspaces: job.selection.includePersonalWorkspaces,
+    }).map((mapping) => ({
       component: mapping.component,
       sourcePath: resolveMigrationDataPath(dataRoot, mapping),
       archiveRoot: mapping.archiveRoot,
     }));
+    const virtualFileContents = new Map<string, string>();
 
     for (const root of componentRoots) {
       job.phase = `Scanning ${root.component}`;
@@ -266,7 +529,21 @@ async function runExport(job: MigrationExportJob): Promise<void> {
       files.push(...await collectFiles(root.component, root.sourcePath, root.archiveRoot));
     }
 
-    const manifest = buildManifest({ exportId: job.id, components: job.components, files });
+    const reconnectManifest = await buildReconnectManifest({ dataRoot, job });
+    if (reconnectManifest) {
+      files.push(reconnectManifest.entry);
+      virtualFileContents.set(reconnectManifest.entry.archivePath, reconnectManifest.content);
+    }
+
+    const manifest = buildManifest({
+      exportId: job.id,
+      profile: job.profile,
+      components: job.components,
+      selection: job.selection,
+      source: job.source,
+      security: buildExportSecurity(job.components),
+      files,
+    });
     job.manifest = manifest;
     job.progress.fileCount = manifest.fileCount;
     job.progress.totalBytes = manifest.totalBytes;
@@ -300,6 +577,14 @@ async function runExport(job: MigrationExportJob): Promise<void> {
     }
 
     for (const entry of files) {
+      const virtualContent = virtualFileContents.get(entry.archivePath);
+      if (virtualContent) {
+        await addZipEntry(archive, virtualContent, { name: entry.archivePath });
+        job.progress.bytesProcessed += Buffer.byteLength(virtualContent);
+        job.progress.filesProcessed++;
+        await persist();
+        continue;
+      }
       const sourcePath = filePathByArchivePath.get(entry.archivePath);
       if (!sourcePath) continue;
       const stats = await fs.stat(sourcePath);
@@ -333,12 +618,21 @@ async function runExport(job: MigrationExportJob): Promise<void> {
 export async function createMigrationExportJob(options: Partial<MigrationExportOptions>): Promise<MigrationExportJob> {
   const id = crypto.randomUUID();
   const components = cloneComponents(options.components);
+  const profile = normalizeMigrationExportProfile(options.profile);
+  const selection = buildExportSelection({
+    profile,
+    includePersonalWorkspaces: options.includePersonalWorkspaces,
+  });
+  const source = buildExportSource(options.source);
   const now = new Date().toISOString();
   const job: MigrationExportJob = {
     id,
     status: 'queued',
     phase: 'Queued',
+    profile,
     components,
+    selection,
+    source,
     createdAt: now,
     updatedAt: now,
     fileName: `canvas-migration-${getCurrentAppVersion()}-${new Date().toISOString().replace(/[:.]/g, '-')}.zip`,
@@ -371,6 +665,16 @@ export function normalizeMigrationComponents(input: unknown): MigrationComponent
     }
   }
   return components;
+}
+
+export function normalizeMigrationExportOptions(input: unknown): Pick<MigrationExportOptions, 'components' | 'profile' | 'includePersonalWorkspaces'> {
+  const source = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+  const profile = normalizeMigrationExportProfile(source.profile);
+  return {
+    components: normalizeMigrationComponents(source.components),
+    profile,
+    includePersonalWorkspaces: profile === 'full_admin' && source.includePersonalWorkspaces === true,
+  };
 }
 
 export async function getMigrationArchiveSize(filePath: string): Promise<number> {

--- a/app/lib/migration/export-service.ts
+++ b/app/lib/migration/export-service.ts
@@ -69,8 +69,8 @@ function buildExportSelection(params: {
 
 function buildExportSource(source?: Partial<MigrationExportSource>): MigrationExportSource {
   return {
-    databaseProvider: source?.databaseProvider || getDatabaseProvider(),
-    deploymentMode: source?.deploymentMode || getDeploymentMode(),
+    databaseProvider: source?.databaseProvider ?? getDatabaseProvider(),
+    deploymentMode: source?.deploymentMode ?? getDeploymentMode(),
     teamFeaturesEnabled: source?.teamFeaturesEnabled ?? process.env.CANVAS_TEAM_FEATURES_ENABLED === 'true',
     managedServicesEnabled: source?.managedServicesEnabled ?? process.env.CANVAS_MANAGED_SERVICES_ENABLED === 'true',
     organizationId: source?.organizationId ?? (process.env.CANVAS_ORGANIZATION_ID?.trim() || null),
@@ -187,7 +187,34 @@ async function addZipEntry(
   });
 }
 
+const ALLOWED_SANITIZE_TABLES = new Set([
+  'public_file_shares',
+  'session',
+  'verification',
+  'channel_link_tokens',
+  'oauth_tokens',
+  'todo_email_reply_events',
+  'todo_email_reply_watchers',
+  'composio_webhook_subscriptions',
+  'automation_webhook_triggers',
+  'account',
+]);
+
+function assertAllowedSanitizeTable(tableName: string): void {
+  if (!ALLOWED_SANITIZE_TABLES.has(tableName)) {
+    throw new Error(`Unexpected migration sanitize table: ${tableName}`);
+  }
+}
+
+function quoteSqlIdentifier(identifier: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(identifier)) {
+    throw new Error(`Unexpected SQL identifier: ${identifier}`);
+  }
+  return `"${identifier}"`;
+}
+
 function tableExists(sqlite: InstanceType<typeof Database>, tableName: string): boolean {
+  assertAllowedSanitizeTable(tableName);
   const row = sqlite.prepare(`
     SELECT 1
     FROM sqlite_master
@@ -198,18 +225,22 @@ function tableExists(sqlite: InstanceType<typeof Database>, tableName: string): 
 }
 
 function tableColumns(sqlite: InstanceType<typeof Database>, tableName: string): Set<string> {
+  assertAllowedSanitizeTable(tableName);
   return new Set(
-    sqlite.prepare(`PRAGMA table_info(${tableName})`).all()
+    sqlite.prepare(`PRAGMA table_info(${quoteSqlIdentifier(tableName)})`).all()
       .map((column) => (column as { name: string }).name),
   );
 }
 
 function nullColumns(sqlite: InstanceType<typeof Database>, tableName: string, columns: string[]): void {
+  assertAllowedSanitizeTable(tableName);
   if (!tableExists(sqlite, tableName)) return;
   const existing = tableColumns(sqlite, tableName);
-  const assignments = columns.filter((column) => existing.has(column)).map((column) => `${column} = NULL`);
+  const assignments = columns
+    .filter((column) => existing.has(column))
+    .map((column) => `${quoteSqlIdentifier(column)} = NULL`);
   if (assignments.length === 0) return;
-  sqlite.prepare(`UPDATE ${tableName} SET ${assignments.join(', ')}`).run();
+  sqlite.prepare(`UPDATE ${quoteSqlIdentifier(tableName)} SET ${assignments.join(', ')}`).run();
 }
 
 function sanitizeSqliteMigrationSnapshot(snapshotPath: string): void {
@@ -254,7 +285,7 @@ function sanitizeSqliteMigrationSnapshot(snapshotPath: string): void {
           values.push('paused');
         }
         if (assignments.length > 0) {
-          snapshot.prepare(`UPDATE composio_webhook_subscriptions SET ${assignments.join(', ')}`).run(...values);
+          snapshot.prepare(`UPDATE ${quoteSqlIdentifier('composio_webhook_subscriptions')} SET ${assignments.join(', ')}`).run(...values);
         }
       }
       if (tableExists(snapshot, 'automation_webhook_triggers')) {
@@ -269,8 +300,12 @@ function sanitizeSqliteMigrationSnapshot(snapshotPath: string): void {
           assignments.push('secret_preview = ?');
           values.push('redacted');
         }
+        if (columns.has('secret_hash')) {
+          assignments.push('secret_hash = ?');
+          values.push('redacted');
+        }
         if (assignments.length > 0) {
-          snapshot.prepare(`UPDATE automation_webhook_triggers SET ${assignments.join(', ')}`).run(...values);
+          snapshot.prepare(`UPDATE ${quoteSqlIdentifier('automation_webhook_triggers')} SET ${assignments.join(', ')}`).run(...values);
         }
       }
       nullColumns(snapshot, 'account', [

--- a/app/lib/migration/types.ts
+++ b/app/lib/migration/types.ts
@@ -15,6 +15,10 @@ export type MigrationComponentKey = (typeof MIGRATION_COMPONENT_KEYS)[number];
 
 export type MigrationComponents = Record<MigrationComponentKey, boolean>;
 
+export const MIGRATION_EXPORT_PROFILES = ['standard', 'full_admin'] as const;
+
+export type MigrationExportProfile = (typeof MIGRATION_EXPORT_PROFILES)[number];
+
 export const DEFAULT_MIGRATION_COMPONENTS: MigrationComponents = {
   database: true,
   workspace: true,
@@ -52,22 +56,57 @@ export interface CanvasMigrationManifest {
   appVersion: string;
   exportedAt: string;
   exportId: string;
+  exportProfile?: MigrationExportProfile;
   components: MigrationComponents;
+  selection?: MigrationExportSelection;
+  source?: MigrationExportSource;
+  security?: MigrationExportSecurity;
   fileCount: number;
   totalBytes: number;
   warnings: string[];
   files: MigrationFileEntry[];
 }
 
+export interface MigrationExportSelection {
+  includePersonalWorkspaces: boolean;
+  includePublicLinks: false;
+  includeRawSecrets: false;
+}
+
+export interface MigrationExportSource {
+  databaseProvider: string;
+  deploymentMode: string;
+  teamFeaturesEnabled: boolean;
+  managedServicesEnabled: boolean;
+  organizationId: string | null;
+  createdByUserId: string | null;
+  createdByEmail: string | null;
+  createdByRole: string | null;
+}
+
+export interface MigrationExportSecurity {
+  publicLinksIncluded: false;
+  publicLinkTokensIncluded: false;
+  rawSecretsIncluded: false;
+  secretsMode: 'excluded' | 'reconnect_manifest';
+  unencryptedArchive: true;
+}
+
 export interface MigrationExportOptions {
   components: MigrationComponents;
+  profile?: MigrationExportProfile;
+  includePersonalWorkspaces?: boolean;
+  source?: Partial<MigrationExportSource>;
 }
 
 export interface MigrationExportJob {
   id: string;
   status: MigrationExportStatus;
   phase: string;
+  profile: MigrationExportProfile;
   components: MigrationComponents;
+  selection: MigrationExportSelection;
+  source: MigrationExportSource;
   createdAt: string;
   updatedAt: string;
   fileName: string;

--- a/docs/architecture/canvas-notebook/team-workspace/15-export-import-backup-restore-policy.md
+++ b/docs/architecture/canvas-notebook/team-workspace/15-export-import-backup-restore-policy.md
@@ -69,6 +69,17 @@ Regeln:
 - Wenn Postgres genutzt wird, kann ein bewusst aktivierter Full Technical Export einen Postgres-Dump enthalten. Normale Migration Exports bleiben logisch und provider-aware.
 - V1-Technical-Exports und lokale Backup-Artefakte werden nicht automatisch verschluesselt. Die UI muss deshalb warnen, dass ein Host-/Container-Admin sie lesen kann.
 
+V1-Implementierungsstand:
+
+- Exportprofile: `standard` und `full_admin`.
+- `standard` exportiert keine `/data/workspaces/personal/*`-Dateien, auch wenn der Client dies anfordert.
+- `full_admin` kann Personal Workspaces nur mit expliziter Auswahl exportieren.
+- Das Migration-Bundle enthaelt keine rohen Secret-Dateien aus `/data/secrets`.
+- Wenn die Komponente `secrets` ausgewaehlt ist, wird nur `data/reconnect-manifest.json` mit redacted Reconnect-Hinweisen geschrieben.
+- Der SQLite-Snapshot wird fuer Migration-Exports bereinigt: Public Shares, Session-/Verification-Tokens, OAuth-Tokens, Channel-Link-Tokens und E-Mail-Reply-Token werden entfernt oder redacted.
+- Composio-Webhooks und Automation-Webhooks werden im Snapshot pausiert bzw. ihre Secrets redacted.
+- Die UI zeigt Exportprofil, Personal-Workspace-Auswahl und unverschluesseltes V1-Archiv sichtbar an.
+
 ## Bestehendes Migration Manifest
 
 Im aktuellen Code existiert bereits ein Migration-Bundle-Manifest:

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -448,7 +448,7 @@
     {
       "id": 27,
       "title": "Admin-only Export mit granularer Auswahl fuer Migrationen implementieren",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/07-filesystem-migration-and-write-policy.md",

--- a/messages/de.json
+++ b/messages/de.json
@@ -2139,7 +2139,22 @@
         "files": "Dateien",
         "size": "Größe",
         "exportedAt": "Exportiert",
-        "secretsWarning": "Secrets sind in diesem Export enthalten. Dieses ZIP muss wie ein Zugangsschlüssel gespeichert und übertragen werden.",
+        "unencryptedWarning": "Dieses V1-Migrations-ZIP wird lokal unverschlüsselt erstellt. Public Links, Public-Link-Tokens, OAuth-Tokens und rohe Secret-Dateien werden nicht exportiert.",
+        "secretsWarning": "Secrets werden nur als redacted Reconnect-Manifest exportiert. API-Keys, OAuth-Tokens und lokale Credentials müssen auf dem Zielsystem neu verbunden werden.",
+        "profiles": {
+          "standard": {
+            "label": "Standard-Migration",
+            "hint": "Exportiert ausgewählte App-Daten ohne persönliche Workspace-Verzeichnisse."
+          },
+          "full_admin": {
+            "label": "Full Admin Export",
+            "hint": "Erlaubt den expliziten Einschluss persönlicher Workspace-Verzeichnisse."
+          }
+        },
+        "includePersonalWorkspaces": {
+          "label": "Persönliche Workspaces einschließen",
+          "hint": "Nur für Full Admin Export. Normale Migrationen schließen persönliche Workspace-Verzeichnisse aus."
+        },
         "importTitle": "Bundle importieren",
         "importDescription": "Große ZIP-Dateien werden in Chunks hochgeladen, geprüft und nach einem kontrollierten App-Neustart wiederhergestellt.",
         "uploading": "Migrations-ZIP wird hochgeladen...",
@@ -2180,8 +2195,8 @@
             "hint": "Installierte Skill-Ordner"
           },
           "secrets": {
-            "label": "Secrets",
-            "hint": "Integrations-Env-Dateien und lokale Credentials"
+            "label": "Reconnect-Manifest",
+            "hint": "Redacted Secret-/OAuth-Hinweise ohne Credential-Werte"
           }
         },
         "compatibility": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -2140,7 +2140,22 @@
         "files": "Files",
         "size": "Size",
         "exportedAt": "Exported",
-        "secretsWarning": "Secrets are included in this export. Store and transfer this ZIP like a credential.",
+        "unencryptedWarning": "This V1 migration ZIP is created locally without encryption. Public links, public-link tokens, OAuth tokens, and raw secret files are not exported.",
+        "secretsWarning": "Secrets are exported only as a redacted reconnect manifest. API keys, OAuth tokens, and local credentials must be reconnected on the target system.",
+        "profiles": {
+          "standard": {
+            "label": "Standard migration",
+            "hint": "Exports selected app data without personal workspace directories."
+          },
+          "full_admin": {
+            "label": "Full Admin export",
+            "hint": "Allows explicit inclusion of personal workspace directories."
+          }
+        },
+        "includePersonalWorkspaces": {
+          "label": "Include personal workspaces",
+          "hint": "Only for Full Admin export. Normal migrations exclude personal workspace directories."
+        },
         "importTitle": "Import bundle",
         "importDescription": "Large ZIP files are uploaded in chunks, inspected, and restored after a controlled app restart.",
         "uploading": "Uploading migration ZIP...",
@@ -2181,8 +2196,8 @@
             "hint": "Installed skill folders"
           },
           "secrets": {
-            "label": "Secrets",
-            "hint": "Integration env files and local credentials"
+            "label": "Reconnect manifest",
+            "hint": "Redacted secret/OAuth hints without credential values"
           }
         },
         "compatibility": {

--- a/scripts/migration-export-policy-test.ts
+++ b/scripts/migration-export-policy-test.ts
@@ -196,8 +196,8 @@ async function main() {
         { encryptedSecret: 'redacted', secretPreview: 'redacted', status: 'paused' },
       );
       assert.deepEqual(
-        snapshot.prepare('SELECT secret_preview AS secretPreview, status FROM automation_webhook_triggers').get(),
-        { secretPreview: 'redacted', status: 'paused' },
+        snapshot.prepare('SELECT secret_hash AS secretHash, secret_preview AS secretPreview, status FROM automation_webhook_triggers').get(),
+        { secretHash: 'redacted', secretPreview: 'redacted', status: 'paused' },
       );
     } finally {
       snapshot.close();

--- a/scripts/migration-export-policy-test.ts
+++ b/scripts/migration-export-policy-test.ts
@@ -1,0 +1,239 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import Database from 'better-sqlite3';
+
+import { DEFAULT_MIGRATION_COMPONENTS, type MigrationComponents } from '../app/lib/migration/types';
+
+const execFileAsync = promisify(execFile);
+
+async function unzipList(archivePath: string): Promise<string> {
+  const { stdout } = await execFileAsync('unzip', ['-Z1', archivePath], {
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+async function unzipEntryText(archivePath: string, entry: string): Promise<string> {
+  const { stdout } = await execFileAsync('unzip', ['-p', archivePath, entry], {
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+async function unzipEntryToFile(archivePath: string, entry: string, targetPath: string): Promise<void> {
+  const { stdout } = await execFileAsync('unzip', ['-p', archivePath, entry], {
+    encoding: 'buffer',
+    maxBuffer: 100 * 1024 * 1024,
+  });
+  await writeFile(targetPath, stdout);
+}
+
+async function waitForExport(
+  getMigrationExportJob: (id: string) => Promise<{ status: string; filePath?: string; error?: string } | null>,
+  exportId: string,
+) {
+  for (let attempt = 0; attempt < 120; attempt++) {
+    const job = await getMigrationExportJob(exportId);
+    if (job?.status === 'completed') return job;
+    if (job?.status === 'failed') throw new Error(job.error || 'export failed');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for export ${exportId}`);
+}
+
+async function main() {
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'canvas-migration-export-policy-'));
+  const previousData = process.env.DATA;
+  const previousCanvasDataRoot = process.env.CANVAS_DATA_ROOT;
+  const previousDatabaseProvider = process.env.CANVAS_DATABASE_PROVIDER;
+  const previousDeploymentMode = process.env.CANVAS_DEPLOYMENT_MODE;
+
+  process.env.DATA = dataRoot;
+  process.env.CANVAS_DATA_ROOT = dataRoot;
+  process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
+  process.env.CANVAS_DEPLOYMENT_MODE = 'team';
+
+  try {
+    await mkdir(path.join(dataRoot, 'workspace'), { recursive: true });
+    await mkdir(path.join(dataRoot, 'workspaces', 'team', 'org-export', 'files'), { recursive: true });
+    await mkdir(path.join(dataRoot, 'workspaces', 'personal', 'user-export', 'files'), { recursive: true });
+    await mkdir(path.join(dataRoot, 'secrets'), { recursive: true });
+    await writeFile(path.join(dataRoot, 'workspace', 'legacy.md'), '# Legacy\n');
+    await writeFile(path.join(dataRoot, 'workspaces', 'team', 'org-export', 'files', 'team.md'), '# Team\n');
+    await writeFile(path.join(dataRoot, 'workspaces', 'personal', 'user-export', 'files', 'private.md'), '# Private\n');
+    await writeFile(path.join(dataRoot, 'secrets', 'Canvas-Integrations.env'), 'OPENAI_API_KEY=sk-secret\nCOMPOSIO_API_KEY=secret\n');
+
+    const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+    try {
+      sqlite.exec(`
+        CREATE TABLE public_file_shares (id TEXT PRIMARY KEY, token TEXT, token_hash TEXT, status TEXT);
+        CREATE TABLE session (id TEXT PRIMARY KEY, token TEXT);
+        CREATE TABLE verification (id TEXT PRIMARY KEY, identifier TEXT, value TEXT);
+        CREATE TABLE account (
+          id TEXT PRIMARY KEY,
+          access_token TEXT,
+          refresh_token TEXT,
+          id_token TEXT,
+          access_token_expires_at INTEGER,
+          refresh_token_expires_at INTEGER,
+          password TEXT
+        );
+        CREATE TABLE oauth_tokens (id TEXT PRIMARY KEY, provider TEXT, access_token TEXT, refresh_token TEXT);
+        CREATE TABLE channel_link_tokens (id INTEGER PRIMARY KEY, token TEXT);
+        CREATE TABLE todo_email_reply_watchers (id TEXT PRIMARY KEY, reply_token TEXT);
+        CREATE TABLE todo_email_reply_events (id TEXT PRIMARY KEY, watcher_id TEXT);
+        CREATE TABLE composio_webhook_subscriptions (
+          id TEXT PRIMARY KEY,
+          encrypted_secret TEXT NOT NULL,
+          secret_preview TEXT,
+          status TEXT NOT NULL
+        );
+        CREATE TABLE automation_webhook_triggers (
+          id TEXT PRIMARY KEY,
+          secret_hash TEXT NOT NULL,
+          secret_preview TEXT NOT NULL,
+          status TEXT NOT NULL
+        );
+
+        INSERT INTO public_file_shares VALUES ('share-1', 'public-token', 'hash', 'active');
+        INSERT INTO session VALUES ('session-1', 'session-token');
+        INSERT INTO verification VALUES ('verification-1', 'email', 'verification-token');
+        INSERT INTO account VALUES ('account-1', 'access-token', 'refresh-token', 'id-token', 1, 2, 'password-secret');
+        INSERT INTO oauth_tokens VALUES ('oauth-1', 'pi', 'oauth-access', 'oauth-refresh');
+        INSERT INTO channel_link_tokens VALUES (1, 'channel-token');
+        INSERT INTO todo_email_reply_watchers VALUES ('watcher-1', 'reply-token');
+        INSERT INTO todo_email_reply_events VALUES ('event-1', 'watcher-1');
+        INSERT INTO composio_webhook_subscriptions VALUES ('sub-1', 'encrypted-secret', 'sec...', 'active');
+        INSERT INTO automation_webhook_triggers VALUES ('trigger-1', 'secret-hash', 'sec...', 'active');
+      `);
+    } finally {
+      sqlite.close();
+    }
+
+    const {
+      createMigrationExportJob,
+      getMigrationExportJob,
+    } = await import('../app/lib/migration/export-service');
+
+    const components: MigrationComponents = {
+      ...DEFAULT_MIGRATION_COMPONENTS,
+      studioAssets: false,
+      studioOutputs: false,
+      userUploads: false,
+      agents: false,
+      skills: false,
+      secrets: true,
+    };
+
+    const standardJob = await createMigrationExportJob({
+      components,
+      profile: 'standard',
+      includePersonalWorkspaces: true,
+      source: {
+        organizationId: 'org-export',
+        createdByUserId: 'user-admin',
+        createdByEmail: 'admin@example.test',
+        createdByRole: 'admin',
+      },
+    });
+    const completedStandard = await waitForExport(getMigrationExportJob, standardJob.id);
+    assert.ok(completedStandard.filePath);
+
+    const entries = (await unzipList(completedStandard.filePath!))
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    assert.ok(entries.includes('manifest.json'));
+    assert.ok(entries.includes('data/sqlite.db'));
+    assert.ok(entries.includes('data/workspace/legacy.md'));
+    assert.ok(entries.includes('data/workspaces/team/org-export/files/team.md'));
+    assert.equal(entries.includes('data/workspaces/personal/user-export/files/private.md'), false);
+    assert.equal(entries.includes('data/secrets/Canvas-Integrations.env'), false);
+    assert.ok(entries.includes('data/reconnect-manifest.json'));
+
+    const manifest = JSON.parse(await unzipEntryText(completedStandard.filePath!, 'manifest.json'));
+    assert.equal(manifest.exportProfile, 'standard');
+    assert.equal(manifest.selection.includePersonalWorkspaces, false);
+    assert.equal(manifest.selection.includePublicLinks, false);
+    assert.equal(manifest.selection.includeRawSecrets, false);
+    assert.equal(manifest.security.publicLinksIncluded, false);
+    assert.equal(manifest.security.publicLinkTokensIncluded, false);
+    assert.equal(manifest.security.rawSecretsIncluded, false);
+    assert.equal(manifest.security.secretsMode, 'reconnect_manifest');
+    assert.equal(manifest.source.organizationId, 'org-export');
+    assert.equal(manifest.source.createdByUserId, 'user-admin');
+
+    const reconnectManifest = JSON.parse(await unzipEntryText(completedStandard.filePath!, 'data/reconnect-manifest.json'));
+    assert.equal(reconnectManifest.rawSecretsIncluded, false);
+    assert.ok(JSON.stringify(reconnectManifest).includes('OPENAI_API_KEY'));
+    assert.equal(JSON.stringify(reconnectManifest).includes('sk-secret'), false);
+
+    const snapshotPath = path.join(dataRoot, 'snapshot-check.sqlite.db');
+    await unzipEntryToFile(completedStandard.filePath!, 'data/sqlite.db', snapshotPath);
+    const snapshot = new Database(snapshotPath, { readonly: true, fileMustExist: true });
+    try {
+      assert.equal((snapshot.prepare('SELECT COUNT(*) AS count FROM public_file_shares').get() as { count: number }).count, 0);
+      assert.equal((snapshot.prepare('SELECT COUNT(*) AS count FROM session').get() as { count: number }).count, 0);
+      assert.equal((snapshot.prepare('SELECT COUNT(*) AS count FROM verification').get() as { count: number }).count, 0);
+      assert.equal((snapshot.prepare('SELECT COUNT(*) AS count FROM oauth_tokens').get() as { count: number }).count, 0);
+      assert.equal((snapshot.prepare('SELECT COUNT(*) AS count FROM channel_link_tokens').get() as { count: number }).count, 0);
+      assert.equal((snapshot.prepare('SELECT COUNT(*) AS count FROM todo_email_reply_watchers').get() as { count: number }).count, 0);
+      const account = snapshot.prepare('SELECT access_token AS accessToken, refresh_token AS refreshToken, id_token AS idToken, password FROM account').get() as {
+        accessToken: string | null;
+        refreshToken: string | null;
+        idToken: string | null;
+        password: string | null;
+      };
+      assert.deepEqual(account, { accessToken: null, refreshToken: null, idToken: null, password: null });
+      assert.deepEqual(
+        snapshot.prepare('SELECT encrypted_secret AS encryptedSecret, secret_preview AS secretPreview, status FROM composio_webhook_subscriptions').get(),
+        { encryptedSecret: 'redacted', secretPreview: 'redacted', status: 'paused' },
+      );
+      assert.deepEqual(
+        snapshot.prepare('SELECT secret_preview AS secretPreview, status FROM automation_webhook_triggers').get(),
+        { secretPreview: 'redacted', status: 'paused' },
+      );
+    } finally {
+      snapshot.close();
+    }
+
+    const fullAdminJob = await createMigrationExportJob({
+      components: {
+        ...components,
+        database: false,
+        secrets: false,
+      },
+      profile: 'full_admin',
+      includePersonalWorkspaces: true,
+    });
+    const completedFullAdmin = await waitForExport(getMigrationExportJob, fullAdminJob.id);
+    const fullAdminEntries = (await unzipList(completedFullAdmin.filePath!))
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    assert.ok(fullAdminEntries.includes('data/workspaces/personal/user-export/files/private.md'));
+
+    console.log('migration-export-policy-test: ok');
+  } finally {
+    if (previousData === undefined) delete process.env.DATA;
+    else process.env.DATA = previousData;
+    if (previousCanvasDataRoot === undefined) delete process.env.CANVAS_DATA_ROOT;
+    else process.env.CANVAS_DATA_ROOT = previousCanvasDataRoot;
+    if (previousDatabaseProvider === undefined) delete process.env.CANVAS_DATABASE_PROVIDER;
+    else process.env.CANVAS_DATABASE_PROVIDER = previousDatabaseProvider;
+    if (previousDeploymentMode === undefined) delete process.env.CANVAS_DEPLOYMENT_MODE;
+    else process.env.CANVAS_DEPLOYMENT_MODE = previousDeploymentMode;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add standard vs full_admin migration export profiles with explicit personal workspace inclusion
- exclude raw secrets from migration exports and emit a redacted reconnect manifest instead
- sanitize SQLite migration snapshots by removing public links, session/OAuth/link-token data, and pausing/redacting webhook secrets
- add Settings UI controls and copy for export profiles, personal workspace inclusion, and unencrypted archive warnings
- mark Task 27 complete and document the V1 implementation status

## Verification
- npx tsc --noEmit --pretty false
- npm run lint
- node -e "JSON.parse(require('fs').readFileSync('messages/de.json','utf8')); JSON.parse(require('fs').readFileSync('messages/en.json','utf8')); JSON.parse(require('fs').readFileSync('docs/architecture/canvas-notebook/todo.json','utf8')); console.log('json ok')"
- tsx --conditions react-server scripts/migration-export-policy-test.ts
- npm run build
- git diff --check

## Notes
- UI browser tests were not run because Playwright/Chrome tests require explicit user approval in AGENTS.md.
- Greptile should run the first review automatically after PR creation; no manual greploop trigger was posted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a granular migration export policy with two profiles (`standard` and `full_admin`), replaces raw secret file exports with a redacted reconnect manifest, sanitizes the SQLite snapshot of all session/token/OAuth/webhook-secret data, and adds corresponding Settings UI controls and i18n copy.

- **Secrets handling completely reworked**: the `secrets` path mapping is removed from `COMPONENT_PATH_MAPPINGS`; when `secrets: true`, only a `data/reconnect-manifest.json` listing redacted env-key names and directory hints is written — raw credential files are never included in the archive.
- **SQLite sanitization runs in a single transaction before the integrity check**: public-link shares, sessions, verifications, OAuth tokens, channel-link tokens, email-reply rows, and webhook secrets (`encrypted_secret`, `secret_hash`, `secret_preview`) are deleted or overwritten; `account` OAuth/token columns are nulled; WAL is checkpointed before the snapshot is zipped.
- **Profile enforcement is double-gated** at both the normalizer (`normalizeMigrationExportOptions`) and `buildExportSelection`, so a standard-profile request that includes `includePersonalWorkspaces: true` in the JSON body is silently clamped to `false` server-side.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the sanitization logic is transaction-wrapped and allowlist-guarded, all credential columns are covered, and the personal-workspace exclusion is enforced at the server layer regardless of client input.

All issues raised in prior review threads have been addressed in this revision: secret_hash is now redacted in automation_webhook_triggers, SQL identifiers go through quoteSqlIdentifier backed by assertAllowedSanitizeTable, and ?? coalescing is used consistently throughout buildExportSource. The new code paths are well-covered by the accompanying policy test script.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/migration/export-service.ts | Core export logic — adds sanitization, reconnect manifest, profile/selection/source/security builders; all three previous-thread issues now resolved (secret_hash redacted, identifiers allowlisted + quoted, ?? coalescing used throughout) |
| app/lib/migration/component-paths.ts | Adds granular workspace sub-paths (team/project/personal) and a personal-workspace exclusion filter; secrets path mapping correctly removed since raw secrets are now replaced by the reconnect manifest |
| app/lib/migration/types.ts | Adds MigrationExportProfile, MigrationExportSelection, MigrationExportSource, and MigrationExportSecurity types; manifest fields marked optional for backward compatibility with older bundles |
| app/api/migration/export/route.ts | Route now forwards authenticated admin identity (userId, email, role, organizationId) into the export source record; normalizeMigrationExportOptions correctly gates includePersonalWorkspaces on full_admin profile server-side |
| app/components/settings/WorkspaceSettingsPanel.tsx | Adds profile picker, personal-workspace checkbox (correctly disabled for non-full_admin and when workspace component is unchecked), and unencrypted-archive warning banner |
| scripts/migration-export-policy-test.ts | New end-to-end script verifying personal-workspace exclusion, secrets-never-exported, reconnect-manifest content, and all SQLite sanitization assertions including secret_hash; covers both standard and full_admin profiles |

</details>

<sub>Reviews (2): Last reviewed commit: ["Address migration export review feedback"](https://github.com/canvascoding/canvas-notebook/commit/73b98057e81808714dba4f4e0fb80b1db05cc593) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38896624)</sub>

<!-- /greptile_comment -->