### PR TITLE
Add migration import dry-run mapping

### DIFF
--- a/app/components/settings/WorkspaceSettingsPanel.tsx
+++ b/app/components/settings/WorkspaceSettingsPanel.tsx
@@ -820,8 +820,8 @@ export function WorkspaceSettingsPanel({ isAdmin = false, organizationPermission
                     {inspection.dryRun.blockers.length > 0 ? (
                       <div className="space-y-1 rounded-md border border-destructive/40 bg-destructive/5 p-2">
                         <p className="text-xs font-medium text-destructive">{t('workspacePanel.migration.dryRun.blockers')}</p>
-                        {inspection.dryRun.blockers.map((blocker) => (
-                          <p key={blocker} className="text-xs text-destructive">- {blocker}</p>
+                        {inspection.dryRun.blockers.map((blocker, blockerIndex) => (
+                          <p key={`${blockerIndex}:${blocker}`} className="text-xs text-destructive">- {blocker}</p>
                         ))}
                       </div>
                     ) : null}

--- a/app/components/settings/WorkspaceSettingsPanel.tsx
+++ b/app/components/settings/WorkspaceSettingsPanel.tsx
@@ -801,6 +801,74 @@ export function WorkspaceSettingsPanel({ isAdmin = false, organizationPermission
                     <span>{t('workspacePanel.migration.exportedAt')}: {new Date(inspection.manifest.exportedAt).toLocaleString()}</span>
                   </div>
                 ) : null}
+                {inspection.dryRun ? (
+                  <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="text-sm font-medium">
+                        {t(`workspacePanel.migration.dryRun.status.${inspection.dryRun.status}`)}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {t('workspacePanel.migration.dryRun.summary', {
+                          users: inspection.dryRun.stats.userMappings,
+                          workspaces: inspection.dryRun.stats.workspaceMappings,
+                          reconnects: inspection.dryRun.stats.reconnectRequirements,
+                          blockers: inspection.dryRun.stats.blockers,
+                        })}
+                      </div>
+                    </div>
+
+                    {inspection.dryRun.blockers.length > 0 ? (
+                      <div className="space-y-1 rounded-md border border-destructive/40 bg-destructive/5 p-2">
+                        <p className="text-xs font-medium text-destructive">{t('workspacePanel.migration.dryRun.blockers')}</p>
+                        {inspection.dryRun.blockers.map((blocker) => (
+                          <p key={blocker} className="text-xs text-destructive">- {blocker}</p>
+                        ))}
+                      </div>
+                    ) : null}
+
+                    {inspection.dryRun.users.length > 0 ? (
+                      <div className="space-y-1">
+                        <p className="text-xs font-medium">{t('workspacePanel.migration.dryRun.users')}</p>
+                        {inspection.dryRun.users.map((mapping) => (
+                          <p key={`${mapping.sourceUserId || 'no-id'}:${mapping.sourceEmail || 'no-email'}`} className="text-xs text-muted-foreground">
+                            {mapping.sourceEmail || mapping.sourceUserId || t('workspacePanel.migration.dryRun.unknownSource')}
+                            {' -> '}
+                            {mapping.targetEmail || mapping.targetUserId || t('workspacePanel.migration.dryRun.unresolved')}
+                            {' · '}
+                            {t(`workspacePanel.migration.dryRun.mappingStatus.${mapping.status}`)}
+                          </p>
+                        ))}
+                      </div>
+                    ) : null}
+
+                    {inspection.dryRun.workspaces.length > 0 ? (
+                      <div className="space-y-1">
+                        <p className="text-xs font-medium">{t('workspacePanel.migration.dryRun.workspaces')}</p>
+                        {inspection.dryRun.workspaces.map((mapping) => (
+                          <p key={mapping.sourcePath} className="text-xs text-muted-foreground">
+                            {mapping.sourcePath}
+                            {' -> '}
+                            {mapping.targetPath || t('workspacePanel.migration.dryRun.unresolved')}
+                            {' · '}
+                            {t(`workspacePanel.migration.dryRun.mappingStatus.${mapping.status}`)}
+                          </p>
+                        ))}
+                      </div>
+                    ) : null}
+
+                    {inspection.dryRun.reconnect.length > 0 ? (
+                      <div className="space-y-1">
+                        <p className="text-xs font-medium">{t('workspacePanel.migration.dryRun.reconnect')}</p>
+                        {inspection.dryRun.reconnect.map((item) => (
+                          <p key={`${item.kind}:${item.scope}:${item.path}`} className="text-xs text-muted-foreground">
+                            {item.path}
+                            {item.secretNames.length > 0 ? ` · ${item.secretNames.join(', ')}` : ''}
+                          </p>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
                 <div className="space-y-1">
                   {inspection.risks.map((risk) => (
                     <p key={risk} className="text-sm text-muted-foreground">- {risk}</p>

--- a/app/lib/migration/inspect-service.ts
+++ b/app/lib/migration/inspect-service.ts
@@ -7,12 +7,26 @@ import { getCurrentAppVersion } from '@/app/lib/migration/app-version';
 import {
   MIGRATION_BUNDLE_SCHEMA_VERSION,
   MIGRATION_COMPONENT_KEYS,
+  MIGRATION_EXPORT_PROFILES,
   type CanvasMigrationManifest,
   type MigrationComponentKey,
   type MigrationComponents,
+  type MigrationExportProfile,
+  type MigrationExportSecurity,
+  type MigrationExportSelection,
+  type MigrationExportSource,
+  type MigrationImportDryRun,
+  type MigrationImportReconnectRequirement,
+  type MigrationImportUserMapping,
+  type MigrationImportWorkspaceMapping,
   type MigrationInspection,
 } from '@/app/lib/migration/types';
 import { formatVersionCompatibilityMessage } from '@/app/lib/migration/version';
+import {
+  getDatabaseProvider,
+  getDeploymentMode,
+  openOrganizationBootstrapDatabase,
+} from '@/app/lib/organization/bootstrap';
 
 const execFileAsync = promisify(execFile);
 
@@ -45,6 +59,61 @@ function parseComponents(value: unknown): MigrationComponents | null {
   return components;
 }
 
+function optionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function optionalBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function parseExportSource(value: unknown): MigrationExportSource | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const source = value as Record<string, unknown>;
+  const databaseProvider = optionalString(source.databaseProvider);
+  const deploymentMode = optionalString(source.deploymentMode);
+  const teamFeaturesEnabled = optionalBoolean(source.teamFeaturesEnabled);
+  const managedServicesEnabled = optionalBoolean(source.managedServicesEnabled);
+  if (!databaseProvider || !deploymentMode || teamFeaturesEnabled === null || managedServicesEnabled === null) {
+    return undefined;
+  }
+
+  return {
+    databaseProvider,
+    deploymentMode,
+    teamFeaturesEnabled,
+    managedServicesEnabled,
+    organizationId: optionalString(source.organizationId),
+    createdByUserId: optionalString(source.createdByUserId),
+    createdByEmail: optionalString(source.createdByEmail),
+    createdByRole: optionalString(source.createdByRole),
+  };
+}
+
+function parseExportSelection(value: unknown): MigrationExportSelection | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const selection = value as Record<string, unknown>;
+  if (typeof selection.includePersonalWorkspaces !== 'boolean') return undefined;
+  return {
+    includePersonalWorkspaces: selection.includePersonalWorkspaces,
+    includePublicLinks: false,
+    includeRawSecrets: false,
+  };
+}
+
+function parseExportSecurity(value: unknown): MigrationExportSecurity | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const security = value as Record<string, unknown>;
+  const secretsMode = security.secretsMode === 'reconnect_manifest' ? 'reconnect_manifest' : 'excluded';
+  return {
+    publicLinksIncluded: false,
+    publicLinkTokensIncluded: false,
+    rawSecretsIncluded: false,
+    secretsMode,
+    unencryptedArchive: true,
+  };
+}
+
 function parseManifest(raw: string): CanvasMigrationManifest | null {
   let parsed: unknown;
   try {
@@ -64,6 +133,9 @@ function parseManifest(raw: string): CanvasMigrationManifest | null {
   if (typeof record.exportId !== 'string') return null;
   if (typeof record.fileCount !== 'number') return null;
   if (typeof record.totalBytes !== 'number') return null;
+  const exportProfile = MIGRATION_EXPORT_PROFILES.includes(record.exportProfile as MigrationExportProfile)
+    ? record.exportProfile as MigrationExportProfile
+    : undefined;
 
   return {
     format: 'canvas-notebook-migration',
@@ -71,7 +143,11 @@ function parseManifest(raw: string): CanvasMigrationManifest | null {
     appVersion: record.appVersion,
     exportedAt: record.exportedAt,
     exportId: record.exportId,
+    exportProfile,
     components,
+    selection: parseExportSelection(record.selection),
+    source: parseExportSource(record.source),
+    security: parseExportSecurity(record.security),
     fileCount: record.fileCount,
     totalBytes: record.totalBytes,
     warnings: Array.isArray(record.warnings) ? record.warnings.filter((item): item is string => typeof item === 'string') : [],
@@ -85,6 +161,376 @@ function parseManifest(raw: string): CanvasMigrationManifest | null {
           typeof file.modifiedAt === 'string';
       })
       : [],
+  };
+}
+
+type LocalUser = {
+  id: string;
+  email: string | null;
+};
+
+type LocalWorkspace = {
+  id: string;
+  organizationId: string;
+  type: string;
+  ownerUserId: string | null;
+  rootRelativePath: string;
+  displayName: string;
+};
+
+type LocalImportContext = {
+  databaseProvider: string;
+  deploymentMode: string;
+  organizationId: string | null;
+  teamFeaturesEnabled: boolean;
+  users: LocalUser[];
+  workspaces: LocalWorkspace[];
+};
+
+type ReconnectManifestEntry = {
+  kind?: unknown;
+  scope?: unknown;
+  path?: unknown;
+  secretNames?: unknown;
+};
+
+function readLocalImportContext(warnings: string[]): LocalImportContext {
+  const fallback: LocalImportContext = {
+    databaseProvider: getDatabaseProvider(),
+    deploymentMode: getDeploymentMode(),
+    organizationId: null,
+    teamFeaturesEnabled: false,
+    users: [],
+    workspaces: [],
+  };
+
+  let sqlite: ReturnType<typeof openOrganizationBootstrapDatabase> | null = null;
+  try {
+    sqlite = openOrganizationBootstrapDatabase();
+    const organization = sqlite.prepare(`
+      SELECT organization_id AS organizationId, deployment_mode AS deploymentMode, team_features_enabled AS teamFeaturesEnabled
+      FROM canvas_organization_settings
+      ORDER BY created_at ASC
+      LIMIT 1
+    `).get() as { organizationId: string; deploymentMode: string; teamFeaturesEnabled: number } | undefined;
+    const users = sqlite.prepare(`
+      SELECT id, email
+      FROM user
+      ORDER BY created_at ASC
+    `).all() as LocalUser[];
+    const workspaces = sqlite.prepare(`
+      SELECT
+        id,
+        organization_id AS organizationId,
+        type,
+        owner_user_id AS ownerUserId,
+        root_relative_path AS rootRelativePath,
+        display_name AS displayName
+      FROM canvas_workspaces
+      WHERE status = 'active'
+      ORDER BY created_at ASC
+    `).all() as LocalWorkspace[];
+
+    return {
+      databaseProvider: getDatabaseProvider(),
+      deploymentMode: organization?.deploymentMode || getDeploymentMode(),
+      organizationId: organization?.organizationId || null,
+      teamFeaturesEnabled: organization ? organization.teamFeaturesEnabled === 1 : false,
+      users,
+      workspaces,
+    };
+  } catch (error) {
+    warnings.push(`Target mapping context could not be read: ${error instanceof Error ? error.message : 'unknown error'}`);
+    return fallback;
+  } finally {
+    sqlite?.close();
+  }
+}
+
+function parseReconnectManifest(raw: string | null): MigrationImportReconnectRequirement[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+  const entries = (parsed as { entries?: unknown }).entries;
+  if (!Array.isArray(entries)) return [];
+
+  return entries
+    .filter((entry): entry is ReconnectManifestEntry => Boolean(entry && typeof entry === 'object' && !Array.isArray(entry)))
+    .map((entry) => {
+      const kind = entry.kind === 'env_file' || entry.kind === 'oauth_store' || entry.kind === 'secret_directory'
+        ? entry.kind
+        : 'unknown';
+      const scope = entry.scope === 'legacy' || entry.scope === 'user' || entry.scope === 'organization' || entry.scope === 'system'
+        ? entry.scope
+        : 'unknown';
+      const secretNames = Array.isArray(entry.secretNames)
+        ? entry.secretNames.filter((item): item is string => typeof item === 'string').sort((a, b) => a.localeCompare(b))
+        : [];
+      return {
+        kind,
+        scope,
+        path: optionalString(entry.path) || 'unknown',
+        secretNames,
+        required: true,
+        reason: 'Reconnect on the target before re-enabling integrations, agents, automations, or mailboxes that depend on these credentials.',
+      };
+    });
+}
+
+function sourceArchivePaths(manifest: CanvasMigrationManifest, entries: string[]): string[] {
+  return [...new Set([
+    ...manifest.files.map((file) => file.archivePath),
+    ...entries.filter((entry) => entry.startsWith('data/')),
+  ])].sort((a, b) => a.localeCompare(b));
+}
+
+function buildUserMappings(params: {
+  manifest: CanvasMigrationManifest;
+  archivePaths: string[];
+  target: LocalImportContext;
+}): MigrationImportUserMapping[] {
+  const candidates = new Map<string, { userId: string | null; email: string | null; required: boolean; reason: string }>();
+  const addCandidate = (input: { userId: string | null; email: string | null; required: boolean; reason: string }) => {
+    if (!input.userId && !input.email) return;
+    const key = `${input.userId || ''}:${input.email || ''}`;
+    const existing = candidates.get(key);
+    if (existing) {
+      existing.required ||= input.required;
+      existing.reason = existing.required ? existing.reason : input.reason;
+      return;
+    }
+    candidates.set(key, input);
+  };
+
+  addCandidate({
+    userId: params.manifest.source?.createdByUserId ?? null,
+    email: params.manifest.source?.createdByEmail ?? null,
+    required: params.manifest.components.database,
+    reason: 'Export creator and actor references from the source bundle.',
+  });
+
+  for (const archivePath of params.archivePaths) {
+    const personalMatch = /^data\/workspaces\/personal\/([^/]+)\/files(?:\/|$)/u.exec(archivePath);
+    if (!personalMatch?.[1]) continue;
+    addCandidate({
+      userId: personalMatch[1],
+      email: null,
+      required: true,
+      reason: 'Personal workspace files require an explicit target user mapping.',
+    });
+  }
+
+  return [...candidates.values()].map((candidate) => {
+    const byId = candidate.userId ? params.target.users.find((user) => user.id === candidate.userId) : null;
+    const byEmail = !byId && candidate.email
+      ? params.target.users.find((user) => user.email?.toLowerCase() === candidate.email?.toLowerCase())
+      : null;
+    if (byId) {
+      return {
+        sourceUserId: candidate.userId,
+        sourceEmail: candidate.email,
+        targetUserId: byId.id,
+        targetEmail: byId.email,
+        status: 'mapped',
+        required: candidate.required,
+        reason: candidate.reason,
+      };
+    }
+    if (byEmail) {
+      return {
+        sourceUserId: candidate.userId,
+        sourceEmail: candidate.email,
+        targetUserId: byEmail.id,
+        targetEmail: byEmail.email,
+        status: 'proposed',
+        required: candidate.required,
+        reason: `${candidate.reason} Email matched, but the current restore engine cannot rewrite user IDs yet.`,
+      };
+    }
+    return {
+      sourceUserId: candidate.userId,
+      sourceEmail: candidate.email,
+      targetUserId: null,
+      targetEmail: null,
+      status: candidate.required ? 'unresolved' : 'not_required',
+      required: candidate.required,
+      reason: candidate.reason,
+    };
+  });
+}
+
+function buildWorkspaceMappings(params: {
+  archivePaths: string[];
+  target: LocalImportContext;
+  users: MigrationImportUserMapping[];
+}): MigrationImportWorkspaceMapping[] {
+  const roots = new Map<string, MigrationImportWorkspaceMapping>();
+  const teamWorkspace = params.target.workspaces.find((workspace) => workspace.type === 'team' && workspace.organizationId === params.target.organizationId) || null;
+
+  for (const archivePath of params.archivePaths) {
+    if (archivePath.startsWith('data/workspace/')) {
+      roots.set('legacy:data/workspace', {
+        kind: 'legacy',
+        sourcePath: 'data/workspace',
+        sourceWorkspaceId: null,
+        sourceOrganizationId: null,
+        sourceOwnerUserId: null,
+        targetWorkspaceId: null,
+        targetPath: 'data/workspace',
+        status: 'mapped',
+        required: false,
+        reason: 'Legacy workspace paths are restored without ID mapping.',
+      });
+    }
+
+    const scopedMatch = /^data\/workspaces\/(team|personal|project)\/([^/]+)\/files(?:\/|$)/u.exec(archivePath);
+    if (!scopedMatch?.[1] || !scopedMatch[2]) continue;
+    const [, kind, id] = scopedMatch;
+    const key = `${kind}:${id}`;
+    if (roots.has(key)) continue;
+
+    if (kind === 'team') {
+      const sourcePath = `data/workspaces/team/${id}/files`;
+      if (teamWorkspace && params.target.organizationId === id) {
+        roots.set(key, {
+          kind: 'team',
+          sourcePath,
+          sourceWorkspaceId: null,
+          sourceOrganizationId: id,
+          sourceOwnerUserId: null,
+          targetWorkspaceId: teamWorkspace.id,
+          targetPath: `data/${teamWorkspace.rootRelativePath}`,
+          status: 'mapped',
+          required: true,
+          reason: 'Team workspace organization ID matches the target organization.',
+        });
+      } else {
+        roots.set(key, {
+          kind: 'team',
+          sourcePath,
+          sourceWorkspaceId: null,
+          sourceOrganizationId: id,
+          sourceOwnerUserId: null,
+          targetWorkspaceId: teamWorkspace?.id ?? null,
+          targetPath: teamWorkspace ? `data/${teamWorkspace.rootRelativePath}` : null,
+          status: teamWorkspace ? 'proposed' : 'unresolved',
+          required: true,
+          reason: teamWorkspace
+            ? 'Team workspace requires organization remapping before this restore engine can apply it safely.'
+            : 'Target instance has no active team workspace for this bundle.',
+        });
+      }
+    }
+
+    if (kind === 'personal') {
+      const sourcePath = `data/workspaces/personal/${id}/files`;
+      const userMapping = params.users.find((mapping) => mapping.sourceUserId === id);
+      const personalWorkspace = userMapping?.targetUserId
+        ? params.target.workspaces.find((workspace) => workspace.type === 'personal' && workspace.ownerUserId === userMapping.targetUserId)
+        : null;
+      const mapsWithoutRewrite = userMapping?.status === 'mapped' && userMapping.targetUserId === id && personalWorkspace?.rootRelativePath === `workspaces/personal/${id}/files`;
+      roots.set(key, {
+        kind: 'personal',
+        sourcePath,
+        sourceWorkspaceId: null,
+        sourceOrganizationId: null,
+        sourceOwnerUserId: id,
+        targetWorkspaceId: personalWorkspace?.id ?? null,
+        targetPath: personalWorkspace ? `data/${personalWorkspace.rootRelativePath}` : null,
+        status: mapsWithoutRewrite ? 'mapped' : userMapping?.targetUserId ? 'proposed' : 'unresolved',
+        required: true,
+        reason: mapsWithoutRewrite
+          ? 'Personal workspace owner matches an existing target user and path.'
+          : 'Personal workspace requires explicit user/path remapping before restore.',
+      });
+    }
+
+    if (kind === 'project') {
+      roots.set(key, {
+        kind: 'project',
+        sourcePath: `data/workspaces/project/${id}/files`,
+        sourceWorkspaceId: id,
+        sourceOrganizationId: null,
+        sourceOwnerUserId: null,
+        targetWorkspaceId: null,
+        targetPath: null,
+        status: 'unresolved',
+        required: true,
+        reason: 'Project workspace remapping is not implemented in the V1 restore engine.',
+      });
+    }
+  }
+
+  return [...roots.values()].sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
+}
+
+function buildDryRun(params: {
+  manifest: CanvasMigrationManifest;
+  entries: string[];
+  reconnect: MigrationImportReconnectRequirement[];
+  warnings: string[];
+}): MigrationImportDryRun {
+  const target = readLocalImportContext(params.warnings);
+  const archivePaths = sourceArchivePaths(params.manifest, params.entries);
+  const users = buildUserMappings({ manifest: params.manifest, archivePaths, target });
+  const workspaces = buildWorkspaceMappings({ archivePaths, target, users });
+  const blockers: string[] = [];
+
+  if (params.manifest.components.database) {
+    const sourceProvider = params.manifest.source?.databaseProvider ?? 'sqlite';
+    if (sourceProvider !== 'sqlite') {
+      blockers.push(`Source database provider ${sourceProvider} is not supported by the V1 restore engine.`);
+    }
+    if (target.databaseProvider !== 'sqlite') {
+      blockers.push(`Target database provider ${target.databaseProvider} requires a provider-aware import path before database restore.`);
+    }
+  }
+
+  for (const mapping of users) {
+    if (mapping.required && mapping.status !== 'mapped') {
+      blockers.push(`User mapping unresolved: ${mapping.sourceEmail || mapping.sourceUserId || 'unknown user'}.`);
+    }
+  }
+  for (const mapping of workspaces) {
+    if (mapping.required && mapping.status !== 'mapped') {
+      blockers.push(`Workspace mapping unresolved: ${mapping.sourcePath}.`);
+    }
+  }
+
+  const canApply = blockers.length === 0;
+  const status = !canApply ? 'blocked' : params.reconnect.length > 0 ? 'attention_required' : 'ready';
+  return {
+    status,
+    canApply,
+    blockers,
+    source: {
+      exportProfile: params.manifest.exportProfile ?? null,
+      databaseProvider: params.manifest.source?.databaseProvider ?? null,
+      deploymentMode: params.manifest.source?.deploymentMode ?? null,
+      organizationId: params.manifest.source?.organizationId ?? null,
+      createdByUserId: params.manifest.source?.createdByUserId ?? null,
+      createdByEmail: params.manifest.source?.createdByEmail ?? null,
+    },
+    target: {
+      databaseProvider: target.databaseProvider,
+      deploymentMode: target.deploymentMode,
+      organizationId: target.organizationId,
+      teamFeaturesEnabled: target.teamFeaturesEnabled,
+    },
+    users,
+    workspaces,
+    reconnect: params.reconnect,
+    stats: {
+      userMappings: users.length,
+      workspaceMappings: workspaces.length,
+      reconnectRequirements: params.reconnect.length,
+      blockers: blockers.length,
+    },
   };
 }
 
@@ -157,6 +603,23 @@ export async function inspectMigrationArchive(params: {
     compatibility.message,
     ...(manifest?.warnings ?? []),
   ];
+  let reconnect: MigrationImportReconnectRequirement[] = [];
+  if (manifest?.components.secrets || manifest?.security?.secretsMode === 'reconnect_manifest') {
+    const rawReconnect = await unzipText(['-p', params.archivePath, 'data/reconnect-manifest.json'], 20 * 1024 * 1024)
+      .catch(() => null);
+    reconnect = parseReconnectManifest(rawReconnect);
+    if (manifest.components.secrets && reconnect.length === 0) {
+      warnings.push('Secrets were selected in the source export, but no reconnect manifest was found.');
+    }
+  }
+  const dryRun = manifest
+    ? buildDryRun({ manifest, entries, reconnect, warnings })
+    : undefined;
+  if (dryRun && !dryRun.canApply) {
+    warnings.push('Import dry run is blocked. Resolve required user/workspace mappings before staging restore.');
+  } else if (dryRun?.reconnect.length) {
+    warnings.push('Import dry run passed, but integrations listed in the reconnect manifest must be reconnected after restore.');
+  }
 
   return {
     uploadId: params.uploadId,
@@ -164,8 +627,9 @@ export async function inspectMigrationArchive(params: {
     currentAppVersion,
     exportAppVersion: manifest?.appVersion ?? null,
     compatibility: compatibility.compatibility,
-    canRestore: compatibility.canRestore,
+    canRestore: compatibility.canRestore && (dryRun?.canApply ?? false),
     manifest,
+    dryRun,
     warnings,
     risks: buildRisks(manifest),
   };

--- a/app/lib/migration/inspect-service.ts
+++ b/app/lib/migration/inspect-service.ts
@@ -294,16 +294,35 @@ function buildUserMappings(params: {
   archivePaths: string[];
   target: LocalImportContext;
 }): MigrationImportUserMapping[] {
-  const candidates = new Map<string, { userId: string | null; email: string | null; required: boolean; reason: string }>();
+  type UserCandidate = { userId: string | null; email: string | null; required: boolean; reason: string };
+  const candidates = new Map<string, UserCandidate>();
+  const candidateKey = (input: Pick<UserCandidate, 'userId' | 'email'>) => {
+    if (input.userId) return `id:${input.userId}`;
+    if (input.email) return `email:${input.email.toLowerCase()}`;
+    return null;
+  };
+  const findExistingCandidateKey = (input: Pick<UserCandidate, 'userId' | 'email'>) => {
+    for (const [key, candidate] of candidates.entries()) {
+      if (input.userId && candidate.userId === input.userId) return key;
+      if (input.email && candidate.email?.toLowerCase() === input.email.toLowerCase()) return key;
+    }
+    return null;
+  };
   const addCandidate = (input: { userId: string | null; email: string | null; required: boolean; reason: string }) => {
     if (!input.userId && !input.email) return;
-    const key = `${input.userId || ''}:${input.email || ''}`;
-    const existing = candidates.get(key);
+    const existingKey = findExistingCandidateKey(input);
+    const existing = existingKey ? candidates.get(existingKey) : null;
     if (existing) {
+      existing.userId ||= input.userId;
+      existing.email ||= input.email;
       existing.required ||= input.required;
-      existing.reason = existing.required ? existing.reason : input.reason;
+      if (!existing.reason.includes(input.reason)) {
+        existing.reason = `${existing.reason} ${input.reason}`;
+      }
       return;
     }
+    const key = candidateKey(input);
+    if (!key) return;
     candidates.set(key, input);
   };
 
@@ -493,12 +512,17 @@ function buildDryRun(params: {
 
   for (const mapping of users) {
     if (mapping.required && mapping.status !== 'mapped') {
-      blockers.push(`User mapping unresolved: ${mapping.sourceEmail || mapping.sourceUserId || 'unknown user'}.`);
+      const label = mapping.sourceEmail || mapping.sourceUserId || 'unknown user';
+      blockers.push(mapping.status === 'proposed'
+        ? `User mapping proposed but cannot be auto-applied by the V1 restore engine: ${label}.`
+        : `User mapping unresolved: ${label}.`);
     }
   }
   for (const mapping of workspaces) {
     if (mapping.required && mapping.status !== 'mapped') {
-      blockers.push(`Workspace mapping unresolved: ${mapping.sourcePath}.`);
+      blockers.push(mapping.status === 'proposed'
+        ? `Workspace mapping proposed but cannot be auto-applied by the V1 restore engine: ${mapping.sourcePath}.`
+        : `Workspace mapping unresolved: ${mapping.sourcePath}.`);
     }
   }
 

--- a/app/lib/migration/restore-service.ts
+++ b/app/lib/migration/restore-service.ts
@@ -25,6 +25,9 @@ export async function writePendingMigrationRestore(params: {
   if (!params.inspection.canRestore || !params.inspection.manifest) {
     throw new Error('Migration archive cannot be restored.');
   }
+  if (params.inspection.dryRun && !params.inspection.dryRun.canApply) {
+    throw new Error('Migration dry run has unresolved blockers and cannot be restored.');
+  }
 
   const pending: PendingMigrationRestore = {
     id: crypto.randomUUID(),

--- a/app/lib/migration/types.ts
+++ b/app/lib/migration/types.ts
@@ -150,8 +150,72 @@ export interface MigrationInspection {
   compatibility: MigrationVersionCompatibility;
   canRestore: boolean;
   manifest: CanvasMigrationManifest | null;
+  dryRun?: MigrationImportDryRun;
   risks: string[];
   warnings: string[];
+}
+
+export type MigrationImportMappingStatus = 'mapped' | 'proposed' | 'unresolved' | 'not_required';
+
+export interface MigrationImportUserMapping {
+  sourceUserId: string | null;
+  sourceEmail: string | null;
+  targetUserId: string | null;
+  targetEmail: string | null;
+  status: MigrationImportMappingStatus;
+  required: boolean;
+  reason: string;
+}
+
+export interface MigrationImportWorkspaceMapping {
+  kind: 'legacy' | 'team' | 'personal' | 'project' | 'unknown';
+  sourcePath: string;
+  sourceWorkspaceId: string | null;
+  sourceOrganizationId: string | null;
+  sourceOwnerUserId: string | null;
+  targetWorkspaceId: string | null;
+  targetPath: string | null;
+  status: MigrationImportMappingStatus;
+  required: boolean;
+  reason: string;
+}
+
+export interface MigrationImportReconnectRequirement {
+  kind: 'env_file' | 'oauth_store' | 'secret_directory' | 'unknown';
+  scope: 'legacy' | 'user' | 'organization' | 'system' | 'unknown';
+  path: string;
+  secretNames: string[];
+  required: boolean;
+  reason: string;
+}
+
+export interface MigrationImportDryRun {
+  status: 'ready' | 'attention_required' | 'blocked';
+  canApply: boolean;
+  blockers: string[];
+  source: {
+    exportProfile: MigrationExportProfile | null;
+    databaseProvider: string | null;
+    deploymentMode: string | null;
+    organizationId: string | null;
+    createdByUserId: string | null;
+    createdByEmail: string | null;
+  };
+  target: {
+    databaseProvider: string;
+    deploymentMode: string;
+    organizationId: string | null;
+    teamFeaturesEnabled: boolean;
+  };
+  users: MigrationImportUserMapping[];
+  workspaces: MigrationImportWorkspaceMapping[];
+  reconnect: MigrationImportReconnectRequirement[];
+  stats: {
+    userMappings: number;
+    workspaceMappings: number;
+    reconnectRequirements: number;
+    blockers: number;
+  };
 }
 
 export interface PendingMigrationRestore {

--- a/docs/architecture/canvas-notebook/team-workspace/15-export-import-backup-restore-policy.md
+++ b/docs/architecture/canvas-notebook/team-workspace/15-export-import-backup-restore-policy.md
@@ -171,6 +171,16 @@ Regeln:
 - To-dos, Automations und Agent-Verknuepfungen duerfen erst aktiviert werden, wenn ihre User-/Workspace-/Secret-Referenzen aufgeloest sind.
 - Team-RAG-/Embedding-/Knowledge-Graph-Daten duerfen nicht in ein SQLite-Ziel importiert werden; der Dry Run muss `requires_postgres` oder `requires_reindex` melden.
 
+V1-Implementierungsstand:
+
+- Upload-Inspection erzeugt `inspection.dryRun` mit Zielkontext, User-Mappings, Workspace-Mappings, Reconnect-Anforderungen und Blockern.
+- Der Dry Run liest lokale Ziel-User, Ziel-Organisation und aktive Workspace-Records nur fuer Preflight; es werden keine Importdaten geschrieben.
+- `createdByUserId`/`createdByEmail` aus dem Export-Manifest und Personal-Workspace-Owner aus Archivpfaden werden als User-Mappings ausgewertet.
+- Team-, Personal-, Project- und Legacy-Workspace-Pfade werden aus Manifest-/Archivpfaden erkannt.
+- Restore wird serverseitig blockiert, wenn erforderliche User-/Workspace-Mappings nicht ohne Rewrite anwendbar sind.
+- Secret-/OAuth-Reconnects aus `data/reconnect-manifest.json` werden als Nacharbeit angezeigt, aber nicht als Dateisecrets importiert.
+- Die Settings-UI zeigt Dry-Run-Status, Blocker, User-/Workspace-Mappings und Reconnect-Schritte vor dem Restore-Button an.
+
 ## Full Backup
 
 Full Backup ist fuer Betrieb und Disaster Recovery. Es soll die komplette Instanz wiederherstellbar machen.

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -460,7 +460,7 @@
     {
       "id": 28,
       "title": "Import-Flow mit User-/Workspace-Mapping, Dry-Run und Reconnect fuer Secrets/OAuth vorbereiten",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/07-filesystem-migration-and-write-policy.md",

--- a/messages/de.json
+++ b/messages/de.json
@@ -2165,6 +2165,26 @@
         "restore": "Full Restore starten",
         "restoreRestarting": "Restore wurde vorbereitet. Die App startet neu und wendet die Migration vor dem Start an.",
         "restoreRestartRequired": "Restore wurde vorbereitet. Starte App/Container neu, damit die Migration vor dem Start angewendet wird.",
+        "dryRun": {
+          "status": {
+            "ready": "Dry Run bestanden",
+            "attention_required": "Dry Run bestanden mit Reconnect-Schritten",
+            "blocked": "Dry Run blockiert"
+          },
+          "summary": "{users} User · {workspaces} Workspaces · {reconnects} Reconnects · {blockers} Blocker",
+          "blockers": "Blocker",
+          "users": "User-Mapping",
+          "workspaces": "Workspace-Mapping",
+          "reconnect": "Nach Restore neu verbinden",
+          "unknownSource": "Unbekannte Quelle",
+          "unresolved": "Nicht aufgelöst",
+          "mappingStatus": {
+            "mapped": "gemappt",
+            "proposed": "braucht explizites Mapping",
+            "unresolved": "nicht aufgelöst",
+            "not_required": "nicht erforderlich"
+          }
+        },
         "components": {
           "database": {
             "label": "SQLite-Datenbank",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2166,6 +2166,26 @@
         "restore": "Start full restore",
         "restoreRestarting": "Restore staged. The app is restarting and will apply the migration before startup.",
         "restoreRestartRequired": "Restore staged. Restart the app/container to apply the migration before startup.",
+        "dryRun": {
+          "status": {
+            "ready": "Dry run passed",
+            "attention_required": "Dry run passed with reconnect steps",
+            "blocked": "Dry run blocked"
+          },
+          "summary": "{users} users · {workspaces} workspaces · {reconnects} reconnects · {blockers} blockers",
+          "blockers": "Blockers",
+          "users": "User mapping",
+          "workspaces": "Workspace mapping",
+          "reconnect": "Reconnect after restore",
+          "unknownSource": "Unknown source",
+          "unresolved": "Unresolved",
+          "mappingStatus": {
+            "mapped": "mapped",
+            "proposed": "needs explicit mapping",
+            "unresolved": "unresolved",
+            "not_required": "not required"
+          }
+        },
         "components": {
           "database": {
             "label": "SQLite database",

--- a/scripts/migration-import-dry-run-test.ts
+++ b/scripts/migration-import-dry-run-test.ts
@@ -1,0 +1,222 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../app/lib/db/migrate';
+import {
+  DEFAULT_MIGRATION_COMPONENTS,
+  MIGRATION_BUNDLE_SCHEMA_VERSION,
+  type CanvasMigrationManifest,
+  type MigrationComponents,
+} from '../app/lib/migration/types';
+
+const execFileAsync = promisify(execFile);
+
+async function createZipArchive(root: string, name: string, manifest: CanvasMigrationManifest, files: Record<string, string>): Promise<string> {
+  const bundleDir = path.join(root, name);
+  await mkdir(bundleDir, { recursive: true });
+  await writeFile(path.join(bundleDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(bundleDir, ...relativePath.split('/'));
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, content);
+  }
+  const archivePath = path.join(root, `${name}.zip`);
+  await execFileAsync('zip', ['-qr', archivePath, '.'], { cwd: bundleDir });
+  return archivePath;
+}
+
+async function seedTargetDatabase(dataRoot: string) {
+  const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+  try {
+    runMigrations(sqlite);
+    const now = Date.now();
+    sqlite.prepare(`
+      INSERT INTO user (id, name, email, email_verified, role, created_at, updated_at)
+      VALUES (?, ?, ?, 1, 'admin', ?, ?)
+    `).run('user-target', 'Target Admin', 'admin@example.test', now, now);
+    sqlite.prepare(`
+      INSERT INTO canvas_organization_settings (
+        organization_id, owner_user_id, deployment_mode, team_features_enabled, created_at, updated_at
+      ) VALUES (?, ?, 'team', 1, ?, ?)
+    `).run('org-target', 'user-target', now, now);
+    sqlite.prepare(`
+      INSERT INTO canvas_workspaces (
+        id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?)
+    `).run(
+      'workspace-team-target',
+      'org-target',
+      'team',
+      null,
+      'workspaces/team/org-target/files',
+      'Team Workspace',
+      now,
+      now,
+    );
+    sqlite.prepare(`
+      INSERT INTO canvas_workspaces (
+        id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?)
+    `).run(
+      'workspace-personal-target',
+      'org-target',
+      'personal',
+      'user-target',
+      'workspaces/personal/user-target/files',
+      'Personal Workspace',
+      now,
+      now,
+    );
+  } finally {
+    sqlite.close();
+  }
+}
+
+async function main() {
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'canvas-migration-import-dry-run-data-'));
+  const archiveRoot = await mkdtemp(path.join(tmpdir(), 'canvas-migration-import-dry-run-archives-'));
+  const previousData = process.env.DATA;
+  const previousCanvasDataRoot = process.env.CANVAS_DATA_ROOT;
+  const previousDatabaseProvider = process.env.CANVAS_DATABASE_PROVIDER;
+  const previousDeploymentMode = process.env.CANVAS_DEPLOYMENT_MODE;
+
+  process.env.DATA = dataRoot;
+  process.env.CANVAS_DATA_ROOT = dataRoot;
+  process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
+  process.env.CANVAS_DEPLOYMENT_MODE = 'team';
+
+  try {
+    await seedTargetDatabase(dataRoot);
+    const packageJson = JSON.parse(await readFile(path.join(process.cwd(), 'package.json'), 'utf8')) as { version: string };
+    const appVersion = packageJson.version;
+    const components: MigrationComponents = {
+      ...DEFAULT_MIGRATION_COMPONENTS,
+      studioAssets: false,
+      studioOutputs: false,
+      userUploads: false,
+      agents: false,
+      skills: false,
+      secrets: true,
+    };
+
+    const matchingManifest: CanvasMigrationManifest = {
+      format: 'canvas-notebook-migration',
+      bundleSchemaVersion: MIGRATION_BUNDLE_SCHEMA_VERSION,
+      appVersion,
+      exportedAt: new Date().toISOString(),
+      exportId: 'export-matching',
+      exportProfile: 'full_admin',
+      components,
+      selection: {
+        includePersonalWorkspaces: true,
+        includePublicLinks: false,
+        includeRawSecrets: false,
+      },
+      source: {
+        databaseProvider: 'sqlite',
+        deploymentMode: 'team',
+        teamFeaturesEnabled: true,
+        managedServicesEnabled: false,
+        organizationId: 'org-target',
+        createdByUserId: 'user-target',
+        createdByEmail: 'admin@example.test',
+        createdByRole: 'admin',
+      },
+      security: {
+        publicLinksIncluded: false,
+        publicLinkTokensIncluded: false,
+        rawSecretsIncluded: false,
+        secretsMode: 'reconnect_manifest',
+        unencryptedArchive: true,
+      },
+      fileCount: 4,
+      totalBytes: 4,
+      warnings: [],
+      files: [
+        { component: 'workspace', archivePath: 'data/workspaces/team/org-target/files/team.md', size: 1, modifiedAt: new Date().toISOString() },
+        { component: 'workspace', archivePath: 'data/workspaces/personal/user-target/files/private.md', size: 1, modifiedAt: new Date().toISOString() },
+        { component: 'secrets', archivePath: 'data/reconnect-manifest.json', size: 1, modifiedAt: new Date().toISOString() },
+        { component: 'database', archivePath: 'data/sqlite.db', size: 1, modifiedAt: new Date().toISOString() },
+      ],
+    };
+
+    const matchingArchive = await createZipArchive(archiveRoot, 'matching', matchingManifest, {
+      'data/workspaces/team/org-target/files/team.md': '# Team\n',
+      'data/workspaces/personal/user-target/files/private.md': '# Private\n',
+      'data/reconnect-manifest.json': `${JSON.stringify({
+        format: 'canvas-notebook-reconnect-manifest',
+        rawSecretsIncluded: false,
+        entries: [
+          {
+            kind: 'env_file',
+            scope: 'legacy',
+            path: 'secrets/Canvas-Integrations.env',
+            secretNames: ['OPENAI_API_KEY'],
+            requiresReconnect: true,
+          },
+        ],
+      })}\n`,
+      'data/sqlite.db': 'placeholder',
+    });
+
+    const { inspectMigrationArchive } = await import('../app/lib/migration/inspect-service');
+    const matchingInspection = await inspectMigrationArchive({ uploadId: 'matching-upload', archivePath: matchingArchive });
+    assert.equal(matchingInspection.canRestore, true);
+    assert.equal(matchingInspection.dryRun?.status, 'attention_required');
+    assert.equal(matchingInspection.dryRun?.stats.blockers, 0);
+    assert.equal(matchingInspection.dryRun?.stats.reconnectRequirements, 1);
+    assert.equal(matchingInspection.dryRun?.users[0]?.status, 'mapped');
+    assert.equal(matchingInspection.dryRun?.workspaces.every((mapping) => mapping.status === 'mapped'), true);
+
+    const blockedManifest: CanvasMigrationManifest = {
+      ...matchingManifest,
+      exportId: 'export-blocked',
+      source: {
+        ...matchingManifest.source!,
+        organizationId: 'org-source',
+        createdByUserId: 'source-user',
+        createdByEmail: 'source@example.test',
+      },
+      files: [
+        { component: 'workspace', archivePath: 'data/workspaces/team/org-source/files/team.md', size: 1, modifiedAt: new Date().toISOString() },
+        { component: 'workspace', archivePath: 'data/workspaces/personal/source-user/files/private.md', size: 1, modifiedAt: new Date().toISOString() },
+        { component: 'workspace', archivePath: 'data/workspaces/project/project-source/files/project.md', size: 1, modifiedAt: new Date().toISOString() },
+      ],
+    };
+    const blockedArchive = await createZipArchive(archiveRoot, 'blocked', blockedManifest, {
+      'data/workspaces/team/org-source/files/team.md': '# Team\n',
+      'data/workspaces/personal/source-user/files/private.md': '# Private\n',
+      'data/workspaces/project/project-source/files/project.md': '# Project\n',
+    });
+    const blockedInspection = await inspectMigrationArchive({ uploadId: 'blocked-upload', archivePath: blockedArchive });
+    assert.equal(blockedInspection.canRestore, false);
+    assert.equal(blockedInspection.dryRun?.status, 'blocked');
+    assert.ok((blockedInspection.dryRun?.stats.blockers ?? 0) >= 3);
+    assert.ok(blockedInspection.dryRun?.blockers.some((blocker) => blocker.includes('source-user')));
+    assert.ok(blockedInspection.dryRun?.blockers.some((blocker) => blocker.includes('data/workspaces/team/org-source/files')));
+    assert.ok(blockedInspection.dryRun?.blockers.some((blocker) => blocker.includes('data/workspaces/project/project-source/files')));
+
+    console.log('migration-import-dry-run-test: ok');
+  } finally {
+    if (previousData === undefined) delete process.env.DATA;
+    else process.env.DATA = previousData;
+    if (previousCanvasDataRoot === undefined) delete process.env.CANVAS_DATA_ROOT;
+    else process.env.CANVAS_DATA_ROOT = previousCanvasDataRoot;
+    if (previousDatabaseProvider === undefined) delete process.env.CANVAS_DATABASE_PROVIDER;
+    else process.env.CANVAS_DATABASE_PROVIDER = previousDatabaseProvider;
+    if (previousDeploymentMode === undefined) delete process.env.CANVAS_DEPLOYMENT_MODE;
+    else process.env.CANVAS_DEPLOYMENT_MODE = previousDeploymentMode;
+    await rm(dataRoot, { recursive: true, force: true });
+    await rm(archiveRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/migration-import-dry-run-test.ts
+++ b/scripts/migration-import-dry-run-test.ts
@@ -170,6 +170,8 @@ async function main() {
     assert.equal(matchingInspection.dryRun?.status, 'attention_required');
     assert.equal(matchingInspection.dryRun?.stats.blockers, 0);
     assert.equal(matchingInspection.dryRun?.stats.reconnectRequirements, 1);
+    assert.equal(matchingInspection.dryRun?.stats.userMappings, 1);
+    assert.equal(matchingInspection.dryRun?.users.length, 1);
     assert.equal(matchingInspection.dryRun?.users[0]?.status, 'mapped');
     assert.equal(matchingInspection.dryRun?.workspaces.every((mapping) => mapping.status === 'mapped'), true);
 


### PR DESCRIPTION
## Summary
- add structured migration import dry-run data to upload inspection
- preserve export source/security/selection metadata while parsing manifests
- detect user mappings, workspace mappings, provider blockers, and reconnect requirements before restore
- block restore staging server-side when dry-run blockers remain
- surface dry-run status, blockers, mappings, and reconnect steps in Settings UI
- mark Task 28 complete and document the V1 implementation status

## Verification
- npx tsc --noEmit --pretty false
- npm run lint
- node -e "JSON.parse(require('fs').readFileSync('messages/de.json','utf8')); JSON.parse(require('fs').readFileSync('messages/en.json','utf8')); JSON.parse(require('fs').readFileSync('docs/architecture/canvas-notebook/todo.json','utf8')); console.log('json ok')"
- tsx --conditions react-server scripts/migration-import-dry-run-test.ts
- tsx --conditions react-server scripts/migration-upload-test.ts
- tsx --conditions react-server scripts/migration-export-policy-test.ts
- npm run build
- git diff --check

## Notes
- UI browser tests were not run because AGENTS.md requires explicit user approval for Playwright/Chrome tests.
- Greptile should run the first review automatically after PR creation; no manual greploop trigger was posted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up a full dry-run analysis pass during migration upload inspection: it reads the local target database context (users, workspaces, organization), maps source users and workspace paths to target equivalents, parses the reconnect manifest, and produces structured blockers that gate the restore button server-side. The Settings UI now renders dry-run status, blockers, per-user/workspace mapping rows, and reconnect steps.

- `inspect-service.ts` gains ~400 lines of mapping logic (`buildUserMappings`, `buildWorkspaceMappings`, `buildDryRun`, `readLocalImportContext`, `parseReconnectManifest`) with careful deduplication via a `findExistingCandidateKey` scan that merges candidates matched by either userId or email.
- `canRestore` now requires both `compatibility.canRestore` and `dryRun.canApply`; `restore-service.ts` adds a redundant (but safe) secondary guard so staging is blocked even if the inspection result is replayed stale.
- Previous review concerns (blocker key collisions, duplicate user candidates, misleading `proposed` blocker text) are all addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all paths that could allow an unresolvable restore are blocked both at the inspection layer and defensively in the restore staging handler.

The mapping logic is thorough and the deduplication rewrite correctly handles the user-candidate merging edge case flagged in the prior review round. No functional defects were found in the dry-run gating or blocker propagation paths. The open observations are about test assertion precision and UI label clarity, not correctness.

The end-to-end test in scripts/migration-import-dry-run-test.ts has one assertion that passes for an indirect reason (workspace path blocker rather than user-mapping blocker text); worth tightening if test coverage gaps are a concern.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/migration/inspect-service.ts | Adds ~400 lines of dry-run logic: local DB context reading, user/workspace mapping, reconnect manifest parsing, and blocker generation. Dense but well-structured; a few minor edge-case observations noted. |
| app/lib/migration/types.ts | Adds new dry-run types (MigrationImportDryRun, UserMapping, WorkspaceMapping, ReconnectRequirement). Type literals enforce V1 constraints (unencryptedArchive: true, publicLinksIncluded: false). Clean. |
| app/lib/migration/restore-service.ts | Adds a defensive dryRun.canApply guard before staging restore. Redundant with canRestore logic (which already incorporates canApply) but safe belt-and-suspenders approach. |
| app/components/settings/WorkspaceSettingsPanel.tsx | Adds dry-run status, blockers, user/workspace mappings, and reconnect items to the inspection UI. Blocker keys now use index prefix (fixing the previous collision concern). |
| scripts/migration-import-dry-run-test.ts | End-to-end test covering matching and blocked archive scenarios. One assertion passes via workspace-path blocker rather than user-mapping blocker — slightly misleading coverage. |
| messages/en.json | Adds dryRun i18n keys for status, summary, blockers, mapping sections, and mapping statuses. Complete and consistent with de.json. |
| messages/de.json | German translations for dryRun keys, matching the en.json structure. Consistent and complete. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fimport-dry-run-mapping%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fimport-dry-run-mapping%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fmigration-import-dry-run-test.ts%3A1027%0A**Test%20assertion%20passes%20via%20workspace-path%20blocker%2C%20not%20user-mapping%20blocker**%0A%0AThe%20assertion%20checks%20%60blocker.includes%28'source-user'%29%60%2C%20but%20the%20user-mapping%20blocker%20for%20this%20candidate%20uses%20the%20email%20label%3A%20%60User%20mapping%20unresolved%3A%20source%40example.test.%60%20%E2%80%94%20the%20string%20%60'source-user'%60%20does%20not%20appear%20in%20it.%20The%20assertion%20passes%20because%20the%20*personal%20workspace*%20blocker%20message%20%28%60Workspace%20mapping%20unresolved%3A%20data%2Fworkspaces%2Fpersonal%2Fsource-user%2Ffiles.%60%29%20contains%20the%20user%20ID%20embedded%20in%20the%20path.%0A%0AThis%20means%20a%20bug%20that%20silently%20swapped%20the%20user-mapping%20label%20from%20userId%20to%20email%20%28or%20vice%20versa%29%20would%20not%20be%20caught%20here.%20A%20more%20targeted%20assertion%20like%20%60blocker.includes%28'source%40example.test'%29%60%20on%20the%20user-mapping%20blocker%2C%20and%20a%20separate%20one%20on%20the%20workspace%20path%2C%20would%20give%20tighter%20coverage.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Flib%2Fmigration%2Finspect-service.ts%3A584-589%0A**%60stats.userMappings%60%20counts%20all%20candidates%2C%20including%20fully-mapped%20ones**%0A%0A%60userMappings%3A%20users.length%60%20reflects%20every%20user%20candidate%20regardless%20of%20status%2C%20so%20a%20same-instance%20restore%20where%20all%20users%20are%20cleanly%20%60mapped%60%20still%20shows%20e.g.%20%223%20users%20%C2%B7%202%20workspaces%20%C2%B7%200%20reconnects%20%C2%B7%200%20blockers%22%20in%20the%20UI%20summary.%20The%20%60blockers%60%20count%20makes%20it%20obvious%20when%20action%20is%20needed%2C%20but%20%223%20user%20mappings%22%20can%20read%20as%20%223%20things%20to%20resolve%22.%20Consider%20naming%20the%20stat%20%60userCandidates%60%20or%20filtering%20to%20%60users.filter%28u%20%3D%3E%20u.status%20!%3D%3D%20'not_required'%29.length%60%20if%20the%20intent%20is%20to%20show%20migration%20complexity%20rather%20than%20total%20count.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Flib%2Fmigration%2Finspect-service.ts%3A148-155%0A**%60parseExportSecurity%60%20silently%20ignores%20actual%20archive%20values%20for%20most%20fields**%0A%0AFour%20of%20the%20five%20fields%20%E2%80%94%20%60publicLinksIncluded%60%2C%20%60publicLinkTokensIncluded%60%2C%20%60rawSecretsIncluded%60%2C%20and%20%60unencryptedArchive%60%20%E2%80%94%20are%20hardcoded%20regardless%20of%20what%20the%20zip's%20%60security%60%20object%20contains.%20The%20type%20definition%20enforces%20literal%20%60false%60%2F%60true%60%20for%20these%20fields%2C%20so%20for%20V1%20archives%20this%20is%20always%20correct.%20However%2C%20if%20a%20future%20archive%20version%20sets%20%60unencryptedArchive%3A%20false%60%20%28encrypted%29%2C%20the%20parser%20would%20silently%20report%20it%20as%20%60true%60%2C%20giving%20the%20dry-run%20an%20incorrect%20security%20picture.%20A%20note%20in%20the%20function%20or%20a%20guard%20%28%60if%20%28security.unencryptedArchive%20!%3D%3D%20true%29%20return%20undefined%3B%60%29%20would%20make%20the%20V1-only%20assumption%20explicit%20and%20fail%20loudly%20for%20out-of-spec%20archives.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=30&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address import dry-run review feedback"](https://github.com/canvascoding/canvas-notebook/commit/d7a7daebf4c7ddbabddfb2dfd644dae77c57af2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38898080)</sub>

<!-- /greptile_comment -->