### PR TITLE
Add workspace trash retention foundation

### DIFF
--- a/app/api/files/delete/route.ts
+++ b/app/api/files/delete/route.ts
@@ -62,10 +62,11 @@ export async function DELETE(request: NextRequest) {
       eventType: 'file',
       entityType: 'workspace_path',
       entityId: deletedPaths.join(','),
-      action: 'file.trash',
+      action: 'file.delete',
       status: result.failed.length > 0 ? 'failure' : 'success',
       summary: `${result.trashed.length} path(s) moved to trash; ${result.failed.length} failed.`,
       metadata: {
+        deleteMode: 'trash',
         requestedPaths: pathsToDelete,
         trashed: result.trashed.map((entry) => ({
           id: entry.id,

--- a/app/api/files/delete/route.ts
+++ b/app/api/files/delete/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
-import { batchDelete } from '@/app/lib/filesystem/workspace-files';
 import { isProtectedAppOutputFolder } from '@/app/lib/filesystem/app-output-folders';
+import { trashWorkspacePaths } from '@/app/lib/filesystem/workspace-trash';
 import { syncPublicSharesAfterDelete } from '@/app/lib/public-sharing/public-file-shares';
 import { getParentDirectory } from '@/app/lib/files/path-utils';
 import {
@@ -42,12 +42,17 @@ export async function DELETE(request: NextRequest) {
       return jsonError(`Protected app output folder(s) cannot be deleted: ${protectedPaths.join(', ')}`, 403);
     }
 
-    const result = await batchDelete(pathsToDelete, fileOptions);
-    await syncPublicSharesAfterDelete(result.deleted, workspaceResult.workspace);
+    const result = await trashWorkspacePaths({
+      workspace: workspaceResult.workspace,
+      paths: pathsToDelete,
+      deletedByUserId: workspaceResult.session.user.id,
+    });
+    const deletedPaths = result.trashed.map((entry) => entry.originalPath);
+    await syncPublicSharesAfterDelete(deletedPaths, workspaceResult.workspace);
 
     invalidateWorkspaceFileViews({
       fileOptions,
-      subtreeDirs: result.deleted.map(getParentDirectory),
+      subtreeDirs: deletedPaths.map(getParentDirectory),
     });
     await recordAuditEvent({
       organizationId: workspaceResult.workspace.organizationId,
@@ -56,20 +61,33 @@ export async function DELETE(request: NextRequest) {
       source: 'files',
       eventType: 'file',
       entityType: 'workspace_path',
-      entityId: result.deleted.join(','),
-      action: 'file.delete',
+      entityId: deletedPaths.join(','),
+      action: 'file.trash',
       status: result.failed.length > 0 ? 'failure' : 'success',
-      summary: `${result.deleted.length} path(s) deleted; ${result.failed.length} failed.`,
+      summary: `${result.trashed.length} path(s) moved to trash; ${result.failed.length} failed.`,
       metadata: {
         requestedPaths: pathsToDelete,
-        deleted: result.deleted,
+        trashed: result.trashed.map((entry) => ({
+          id: entry.id,
+          originalPath: entry.originalPath,
+          itemType: entry.itemType,
+          sizeBytes: entry.sizeBytes,
+          expiresAt: entry.expiresAt.toISOString(),
+        })),
         failed: result.failed,
         workspaceType: workspaceResult.workspace.workspaceType,
       },
     });
 
     return jsonSuccess({
-      deleted: result.deleted,
+      deleted: deletedPaths,
+      trashEntries: result.trashed.map((entry) => ({
+        id: entry.id,
+        originalPath: entry.originalPath,
+        itemType: entry.itemType,
+        sizeBytes: entry.sizeBytes,
+        expiresAt: entry.expiresAt.toISOString(),
+      })),
       failed: result.failed,
     });
   } catch (error) {

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -129,6 +129,30 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       FOREIGN KEY (owner_user_id) REFERENCES user(id)
     );
 
+    CREATE TABLE IF NOT EXISTS workspace_trash_entries (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      workspace_id TEXT NOT NULL,
+      workspace_type TEXT NOT NULL,
+      owner_user_id TEXT,
+      original_path TEXT NOT NULL,
+      trash_relative_path TEXT NOT NULL,
+      entry_name TEXT NOT NULL,
+      item_type TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL DEFAULT 0,
+      file_count INTEGER NOT NULL DEFAULT 0,
+      directory_count INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'trashed',
+      deleted_by_user_id TEXT,
+      restored_by_user_id TEXT,
+      purged_by_user_id TEXT,
+      deleted_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL,
+      restored_at INTEGER,
+      purged_at INTEGER,
+      metadata_json TEXT
+    );
+
     CREATE TABLE IF NOT EXISTS organization_user_permissions (
       organization_id TEXT NOT NULL,
       user_id TEXT NOT NULL,
@@ -1554,6 +1578,11 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_canvas_workspaces_organization_type ON canvas_workspaces (organization_id, type);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_canvas_workspaces_personal_owner ON canvas_workspaces (owner_user_id) WHERE type = 'personal';
     CREATE UNIQUE INDEX IF NOT EXISTS idx_canvas_workspaces_team_organization ON canvas_workspaces (organization_id) WHERE type = 'team';
+    CREATE INDEX IF NOT EXISTS idx_workspace_trash_workspace_status ON workspace_trash_entries (workspace_id, status, deleted_at);
+    CREATE INDEX IF NOT EXISTS idx_workspace_trash_expires ON workspace_trash_entries (status, expires_at);
+    CREATE INDEX IF NOT EXISTS idx_workspace_trash_org_status ON workspace_trash_entries (organization_id, status, deleted_at);
+    CREATE INDEX IF NOT EXISTS idx_workspace_trash_deleted_by ON workspace_trash_entries (deleted_by_user_id, deleted_at);
+    CREATE INDEX IF NOT EXISTS idx_workspace_trash_original_path ON workspace_trash_entries (workspace_id, original_path, status);
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_user ON organization_user_permissions (user_id);
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_role ON organization_user_permissions (organization_id, role);
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_status ON organization_user_permissions (organization_id, status);

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -150,7 +150,8 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       expires_at INTEGER NOT NULL,
       restored_at INTEGER,
       purged_at INTEGER,
-      metadata_json TEXT
+      metadata_json TEXT,
+      FOREIGN KEY (workspace_id) REFERENCES canvas_workspaces(id) ON DELETE CASCADE
     );
 
     CREATE TABLE IF NOT EXISTS organization_user_permissions (

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -125,6 +125,36 @@ export const canvasWorkspaces = sqliteTable("canvas_workspaces", {
   teamOrganizationIdx: uniqueIndex("idx_canvas_workspaces_team_organization").on(table.organizationId).where(sql`${table.type} = 'team'`),
 }));
 
+export const workspaceTrashEntries = sqliteTable("workspace_trash_entries", {
+  id: text("id").primaryKey(),
+  organizationId: text("organization_id"),
+  workspaceId: text("workspace_id").notNull(),
+  workspaceType: text("workspace_type").notNull(),
+  ownerUserId: text("owner_user_id"),
+  originalPath: text("original_path").notNull(),
+  trashRelativePath: text("trash_relative_path").notNull(),
+  entryName: text("entry_name").notNull(),
+  itemType: text("item_type").notNull(),
+  sizeBytes: integer("size_bytes").notNull().default(0),
+  fileCount: integer("file_count").notNull().default(0),
+  directoryCount: integer("directory_count").notNull().default(0),
+  status: text("status").notNull().default("trashed"),
+  deletedByUserId: text("deleted_by_user_id"),
+  restoredByUserId: text("restored_by_user_id"),
+  purgedByUserId: text("purged_by_user_id"),
+  deletedAt: integer("deleted_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  restoredAt: integer("restored_at", { mode: "timestamp" }),
+  purgedAt: integer("purged_at", { mode: "timestamp" }),
+  metadataJson: text("metadata_json"),
+}, (table) => ({
+  workspaceStatusIdx: index("idx_workspace_trash_workspace_status").on(table.workspaceId, table.status, table.deletedAt),
+  expiresIdx: index("idx_workspace_trash_expires").on(table.status, table.expiresAt),
+  organizationStatusIdx: index("idx_workspace_trash_org_status").on(table.organizationId, table.status, table.deletedAt),
+  deletedByIdx: index("idx_workspace_trash_deleted_by").on(table.deletedByUserId, table.deletedAt),
+  originalPathIdx: index("idx_workspace_trash_original_path").on(table.workspaceId, table.originalPath, table.status),
+}));
+
 export const organizationUserPermissions = sqliteTable("organization_user_permissions", {
   organizationId: text("organization_id").notNull().references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
   userId: text("user_id").notNull().references(() => user.id),

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -128,7 +128,7 @@ export const canvasWorkspaces = sqliteTable("canvas_workspaces", {
 export const workspaceTrashEntries = sqliteTable("workspace_trash_entries", {
   id: text("id").primaryKey(),
   organizationId: text("organization_id"),
-  workspaceId: text("workspace_id").notNull(),
+  workspaceId: text("workspace_id").notNull().references(() => canvasWorkspaces.id, { onDelete: 'cascade' }),
   workspaceType: text("workspace_type").notNull(),
   ownerUserId: text("owner_user_id"),
   originalPath: text("original_path").notNull(),

--- a/app/lib/filesystem/workspace-trash.ts
+++ b/app/lib/filesystem/workspace-trash.ts
@@ -1,0 +1,374 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { and, eq, lte } from 'drizzle-orm';
+
+import { db } from '@/app/lib/db';
+import { workspaceTrashEntries } from '@/app/lib/db/schema';
+import { resolveWorkspaceDataRoot } from '@/app/lib/workspaces/context';
+import { ensureWorkspaceRoot, resolveExistingWorkspacePath, resolveWorkspacePath } from '@/app/lib/workspaces/path-guard';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
+
+export const DEFAULT_WORKSPACE_TRASH_RETENTION_DAYS = 30;
+
+export type WorkspaceTrashStatus = 'trashed' | 'restored' | 'purged';
+export type WorkspaceTrashItemType = 'file' | 'directory' | 'other';
+
+export interface WorkspaceTrashEntry {
+  id: string;
+  organizationId: string | null;
+  workspaceId: string;
+  workspaceType: string;
+  ownerUserId: string | null;
+  originalPath: string;
+  trashRelativePath: string;
+  entryName: string;
+  itemType: WorkspaceTrashItemType;
+  sizeBytes: number;
+  fileCount: number;
+  directoryCount: number;
+  status: WorkspaceTrashStatus;
+  deletedByUserId: string | null;
+  restoredByUserId: string | null;
+  purgedByUserId: string | null;
+  deletedAt: Date;
+  expiresAt: Date;
+  restoredAt: Date | null;
+  purgedAt: Date | null;
+  metadataJson: string | null;
+}
+
+export interface TrashWorkspacePathsResult {
+  trashed: WorkspaceTrashEntry[];
+  failed: { path: string; error: string }[];
+}
+
+export interface PurgeWorkspaceTrashResult {
+  purged: string[];
+  failed: { id: string; error: string }[];
+}
+
+interface PathSummary {
+  itemType: WorkspaceTrashItemType;
+  sizeBytes: number;
+  fileCount: number;
+  directoryCount: number;
+}
+
+function retentionDays(): number {
+  const configured = Number.parseInt(process.env.WORKSPACE_TRASH_RETENTION_DAYS || '', 10);
+  if (Number.isFinite(configured) && configured > 0 && configured <= 3650) return configured;
+  return DEFAULT_WORKSPACE_TRASH_RETENTION_DAYS;
+}
+
+function expiresAtFrom(deletedAt: Date): Date {
+  return new Date(deletedAt.getTime() + retentionDays() * 24 * 60 * 60 * 1000);
+}
+
+function normalizeOriginalPath(workspace: WorkspaceContext, userPath: string): string {
+  const relativePath = resolveWorkspacePath(workspace, userPath).relativePath;
+  if (relativePath === '.') {
+    throw new Error('Workspace root cannot be moved to trash.');
+  }
+  return relativePath;
+}
+
+function safeTrashSegment(value: string | null | undefined, fallback: string): string {
+  const normalized = (value || '').trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return normalized || fallback;
+}
+
+function isSameOrDescendantPath(candidate: string, parentPath: string): boolean {
+  return candidate === parentPath || candidate.startsWith(`${parentPath}/`);
+}
+
+function dedupeNestedPaths(workspace: WorkspaceContext, paths: string[]): { requested: string; originalPath: string }[] {
+  const normalized = paths.map((requested) => ({
+    requested,
+    originalPath: normalizeOriginalPath(workspace, requested),
+  }));
+  normalized.sort((a, b) => a.originalPath.localeCompare(b.originalPath));
+
+  const selected: { requested: string; originalPath: string }[] = [];
+  for (const candidate of normalized) {
+    if (selected.some((existing) => isSameOrDescendantPath(candidate.originalPath, existing.originalPath))) {
+      continue;
+    }
+    selected.push(candidate);
+  }
+  return selected;
+}
+
+function trashRootForWorkspace(workspace: WorkspaceContext): string {
+  const scope = workspace.workspaceType === 'personal' ? 'personal' : workspace.workspaceType;
+  return path.join(
+    resolveWorkspaceDataRoot(),
+    '.trash',
+    'workspaces',
+    safeTrashSegment(scope, 'workspace'),
+    safeTrashSegment(workspace.organizationId, 'no-org'),
+    safeTrashSegment(workspace.workspaceId, 'legacy'),
+  );
+}
+
+function trashRelativePathFor(workspace: WorkspaceContext, entryId: string, originalPath: string): string {
+  const scope = workspace.workspaceType === 'personal' ? 'personal' : workspace.workspaceType;
+  return path.posix.join(
+    '.trash',
+    'workspaces',
+    safeTrashSegment(scope, 'workspace'),
+    safeTrashSegment(workspace.organizationId, 'no-org'),
+    safeTrashSegment(workspace.workspaceId, 'legacy'),
+    entryId,
+    path.posix.basename(originalPath),
+  );
+}
+
+function absoluteDataPath(relativePath: string): string {
+  const dataRoot = path.resolve(resolveWorkspaceDataRoot());
+  const target = path.resolve(dataRoot, relativePath);
+  if (target !== dataRoot && !target.startsWith(`${dataRoot}${path.sep}`)) {
+    throw new Error('Trash path resolves outside data root.');
+  }
+  return target;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function movePath(sourcePath: string, destinationPath: string, recursive: boolean): Promise<void> {
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+  try {
+    await fs.rename(sourcePath, destinationPath);
+  } catch (error) {
+    if (!(error && typeof error === 'object' && 'code' in error && error.code === 'EXDEV')) {
+      throw error;
+    }
+    await fs.cp(sourcePath, destinationPath, { recursive, force: false, errorOnExist: true });
+    await fs.rm(sourcePath, { recursive, force: false });
+  }
+}
+
+async function summarizePath(targetPath: string): Promise<PathSummary> {
+  const stats = await fs.stat(targetPath);
+  if (!stats.isDirectory()) {
+    return {
+      itemType: stats.isFile() ? 'file' : 'other',
+      sizeBytes: stats.size,
+      fileCount: stats.isFile() ? 1 : 0,
+      directoryCount: 0,
+    };
+  }
+
+  let sizeBytes = 0;
+  let fileCount = 0;
+  let directoryCount = 1;
+  const entries = await fs.readdir(targetPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const child = await summarizePath(path.join(targetPath, entry.name));
+    sizeBytes += child.sizeBytes;
+    fileCount += child.fileCount;
+    directoryCount += child.directoryCount;
+  }
+
+  return { itemType: 'directory', sizeBytes, fileCount, directoryCount };
+}
+
+function mapTrashRow(row: typeof workspaceTrashEntries.$inferSelect): WorkspaceTrashEntry {
+  return {
+    id: row.id,
+    organizationId: row.organizationId,
+    workspaceId: row.workspaceId,
+    workspaceType: row.workspaceType,
+    ownerUserId: row.ownerUserId,
+    originalPath: row.originalPath,
+    trashRelativePath: row.trashRelativePath,
+    entryName: row.entryName,
+    itemType: row.itemType as WorkspaceTrashItemType,
+    sizeBytes: row.sizeBytes,
+    fileCount: row.fileCount,
+    directoryCount: row.directoryCount,
+    status: row.status as WorkspaceTrashStatus,
+    deletedByUserId: row.deletedByUserId,
+    restoredByUserId: row.restoredByUserId,
+    purgedByUserId: row.purgedByUserId,
+    deletedAt: row.deletedAt,
+    expiresAt: row.expiresAt,
+    restoredAt: row.restoredAt,
+    purgedAt: row.purgedAt,
+    metadataJson: row.metadataJson,
+  };
+}
+
+export async function trashWorkspacePaths(params: {
+  workspace: WorkspaceContext;
+  paths: string[];
+  deletedByUserId: string;
+  now?: Date;
+}): Promise<TrashWorkspacePathsResult> {
+  await ensureWorkspaceRoot(params.workspace);
+  const now = params.now ?? new Date();
+  const expiresAt = expiresAtFrom(now);
+  const result: TrashWorkspacePathsResult = { trashed: [], failed: [] };
+
+  let candidates: { requested: string; originalPath: string }[];
+  try {
+    candidates = dedupeNestedPaths(params.workspace, params.paths);
+  } catch (error) {
+    return {
+      trashed: [],
+      failed: params.paths.map((candidate) => ({
+        path: candidate,
+        error: error instanceof Error ? error.message : 'Invalid path',
+      })),
+    };
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const sourcePath = await resolveExistingWorkspacePath(params.workspace, candidate.originalPath);
+      const summary = await summarizePath(sourcePath);
+      const id = `trash-${randomUUID()}`;
+      const trashRelativePath = trashRelativePathFor(params.workspace, id, candidate.originalPath);
+      const trashPath = absoluteDataPath(trashRelativePath);
+      await fs.mkdir(trashRootForWorkspace(params.workspace), { recursive: true });
+      await movePath(sourcePath, trashPath, summary.itemType === 'directory');
+
+      const rows = await db.insert(workspaceTrashEntries).values({
+        id,
+        organizationId: params.workspace.organizationId ?? null,
+        workspaceId: params.workspace.workspaceId,
+        workspaceType: params.workspace.workspaceType,
+        ownerUserId: params.workspace.ownerUserId ?? null,
+        originalPath: candidate.originalPath,
+        trashRelativePath,
+        entryName: path.posix.basename(candidate.originalPath),
+        itemType: summary.itemType,
+        sizeBytes: summary.sizeBytes,
+        fileCount: summary.fileCount,
+        directoryCount: summary.directoryCount,
+        status: 'trashed',
+        deletedByUserId: params.deletedByUserId,
+        deletedAt: now,
+        expiresAt,
+        metadataJson: JSON.stringify({
+          retentionDays: retentionDays(),
+          workspaceType: params.workspace.workspaceType,
+          requestedPath: candidate.requested,
+        }),
+      }).returning();
+
+      result.trashed.push(mapTrashRow(rows[0]));
+    } catch (error) {
+      result.failed.push({
+        path: candidate.requested,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+
+  return result;
+}
+
+export async function listWorkspaceTrashEntries(params: {
+  workspace: WorkspaceContext;
+  status?: WorkspaceTrashStatus;
+}): Promise<WorkspaceTrashEntry[]> {
+  const status = params.status ?? 'trashed';
+  const rows = await db.select()
+    .from(workspaceTrashEntries)
+    .where(and(
+      eq(workspaceTrashEntries.workspaceId, params.workspace.workspaceId),
+      eq(workspaceTrashEntries.status, status),
+    ));
+  return rows.map(mapTrashRow);
+}
+
+export async function restoreWorkspaceTrashEntry(params: {
+  workspace: WorkspaceContext;
+  entryId: string;
+  restoredByUserId: string;
+  overwrite?: boolean;
+  now?: Date;
+}): Promise<WorkspaceTrashEntry> {
+  const row = await db.query.workspaceTrashEntries.findFirst({
+    where: and(
+      eq(workspaceTrashEntries.id, params.entryId),
+      eq(workspaceTrashEntries.workspaceId, params.workspace.workspaceId),
+      eq(workspaceTrashEntries.status, 'trashed'),
+    ),
+  });
+  if (!row) throw new Error('Trash entry not found.');
+
+  const trashPath = absoluteDataPath(row.trashRelativePath);
+  const restoreResolution = resolveWorkspacePath(params.workspace, row.originalPath);
+  const destinationPath = restoreResolution.absolutePath;
+  const destinationExists = await pathExists(destinationPath);
+  if (destinationExists && params.overwrite !== true) {
+    throw new Error(`Restore target already exists: ${row.originalPath}`);
+  }
+
+  if (destinationExists) {
+    await fs.rm(destinationPath, { recursive: true, force: true });
+  }
+
+  await movePath(trashPath, destinationPath, row.itemType === 'directory');
+  const restoredAt = params.now ?? new Date();
+  const restoredRows = await db.update(workspaceTrashEntries)
+    .set({
+      status: 'restored',
+      restoredByUserId: params.restoredByUserId,
+      restoredAt,
+    })
+    .where(eq(workspaceTrashEntries.id, row.id))
+    .returning();
+
+  return mapTrashRow(restoredRows[0]);
+}
+
+export async function purgeExpiredWorkspaceTrash(params: {
+  now?: Date;
+  limit?: number;
+  purgedByUserId?: string | null;
+} = {}): Promise<PurgeWorkspaceTrashResult> {
+  const now = params.now ?? new Date();
+  const limit = Math.max(1, Math.min(params.limit ?? 100, 1000));
+  const rows = await db.select()
+    .from(workspaceTrashEntries)
+    .where(and(
+      eq(workspaceTrashEntries.status, 'trashed'),
+      lte(workspaceTrashEntries.expiresAt, now),
+    ))
+    .limit(limit);
+
+  const result: PurgeWorkspaceTrashResult = { purged: [], failed: [] };
+  for (const row of rows) {
+    try {
+      await fs.rm(absoluteDataPath(row.trashRelativePath), { recursive: true, force: true });
+      await db.update(workspaceTrashEntries)
+        .set({
+          status: 'purged',
+          purgedAt: now,
+          purgedByUserId: params.purgedByUserId ?? null,
+        })
+        .where(eq(workspaceTrashEntries.id, row.id));
+      result.purged.push(row.id);
+    } catch (error) {
+      result.failed.push({
+        id: row.id,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+
+  return result;
+}

--- a/app/lib/filesystem/workspace-trash.ts
+++ b/app/lib/filesystem/workspace-trash.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { and, eq, lte } from 'drizzle-orm';
+import { and, desc, eq, lte } from 'drizzle-orm';
 
 import { db } from '@/app/lib/db';
 import { workspaceTrashEntries } from '@/app/lib/db/schema';
@@ -181,7 +181,16 @@ async function movePath(sourcePath: string, destinationPath: string, recursive: 
 }
 
 async function summarizePath(targetPath: string): Promise<PathSummary> {
-  const stats = await fs.stat(targetPath);
+  const stats = await fs.lstat(targetPath);
+  if (stats.isSymbolicLink()) {
+    return {
+      itemType: 'other',
+      sizeBytes: stats.size,
+      fileCount: 0,
+      directoryCount: 0,
+    };
+  }
+
   if (!stats.isDirectory()) {
     return {
       itemType: stats.isFile() ? 'file' : 'other',
@@ -196,7 +205,14 @@ async function summarizePath(targetPath: string): Promise<PathSummary> {
   let directoryCount = 1;
   const entries = await fs.readdir(targetPath, { withFileTypes: true });
   for (const entry of entries) {
-    const child = await summarizePath(path.join(targetPath, entry.name));
+    const childPath = path.join(targetPath, entry.name);
+    if (entry.isSymbolicLink()) {
+      const linkStats = await fs.lstat(childPath);
+      sizeBytes += linkStats.size;
+      continue;
+    }
+
+    const child = await summarizePath(childPath);
     sizeBytes += child.sizeBytes;
     fileCount += child.fileCount;
     directoryCount += child.directoryCount;
@@ -308,14 +324,21 @@ export async function trashWorkspacePaths(params: {
 export async function listWorkspaceTrashEntries(params: {
   workspace: WorkspaceContext;
   status?: WorkspaceTrashStatus;
+  limit?: number;
+  offset?: number;
 }): Promise<WorkspaceTrashEntry[]> {
   const status = params.status ?? 'trashed';
+  const limit = Math.max(1, Math.min(params.limit ?? 100, 1000));
+  const offset = Math.max(0, params.offset ?? 0);
   const rows = await db.select()
     .from(workspaceTrashEntries)
     .where(and(
       eq(workspaceTrashEntries.workspaceId, params.workspace.workspaceId),
       eq(workspaceTrashEntries.status, status),
-    ));
+    ))
+    .orderBy(desc(workspaceTrashEntries.deletedAt))
+    .limit(limit)
+    .offset(offset);
   return rows.map(mapTrashRow);
 }
 
@@ -393,14 +416,35 @@ export async function purgeExpiredWorkspaceTrash(params: {
   const result: PurgeWorkspaceTrashResult = { purged: [], failed: [] };
   for (const row of rows) {
     try {
-      await fs.rm(absoluteDataPath(row.trashRelativePath), { recursive: true, force: true });
-      await db.update(workspaceTrashEntries)
+      const purgedRows = await db.update(workspaceTrashEntries)
         .set({
           status: 'purged',
           purgedAt: now,
           purgedByUserId: params.purgedByUserId ?? null,
         })
-        .where(eq(workspaceTrashEntries.id, row.id));
+        .where(eq(workspaceTrashEntries.id, row.id))
+        .returning({ id: workspaceTrashEntries.id });
+      if (!purgedRows[0]) throw new Error('Trash entry was not marked purged.');
+
+      try {
+        await fs.rm(absoluteDataPath(row.trashRelativePath), { recursive: true, force: true });
+      } catch (fsError) {
+        try {
+          await db.update(workspaceTrashEntries)
+            .set({
+              status: 'trashed',
+              purgedAt: null,
+              purgedByUserId: null,
+            })
+            .where(eq(workspaceTrashEntries.id, row.id));
+        } catch (rollbackError) {
+          throw new Error(
+            `Failed to remove purged trash file (${formatErrorMessage(fsError)}); rollback failed: ${formatErrorMessage(rollbackError)}`
+          );
+        }
+        throw fsError;
+      }
+
       result.purged.push(row.id);
     } catch (error) {
       result.failed.push({

--- a/app/lib/filesystem/workspace-trash.ts
+++ b/app/lib/filesystem/workspace-trash.ts
@@ -176,7 +176,12 @@ async function movePath(sourcePath: string, destinationPath: string, recursive: 
       throw error;
     }
     await fs.cp(sourcePath, destinationPath, { recursive, force: false, errorOnExist: true });
-    await fs.rm(sourcePath, { recursive, force: false });
+    try {
+      await fs.rm(sourcePath, { recursive, force: false });
+    } catch (rmError) {
+      await fs.rm(destinationPath, { recursive: true, force: true }).catch(() => undefined);
+      throw rmError;
+    }
   }
 }
 

--- a/app/lib/filesystem/workspace-trash.ts
+++ b/app/lib/filesystem/workspace-trash.ts
@@ -383,7 +383,13 @@ export async function restoreWorkspaceTrashEntry(params: {
     await movePath(trashPath, destinationPath, row.itemType === 'directory');
   } catch (moveError) {
     if (overwrittenPath && await pathExists(overwrittenPath)) {
-      await movePath(overwrittenPath, destinationPath, overwrittenWasDirectory);
+      try {
+        await movePath(overwrittenPath, destinationPath, overwrittenWasDirectory);
+      } catch (rollbackError) {
+        throw new Error(
+          `Restore failed (${formatErrorMessage(moveError)}); rollback of overwritten file failed: ${formatErrorMessage(rollbackError)}`
+        );
+      }
     }
     throw moveError;
   }

--- a/app/lib/filesystem/workspace-trash.ts
+++ b/app/lib/filesystem/workspace-trash.ts
@@ -69,8 +69,8 @@ function retentionDays(): number {
   return DEFAULT_WORKSPACE_TRASH_RETENTION_DAYS;
 }
 
-function expiresAtFrom(deletedAt: Date): Date {
-  return new Date(deletedAt.getTime() + retentionDays() * 24 * 60 * 60 * 1000);
+function expiresAtFrom(deletedAt: Date, days = retentionDays()): Date {
+  return new Date(deletedAt.getTime() + days * 24 * 60 * 60 * 1000);
 }
 
 function normalizeOriginalPath(workspace: WorkspaceContext, userPath: string): string {
@@ -255,7 +255,8 @@ export async function trashWorkspacePaths(params: {
 }): Promise<TrashWorkspacePathsResult> {
   await ensureWorkspaceRoot(params.workspace);
   const now = params.now ?? new Date();
-  const expiresAt = expiresAtFrom(now);
+  const days = retentionDays();
+  const expiresAt = expiresAtFrom(now, days);
   const result: TrashWorkspacePathsResult = { trashed: [], failed: [] };
 
   const { selected: candidates, failed: invalidPaths } = dedupeNestedPaths(params.workspace, params.paths);
@@ -290,7 +291,7 @@ export async function trashWorkspacePaths(params: {
           deletedAt: now,
           expiresAt,
           metadataJson: JSON.stringify({
-            retentionDays: retentionDays(),
+            retentionDays: days,
             workspaceType: params.workspace.workspaceType,
             requestedPath: candidate.requested,
           }),

--- a/app/lib/filesystem/workspace-trash.ts
+++ b/app/lib/filesystem/workspace-trash.ts
@@ -362,15 +362,32 @@ export async function restoreWorkspaceTrashEntry(params: {
   const restoreResolution = resolveWorkspacePath(params.workspace, row.originalPath);
   const destinationPath = restoreResolution.absolutePath;
   const destinationExists = await pathExists(destinationPath);
+  let overwrittenPath: string | null = null;
+  let overwrittenWasDirectory = false;
   if (destinationExists && params.overwrite !== true) {
     throw new Error(`Restore target already exists: ${row.originalPath}`);
   }
 
   if (destinationExists) {
-    await fs.rm(destinationPath, { recursive: true, force: true });
+    const destinationStats = await fs.lstat(destinationPath);
+    overwrittenWasDirectory = destinationStats.isDirectory();
+    overwrittenPath = absoluteDataPath(path.posix.join(
+      path.posix.dirname(row.trashRelativePath),
+      `overwritten-${randomUUID()}-${path.posix.basename(row.originalPath)}`,
+    ));
+    await movePath(destinationPath, overwrittenPath, overwrittenWasDirectory);
   }
 
-  await movePath(trashPath, destinationPath, row.itemType === 'directory');
+  try {
+    await movePath(trashPath, destinationPath, row.itemType === 'directory');
+  } catch (moveError) {
+    if (overwrittenPath && await pathExists(overwrittenPath)) {
+      await movePath(overwrittenPath, destinationPath, overwrittenWasDirectory);
+    }
+    throw moveError;
+  }
+
+  let restoredEntry: WorkspaceTrashEntry | null = null;
   try {
     const restoredAt = params.now ?? new Date();
     const restoredRows = await db.update(workspaceTrashEntries)
@@ -383,11 +400,14 @@ export async function restoreWorkspaceTrashEntry(params: {
       .returning();
     const restoredRow = restoredRows[0];
     if (!restoredRow) throw new Error('Trash entry was not marked restored.');
-    return mapTrashRow(restoredRow);
+    restoredEntry = mapTrashRow(restoredRow);
   } catch (dbError) {
     try {
       if (await pathExists(destinationPath)) {
         await movePath(destinationPath, trashPath, row.itemType === 'directory');
+      }
+      if (overwrittenPath && await pathExists(overwrittenPath)) {
+        await movePath(overwrittenPath, destinationPath, overwrittenWasDirectory);
       }
     } catch (rollbackError) {
       throw new Error(
@@ -396,6 +416,12 @@ export async function restoreWorkspaceTrashEntry(params: {
     }
     throw dbError;
   }
+
+  if (overwrittenPath) {
+    await fs.rm(overwrittenPath, { recursive: true, force: true }).catch(() => undefined);
+  }
+  if (!restoredEntry) throw new Error('Trash entry was not marked restored.');
+  return restoredEntry;
 }
 
 export async function purgeExpiredWorkspaceTrash(params: {
@@ -422,9 +448,12 @@ export async function purgeExpiredWorkspaceTrash(params: {
           purgedAt: now,
           purgedByUserId: params.purgedByUserId ?? null,
         })
-        .where(eq(workspaceTrashEntries.id, row.id))
+        .where(and(
+          eq(workspaceTrashEntries.id, row.id),
+          eq(workspaceTrashEntries.status, 'trashed'),
+        ))
         .returning({ id: workspaceTrashEntries.id });
-      if (!purgedRows[0]) throw new Error('Trash entry was not marked purged.');
+      if (!purgedRows[0]) continue;
 
       try {
         await fs.rm(absoluteDataPath(row.trashRelativePath), { recursive: true, force: true });

--- a/app/lib/filesystem/workspace-trash.ts
+++ b/app/lib/filesystem/workspace-trash.ts
@@ -58,6 +58,11 @@ interface PathSummary {
   directoryCount: number;
 }
 
+interface NormalizedTrashPaths {
+  selected: { requested: string; originalPath: string }[];
+  failed: { path: string; error: string }[];
+}
+
 function retentionDays(): number {
   const configured = Number.parseInt(process.env.WORKSPACE_TRASH_RETENTION_DAYS || '', 10);
   if (Number.isFinite(configured) && configured > 0 && configured <= 3650) return configured;
@@ -85,11 +90,28 @@ function isSameOrDescendantPath(candidate: string, parentPath: string): boolean 
   return candidate === parentPath || candidate.startsWith(`${parentPath}/`);
 }
 
-function dedupeNestedPaths(workspace: WorkspaceContext, paths: string[]): { requested: string; originalPath: string }[] {
-  const normalized = paths.map((requested) => ({
-    requested,
-    originalPath: normalizeOriginalPath(workspace, requested),
-  }));
+function formatErrorMessage(error: unknown, fallback = 'Unknown error'): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function dedupeNestedPaths(workspace: WorkspaceContext, paths: string[]): NormalizedTrashPaths {
+  const normalized: { requested: string; originalPath: string }[] = [];
+  const failed: { path: string; error: string }[] = [];
+
+  for (const requested of paths) {
+    try {
+      normalized.push({
+        requested,
+        originalPath: normalizeOriginalPath(workspace, requested),
+      });
+    } catch (error) {
+      failed.push({
+        path: requested,
+        error: formatErrorMessage(error, 'Invalid path'),
+      });
+    }
+  }
+
   normalized.sort((a, b) => a.originalPath.localeCompare(b.originalPath));
 
   const selected: { requested: string; originalPath: string }[] = [];
@@ -99,7 +121,7 @@ function dedupeNestedPaths(workspace: WorkspaceContext, paths: string[]): { requ
     }
     selected.push(candidate);
   }
-  return selected;
+  return { selected, failed };
 }
 
 function trashRootForWorkspace(workspace: WorkspaceContext): string {
@@ -220,18 +242,8 @@ export async function trashWorkspacePaths(params: {
   const expiresAt = expiresAtFrom(now);
   const result: TrashWorkspacePathsResult = { trashed: [], failed: [] };
 
-  let candidates: { requested: string; originalPath: string }[];
-  try {
-    candidates = dedupeNestedPaths(params.workspace, params.paths);
-  } catch (error) {
-    return {
-      trashed: [],
-      failed: params.paths.map((candidate) => ({
-        path: candidate,
-        error: error instanceof Error ? error.message : 'Invalid path',
-      })),
-    };
-  }
+  const { selected: candidates, failed: invalidPaths } = dedupeNestedPaths(params.workspace, params.paths);
+  result.failed.push(...invalidPaths);
 
   for (const candidate of candidates) {
     try {
@@ -243,35 +255,49 @@ export async function trashWorkspacePaths(params: {
       await fs.mkdir(trashRootForWorkspace(params.workspace), { recursive: true });
       await movePath(sourcePath, trashPath, summary.itemType === 'directory');
 
-      const rows = await db.insert(workspaceTrashEntries).values({
-        id,
-        organizationId: params.workspace.organizationId ?? null,
-        workspaceId: params.workspace.workspaceId,
-        workspaceType: params.workspace.workspaceType,
-        ownerUserId: params.workspace.ownerUserId ?? null,
-        originalPath: candidate.originalPath,
-        trashRelativePath,
-        entryName: path.posix.basename(candidate.originalPath),
-        itemType: summary.itemType,
-        sizeBytes: summary.sizeBytes,
-        fileCount: summary.fileCount,
-        directoryCount: summary.directoryCount,
-        status: 'trashed',
-        deletedByUserId: params.deletedByUserId,
-        deletedAt: now,
-        expiresAt,
-        metadataJson: JSON.stringify({
-          retentionDays: retentionDays(),
+      try {
+        const rows = await db.insert(workspaceTrashEntries).values({
+          id,
+          organizationId: params.workspace.organizationId ?? null,
+          workspaceId: params.workspace.workspaceId,
           workspaceType: params.workspace.workspaceType,
-          requestedPath: candidate.requested,
-        }),
-      }).returning();
-
-      result.trashed.push(mapTrashRow(rows[0]));
+          ownerUserId: params.workspace.ownerUserId ?? null,
+          originalPath: candidate.originalPath,
+          trashRelativePath,
+          entryName: path.posix.basename(candidate.originalPath),
+          itemType: summary.itemType,
+          sizeBytes: summary.sizeBytes,
+          fileCount: summary.fileCount,
+          directoryCount: summary.directoryCount,
+          status: 'trashed',
+          deletedByUserId: params.deletedByUserId,
+          deletedAt: now,
+          expiresAt,
+          metadataJson: JSON.stringify({
+            retentionDays: retentionDays(),
+            workspaceType: params.workspace.workspaceType,
+            requestedPath: candidate.requested,
+          }),
+        }).returning();
+        const row = rows[0];
+        if (!row) throw new Error('Trash entry was not persisted.');
+        result.trashed.push(mapTrashRow(row));
+      } catch (dbError) {
+        try {
+          if (await pathExists(trashPath)) {
+            await movePath(trashPath, sourcePath, summary.itemType === 'directory');
+          }
+        } catch (rollbackError) {
+          throw new Error(
+            `Failed to persist trash entry (${formatErrorMessage(dbError)}); rollback failed: ${formatErrorMessage(rollbackError)}`
+          );
+        }
+        throw dbError;
+      }
     } catch (error) {
       result.failed.push({
         path: candidate.requested,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: formatErrorMessage(error),
       });
     }
   }
@@ -322,17 +348,31 @@ export async function restoreWorkspaceTrashEntry(params: {
   }
 
   await movePath(trashPath, destinationPath, row.itemType === 'directory');
-  const restoredAt = params.now ?? new Date();
-  const restoredRows = await db.update(workspaceTrashEntries)
-    .set({
-      status: 'restored',
-      restoredByUserId: params.restoredByUserId,
-      restoredAt,
-    })
-    .where(eq(workspaceTrashEntries.id, row.id))
-    .returning();
-
-  return mapTrashRow(restoredRows[0]);
+  try {
+    const restoredAt = params.now ?? new Date();
+    const restoredRows = await db.update(workspaceTrashEntries)
+      .set({
+        status: 'restored',
+        restoredByUserId: params.restoredByUserId,
+        restoredAt,
+      })
+      .where(eq(workspaceTrashEntries.id, row.id))
+      .returning();
+    const restoredRow = restoredRows[0];
+    if (!restoredRow) throw new Error('Trash entry was not marked restored.');
+    return mapTrashRow(restoredRow);
+  } catch (dbError) {
+    try {
+      if (await pathExists(destinationPath)) {
+        await movePath(destinationPath, trashPath, row.itemType === 'directory');
+      }
+    } catch (rollbackError) {
+      throw new Error(
+        `Failed to mark trash entry restored (${formatErrorMessage(dbError)}); rollback failed: ${formatErrorMessage(rollbackError)}`
+      );
+    }
+    throw dbError;
+  }
 }
 
 export async function purgeExpiredWorkspaceTrash(params: {
@@ -365,7 +405,7 @@ export async function purgeExpiredWorkspaceTrash(params: {
     } catch (error) {
       result.failed.push({
         id: row.id,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: formatErrorMessage(error),
       });
     }
   }

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -511,8 +511,21 @@
     {
       "id": 30,
       "title": "Retention, Trash und Datenloeschung fuer Teamdaten planen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
+      "implementationArtifacts": [
+        "app/lib/db/schema.ts",
+        "app/lib/db/migrate.ts",
+        "app/lib/filesystem/workspace-trash.ts",
+        "app/api/files/delete/route.ts",
+        "scripts/workspace-trash-retention-test.ts"
+      ],
+      "verification": [
+        "npx tsc --noEmit --pretty false",
+        "npx tsx --conditions react-server scripts/workspace-trash-retention-test.ts",
+        "npm run lint",
+        "npm run build"
+      ],
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/05-actor-audit-retention.md",
         "docs/architecture/canvas-notebook/team-workspace/11-automation-execution-model.md",

--- a/scripts/workspace-trash-retention-test.ts
+++ b/scripts/workspace-trash-retention-test.ts
@@ -43,6 +43,41 @@ async function main() {
     const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
     try {
       runMigrations(sqlite);
+      sqlite.exec(`
+        INSERT INTO user (id, name, email, email_verified, created_at, updated_at)
+        VALUES ('user-admin', 'Admin', 'admin@example.test', 1, 1767225600000, 1767225600000);
+
+        INSERT INTO canvas_organization_settings (
+          organization_id,
+          owner_user_id,
+          deployment_mode,
+          team_features_enabled,
+          created_at,
+          updated_at
+        )
+        VALUES ('org-trash', 'user-admin', 'team', 1, 1767225600000, 1767225600000);
+
+        INSERT INTO canvas_workspaces (
+          id,
+          organization_id,
+          type,
+          root_relative_path,
+          display_name,
+          status,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          'team-ws',
+          'org-trash',
+          'team',
+          'workspaces/team/org-trash/files',
+          'Team',
+          'active',
+          1767225600000,
+          1767225600000
+        );
+      `);
     } finally {
       sqlite.close();
     }

--- a/scripts/workspace-trash-retention-test.ts
+++ b/scripts/workspace-trash-retention-test.ts
@@ -123,6 +123,26 @@ async function main() {
       execSqlite(dataRoot, 'DROP TRIGGER IF EXISTS fail_workspace_trash_insert;');
     }
 
+    await fs.mkdir(path.join(workspaceRoot, 'docs', 'links'), { recursive: true });
+    await fs.writeFile(path.join(workspaceRoot, 'docs', 'links', 'note.md'), '# Link note\n');
+    await fs.symlink(
+      path.join(workspaceRoot, 'docs', 'links'),
+      path.join(workspaceRoot, 'docs', 'links', 'self'),
+      'dir'
+    );
+    const symlinkBatch = await trashWorkspacePaths({
+      workspace,
+      paths: ['docs/links'],
+      deletedByUserId: 'user-admin',
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    assert.equal(symlinkBatch.failed.length, 0);
+    assert.equal(symlinkBatch.trashed.length, 1);
+    assert.equal(symlinkBatch.trashed[0].originalPath, 'docs/links');
+    assert.equal(symlinkBatch.trashed[0].fileCount, 1);
+    assert.equal(symlinkBatch.trashed[0].directoryCount, 1);
+    assert.equal(await exists(path.join(workspaceRoot, 'docs', 'links')), false);
+
     const trashed = await trashWorkspacePaths({
       workspace,
       paths: ['docs/report.md', 'docs/archive', 'docs/archive/old.md'],
@@ -177,12 +197,39 @@ async function main() {
     assert.equal(await exists(path.join(workspaceRoot, 'docs', 'report.md')), true);
     assert.equal(await fs.readFile(path.join(workspaceRoot, 'docs', 'report.md'), 'utf8'), '# Report\n');
 
+    const pagedTrash = await listWorkspaceTrashEntries({ workspace, limit: 1 });
+    assert.equal(pagedTrash.length, 1);
+
+    const archiveEntry = trashed.trashed.find((entry) => entry.originalPath === 'docs/archive');
+    assert.ok(archiveEntry);
+    execSqlite(dataRoot, `
+      CREATE TRIGGER fail_workspace_trash_purge_update
+      BEFORE UPDATE OF status ON workspace_trash_entries
+      WHEN NEW.status = 'purged'
+      BEGIN
+        SELECT RAISE(FAIL, 'purge update failed');
+      END;
+    `);
+    try {
+      const failedPurge = await purgeExpiredWorkspaceTrash({
+        now: new Date('2026-01-03T00:00:00.000Z'),
+        purgedByUserId: 'system-cleanup',
+      });
+      assert.equal(failedPurge.purged.length, 0);
+      assert.equal(failedPurge.failed.length, 3);
+      assert.equal(await exists(path.join(dataRoot, mixedBatch.trashed[0].trashRelativePath)), true);
+      assert.equal(await exists(path.join(dataRoot, symlinkBatch.trashed[0].trashRelativePath)), true);
+      assert.equal(await exists(path.join(dataRoot, archiveEntry.trashRelativePath)), true);
+    } finally {
+      execSqlite(dataRoot, 'DROP TRIGGER IF EXISTS fail_workspace_trash_purge_update;');
+    }
+
     const purge = await purgeExpiredWorkspaceTrash({
       now: new Date('2026-01-03T00:00:00.000Z'),
       purgedByUserId: 'system-cleanup',
     });
     assert.equal(purge.failed.length, 0);
-    assert.equal(purge.purged.length, 2);
+    assert.equal(purge.purged.length, 3);
 
     const activeTrash = await listWorkspaceTrashEntries({ workspace });
     assert.equal(activeTrash.length, 0);
@@ -195,6 +242,7 @@ async function main() {
       }>;
       assert.deepEqual(rows, [
         { originalPath: 'docs/archive', status: 'purged' },
+        { originalPath: 'docs/links', status: 'purged' },
         { originalPath: 'docs/mixed-valid.md', status: 'purged' },
         { originalPath: 'docs/report.md', status: 'restored' },
       ]);

--- a/scripts/workspace-trash-retention-test.ts
+++ b/scripts/workspace-trash-retention-test.ts
@@ -17,6 +17,15 @@ async function exists(targetPath: string): Promise<boolean> {
   }
 }
 
+function execSqlite(dataRoot: string, sql: string) {
+  const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+  try {
+    sqlite.exec(sql);
+  } finally {
+    sqlite.close();
+  }
+}
+
 async function main() {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-workspace-trash-'));
   const dataRoot = path.join(tempRoot, 'data');
@@ -74,6 +83,46 @@ async function main() {
     assert.equal(blockedRoot.failed.length, 1);
     assert.match(blockedRoot.failed[0].error, /root/i);
 
+    await fs.writeFile(path.join(workspaceRoot, 'docs', 'mixed-valid.md'), '# Mixed\n');
+    const mixedBatch = await trashWorkspacePaths({
+      workspace,
+      paths: ['docs/mixed-valid.md', '../outside'],
+      deletedByUserId: 'user-admin',
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    assert.equal(mixedBatch.trashed.length, 1);
+    assert.equal(mixedBatch.failed.length, 1);
+    assert.equal(mixedBatch.trashed[0].originalPath, 'docs/mixed-valid.md');
+    assert.match(mixedBatch.failed[0].error, /traversal|outside|invalid/i);
+    assert.equal(await exists(path.join(workspaceRoot, 'docs', 'mixed-valid.md')), false);
+
+    await fs.writeFile(path.join(workspaceRoot, 'docs', 'insert-rollback.md'), '# Insert rollback\n');
+    execSqlite(dataRoot, `
+      CREATE TRIGGER fail_workspace_trash_insert
+      BEFORE INSERT ON workspace_trash_entries
+      BEGIN
+        SELECT RAISE(FAIL, 'trash insert failed');
+      END;
+    `);
+    try {
+      const insertRollback = await trashWorkspacePaths({
+        workspace,
+        paths: ['docs/insert-rollback.md'],
+        deletedByUserId: 'user-admin',
+        now: new Date('2026-01-01T00:00:00.000Z'),
+      });
+      assert.equal(insertRollback.trashed.length, 0);
+      assert.equal(insertRollback.failed.length, 1);
+      assert.match(insertRollback.failed[0].error, /trash insert failed/);
+      assert.equal(await exists(path.join(workspaceRoot, 'docs', 'insert-rollback.md')), true);
+      assert.equal(
+        await fs.readFile(path.join(workspaceRoot, 'docs', 'insert-rollback.md'), 'utf8'),
+        '# Insert rollback\n'
+      );
+    } finally {
+      execSqlite(dataRoot, 'DROP TRIGGER IF EXISTS fail_workspace_trash_insert;');
+    }
+
     const trashed = await trashWorkspacePaths({
       workspace,
       paths: ['docs/report.md', 'docs/archive', 'docs/archive/old.md'],
@@ -94,6 +143,30 @@ async function main() {
 
     const reportEntry = trashed.trashed.find((entry) => entry.originalPath === 'docs/report.md');
     assert.ok(reportEntry);
+    execSqlite(dataRoot, `
+      CREATE TRIGGER fail_workspace_trash_restore_update
+      BEFORE UPDATE OF status ON workspace_trash_entries
+      WHEN NEW.status = 'restored'
+      BEGIN
+        SELECT RAISE(FAIL, 'restore update failed');
+      END;
+    `);
+    try {
+      await assert.rejects(
+        () => restoreWorkspaceTrashEntry({
+          workspace,
+          entryId: reportEntry.id,
+          restoredByUserId: 'user-admin',
+          now: new Date('2026-01-01T00:30:00.000Z'),
+        }),
+        /restore update failed/
+      );
+      assert.equal(await exists(path.join(workspaceRoot, 'docs', 'report.md')), false);
+      assert.equal(await exists(path.join(dataRoot, reportEntry.trashRelativePath)), true);
+    } finally {
+      execSqlite(dataRoot, 'DROP TRIGGER IF EXISTS fail_workspace_trash_restore_update;');
+    }
+
     const restored = await restoreWorkspaceTrashEntry({
       workspace,
       entryId: reportEntry.id,
@@ -109,7 +182,7 @@ async function main() {
       purgedByUserId: 'system-cleanup',
     });
     assert.equal(purge.failed.length, 0);
-    assert.equal(purge.purged.length, 1);
+    assert.equal(purge.purged.length, 2);
 
     const activeTrash = await listWorkspaceTrashEntries({ workspace });
     assert.equal(activeTrash.length, 0);
@@ -122,6 +195,7 @@ async function main() {
       }>;
       assert.deepEqual(rows, [
         { originalPath: 'docs/archive', status: 'purged' },
+        { originalPath: 'docs/mixed-valid.md', status: 'purged' },
         { originalPath: 'docs/report.md', status: 'restored' },
       ]);
     } finally {

--- a/scripts/workspace-trash-retention-test.ts
+++ b/scripts/workspace-trash-retention-test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../app/lib/db/migrate';
+import type { WorkspaceContext } from '../app/lib/workspaces/types';
+
+async function exists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-workspace-trash-'));
+  const dataRoot = path.join(tempRoot, 'data');
+  const workspaceRoot = path.join(dataRoot, 'workspaces', 'team', 'org-trash', 'files');
+  const previousData = process.env.DATA;
+  const previousTrashRetention = process.env.WORKSPACE_TRASH_RETENTION_DAYS;
+  process.env.DATA = dataRoot;
+  process.env.WORKSPACE_TRASH_RETENTION_DAYS = '1';
+
+  try {
+    await fs.mkdir(path.join(workspaceRoot, 'docs', 'archive'), { recursive: true });
+    await fs.writeFile(path.join(workspaceRoot, 'docs', 'report.md'), '# Report\n');
+    await fs.writeFile(path.join(workspaceRoot, 'docs', 'archive', 'old.md'), '# Old\n');
+
+    const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+    try {
+      runMigrations(sqlite);
+    } finally {
+      sqlite.close();
+    }
+
+    const workspace: WorkspaceContext = {
+      workspaceId: 'team-ws',
+      workspaceType: 'team',
+      rootPath: workspaceRoot,
+      rootRelativePath: 'workspaces/team/org-trash/files',
+      displayName: 'Team',
+      organizationId: 'org-trash',
+      ownerUserId: null,
+      permissions: {
+        canRead: true,
+        canWrite: true,
+        canDelete: true,
+        canCreatePublicLinks: true,
+        canManageWorkspace: true,
+        canRunAgent: true,
+      },
+      legacy: false,
+    };
+
+    const {
+      listWorkspaceTrashEntries,
+      purgeExpiredWorkspaceTrash,
+      restoreWorkspaceTrashEntry,
+      trashWorkspacePaths,
+    } = await import('../app/lib/filesystem/workspace-trash');
+
+    const blockedRoot = await trashWorkspacePaths({
+      workspace,
+      paths: ['.'],
+      deletedByUserId: 'user-admin',
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    assert.equal(blockedRoot.trashed.length, 0);
+    assert.equal(blockedRoot.failed.length, 1);
+    assert.match(blockedRoot.failed[0].error, /root/i);
+
+    const trashed = await trashWorkspacePaths({
+      workspace,
+      paths: ['docs/report.md', 'docs/archive', 'docs/archive/old.md'],
+      deletedByUserId: 'user-admin',
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    assert.equal(trashed.failed.length, 0);
+    assert.equal(trashed.trashed.length, 2);
+    assert.deepEqual(trashed.trashed.map((entry) => entry.originalPath).sort(), ['docs/archive', 'docs/report.md']);
+    assert.equal(await exists(path.join(workspaceRoot, 'docs', 'report.md')), false);
+    assert.equal(await exists(path.join(workspaceRoot, 'docs', 'archive')), false);
+
+    for (const entry of trashed.trashed) {
+      assert.equal(await exists(path.join(dataRoot, entry.trashRelativePath)), true);
+      assert.equal(entry.status, 'trashed');
+      assert.equal(entry.expiresAt.toISOString(), '2026-01-02T00:00:00.000Z');
+    }
+
+    const reportEntry = trashed.trashed.find((entry) => entry.originalPath === 'docs/report.md');
+    assert.ok(reportEntry);
+    const restored = await restoreWorkspaceTrashEntry({
+      workspace,
+      entryId: reportEntry.id,
+      restoredByUserId: 'user-admin',
+      now: new Date('2026-01-01T01:00:00.000Z'),
+    });
+    assert.equal(restored.status, 'restored');
+    assert.equal(await exists(path.join(workspaceRoot, 'docs', 'report.md')), true);
+    assert.equal(await fs.readFile(path.join(workspaceRoot, 'docs', 'report.md'), 'utf8'), '# Report\n');
+
+    const purge = await purgeExpiredWorkspaceTrash({
+      now: new Date('2026-01-03T00:00:00.000Z'),
+      purgedByUserId: 'system-cleanup',
+    });
+    assert.equal(purge.failed.length, 0);
+    assert.equal(purge.purged.length, 1);
+
+    const activeTrash = await listWorkspaceTrashEntries({ workspace });
+    assert.equal(activeTrash.length, 0);
+
+    const verifyDb = new Database(path.join(dataRoot, 'sqlite.db'), { readonly: true, fileMustExist: true });
+    try {
+      const rows = verifyDb.prepare('SELECT original_path AS originalPath, status FROM workspace_trash_entries ORDER BY original_path').all() as Array<{
+        originalPath: string;
+        status: string;
+      }>;
+      assert.deepEqual(rows, [
+        { originalPath: 'docs/archive', status: 'purged' },
+        { originalPath: 'docs/report.md', status: 'restored' },
+      ]);
+    } finally {
+      verifyDb.close();
+    }
+
+    console.log('workspace-trash-retention-test: ok');
+  } finally {
+    if (previousData === undefined) delete process.env.DATA;
+    else process.env.DATA = previousData;
+    if (previousTrashRetention === undefined) delete process.env.WORKSPACE_TRASH_RETENTION_DAYS;
+    else process.env.WORKSPACE_TRASH_RETENTION_DAYS = previousTrashRetention;
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/workspace-trash-retention-test.ts
+++ b/scripts/workspace-trash-retention-test.ts
@@ -197,6 +197,56 @@ async function main() {
     assert.equal(await exists(path.join(workspaceRoot, 'docs', 'report.md')), true);
     assert.equal(await fs.readFile(path.join(workspaceRoot, 'docs', 'report.md'), 'utf8'), '# Report\n');
 
+    await fs.writeFile(path.join(workspaceRoot, 'docs', 'overwrite.md'), '# Replacement\n');
+    const overwriteTrash = await trashWorkspacePaths({
+      workspace,
+      paths: ['docs/overwrite.md'],
+      deletedByUserId: 'user-admin',
+      now: new Date('2026-01-01T01:05:00.000Z'),
+    });
+    assert.equal(overwriteTrash.failed.length, 0);
+    assert.equal(overwriteTrash.trashed.length, 1);
+    const overwriteEntry = overwriteTrash.trashed[0];
+    await fs.writeFile(path.join(workspaceRoot, 'docs', 'overwrite.md'), '# Existing destination\n');
+    execSqlite(dataRoot, `
+      CREATE TRIGGER fail_workspace_trash_overwrite_restore_update
+      BEFORE UPDATE OF status ON workspace_trash_entries
+      WHEN NEW.status = 'restored'
+      BEGIN
+        SELECT RAISE(FAIL, 'overwrite restore update failed');
+      END;
+    `);
+    try {
+      await assert.rejects(
+        () => restoreWorkspaceTrashEntry({
+          workspace,
+          entryId: overwriteEntry.id,
+          restoredByUserId: 'user-admin',
+          overwrite: true,
+          now: new Date('2026-01-01T01:10:00.000Z'),
+        }),
+        /overwrite restore update failed/
+      );
+      assert.equal(await exists(path.join(dataRoot, overwriteEntry.trashRelativePath)), true);
+      assert.equal(
+        await fs.readFile(path.join(workspaceRoot, 'docs', 'overwrite.md'), 'utf8'),
+        '# Existing destination\n'
+      );
+    } finally {
+      execSqlite(dataRoot, 'DROP TRIGGER IF EXISTS fail_workspace_trash_overwrite_restore_update;');
+    }
+
+    const overwriteRestored = await restoreWorkspaceTrashEntry({
+      workspace,
+      entryId: overwriteEntry.id,
+      restoredByUserId: 'user-admin',
+      overwrite: true,
+      now: new Date('2026-01-01T01:15:00.000Z'),
+    });
+    assert.equal(overwriteRestored.status, 'restored');
+    assert.equal(await exists(path.join(dataRoot, overwriteEntry.trashRelativePath)), false);
+    assert.equal(await fs.readFile(path.join(workspaceRoot, 'docs', 'overwrite.md'), 'utf8'), '# Replacement\n');
+
     const pagedTrash = await listWorkspaceTrashEntries({ workspace, limit: 1 });
     assert.equal(pagedTrash.length, 1);
 
@@ -244,6 +294,7 @@ async function main() {
         { originalPath: 'docs/archive', status: 'purged' },
         { originalPath: 'docs/links', status: 'purged' },
         { originalPath: 'docs/mixed-valid.md', status: 'purged' },
+        { originalPath: 'docs/overwrite.md', status: 'restored' },
         { originalPath: 'docs/report.md', status: 'restored' },
       ]);
     } finally {


### PR DESCRIPTION
## Summary
- add a persisted workspace trash table and migration for soft-deleted workspace paths
- add workspace trash helpers for delete, restore, list, and expired purge behavior with retention metadata
- route file deletes through workspace trash while preserving the existing deleted-path response and public-share revocation flow
- mark Task 30 complete in the architecture todo source of truth

## Verification
- `npx tsc --noEmit --pretty false`
- `npx tsx --conditions react-server scripts/workspace-trash-retention-test.ts`
- `npm run lint`
- `npm run build`

## Greptile
Pending automatic first review after PR creation. No manual greploop trigger has been started.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a soft-delete workspace trash system: a new `workspace_trash_entries` SQLite table with retention metadata, a `workspace-trash.ts` module for trash/restore/list/purge operations, and routes all file deletes through `trashWorkspacePaths` instead of the previous immediate `batchDelete`. All issues surfaced in the prior review round (DB/FS ordering, batch error isolation, symlink loops, concurrent purge/restore, overwrite staging, pagination) have been addressed in this version.

- **New `workspace-trash.ts`**: handles move-to-trash with per-path rollback on DB failure, paginated listing, restore with overwrite staging and full rollback, and an optimistic-lock purge that marks DB first then deletes on disk.
- **Route change**: `DELETE /api/files/delete` now returns `trashEntries` alongside the existing `deleted` field, preserving backward compatibility while surfacing trash metadata (id, expiresAt) to callers.
- **Integration test**: covers root-blocking, path traversal isolation, DB-trigger-induced rollback, symlink trees, overwrite restore, and full purge cycle against a real SQLite database.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all core trash/restore/purge logic is sound and the previous review issues have been thoroughly addressed.

The implementation correctly handles DB/FS ordering with rollbacks, batch error isolation, symlink traversal, concurrent purge protection, overwrite staging, and pagination. The two new observations (cross-device rm-after-cp orphan and missing workspace FK) are both narrow edge cases that don't affect correctness under normal deployment conditions.

app/lib/filesystem/workspace-trash.ts (movePath EXDEV path) and app/lib/db/schema.ts (workspaceId FK absence)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/filesystem/workspace-trash.ts | New 494-line module: soft-delete, restore, list, and purge. All previous review issues addressed. One new edge-case: EXDEV copy+rm failure leaves an orphaned trash copy with no DB record. |
| app/api/files/delete/route.ts | Switches batchDelete to trashWorkspacePaths; backward-compatible response (keeps `deleted`), adds `trashEntries`; audit event metadata updated accordingly. Clean integration. |
| app/lib/db/schema.ts | Adds workspaceTrashEntries table with five indexes; missing FK reference on workspaceId (no cascade-delete when a workspace is removed, unlike other tables in the schema). |
| app/lib/db/migrate.ts | Adds CREATE TABLE IF NOT EXISTS and five matching indexes for workspace_trash_entries; aligns with schema.ts. No FK constraint on workspace_id (mirrors schema omission). |
| scripts/workspace-trash-retention-test.ts | Comprehensive integration test covering trash, restore (with rollback via trigger), overwrite restore, pagination, purge, and symlink handling against a real SQLite DB in a temp directory. |
| docs/architecture/canvas-notebook/todo.json | Marks task 30 as completed and adds implementation/verification artifacts. No logic changes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DELETE /api/files/delete] --> B[trashWorkspacePaths]
    B --> C{dedupeNestedPaths}
    C -->|invalid path| D[result.failed]
    C -->|valid paths| E[resolveExistingWorkspacePath]
    E --> F[summarizePath]
    F --> G[movePath: workspace → trash dir]
    G -->|EXDEV fallback| G1[fs.cp then fs.rm]
    G1 -->|rm fails| G2[orphaned copy in trash]
    G --> H[db.insert workspaceTrashEntries]
    H -->|success| I[result.trashed]
    H -->|failure| J[movePath: trash → workspace rollback]
    J --> D
    I --> K[syncPublicSharesAfterDelete]
    K --> L[recordAuditEvent]
    L --> M[jsonSuccess response]

    N[purgeExpiredWorkspaceTrash] --> O[SELECT status=trashed AND expiresAt<=now]
    O --> P[db.update status=purged WHERE id AND status=trashed]
    P -->|no row matched| Q[skip - concurrent restore won]
    P -->|updated| R[fs.rm trash file]
    R -->|fsError| S[db.update rollback status=trashed]
    R -->|success| T[result.purged]

    U[restoreWorkspaceTrashEntry] --> V[SELECT WHERE id AND workspace AND status=trashed]
    V --> W{destinationExists?}
    W -->|yes, overwrite=false| X[throw: target exists]
    W -->|yes, overwrite=true| Y[movePath: dest → staging]
    W -->|no| Z[movePath: trash → dest]
    Y --> Z
    Z --> AA[db.update status=restored]
    AA -->|failure| AB[rollback: dest→trash, staging→dest]
    AA -->|success| AC[fs.rm staging]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[DELETE /api/files/delete] --> B[trashWorkspacePaths]
    B --> C{dedupeNestedPaths}
    C -->|invalid path| D[result.failed]
    C -->|valid paths| E[resolveExistingWorkspacePath]
    E --> F[summarizePath]
    F --> G[movePath: workspace → trash dir]
    G -->|EXDEV fallback| G1[fs.cp then fs.rm]
    G1 -->|rm fails| G2[orphaned copy in trash]
    G --> H[db.insert workspaceTrashEntries]
    H -->|success| I[result.trashed]
    H -->|failure| J[movePath: trash → workspace rollback]
    J --> D
    I --> K[syncPublicSharesAfterDelete]
    K --> L[recordAuditEvent]
    L --> M[jsonSuccess response]

    N[purgeExpiredWorkspaceTrash] --> O[SELECT status=trashed AND expiresAt<=now]
    O --> P[db.update status=purged WHERE id AND status=trashed]
    P -->|no row matched| Q[skip - concurrent restore won]
    P -->|updated| R[fs.rm trash file]
    R -->|fsError| S[db.update rollback status=trashed]
    R -->|success| T[result.purged]

    U[restoreWorkspaceTrashEntry] --> V[SELECT WHERE id AND workspace AND status=trashed]
    V --> W{destinationExists?}
    W -->|yes, overwrite=false| X[throw: target exists]
    W -->|yes, overwrite=true| Y[movePath: dest → staging]
    W -->|no| Z[movePath: trash → dest]
    Y --> Z
    Z --> AA[db.update status=restored]
    AA -->|failure| AB[rollback: dest→trash, staging→dest]
    AA -->|success| AC[fs.rm staging]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fteam-retention-trash%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fteam-retention-trash%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Flib%2Ffilesystem%2Fworkspace-trash.ts%3A337-348%0A**Orphaned%20trash%20copy%20on%20cross-device%20%60rm%60%20failure**%0A%0AIn%20the%20EXDEV%20fallback%20path%2C%20%60fs.cp%60%20to%20%60trashPath%60%20succeeds%20first%3B%20if%20the%20subsequent%20%60fs.rm%28sourcePath%2C%20%7B%20recursive%2C%20force%3A%20false%20%7D%29%60%20throws%2C%20%60movePath%60%20re-throws%20that%20error.%20Back%20in%20%60trashWorkspacePaths%60%20this%20exits%20the%20outer%20%60try%60%20block%20before%20the%20inner%20%60db.insert%60%20block%20is%20ever%20entered%2C%20so%20the%20DB-rollback%20code%20%28%60movePath%28trashPath%2C%20sourcePath%29%60%29%20never%20runs.%20The%20copied%20content%20sits%20at%20%60trashPath%60%20permanently%20%E2%80%94%20no%20DB%20record%20means%20%60purgeExpiredWorkspaceTrash%60%20will%20never%20see%20it%20and%20the%20bytes%20accumulate%20silently.%20The%20user-visible%20result%20is%20correctly%20%22failed%22%2C%20but%20the%20trash%20directory%20leaks%20storage%20until%20manual%20intervention.%0A%0AA%20minimal%20fix%20is%20to%20%60fs.rm%28destinationPath%2C%20%7B%20recursive%2C%20force%3A%20true%20%7D%29%60%20in%20the%20%60catch%60%20block%20of%20the%20EXDEV%20path%20before%20re-throwing%2C%20so%20a%20failed%20copy-then-rm%20never%20leaves%20a%20partial%20destination%20behind.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Flib%2Fdb%2Fschema.ts%3A128-156%0A**No%20FK%20constraint%20on%20%60workspaceId%60%20%E2%80%94%20orphaned%20rows%20if%20workspace%20is%20deleted**%0A%0A%60canvasWorkspaces%60%20itself%20cascades%20on%20%60organizationId%60%2C%20and%20%60organizationUserPermissions.organizationId%60%20is%20declared%20with%20%60%7B%20onDelete%3A%20'cascade'%20%7D%60.%20%60workspaceTrashEntries.workspaceId%60%20carries%20no%20%60.references%28%28%29%20%3D%3E%20canvasWorkspaces.id%2C%20%7B%20onDelete%3A%20'cascade'%20%7D%29%60%2C%20so%20deleting%20a%20workspace%20record%20silently%20leaves%20its%20trash%20entries%20behind.%20Entries%20with%20%60status%20%3D%20'trashed'%60%20and%20a%20future%20%60expiresAt%60%20will%20linger%20indefinitely%20because%20%60purgeExpiredWorkspaceTrash%60%20only%20filters%20on%20expiry%2C%20not%20on%20whether%20the%20owning%20workspace%20still%20exists.%20The%20same%20gap%20exists%20in%20the%20SQL%20migration%20%E2%80%94%20no%20%60FOREIGN%20KEY%60%20clause%20is%20present%20on%20%60workspace_id%60.%0A%0AIf%20intentional%20%28e.g.%2C%20audit%20retention%20across%20workspace%20deletion%29%2C%20a%20comment%20explaining%20the%20decision%20would%20help%20future%20readers.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=32&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["Guard workspace trash restore rollback e..."](https://github.com/canvascoding/canvas-notebook/commit/694c5e67b7e2f76dc0dec0c0aa38be420485a0e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38930005)</sub>

<!-- /greptile_comment -->