### PR TITLE
Add audit trail foundation

### DIFF
--- a/app/api/admin/organization/users/[userId]/offboarding/route.ts
+++ b/app/api/admin/organization/users/[userId]/offboarding/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import {
   createOffboardingPreflight,
   offboardUser,
@@ -78,6 +79,25 @@ export async function POST(request: NextRequest, context: RouteContext) {
       requestedByUserId: guard.session.user.id,
       reason: typeof body.reason === 'string' ? body.reason : null,
       acknowledgeWarnings: body.acknowledgeWarnings === true,
+    });
+    await recordAuditEvent({
+      organizationId: guard.state.organizationId,
+      userId: guard.session.user.id,
+      source: 'admin',
+      eventType: 'admin',
+      entityType: 'user',
+      entityId: userId,
+      action: 'user.offboard',
+      status: 'success',
+      summary: `User ${userId} offboarded.`,
+      metadata: {
+        targetUserId: userId,
+        reasonProvided: typeof body.reason === 'string' && body.reason.trim().length > 0,
+        acknowledgeWarnings: body.acknowledgeWarnings === true,
+        actionCount: result.actions.length,
+        blockers: result.preflight.blockers.length,
+        warnings: result.preflight.warnings.length,
+      },
     });
     return NextResponse.json({
       success: true,

--- a/app/api/agents/config/route.ts
+++ b/app/api/agents/config/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 import {
@@ -249,6 +250,23 @@ export async function PATCH(request: NextRequest) {
         defaultThinking: thinkingLevel || providerConfig.thinking || 'off',
       });
       const effective = await resolveAgentRuntimeSettings(agentId);
+      await recordAuditEvent({
+        userId: session.user.id,
+        agentId,
+        source: 'agents',
+        eventType: 'agent',
+        entityType: 'agent_runtime_config',
+        entityId: agentId,
+        action: 'agent_runtime_config.patch',
+        status: 'success',
+        summary: `Runtime config patched for agent ${agentId}.`,
+        metadata: {
+          provider,
+          model: model || providerConfig.model,
+          thinkingLevel: thinkingLevel || providerConfig.thinking || 'off',
+          makeActiveProvider: false,
+        },
+      });
 
       return NextResponse.json({
         success: true,
@@ -269,6 +287,23 @@ export async function PATCH(request: NextRequest) {
       },
     });
     const effective = await resolveAgentRuntimeSettings(agentId);
+    await recordAuditEvent({
+      userId: session.user.id,
+      agentId,
+      source: 'agents',
+      eventType: 'agent',
+      entityType: 'agent_runtime_config',
+      entityId: agentId,
+      action: 'agent_runtime_config.patch',
+      status: 'success',
+      summary: `Runtime config patched for agent ${agentId}.`,
+      metadata: {
+        provider,
+        model: model || providerConfig.model,
+        thinkingLevel: thinkingLevel || providerConfig.thinking || 'off',
+        makeActiveProvider: payload.makeActiveProvider === true,
+      },
+    });
 
     return NextResponse.json({
       success: true,
@@ -328,6 +363,22 @@ export async function PUT(request: NextRequest) {
       });
 
       const effective = await resolveAgentRuntimeSettings(agentId);
+      await recordAuditEvent({
+        userId: session.user.id,
+        agentId,
+        source: 'agents',
+        eventType: 'agent',
+        entityType: 'agent_runtime_config',
+        entityId: agentId,
+        action: 'agent_runtime_config.replace',
+        status: 'success',
+        summary: `Runtime config replaced for agent ${agentId}.`,
+        metadata: {
+          provider,
+          model,
+          thinking,
+        },
+      });
 
       return NextResponse.json({
         success: true,
@@ -337,6 +388,21 @@ export async function PUT(request: NextRequest) {
 
     const piConfig = await writePiRuntimeConfig(piConfigInput);
     const effective = await resolveAgentRuntimeSettings(agentId);
+    await recordAuditEvent({
+      userId: session.user.id,
+      agentId,
+      source: 'agents',
+      eventType: 'agent',
+      entityType: 'agent_runtime_config',
+      entityId: agentId,
+      action: 'agent_runtime_config.replace',
+      status: 'success',
+      summary: `Runtime config replaced for agent ${agentId}.`,
+      metadata: {
+        activeProvider: piConfig.activeProvider,
+        providers: Object.keys(piConfig.providers || {}),
+      },
+    });
 
     return NextResponse.json({
       success: true,

--- a/app/api/agents/files/route.ts
+++ b/app/api/agents/files/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 import {
@@ -117,6 +118,26 @@ export async function PUT(request: NextRequest) {
     }
 
     const content = await writeManagedAgentFile(fileName, payload.content, agentId, { userId: session.user.id });
+    const normalizedAgentId = normalizeManagedAgentId(agentId);
+    await recordAuditEvent({
+      userId: session.user.id,
+      agentId: normalizedAgentId,
+      source: 'agents',
+      eventType: 'agent',
+      entityType: 'agent_managed_file',
+      entityId: `${normalizedAgentId}:${fileName}`,
+      action: 'agent_file.write',
+      status: 'success',
+      summary: `Managed agent file ${fileName} written for ${normalizedAgentId}.`,
+      metadata: {
+        fileName,
+        contentLength: payload.content.length,
+      },
+      input: {
+        fileName,
+        contentLength: payload.content.length,
+      },
+    });
     return NextResponse.json({
       success: true,
       data: {
@@ -179,6 +200,21 @@ export async function POST(request: NextRequest) {
       }
 
       const content = await resetManagedAgentFile(fileName, agentId, { userId: session.user.id });
+      const normalizedAgentId = normalizeManagedAgentId(agentId);
+      await recordAuditEvent({
+        userId: session.user.id,
+        agentId: normalizedAgentId,
+        source: 'agents',
+        eventType: 'agent',
+        entityType: 'agent_managed_file',
+        entityId: `${normalizedAgentId}:${fileName}`,
+        action: 'agent_file.reset',
+        status: 'success',
+        summary: `Managed agent file ${fileName} reset for ${normalizedAgentId}.`,
+        metadata: {
+          fileName,
+        },
+      });
 
       return NextResponse.json({
         success: true,
@@ -199,6 +235,21 @@ export async function POST(request: NextRequest) {
         const content = await resetManagedAgentFile(fileName, agentId, { userId: session.user.id });
         results.push({ fileName, content });
       }
+      const normalizedAgentId = normalizeManagedAgentId(agentId);
+      await recordAuditEvent({
+        userId: session.user.id,
+        agentId: normalizedAgentId,
+        source: 'agents',
+        eventType: 'agent',
+        entityType: 'agent_managed_file',
+        entityId: normalizedAgentId,
+        action: 'agent_files.reset_all',
+        status: 'success',
+        summary: `Managed agent files reset for ${normalizedAgentId}.`,
+        metadata: {
+          fileNames,
+        },
+      });
 
       return NextResponse.json({
         success: true,

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import {
   createAgentProfile,
@@ -115,7 +116,26 @@ export async function POST(request: NextRequest) {
       relevantSkills: stringArrayValue(payload.relevantSkills),
       relevantConnections: stringArrayValue(payload.relevantConnections),
     });
-    await writeInitialAgentFiles(agent.agentId, managedFilesValue(payload.files), session.user.id);
+    const managedFiles = managedFilesValue(payload.files);
+    await writeInitialAgentFiles(agent.agentId, managedFiles, session.user.id);
+    await recordAuditEvent({
+      userId: session.user.id,
+      agentId: agent.agentId,
+      source: 'agents',
+      eventType: 'agent',
+      entityType: 'agent_profile',
+      entityId: agent.agentId,
+      action: 'agent.create',
+      status: 'success',
+      summary: `Agent ${agent.agentId} created.`,
+      metadata: {
+        name: agent.name,
+        defaultProvider: agent.defaultProvider,
+        defaultModel: agent.defaultModel,
+        defaultThinking: agent.defaultThinking,
+        managedFiles: Object.keys(managedFiles),
+      },
+    });
     return NextResponse.json({ success: true, data: { agent } });
   } catch (error) {
     return NextResponse.json(
@@ -157,6 +177,23 @@ export async function PATCH(request: NextRequest) {
       relevantSkills: Object.hasOwn(payload, 'relevantSkills') ? stringArrayValue(payload.relevantSkills) : undefined,
       relevantConnections: Object.hasOwn(payload, 'relevantConnections') ? stringArrayValue(payload.relevantConnections) : undefined,
     });
+    await recordAuditEvent({
+      userId: session.user.id,
+      agentId: agent.agentId,
+      source: 'agents',
+      eventType: 'agent',
+      entityType: 'agent_profile',
+      entityId: agent.agentId,
+      action: 'agent.update',
+      status: 'success',
+      summary: `Agent ${agent.agentId} updated.`,
+      metadata: {
+        changedFields: Object.keys(payload).filter((key) => key !== 'files'),
+        defaultProvider: agent.defaultProvider,
+        defaultModel: agent.defaultModel,
+        defaultThinking: agent.defaultThinking,
+      },
+    });
     return NextResponse.json({ success: true, data: { agent } });
   } catch (error) {
     return NextResponse.json(
@@ -187,6 +224,17 @@ export async function DELETE(request: NextRequest) {
       throw new Error('agentId is required.');
     }
     await deleteAgentProfile(agentId);
+    await recordAuditEvent({
+      userId: session.user.id,
+      agentId,
+      source: 'agents',
+      eventType: 'agent',
+      entityType: 'agent_profile',
+      entityId: agentId,
+      action: 'agent.delete',
+      status: 'success',
+      summary: `Agent ${agentId} deleted.`,
+    });
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json(

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -3,10 +3,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/app/lib/auth';
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 
+function hasAuthPathSegment(pathname: string, segment: string): boolean {
+  return new RegExp(`/${segment}(?:/|$)`).test(pathname);
+}
+
 function authAuditAction(pathname: string): string | null {
-  if (pathname.includes('/sign-in')) return 'auth.sign_in';
-  if (pathname.includes('/sign-out')) return 'auth.sign_out';
-  if (pathname.includes('/sign-up')) return 'auth.sign_up';
+  if (hasAuthPathSegment(pathname, 'sign-in')) return 'auth.sign_in';
+  if (hasAuthPathSegment(pathname, 'sign-out')) return 'auth.sign_out';
+  if (hasAuthPathSegment(pathname, 'sign-up')) return 'auth.sign_up';
   return null;
 }
 
@@ -24,9 +28,44 @@ async function getCurrentAuthUserId(request: NextRequest): Promise<string | null
   }
 }
 
-async function recordAuthRequestAudit(request: NextRequest, action: string, response: Response) {
+function readUserIdFromPayload(value: unknown): string | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const directUserId = typeof record.userId === 'string' ? record.userId.trim() : '';
+  if (directUserId) return directUserId;
+
+  const userValue = record.user;
+  if (!userValue || typeof userValue !== 'object') return null;
+  const userId = (userValue as Record<string, unknown>).id;
+  return typeof userId === 'string' && userId.trim() ? userId.trim() : null;
+}
+
+async function getAuthResponseUserId(response: Response): Promise<string | null> {
+  if (response.status >= 400) return null;
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.toLowerCase().includes('application/json')) return null;
+
+  try {
+    return readUserIdFromPayload(await response.clone().json());
+  } catch {
+    return null;
+  }
+}
+
+async function resolveAuthAuditUserId(request: NextRequest, action: string, response: Response, beforeUserId: string | null): Promise<string | null> {
+  if (action === 'auth.sign_out') return beforeUserId;
+  if (action === 'auth.sign_in') return (await getAuthResponseUserId(response)) ?? null;
+  return beforeUserId;
+}
+
+async function recordAuthRequestAudit(
+  request: NextRequest,
+  action: string,
+  response: Response,
+  beforeUserId: string | null,
+) {
   await recordAuditEvent({
-    userId: await getCurrentAuthUserId(request),
+    userId: await resolveAuthAuditUserId(request, action, response, beforeUserId),
     source: 'auth',
     eventType: 'auth',
     entityType: 'auth_request',
@@ -47,14 +86,15 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   const action = authAuditAction(pathname);
+  const beforeUserId = action ? await getCurrentAuthUserId(request) : null;
 
-  if (pathname.includes('/sign-up')) {
+  if (hasAuthPathSegment(pathname, 'sign-up')) {
     const response = NextResponse.json({ message: 'Sign up is disabled' }, { status: 403 });
-    if (action) await recordAuthRequestAudit(request, action, response);
+    if (action) await recordAuthRequestAudit(request, action, response, beforeUserId);
     return response;
   }
 
   const response = await auth.handler(request);
-  if (action) await recordAuthRequestAudit(request, action, response);
+  if (action) await recordAuthRequestAudit(request, action, response, beforeUserId);
   return response;
 }

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -1,6 +1,44 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { auth } from '@/app/lib/auth';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
+
+function authAuditAction(pathname: string): string | null {
+  if (pathname.includes('/sign-in')) return 'auth.sign_in';
+  if (pathname.includes('/sign-out')) return 'auth.sign_out';
+  if (pathname.includes('/sign-up')) return 'auth.sign_up';
+  return null;
+}
+
+function authAuditStatus(status: number): 'success' | 'failure' | 'blocked' {
+  if (status === 403) return 'blocked';
+  return status < 400 ? 'success' : 'failure';
+}
+
+async function getCurrentAuthUserId(request: NextRequest): Promise<string | null> {
+  try {
+    const session = await auth.api.getSession({ headers: request.headers });
+    return session?.user?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function recordAuthRequestAudit(request: NextRequest, action: string, response: Response) {
+  await recordAuditEvent({
+    userId: await getCurrentAuthUserId(request),
+    source: 'auth',
+    eventType: 'auth',
+    entityType: 'auth_request',
+    action,
+    status: authAuditStatus(response.status),
+    summary: `${action} returned HTTP ${response.status}.`,
+    metadata: {
+      endpoint: request.nextUrl.pathname,
+      statusCode: response.status,
+    },
+  });
+}
 
 export async function GET(request: NextRequest) {
   return auth.handler(request);
@@ -8,10 +46,15 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
+  const action = authAuditAction(pathname);
 
-  if (pathname.includes('/sign-up/')) {
-    return NextResponse.json({ message: 'Sign up is disabled' }, { status: 403 });
+  if (pathname.includes('/sign-up')) {
+    const response = NextResponse.json({ message: 'Sign up is disabled' }, { status: 403 });
+    if (action) await recordAuthRequestAudit(request, action, response);
+    return response;
   }
 
-  return auth.handler(request);
+  const response = await auth.handler(request);
+  if (action) await recordAuthRequestAudit(request, action, response);
+  return response;
 }

--- a/app/api/automations/jobs/[jobId]/route.ts
+++ b/app/api/automations/jobs/[jobId]/route.ts
@@ -7,6 +7,7 @@ import {
 } from '@/app/lib/automations/api';
 import { assertCanAccessAutomationJob } from '@/app/lib/automations/policy';
 import { deleteAutomationJob, getAutomationJob, updateAutomationJob } from '@/app/lib/automations/store';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { deleteGatewayTrigger, updateGatewayTrigger } from '@/app/lib/composio/composio-gateway';
 
 type RouteContext = {
@@ -74,6 +75,25 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     if (!updated) {
       return NextResponse.json({ success: false, error: 'Automation not found.' }, { status: 404 });
     }
+    await recordAuditEvent({
+      organizationId: updated.organizationId,
+      workspaceId: updated.workspaceId,
+      userId: session.user.id,
+      agentId: updated.agentId,
+      source: 'automations',
+      eventType: 'automation',
+      entityType: 'automation_job',
+      entityId: updated.id,
+      action: 'automation_job.update',
+      status: 'success',
+      summary: `Automation job ${updated.id} updated.`,
+      metadata: {
+        scope: updated.scope,
+        jobScope: updated.jobScope,
+        status: updated.status,
+        changedFields: payload && typeof payload === 'object' && !Array.isArray(payload) ? Object.keys(payload) : [],
+      },
+    });
     return NextResponse.json({ success: true, data: updated });
   } catch (error) {
     const status = getAutomationRouteErrorStatus(error);
@@ -112,6 +132,25 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
   if (!deleted) {
     return NextResponse.json({ success: false, error: 'Automation not found.' }, { status: 404 });
   }
+  await recordAuditEvent({
+    organizationId: existing.organizationId,
+    workspaceId: existing.workspaceId,
+    userId: session.user.id,
+    agentId: existing.agentId,
+    source: 'automations',
+    eventType: 'automation',
+    entityType: 'automation_job',
+    entityId: existing.id,
+    action: 'automation_job.delete',
+    status: 'success',
+    summary: `Automation job ${existing.id} deleted.`,
+    metadata: {
+      scope: existing.scope,
+      jobScope: existing.jobScope,
+      status: existing.status,
+      hadComposioTrigger: Boolean(existing.composioTriggerId),
+    },
+  });
 
   return NextResponse.json({ success: true });
 }

--- a/app/api/automations/jobs/[jobId]/run-now/route.ts
+++ b/app/api/automations/jobs/[jobId]/run-now/route.ts
@@ -4,6 +4,7 @@ import { requireAutomationSession, applyAutomationRateLimit } from '@/app/lib/au
 import { assertCanAccessAutomationJob } from '@/app/lib/automations/policy';
 import { dispatchAutomationRunExecution } from '@/app/lib/automations/dispatch';
 import { getAutomationJob, scheduleAutomationJobRun } from '@/app/lib/automations/store';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 
 type RouteContext = {
   params: Promise<{ jobId: string }>;
@@ -37,6 +38,27 @@ export async function POST(request: NextRequest, context: RouteContext) {
       return NextResponse.json({ success: false, error: 'Automation already has an in-flight run.' }, { status: 409 });
     }
     dispatchAutomationRunExecution(run.id);
+    await recordAuditEvent({
+      organizationId: run.organizationId,
+      workspaceId: run.workspaceId,
+      userId: session.user.id,
+      agentId: job.agentId,
+      source: 'automations',
+      eventType: 'automation',
+      entityType: 'automation_run',
+      entityId: run.id,
+      action: 'automation_run.queue_manual',
+      status: 'queued',
+      summary: `Automation run ${run.id} queued manually.`,
+      metadata: {
+        jobId: job.id,
+        scope: run.scope,
+        jobScope: run.jobScope,
+        triggerType: run.triggerType,
+        actorType: run.actorType,
+        actorUserId: run.actorUserId,
+      },
+    });
     return NextResponse.json({ success: true, data: run }, { status: 202 });
   } catch (error) {
     return NextResponse.json(

--- a/app/api/automations/jobs/route.ts
+++ b/app/api/automations/jobs/route.ts
@@ -7,6 +7,7 @@ import {
   requireAutomationSession,
 } from '@/app/lib/automations/api';
 import { createAutomationJob, listAutomationJobs } from '@/app/lib/automations/store';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 
 export async function GET(request: NextRequest) {
   const { session, response } = await requireAutomationSession(request);
@@ -38,6 +39,29 @@ export async function POST(request: NextRequest) {
     const payload = await request.json();
     assertCanCreateRequestedAutomation(payload, session.user);
     const job = await createAutomationJob(payload, session.user);
+    await recordAuditEvent({
+      organizationId: job.organizationId,
+      workspaceId: job.workspaceId,
+      userId: session.user.id,
+      agentId: job.agentId,
+      source: 'automations',
+      eventType: 'automation',
+      entityType: 'automation_job',
+      entityId: job.id,
+      action: 'automation_job.create',
+      status: 'success',
+      summary: `Automation job ${job.id} created.`,
+      metadata: {
+        scope: job.scope,
+        jobScope: job.jobScope,
+        workspaceType: job.workspaceType,
+        scheduleKind: job.schedule.kind,
+        status: job.status,
+        responsibleUserId: job.responsibleUserId,
+        serviceActorId: job.serviceActorId,
+        deliveryMode: job.deliveryMode,
+      },
+    });
     return NextResponse.json({ success: true, data: job }, { status: 201 });
   } catch (error) {
     const status = getAutomationRouteErrorStatus(error);

--- a/app/api/files/copy/route.ts
+++ b/app/api/files/copy/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { batchCopyBetweenWorkspaces } from '@/app/lib/filesystem/workspace-files';
 import { isProtectedAppOutputFolder } from '@/app/lib/filesystem/app-output-folders';
@@ -89,6 +90,31 @@ export async function POST(request: NextRequest) {
     });
 
     invalidateWorkspaceFileViews({ fileOptions: targetFileOptions, subtreeDirs: [destDir] });
+    await recordAuditEvent({
+      organizationId: targetWorkspaceResult.workspace.organizationId,
+      workspaceId: targetWorkspaceResult.workspace.workspaceId,
+      userId: session.user.id,
+      source: 'files',
+      eventType: 'file',
+      entityType: 'workspace_path',
+      entityId: destDir,
+      action: 'file.copy',
+      status: result.failed.length > 0 ? 'failure' : 'success',
+      summary: `${result.copied.length} path(s) copied; ${result.failed.length} failed.`,
+      metadata: {
+        sources,
+        destDir,
+        copied: result.copied,
+        failed: result.failed,
+        skipped: result.skipped,
+        sourceWorkspaceId: sourceWorkspaceResult.workspace.workspaceId,
+        sourceWorkspaceType: sourceWorkspaceResult.workspace.workspaceType,
+        targetWorkspaceId: targetWorkspaceResult.workspace.workspaceId,
+        targetWorkspaceType: targetWorkspaceResult.workspace.workspaceType,
+        overwrite,
+        renameOnCollision,
+      },
+    });
 
     return jsonSuccess({
       copied: result.copied,

--- a/app/api/files/create/route.ts
+++ b/app/api/files/create/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { createDirectory, writeFile } from '@/app/lib/filesystem/workspace-files';
 import { createEmptyExcalidrawFileContent, isExcalidrawFilePath } from '@/app/lib/excalidraw-file';
 import {
@@ -50,6 +51,24 @@ export async function POST(request: NextRequest) {
     }
 
     invalidateWorkspaceFileViews({ fileOptions, fullTree: true });
+    await recordAuditEvent({
+      organizationId: workspaceResult.workspace.organizationId,
+      workspaceId: workspaceResult.workspace.workspaceId,
+      userId: workspaceResult.session.user.id,
+      source: 'files',
+      eventType: 'file',
+      entityType: 'workspace_path',
+      entityId: path,
+      action: type === 'directory' ? 'file.directory.create' : 'file.create',
+      status: 'success',
+      summary: `${type} created at ${path}.`,
+      metadata: {
+        path,
+        type,
+        template: template ?? null,
+        workspaceType: workspaceResult.workspace.workspaceType,
+      },
+    });
 
     return jsonSuccess();
   } catch (error) {

--- a/app/api/files/delete/route.ts
+++ b/app/api/files/delete/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { batchDelete } from '@/app/lib/filesystem/workspace-files';
 import { isProtectedAppOutputFolder } from '@/app/lib/filesystem/app-output-folders';
 import { syncPublicSharesAfterDelete } from '@/app/lib/public-sharing/public-file-shares';
@@ -47,6 +48,24 @@ export async function DELETE(request: NextRequest) {
     invalidateWorkspaceFileViews({
       fileOptions,
       subtreeDirs: result.deleted.map(getParentDirectory),
+    });
+    await recordAuditEvent({
+      organizationId: workspaceResult.workspace.organizationId,
+      workspaceId: workspaceResult.workspace.workspaceId,
+      userId: workspaceResult.session.user.id,
+      source: 'files',
+      eventType: 'file',
+      entityType: 'workspace_path',
+      entityId: result.deleted.join(','),
+      action: 'file.delete',
+      status: result.failed.length > 0 ? 'failure' : 'success',
+      summary: `${result.deleted.length} path(s) deleted; ${result.failed.length} failed.`,
+      metadata: {
+        requestedPaths: pathsToDelete,
+        deleted: result.deleted,
+        failed: result.failed,
+        workspaceType: workspaceResult.workspace.workspaceType,
+      },
     });
 
     return jsonSuccess({

--- a/app/api/files/rename/route.ts
+++ b/app/api/files/rename/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { renameFile, checkRenameConflict, type RenameConflictError } from '@/app/lib/filesystem/workspace-files';
 import { isProtectedAppOutputFolder } from '@/app/lib/filesystem/app-output-folders';
 import { syncPublicSharesAfterMove } from '@/app/lib/public-sharing/public-file-shares';
@@ -52,6 +53,24 @@ export async function POST(request: NextRequest) {
         await renameFile(oldPath, newPath, true, fileOptions);
         await syncPublicSharesAfterMove(oldPath, newPath, workspaceResult.workspace);
         invalidateWorkspaceFileViews({ fileOptions, fullTree: true });
+        await recordAuditEvent({
+          organizationId: workspaceResult.workspace.organizationId,
+          workspaceId: workspaceResult.workspace.workspaceId,
+          userId: workspaceResult.session.user.id,
+          source: 'files',
+          eventType: 'file',
+          entityType: 'workspace_path',
+          entityId: newPath,
+          action: 'file.rename',
+          status: 'success',
+          summary: `Path renamed from ${oldPath} to ${newPath}.`,
+          metadata: {
+            oldPath,
+            newPath,
+            overwrite: true,
+            workspaceType: workspaceResult.workspace.workspaceType,
+          },
+        });
         return jsonSuccess();
       }
 
@@ -66,6 +85,24 @@ export async function POST(request: NextRequest) {
     await renameFile(oldPath, newPath, overwrite, fileOptions);
     await syncPublicSharesAfterMove(oldPath, newPath, workspaceResult.workspace);
     invalidateWorkspaceFileViews({ fileOptions, fullTree: true });
+    await recordAuditEvent({
+      organizationId: workspaceResult.workspace.organizationId,
+      workspaceId: workspaceResult.workspace.workspaceId,
+      userId: workspaceResult.session.user.id,
+      source: 'files',
+      eventType: 'file',
+      entityType: 'workspace_path',
+      entityId: newPath,
+      action: 'file.rename',
+      status: 'success',
+      summary: `Path renamed from ${oldPath} to ${newPath}.`,
+      metadata: {
+        oldPath,
+        newPath,
+        overwrite,
+        workspaceType: workspaceResult.workspace.workspaceType,
+      },
+    });
 
     return jsonSuccess();
   } catch (error) {

--- a/app/api/files/upload/route.ts
+++ b/app/api/files/upload/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'path';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { writeFile, createDirectory } from '@/app/lib/filesystem/workspace-files';
 import { clearFileTreeCache } from '@/app/lib/utils/file-tree-cache';
 import { invalidateFileReferenceCache } from '@/app/lib/filesystem/file-reference-cache';
@@ -151,6 +152,26 @@ export async function POST(request: NextRequest) {
     await syncPublicSharesAfterWrite(uploadedPaths, workspaceResult.workspace);
     clearFileTreeCache(fileOptions.workspace?.workspaceId);
     invalidateFileReferenceCache(fileOptions);
+    await recordAuditEvent({
+      organizationId: workspaceResult.workspace.organizationId,
+      workspaceId: workspaceResult.workspace.workspaceId,
+      userId: workspaceResult.session.user.id,
+      source: 'files',
+      eventType: 'file',
+      entityType: 'workspace_path',
+      entityId: targetDir,
+      action: 'file.upload',
+      status: 'success',
+      summary: `${uploadedPaths.length} file(s) uploaded.`,
+      metadata: {
+        targetDir,
+        uploadedPaths,
+        uploadedFiles,
+        totalSize,
+        workspaceType: workspaceResult.workspace.workspaceType,
+        converted: Boolean(convertParamsList),
+      },
+    });
 
     return NextResponse.json({ success: true, count: files.length, files: uploadedFiles });
   } catch (error) {

--- a/app/api/files/write/route.ts
+++ b/app/api/files/write/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { writeFile } from '@/app/lib/filesystem/workspace-files';
 import { queuePublicSharesAfterWrite } from '@/app/lib/public-sharing/public-file-shares';
 import { getParentDirectory } from '@/app/lib/files/path-utils';
@@ -41,6 +42,28 @@ export async function POST(request: NextRequest) {
     await writeFile(path, finalContent, fileOptions);
     invalidateWorkspaceFileViews({ fileOptions, subtreeDirs: [getParentDirectory(path)] });
     queuePublicSharesAfterWrite([path], workspaceResult.workspace);
+    await recordAuditEvent({
+      organizationId: workspaceResult.workspace.organizationId,
+      workspaceId: workspaceResult.workspace.workspaceId,
+      userId: workspaceResult.session.user.id,
+      source: 'files',
+      eventType: 'file',
+      entityType: 'workspace_path',
+      entityId: path,
+      action: 'file.write',
+      status: 'success',
+      summary: `File written at ${path}.`,
+      metadata: {
+        path,
+        workspaceType: workspaceResult.workspace.workspaceType,
+        contentBytes: Buffer.isBuffer(finalContent) ? finalContent.byteLength : Buffer.byteLength(finalContent),
+        encoded: typeof content === 'string' && content.startsWith('base64:'),
+      },
+      input: {
+        path,
+        contentLength: typeof content === 'string' ? content.length : null,
+      },
+    });
 
     return jsonSuccess();
   } catch (error) {

--- a/app/api/integrations/env/route.ts
+++ b/app/api/integrations/env/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import {
   type EnvScope,
@@ -91,11 +92,43 @@ export async function PUT(request: NextRequest) {
     if (mode === 'raw') {
       await writeScopedEnvRaw(scope, payload.rawContent ?? '', storageScope);
       const updated = await readScopedEnvState(scope, storageScope);
+      await recordAuditEvent({
+        userId: authResult.session.user.id,
+        source: 'integrations',
+        eventType: 'secret',
+        entityType: 'env_scope',
+        entityId: scope,
+        action: 'env.update_raw',
+        status: 'success',
+        summary: `${scope} environment variables updated in raw mode.`,
+        metadata: {
+          scope,
+          mode,
+          rawContentLength: payload.rawContent?.length ?? 0,
+          keys: updated.entries.map((entry) => entry.key),
+        },
+      });
       return NextResponse.json({ success: true, data: updated });
     }
 
     const entries = Array.isArray(payload.entries) ? payload.entries : [];
     const updated = await replaceScopedEnvEntries(scope, entries, storageScope);
+    await recordAuditEvent({
+      userId: authResult.session.user.id,
+      source: 'integrations',
+      eventType: 'secret',
+      entityType: 'env_scope',
+      entityId: scope,
+      action: 'env.update',
+      status: 'success',
+      summary: `${scope} environment variables updated.`,
+      metadata: {
+        scope,
+        mode,
+        keys: updated.entries.map((entry) => entry.key),
+        entryCount: updated.entries.length,
+      },
+    });
     return NextResponse.json({ success: true, data: updated });
   } catch (error) {
     console.error('[API] integrations/env PUT error:', error);

--- a/app/api/migration/export/route.ts
+++ b/app/api/migration/export/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireMigrationExportPermission } from '@/app/lib/migration/auth';
 import { createMigrationExportJob, normalizeMigrationExportOptions } from '@/app/lib/migration/export-service';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
@@ -27,6 +28,25 @@ export async function POST(request: NextRequest) {
         createdByUserId: admin.session.user.id,
         createdByEmail: admin.session.user.email,
         createdByRole: admin.permission.role,
+      },
+    });
+    await recordAuditEvent({
+      organizationId: admin.state.organizationId,
+      userId: admin.session.user.id,
+      source: 'migration',
+      eventType: 'admin',
+      entityType: 'migration_export',
+      entityId: job.id,
+      action: 'migration_export.create',
+      status: 'queued',
+      summary: `Migration export ${job.id} queued with ${job.profile} profile.`,
+      metadata: {
+        profile: job.profile,
+        components: job.components,
+        selection: job.selection,
+        fileName: job.fileName,
+        databaseProvider: admin.state.databaseProvider,
+        teamFeaturesEnabled: admin.state.teamFeaturesEnabled,
       },
     });
     return NextResponse.json({ success: true, job });

--- a/app/api/migration/restore/route.ts
+++ b/app/api/migration/restore/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireMigrationRestorePermission } from '@/app/lib/migration/auth';
 import {
   scheduleMigrationRestartIfSupported,
@@ -48,6 +49,28 @@ export async function POST(request: NextRequest) {
       },
     });
     const restartScheduled = scheduleMigrationRestartIfSupported();
+    await recordAuditEvent({
+      organizationId: admin.state.organizationId,
+      userId: admin.session.user.id,
+      source: 'migration',
+      eventType: 'admin',
+      entityType: 'migration_restore',
+      entityId: pending.id,
+      action: 'migration_restore.stage',
+      status: restartScheduled ? 'queued' : 'success',
+      summary: `Migration restore ${pending.id} staged.`,
+      metadata: {
+        uploadId: upload.id,
+        components: pending.components,
+        invalidateSessions: pending.invalidateSessions,
+        pauseAutomations: pending.pauseAutomations,
+        clearOAuthTokens: pending.clearOAuthTokens,
+        preserveTargetInstanceAndLicense: pending.preserveTargetInstanceAndLicense,
+        restartScheduled,
+      },
+      artifactRef: pending.archivePath,
+      inputHash: upload.archiveSha256 ?? null,
+    });
     return NextResponse.json({ success: true, pending, restartScheduled });
   } catch (error) {
     console.error('[Migration Restore] Failed to stage restore:', error);

--- a/app/api/migration/uploads/[id]/complete/route.ts
+++ b/app/api/migration/uploads/[id]/complete/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireMigrationRestorePermission } from '@/app/lib/migration/auth';
 import { inspectMigrationArchive } from '@/app/lib/migration/inspect-service';
 import {
@@ -34,6 +35,27 @@ export async function POST(
       archivePath: finalized.archivePath,
     });
     const upload = await attachInspectionToUpload(id, inspection);
+    await recordAuditEvent({
+      organizationId: admin.state.organizationId,
+      userId: admin.session.user.id,
+      source: 'migration',
+      eventType: 'admin',
+      entityType: 'migration_upload',
+      entityId: upload.id,
+      action: 'migration_upload.complete',
+      status: inspection.canRestore ? 'success' : 'blocked',
+      summary: `Migration upload ${upload.id} finalized and inspected.`,
+      metadata: {
+        fileName: upload.fileName,
+        totalBytes: upload.totalBytes,
+        archiveSha256: upload.archiveSha256,
+        canRestore: inspection.canRestore,
+        compatibility: inspection.compatibility,
+        dryRunStatus: inspection.dryRun?.status,
+        blockers: inspection.dryRun?.stats.blockers ?? inspection.risks.length,
+      },
+      inputHash: upload.archiveSha256 ?? null,
+    });
     return NextResponse.json({ success: true, upload, inspection });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to inspect migration upload.';

--- a/app/api/migration/uploads/route.ts
+++ b/app/api/migration/uploads/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireMigrationRestorePermission } from '@/app/lib/migration/auth';
 import { createMigrationUpload } from '@/app/lib/migration/upload-service';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
@@ -26,6 +27,23 @@ export async function POST(request: NextRequest) {
       fileName: typeof payload.fileName === 'string' ? payload.fileName : '',
       totalBytes: typeof payload.totalBytes === 'number' ? payload.totalBytes : 0,
       totalParts: typeof payload.totalParts === 'number' ? payload.totalParts : 0,
+    });
+    await recordAuditEvent({
+      organizationId: admin.state.organizationId,
+      userId: admin.session.user.id,
+      source: 'migration',
+      eventType: 'admin',
+      entityType: 'migration_upload',
+      entityId: status.id,
+      action: 'migration_upload.create',
+      status: 'started',
+      summary: `Migration upload ${status.id} created.`,
+      metadata: {
+        fileName: status.fileName,
+        totalBytes: status.totalBytes,
+        totalParts: status.totalParts,
+        databaseProvider: admin.state.databaseProvider,
+      },
     });
     return NextResponse.json({ success: true, upload: status });
   } catch (error) {

--- a/app/api/plugins/[name]/disable/route.ts
+++ b/app/api/plugins/[name]/disable/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { setCanvasPluginEnabled } from '@/app/lib/plugins/canvas-plugin-registry';
 
@@ -25,6 +26,21 @@ export async function POST(
       { status: result.error?.includes('not found') ? 404 : 400 },
     );
   }
+  await recordAuditEvent({
+    organizationId: pluginPermission.state.organizationId,
+    userId: pluginPermission.session.user.id,
+    source: 'plugins',
+    eventType: 'plugin',
+    entityType: 'canvas_plugin',
+    entityId: name,
+    action: 'plugin.disable',
+    status: 'success',
+    summary: `Plugin ${name} disabled.`,
+    metadata: {
+      pluginName: name,
+      version: result.plugin?.version,
+    },
+  });
 
   return NextResponse.json({ success: true, plugin: result.plugin });
 }

--- a/app/api/plugins/[name]/enable/route.ts
+++ b/app/api/plugins/[name]/enable/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { setCanvasPluginEnabled } from '@/app/lib/plugins/canvas-plugin-registry';
 
@@ -25,6 +26,21 @@ export async function POST(
       { status: result.error?.includes('not found') ? 404 : 400 },
     );
   }
+  await recordAuditEvent({
+    organizationId: pluginPermission.state.organizationId,
+    userId: pluginPermission.session.user.id,
+    source: 'plugins',
+    eventType: 'plugin',
+    entityType: 'canvas_plugin',
+    entityId: name,
+    action: 'plugin.enable',
+    status: 'success',
+    summary: `Plugin ${name} enabled.`,
+    metadata: {
+      pluginName: name,
+      version: result.plugin?.version,
+    },
+  });
 
   return NextResponse.json({ success: true, plugin: result.plugin });
 }

--- a/app/api/plugins/[name]/route.ts
+++ b/app/api/plugins/[name]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { headers } from 'next/headers';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { deleteCanvasPlugin, getCanvasPlugin } from '@/app/lib/plugins/canvas-plugin-registry';
@@ -49,6 +50,20 @@ export async function DELETE(
       { status: result.error?.includes('not found') ? 404 : 400 },
     );
   }
+  await recordAuditEvent({
+    organizationId: pluginPermission.state.organizationId,
+    userId: pluginPermission.session.user.id,
+    source: 'plugins',
+    eventType: 'plugin',
+    entityType: 'canvas_plugin',
+    entityId: name,
+    action: 'plugin.delete',
+    status: 'success',
+    summary: `Plugin ${name} deleted.`,
+    metadata: {
+      pluginName: name,
+    },
+  });
 
   return NextResponse.json({ success: true });
 }

--- a/app/api/plugins/install/route.ts
+++ b/app/api/plugins/install/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { installCanvasPluginFromPath } from '@/app/lib/plugins/canvas-plugin-registry';
 
@@ -33,6 +34,24 @@ export async function POST(request: Request) {
     if (!result.success) {
       return NextResponse.json(result, { status: result.validation?.valid === false ? 400 : 409 });
     }
+    await recordAuditEvent({
+      organizationId: pluginPermission.state.organizationId,
+      userId: pluginPermission.session.user.id,
+      source: 'plugins',
+      eventType: 'plugin',
+      entityType: 'canvas_plugin',
+      entityId: result.plugin?.name ?? null,
+      action: 'plugin.install_from_path',
+      status: 'success',
+      summary: `Plugin ${result.plugin?.name ?? 'unknown'} installed from local path.`,
+      metadata: {
+        pluginName: result.plugin?.name,
+        version: result.plugin?.version,
+        enabled: result.plugin?.enabled,
+        replace: body.replace === true,
+        sourcePath: body.sourcePath,
+      },
+    });
 
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/plugins/store/install/route.ts
+++ b/app/api/plugins/store/install/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { installCanvasPluginFromStore } from '@/app/lib/plugins/canvas-plugin-store';
 
@@ -38,6 +39,24 @@ export async function POST(request: Request) {
     if (!result.success) {
       return NextResponse.json(result, { status: result.validation?.valid === false ? 400 : 409 });
     }
+    await recordAuditEvent({
+      organizationId: pluginPermission.state.organizationId,
+      userId: pluginPermission.session.user.id,
+      source: 'plugins',
+      eventType: 'plugin',
+      entityType: 'canvas_plugin',
+      entityId: result.plugin?.name ?? body.name.trim(),
+      action: 'plugin.install_from_store',
+      status: 'success',
+      summary: `Plugin ${result.plugin?.name ?? body.name.trim()} installed from store.`,
+      metadata: {
+        pluginName: result.plugin?.name ?? body.name.trim(),
+        requestedVersion: typeof body.version === 'string' ? body.version.trim() : null,
+        installedVersion: result.plugin?.version,
+        enabled: result.plugin?.enabled,
+        replace: body.replace !== false,
+      },
+    });
 
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/security/public-shares/[id]/route.ts
+++ b/app/api/security/public-shares/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { isAdminUser } from '@/app/lib/admin-auth';
 import { revokePublicFileShare } from '@/app/lib/public-sharing/public-file-shares';
 import { clearFileTreeCache } from '@/app/lib/utils/file-tree-cache';
@@ -39,6 +40,25 @@ export async function DELETE(
     }
 
     clearFileTreeCache(workspace.workspaceId);
+    await recordAuditEvent({
+      organizationId: workspace.organizationId,
+      workspaceId: workspace.workspaceId,
+      userId: session.user.id,
+      source: 'public_shares',
+      eventType: 'file',
+      entityType: 'public_file_share',
+      entityId: share.id,
+      action: 'public_share.revoke',
+      status: 'success',
+      summary: `Public file share ${share.id} revoked.`,
+      metadata: {
+        workspaceType: workspace.workspaceType,
+        workspacePath: share.workspacePath,
+        status: share.status,
+        revokedAt: share.revokedAt,
+        isAdmin,
+      },
+    });
 
     return NextResponse.json({ success: true, share });
   } catch (error) {

--- a/app/api/security/public-shares/route.ts
+++ b/app/api/security/public-shares/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { isAdminUser } from '@/app/lib/admin-auth';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
@@ -141,6 +142,25 @@ export async function POST(request: NextRequest) {
     });
 
     clearFileTreeCache(workspace.workspaceId);
+    await recordAuditEvent({
+      organizationId: workspace.organizationId,
+      workspaceId: workspace.workspaceId,
+      userId: session.user.id,
+      source: 'public_shares',
+      eventType: 'file',
+      entityType: 'public_file_share',
+      entityId: result.shares.map((share) => share.id).join(','),
+      action: 'public_share.create',
+      status: 'success',
+      summary: `${result.shares.length} public file share(s) created.`,
+      metadata: {
+        workspaceType: workspace.workspaceType,
+        paths,
+        shareIds: result.shares.map((share) => share.id),
+        securityModes: result.shares.map((share) => share.securityMode),
+        expiresAt: result.shares.map((share) => share.expiresAt),
+      },
+    });
 
     return NextResponse.json({ success: true, ...result });
   } catch (error) {

--- a/app/api/setup/owner/route.ts
+++ b/app/api/setup/owner/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { createInitialOwner, InitialOwnerSetupError } from '@/app/lib/auth-setup';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 
@@ -11,6 +12,19 @@ export async function POST(request: NextRequest) {
 
   try {
     const owner = await createInitialOwner(body);
+    await recordAuditEvent({
+      userId: owner.id,
+      source: 'auth',
+      eventType: 'admin',
+      entityType: 'user',
+      entityId: owner.id,
+      action: 'owner_setup.create',
+      status: 'success',
+      summary: 'Initial owner account created.',
+      metadata: {
+        email: owner.email,
+      },
+    });
     return NextResponse.json({
       success: true,
       user: {

--- a/app/api/skills/[name]/disable/route.ts
+++ b/app/api/skills/[name]/disable/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { disableSkillInConfig, resolveEnabledSkillNames } from '@/app/lib/skills/enabled-skills';
 import { loadSkillsFromDisk } from '@/app/lib/skills/skill-loader';
@@ -29,6 +30,20 @@ export async function POST(
       });
     }
 
+    await recordAuditEvent({
+      organizationId: skillPermission.state.organizationId,
+      userId: skillPermission.session.user.id,
+      source: 'skills',
+      eventType: 'plugin',
+      entityType: 'canvas_skill',
+      entityId: name,
+      action: 'skill.disable',
+      status: 'success',
+      summary: `Skill ${name} disabled.`,
+      metadata: {
+        skillName: name,
+      },
+    });
     return NextResponse.json({
       success: true,
       message: `Skill "${name}" disabled`,

--- a/app/api/skills/[name]/enable/route.ts
+++ b/app/api/skills/[name]/enable/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { enableSkillInConfig, resolveEnabledSkillNames } from '@/app/lib/skills/enabled-skills';
 import { loadSkillsFromDisk } from '@/app/lib/skills/skill-loader';
@@ -29,6 +30,20 @@ export async function POST(
       });
     }
 
+    await recordAuditEvent({
+      organizationId: skillPermission.state.organizationId,
+      userId: skillPermission.session.user.id,
+      source: 'skills',
+      eventType: 'plugin',
+      entityType: 'canvas_skill',
+      entityId: name,
+      action: 'skill.enable',
+      status: 'success',
+      summary: `Skill ${name} enabled.`,
+      metadata: {
+        skillName: name,
+      },
+    });
     return NextResponse.json({
       success: true,
       message: `Skill "${name}" enabled`,

--- a/app/api/skills/disable-all/route.ts
+++ b/app/api/skills/disable-all/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { loadSkillsFromDisk } from '@/app/lib/skills/skill-loader';
 import { DISABLED_ALL_SKILLS_SENTINEL } from '@/app/lib/skills/enabled-skills';
@@ -20,6 +21,19 @@ export async function POST(request: Request) {
     await writeEnabledSkillsForScope([DISABLED_ALL_SKILLS_SENTINEL], {
       scope,
       updatedBy: skillPermission.session.user.email || skillPermission.session.user.id,
+    });
+    await recordAuditEvent({
+      organizationId: skillPermission.state.organizationId,
+      userId: skillPermission.session.user.id,
+      source: 'skills',
+      eventType: 'plugin',
+      entityType: 'canvas_skill_settings',
+      action: 'skills.disable_all',
+      status: 'success',
+      summary: 'All skills disabled.',
+      metadata: {
+        skillCount: allSkills.length,
+      },
     });
     
     return NextResponse.json({

--- a/app/api/skills/enable-all/route.ts
+++ b/app/api/skills/enable-all/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { loadSkillsFromDisk } from '@/app/lib/skills/skill-loader';
 import { writeEnabledSkillsForScope } from '@/app/lib/skills/skill-settings';
@@ -20,6 +21,19 @@ export async function POST(request: Request) {
     await writeEnabledSkillsForScope([], {
       scope,
       updatedBy: skillPermission.session.user.email || skillPermission.session.user.id,
+    });
+    await recordAuditEvent({
+      organizationId: skillPermission.state.organizationId,
+      userId: skillPermission.session.user.id,
+      source: 'skills',
+      eventType: 'plugin',
+      entityType: 'canvas_skill_settings',
+      action: 'skills.enable_all',
+      status: 'success',
+      summary: 'All skills enabled.',
+      metadata: {
+        skillCount: allSkillNames.length,
+      },
     });
     
     return NextResponse.json({

--- a/app/api/skills/store/install/route.ts
+++ b/app/api/skills/store/install/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
 import { installCanvasSkillFromStore } from '@/app/lib/skills/canvas-skill-store';
 
@@ -38,6 +39,23 @@ export async function POST(request: Request) {
     if (!result.success) {
       return NextResponse.json(result, { status: 400 });
     }
+    await recordAuditEvent({
+      organizationId: skillPermission.state.organizationId,
+      userId: skillPermission.session.user.id,
+      source: 'skills',
+      eventType: 'plugin',
+      entityType: 'canvas_skill',
+      entityId: body.name.trim(),
+      action: 'skill.install_from_store',
+      status: 'success',
+      summary: `Skill ${body.name.trim()} installed from store.`,
+      metadata: {
+        skillName: body.name.trim(),
+        requestedVersion: typeof body.version === 'string' ? body.version.trim() : null,
+        enable: body.enable !== false,
+        replace: body.replace !== false,
+      },
+    });
 
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/studio/generate/route.ts
+++ b/app/api/studio/generate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { createStudioGeneration, runStudioGeneration, type StudioGenerateRequest } from '@/app/lib/integrations/studio-generation-service';
 import { StudioServiceError } from '@/app/lib/integrations/studio-errors';
@@ -27,6 +28,31 @@ export async function POST(request: NextRequest) {
     const { generationId, mode, prompt } = await createStudioGeneration(session.user.id, body);
     runStudioGeneration(generationId).catch((err) => {
       console.error('[Studio Generate] Background generation failed:', err);
+    });
+    await recordAuditEvent({
+      userId: session.user.id,
+      source: 'studio',
+      eventType: 'studio',
+      entityType: 'studio_generation',
+      entityId: generationId,
+      action: 'studio_generation.create',
+      status: 'queued',
+      summary: `Studio generation ${generationId} queued.`,
+      metadata: {
+        mode,
+        promptLength: prompt.length,
+        productCount: body.product_ids?.length ?? 0,
+        personaCount: body.persona_ids?.length ?? 0,
+        styleCount: body.style_ids?.length ?? 0,
+        referenceCount: (body.extra_reference_urls?.length ?? 0) + (body.video_reference_urls?.length ?? 0) + (body.audio_reference_urls?.length ?? 0),
+      },
+      input: {
+        mode,
+        prompt,
+        productIds: body.product_ids,
+        personaIds: body.persona_ids,
+        styleIds: body.style_ids,
+      },
     });
     return NextResponse.json({
       success: true,

--- a/app/api/studio/generations/[id]/outputs/[outId]/route.ts
+++ b/app/api/studio/generations/[id]/outputs/[outId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { and, eq } from 'drizzle-orm';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { db } from '@/app/lib/db';
 import { studioGenerationOutputs, studioGenerations } from '@/app/lib/db/schema';
@@ -19,6 +20,22 @@ export async function DELETE(
 
   try {
     const result = await deleteStudioOutput(outId, studioPermission.session.user.id);
+    await recordAuditEvent({
+      organizationId: studioPermission.state.organizationId,
+      userId: studioPermission.session.user.id,
+      source: 'studio',
+      eventType: 'studio',
+      entityType: 'studio_generation_output',
+      entityId: outId,
+      action: 'studio_output.delete',
+      status: 'success',
+      summary: `Studio output ${outId} deleted.`,
+      metadata: {
+        generationId: _id,
+        generationDeleted: result.generationDeleted,
+        permissionRole: studioPermission.permission.role,
+      },
+    });
     return NextResponse.json({ success: true, generationDeleted: result.generationDeleted });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to delete output';
@@ -76,6 +93,22 @@ export async function PATCH(
       .set({ isFavorite: body.isFavorite })
       .where(eq(studioGenerationOutputs.id, outId))
       .returning();
+    await recordAuditEvent({
+      organizationId: updated.organizationId,
+      workspaceId: updated.workspaceId,
+      userId: session.user.id,
+      source: 'studio',
+      eventType: 'studio',
+      entityType: 'studio_generation_output',
+      entityId: outId,
+      action: 'studio_output.favorite.update',
+      status: 'success',
+      summary: `Studio output ${outId} favorite state updated.`,
+      metadata: {
+        generationId: id,
+        isFavorite: body.isFavorite,
+      },
+    });
 
     return NextResponse.json({ success: true, output: updated });
   } catch (error) {

--- a/app/api/studio/generations/[id]/route.ts
+++ b/app/api/studio/generations/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { getStudioGeneration, deleteStudioGeneration } from '@/app/lib/integrations/studio-generation-service';
 import { StudioServiceError } from '@/app/lib/integrations/studio-errors';
@@ -38,6 +39,20 @@ export async function DELETE(
   const { id } = await params;
   try {
     await deleteStudioGeneration(id, studioPermission.session.user.id);
+    await recordAuditEvent({
+      organizationId: studioPermission.state.organizationId,
+      userId: studioPermission.session.user.id,
+      source: 'studio',
+      eventType: 'studio',
+      entityType: 'studio_generation',
+      entityId: id,
+      action: 'studio_generation.delete',
+      status: 'success',
+      summary: `Studio generation ${id} deleted.`,
+      metadata: {
+        permissionRole: studioPermission.permission.role,
+      },
+    });
     return NextResponse.json({ success: true });
   } catch (error) {
     if (error instanceof StudioServiceError) {

--- a/app/api/studio/outputs/save-to-workspace/route.ts
+++ b/app/api/studio/outputs/save-to-workspace/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'node:path';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { readOutputFile } from '@/app/lib/integrations/studio-workspace';
 import { getFileStats, writeFile } from '@/app/lib/filesystem/workspace-files';
@@ -103,6 +104,25 @@ export async function POST(request: NextRequest) {
       await writeFile(destinationPath, buffer, targetFileOptions);
       savedPaths.push(destinationPath);
     }
+    await recordAuditEvent({
+      organizationId: targetWorkspaceResult.workspace.organizationId,
+      workspaceId: targetWorkspaceResult.workspace.workspaceId,
+      userId: session.user.id,
+      source: 'studio',
+      eventType: 'file',
+      entityType: 'studio_generation_output',
+      entityId: uniqueOutputIds.join(','),
+      action: 'studio_output.copy_to_workspace',
+      status: 'success',
+      summary: `${savedPaths.length} studio output(s) copied to workspace.`,
+      metadata: {
+        outputIds: uniqueOutputIds,
+        targetPath,
+        savedPaths,
+        targetWorkspaceId: targetWorkspaceResult.workspace.workspaceId,
+        targetWorkspaceType: targetWorkspaceResult.workspace.workspaceType,
+      },
+    });
 
     return NextResponse.json({
       success: true,

--- a/app/lib/audit/audit-service.ts
+++ b/app/lib/audit/audit-service.ts
@@ -79,8 +79,28 @@ function redactAuditValue(value: unknown, depth = 0, keyHint = ''): unknown {
   return String(value);
 }
 
+function canonicalizeAuditValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map((item) => canonicalizeAuditValue(item, seen));
+  if (typeof value === 'object') {
+    if (seen.has(value)) return '[CIRCULAR]';
+    seen.add(value);
+
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      result[key] = canonicalizeAuditValue((value as Record<string, unknown>)[key], seen);
+    }
+    seen.delete(value);
+    return result;
+  }
+  return String(value);
+}
+
 function stableStringify(value: unknown): string {
-  return JSON.stringify(redactAuditValue(value));
+  return JSON.stringify(canonicalizeAuditValue(value)) ?? 'null';
 }
 
 export function hashAuditValue(value: unknown): string {

--- a/app/lib/audit/audit-service.ts
+++ b/app/lib/audit/audit-service.ts
@@ -1,0 +1,142 @@
+import 'server-only';
+
+import { createHash, randomUUID } from 'node:crypto';
+
+import { db } from '@/app/lib/db';
+import { auditEvents } from '@/app/lib/db/schema';
+import { logger } from '@/app/lib/logging';
+
+const auditLogger = logger.module('Audit');
+const MAX_METADATA_JSON_LENGTH = 4096;
+const MAX_STRING_LENGTH = 1000;
+const MAX_ARRAY_LENGTH = 50;
+const MAX_OBJECT_KEYS = 80;
+
+const SENSITIVE_KEY_PATTERN = /(secret|token|password|passphrase|credential|authorization|cookie|api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|private[_-]?key)/i;
+
+export type AuditStatus = 'success' | 'failure' | 'blocked' | 'queued' | 'started' | 'completed';
+
+export interface AuditEventInput {
+  organizationId?: string | null;
+  workspaceId?: string | null;
+  userId?: string | null;
+  sessionId?: string | null;
+  agentId?: string | null;
+  source: string;
+  eventType: string;
+  entityType: string;
+  entityId?: string | null;
+  action: string;
+  status?: AuditStatus;
+  summary?: string | null;
+  metadata?: unknown;
+  input?: unknown;
+  output?: unknown;
+  inputHash?: string | null;
+  outputHash?: string | null;
+  artifactRef?: string | null;
+  secretRef?: string | null;
+  secretScope?: string | null;
+  createdAt?: Date;
+}
+
+export interface AuditEventRecord {
+  id: string;
+  createdAt: Date;
+}
+
+function normalizeText(value: string | null | undefined, maxLength = 500): string | null {
+  if (!value) return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  return normalized.length > maxLength ? normalized.slice(0, maxLength) : normalized;
+}
+
+function redactAuditValue(value: unknown, depth = 0, keyHint = ''): unknown {
+  if (SENSITIVE_KEY_PATTERN.test(keyHint)) return '[REDACTED]';
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING_LENGTH ? `${value.slice(0, MAX_STRING_LENGTH)}...[TRUNCATED]` : value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (value instanceof Date) return value.toISOString();
+  if (depth >= 4) return '[MAX_DEPTH]';
+  if (Array.isArray(value)) {
+    const items = value.slice(0, MAX_ARRAY_LENGTH).map((item) => redactAuditValue(item, depth + 1, keyHint));
+    if (value.length > MAX_ARRAY_LENGTH) items.push(`[${value.length - MAX_ARRAY_LENGTH} more items truncated]`);
+    return items;
+  }
+  if (typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    const entries = Object.entries(value as Record<string, unknown>).slice(0, MAX_OBJECT_KEYS);
+    for (const [key, entryValue] of entries) {
+      result[key] = redactAuditValue(entryValue, depth + 1, key);
+    }
+    const totalKeys = Object.keys(value as Record<string, unknown>).length;
+    if (totalKeys > MAX_OBJECT_KEYS) result.__truncatedKeys = totalKeys - MAX_OBJECT_KEYS;
+    return result;
+  }
+  return String(value);
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(redactAuditValue(value));
+}
+
+export function hashAuditValue(value: unknown): string {
+  return createHash('sha256').update(stableStringify(value)).digest('hex');
+}
+
+export function serializeAuditMetadata(metadata: unknown): string | null {
+  if (metadata === undefined || metadata === null) return null;
+  const sanitized = redactAuditValue(metadata);
+  const json = JSON.stringify(sanitized);
+  if (json.length <= MAX_METADATA_JSON_LENGTH) return json;
+
+  return JSON.stringify({
+    truncated: true,
+    originalLength: json.length,
+    preview: json.slice(0, MAX_METADATA_JSON_LENGTH - 120),
+  });
+}
+
+export async function recordAuditEvent(input: AuditEventInput): Promise<AuditEventRecord | null> {
+  const id = `audit-${randomUUID()}`;
+  const createdAt = input.createdAt ?? new Date();
+
+  try {
+    await db.insert(auditEvents).values({
+      id,
+      organizationId: normalizeText(input.organizationId, 200),
+      workspaceId: normalizeText(input.workspaceId, 200),
+      userId: normalizeText(input.userId, 200),
+      sessionId: normalizeText(input.sessionId, 500),
+      agentId: normalizeText(input.agentId, 200),
+      source: normalizeText(input.source, 80) ?? 'unknown',
+      eventType: normalizeText(input.eventType, 80) ?? 'event',
+      entityType: normalizeText(input.entityType, 80) ?? 'unknown',
+      entityId: normalizeText(input.entityId, 500),
+      action: normalizeText(input.action, 120) ?? 'unknown',
+      status: input.status ?? 'success',
+      summary: normalizeText(input.summary, 500),
+      metadataJson: serializeAuditMetadata(input.metadata),
+      inputHash: normalizeText(input.inputHash ?? (input.input === undefined ? null : hashAuditValue(input.input)), 128),
+      outputHash: normalizeText(input.outputHash ?? (input.output === undefined ? null : hashAuditValue(input.output)), 128),
+      artifactRef: normalizeText(input.artifactRef, 500),
+      secretRef: normalizeText(input.secretRef, 500),
+      secretScope: normalizeText(input.secretScope, 120),
+      createdAt,
+    });
+
+    return { id, createdAt };
+  } catch (error) {
+    auditLogger.error('Failed to record audit event', {
+      source: input.source,
+      action: input.action,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -450,6 +450,29 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE SET NULL
     );
 
+    CREATE TABLE IF NOT EXISTS audit_events (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      workspace_id TEXT,
+      user_id TEXT,
+      session_id TEXT,
+      agent_id TEXT,
+      source TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      entity_type TEXT NOT NULL,
+      entity_id TEXT,
+      action TEXT NOT NULL,
+      status TEXT NOT NULL,
+      summary TEXT,
+      metadata_json TEXT,
+      input_hash TEXT,
+      output_hash TEXT,
+      artifact_ref TEXT,
+      secret_ref TEXT,
+      secret_scope TEXT,
+      created_at INTEGER NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS automation_jobs (
       id TEXT PRIMARY KEY NOT NULL,
       name TEXT NOT NULL,
@@ -1252,6 +1275,12 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_user_store ON knowledge_chunks (user_id, knowledge_store, embedding_index_status);
     CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_policy ON knowledge_chunks (policy_decision, scan_status, embedding_index_status);
     CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_content_hash ON knowledge_chunks (content_hash);
+    CREATE INDEX IF NOT EXISTS idx_audit_events_created ON audit_events (created_at);
+    CREATE INDEX IF NOT EXISTS idx_audit_events_org_created ON audit_events (organization_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_audit_events_workspace_created ON audit_events (workspace_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_audit_events_user_created ON audit_events (user_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_audit_events_entity_created ON audit_events (entity_type, entity_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_audit_events_source_action_created ON audit_events (source, action, created_at);
   `);
 
   if (tableExists(sqlite, 'ai_sessions') && tableExists(sqlite, 'ai_messages')) {

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -1036,6 +1036,36 @@ export const channelLinkTokens = sqliteTable("channel_link_tokens", {
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
 });
 
+export const auditEvents = sqliteTable("audit_events", {
+  id: text("id").primaryKey(),
+  organizationId: text("organization_id"),
+  workspaceId: text("workspace_id"),
+  userId: text("user_id"),
+  sessionId: text("session_id"),
+  agentId: text("agent_id"),
+  source: text("source").notNull(),
+  eventType: text("event_type").notNull(),
+  entityType: text("entity_type").notNull(),
+  entityId: text("entity_id"),
+  action: text("action").notNull(),
+  status: text("status").notNull(),
+  summary: text("summary"),
+  metadataJson: text("metadata_json"),
+  inputHash: text("input_hash"),
+  outputHash: text("output_hash"),
+  artifactRef: text("artifact_ref"),
+  secretRef: text("secret_ref"),
+  secretScope: text("secret_scope"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  createdIdx: index("idx_audit_events_created").on(table.createdAt),
+  organizationCreatedIdx: index("idx_audit_events_org_created").on(table.organizationId, table.createdAt),
+  workspaceCreatedIdx: index("idx_audit_events_workspace_created").on(table.workspaceId, table.createdAt),
+  userCreatedIdx: index("idx_audit_events_user_created").on(table.userId, table.createdAt),
+  entityCreatedIdx: index("idx_audit_events_entity_created").on(table.entityType, table.entityId, table.createdAt),
+  sourceActionCreatedIdx: index("idx_audit_events_source_action_created").on(table.source, table.action, table.createdAt),
+}));
+
 export const telegramActiveSession = sqliteTable("telegram_active_session", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   userId: text("user_id").notNull().references(() => user.id),

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -472,8 +472,32 @@
     {
       "id": 29,
       "title": "Vollstaendigen Audit Trail fuer Admin, Auth, Files, Agenten, Automations, Plugins, Integrationen, Export/Import und Studio umsetzen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
+      "implementationArtifacts": [
+        "app/lib/db/schema.ts",
+        "app/lib/db/migrate.ts",
+        "app/lib/audit/audit-service.ts",
+        "app/api/admin/organization/users/[userId]/offboarding/route.ts",
+        "app/api/agents/*",
+        "app/api/auth/[...all]/route.ts",
+        "app/api/automations/jobs/*",
+        "app/api/files/*",
+        "app/api/integrations/env/route.ts",
+        "app/api/migration/*",
+        "app/api/plugins/*",
+        "app/api/security/public-shares/*",
+        "app/api/setup/owner/route.ts",
+        "app/api/skills/*",
+        "app/api/studio/*",
+        "scripts/audit-service-test.ts"
+      ],
+      "verification": [
+        "npx tsc --noEmit --pretty false",
+        "tsx --conditions react-server scripts/audit-service-test.ts",
+        "npm run lint",
+        "npm run build"
+      ],
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/05-actor-audit-retention.md",
         "docs/architecture/canvas-notebook/team-workspace/08-user-scoped-secrets-runtime.md",

--- a/scripts/audit-service-test.ts
+++ b/scripts/audit-service-test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../app/lib/db/migrate';
+
+async function main() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-audit-service-'));
+  const dataRoot = path.join(tempRoot, 'data');
+  process.env.DATA = dataRoot;
+
+  await fs.mkdir(dataRoot, { recursive: true });
+  const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+  runMigrations(sqlite);
+  sqlite.close();
+
+  const { hashAuditValue, recordAuditEvent } = await import('../app/lib/audit/audit-service');
+  const event = await recordAuditEvent({
+    organizationId: 'org-1',
+    workspaceId: 'ws-1',
+    userId: 'user-1',
+    sessionId: 'session-1',
+    agentId: 'canvas-agent',
+    source: 'test',
+    eventType: 'security',
+    entityType: 'integration_secret',
+    entityId: 'secret-ref-1',
+    action: 'integration_secret.update',
+    status: 'success',
+    metadata: {
+      safePath: 'workspaces/team/org-1/files/report.md',
+      apiKey: 'must-not-leak',
+      nested: {
+        refreshToken: 'must-not-leak-either',
+      },
+    },
+    input: { value: 'input', password: 'hidden' },
+    output: { value: 'output', accessToken: 'hidden' },
+  });
+
+  assert.ok(event?.id);
+
+  const verifyDb = new Database(path.join(dataRoot, 'sqlite.db'));
+  try {
+    const rows = verifyDb.prepare('SELECT * FROM audit_events').all() as Array<{
+      source: string;
+      action: string;
+      metadata_json: string;
+      input_hash: string;
+      output_hash: string;
+    }>;
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].source, 'test');
+    assert.equal(rows[0].action, 'integration_secret.update');
+    assert.equal(rows[0].input_hash, hashAuditValue({ value: 'input', password: 'hidden' }));
+    assert.equal(rows[0].output_hash, hashAuditValue({ value: 'output', accessToken: 'hidden' }));
+    assert.doesNotMatch(rows[0].metadata_json, /must-not-leak/);
+    assert.match(rows[0].metadata_json, /\[REDACTED\]/);
+    assert.ok(rows[0].metadata_json.length <= 4096);
+  } finally {
+    verifyDb.close();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().then(() => {
+  console.log('Audit service test passed');
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/audit-service-test.ts
+++ b/scripts/audit-service-test.ts
@@ -57,6 +57,8 @@ async function main() {
     assert.equal(rows[0].action, 'integration_secret.update');
     assert.equal(rows[0].input_hash, hashAuditValue({ value: 'input', password: 'hidden' }));
     assert.equal(rows[0].output_hash, hashAuditValue({ value: 'output', accessToken: 'hidden' }));
+    assert.equal(hashAuditValue({ a: 1, b: 2 }), hashAuditValue({ b: 2, a: 1 }));
+    assert.notEqual(hashAuditValue({ password: 'abc' }), hashAuditValue({ password: 'xyz' }));
     assert.doesNotMatch(rows[0].metadata_json, /must-not-leak/);
     assert.match(rows[0].metadata_json, /\[REDACTED\]/);
     assert.ok(rows[0].metadata_json.length <= 4096);


### PR DESCRIPTION
## Summary
- add the audit_events table plus a non-blocking audit service with metadata redaction and input/output hashing
- record audit events for auth mutations, admin/offboarding, files, agents, automations, plugins, skills, integrations, migration export/import, public shares, setup, and studio mutations
- mark Task 29 completed in docs/architecture/canvas-notebook/todo.json and add a focused audit service regression test

## Verification
- npx tsc --noEmit --pretty false
- tsx --conditions react-server scripts/audit-service-test.ts
- npm run lint
- npm run build

Greptile: pending automatic first review after PR creation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an audit trail foundation: a new `audit_events` SQLite table with six covering indexes, a non-error-propagating `recordAuditEvent` service (with key-sorted canonicalization, field-level redaction, and input/output integrity hashing), and call sites across auth, admin, files, agents, automations, plugins, skills, integrations, migration, public shares, setup, and studio routes. All four issues flagged in the previous review round have been addressed in this version.

- The `audit-service.ts` now uses `canonicalizeAuditValue` (recursive key-sort, circular-ref detection) for hashing, so `hashAuditValue` stores the hash of the raw value — not the redacted one — making input/output hashes useful for integrity verification and deduplication.
- The auth route now captures `beforeUserId` before calling `auth.handler` for sign-out, and parses the sign-in response body to extract the actor for sign-in events; the sign-up block uses a regex anchored on `/` or end-of-string.
- The regression test in `scripts/audit-service-test.ts` covers key-order stability, sensitive-value hash distinctness, and metadata redaction.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the audit service is purely additive and its error path returns null without propagating, so callers are not affected if the DB write fails.

All four issues flagged in the previous review round have been resolved. The core audit service is well-structured: canonicalization sorts keys before hashing, redaction is applied only to stored metadata (not to integrity hashes), and the auth route correctly captures actor identity before session state changes. No new correctness issues were found in the changed files.

app/api/auth/[...all]/route.ts — the sign-in userId extraction via response-body parsing is the only spot that could silently produce null attribution if the auth library response shape differs from the expected shape.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/audit/audit-service.ts | Core audit service with stable key-sorting canonicalization, field-level redaction (not applied to hashes), and safe error swallowing. Previous issues with hash stability and redaction-before-hashing are now fixed. |
| app/lib/db/schema.ts | Adds audit_events table with appropriate indexes on userId/organizationId/entityType/source+action. No FK constraints on actor fields, which is intentional so audit events survive actor deletion. |
| app/lib/db/migrate.ts | Adds audit_events table in the base CREATE TABLE IF NOT EXISTS block with matching indexes; idempotent for both fresh and existing databases, no addColumns needed since the table is new. |
| app/api/auth/[...all]/route.ts | Sign-out userId now captured before session invalidation (fixing previous issue); sign-up check uses regex with word-boundary; sign-in userId resolved from response body via readUserIdFromPayload, which is fragile if auth library changes its response shape. |
| app/api/studio/generate/route.ts | Audit event recorded after successful createStudioGeneration, before response; runStudioGeneration is correctly fire-and-forget; audit does not include raw prompt in metadata (only hash), appropriate. |
| app/api/integrations/env/route.ts | Audits env-variable write operations; records key names (not values) in metadata; no input/output hash (appropriate since values are secrets). |
| scripts/audit-service-test.ts | Regression test verifies DB write, metadata redaction, key-order-stable hashing, and that different sensitive inputs produce distinct hashes - all four previous review issues are now covered. |
| app/api/migration/export/route.ts | Records audit event after successful export job creation with safe metadata (profile, components, no raw export data). |
| app/api/admin/organization/users/[userId]/offboarding/route.ts | Audit event recorded after successful offboard; captures actor userId, target userId, and reason metadata appropriately. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Faudit-trail-foundation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Faudit-trail-foundation%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fapi%2Fauth%2F%5B...all%5D%2Froute.ts%3A57%0A**Sign-in%20userId%20attribution%20depends%20on%20auth%20library%20response%20shape**%0A%0A%60getAuthResponseUserId%60%20extracts%20the%20actor%20ID%20from%20the%20sign-in%20response%20body%20by%20looking%20for%20%60record.userId%60%20or%20%60record.user.id%60.%20If%20%60better-auth%60%20returns%20the%20signed-in%20user%20in%20a%20different%20shape%20%28e.g.%20a%20%60session%60%20wrapper%2C%20or%20a%20%60token%60-only%20response%20for%20certain%20auth%20methods%29%2C%20this%20silently%20returns%20%60null%60%20and%20the%20audit%20event%20records%20%60userId%3A%20null%60%20for%20the%20sign-in%20%E2%80%94%20the%20same%20gap%20the%20sign-out%20fix%20was%20intended%20to%20close.%20Worth%20adding%20a%20log%20at%20debug%20level%20when%20%60getAuthResponseUserId%60%20returns%20null%20for%20a%20successful%20%282xx%29%20sign-in%20so%20the%20gap%20is%20observable%20in%20prod.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Flib%2Faudit%2Faudit-service.ts%3A116-120%0A**Truncated%20metadata%20preview%20may%20embed%20invalid%20JSON%20fragments**%0A%0AWhen%20%60json.length%20%3E%204096%60%2C%20the%20preview%20is%20produced%20by%20slicing%20the%20already-serialized%20JSON%20at%20a%20byte%20boundary%3A%20%60json.slice%280%2C%20MAX_METADATA_JSON_LENGTH%20-%20120%29%60.%20This%20can%20cut%20mid-string%20%28e.g.%20inside%20a%20long%20file%20path%20or%20base64%20blob%29%2C%20so%20the%20%60preview%60%20field%20stored%20in%20%60metadata_json%60%20is%20valid%20JSON%20overall%20but%20its%20%60preview%60%20string%20value%20is%20a%20broken%20JSON%20fragment.%20Any%20consumer%20that%20tries%20to%20re-parse%20%60preview%60%20will%20fail.%20Storing%20%60preview%60%20as%20a%20raw%20string%20is%20fine%2C%20but%20it%20may%20be%20worth%20adding%20a%20comment%20so%20consumers%20know%20not%20to%20attempt%20%60JSON.parse%60%20on%20it.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address audit trail review feedback"](https://github.com/canvascoding/canvas-notebook/commit/12ab73c5b8beca2b431aadfd3267adda43ae03ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38903544)</sub>

<!-- /greptile_comment -->