### PR TITLE
Enforce workspace path security

### DIFF
--- a/app/api/terminal/create/route.ts
+++ b/app/api/terminal/create/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/app/lib/auth';
 import { getTerminalClient } from '@/app/lib/terminal-client';
-import path from 'path';
+import { resolveAgentSessionWorkspaceForUser } from '@/app/lib/pi/session-workspace-context';
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { sessionId, cwd } = body;
+    const { sessionId, workspaceId } = body;
 
     if (!sessionId) {
       return NextResponse.json(
@@ -29,13 +29,26 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    let workspaceRoot: string;
+    try {
+      const workspace = await resolveAgentSessionWorkspaceForUser({
+        userId: session.user.id,
+        workspaceId: typeof workspaceId === 'string' ? workspaceId : null,
+        permissions: ['canRead', 'canWrite'],
+      });
+      workspaceRoot = workspace.rootPath;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Workspace not found or inaccessible';
+      return NextResponse.json(
+        { error: message },
+        { status: message.includes('not found') || message.includes('inaccessible') ? 404 : 403 }
+      );
+    }
+
     const ownerId = String(session.user.id || session.user.email || 'anonymous');
-    const dataDir = path.resolve(/*turbopackIgnore: true*/ process.cwd(), process.env.DATA || 'data');
-    const workspaceDir = path.join(dataDir, 'workspace');
-    const finalCwd = cwd && path.isAbsolute(cwd) ? cwd : workspaceDir;
 
     const client = getTerminalClient();
-    const result = await client.createSession(sessionId, ownerId, finalCwd);
+    const result = await client.createSession(sessionId, ownerId, workspaceRoot);
 
     return NextResponse.json(result);
   } catch (error: unknown) {

--- a/app/api/terminal/create/route.ts
+++ b/app/api/terminal/create/route.ts
@@ -38,10 +38,10 @@ export async function POST(request: NextRequest) {
       });
       workspaceRoot = workspace.rootPath;
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Workspace not found or inaccessible';
+      console.error('[Terminal API] Workspace resolution error:', error);
       return NextResponse.json(
-        { error: message },
-        { status: message.includes('not found') || message.includes('inaccessible') ? 404 : 403 }
+        { error: 'Workspace not found or inaccessible' },
+        { status: 404 }
       );
     }
 

--- a/app/components/terminal/XTerminal.tsx
+++ b/app/components/terminal/XTerminal.tsx
@@ -7,6 +7,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { useTheme } from '@/app/components/ThemeProvider';
+import { useWorkspaceStore } from '@/app/store/workspace-store';
 
 interface XTerminalProps {
   sessionId: string;
@@ -68,6 +69,8 @@ function getTerminalTheme(isDark: boolean) {
 
 export function XTerminal({ sessionId }: XTerminalProps) {
   const t = useTranslations('terminal');
+  const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
+  const activeWorkspaceIdRef = useRef<string | null>(activeWorkspaceId);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -79,6 +82,10 @@ export function XTerminal({ sessionId }: XTerminalProps) {
   const isReady = useRef(false);
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme !== 'light';
+
+  useEffect(() => {
+    activeWorkspaceIdRef.current = activeWorkspaceId;
+  }, [activeWorkspaceId]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -192,7 +199,7 @@ export function XTerminal({ sessionId }: XTerminalProps) {
         const createResponse = await fetch('/api/terminal/create', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sessionId }),
+          body: JSON.stringify({ sessionId, workspaceId: activeWorkspaceIdRef.current }),
         });
 
         if (!createResponse.ok) {

--- a/app/lib/agents/base-system-prompt.ts
+++ b/app/lib/agents/base-system-prompt.ts
@@ -18,8 +18,8 @@ When in doubt, inspect the relevant workspace context first, then do the smalles
 - Relative paths resolve inside the workspace bound to this chat session. Write final user-facing files and organized outputs there.
 - /data/workspace is a legacy alias only; do not treat it as a global workspace root.
 - /data/user-uploads is an intake area for uploaded files. Copy anything the user should keep into the active workspace using the file tools.
-- /data/agents/<agent-id> contains internal agent-managed files. Do not put user-facing deliverables there.
-- /data/skills contains installed skills. Create or update skills there, never inside a user workspace.
+- Agent memory and agent-managed configuration are internal runtime state; use the dedicated memory, agent, skill, or settings tools instead of reading or writing /data/agents directly with file tools.
+- Installed skills are managed through skill/settings tools. Do not read or write /data/skills directly with normal workspace file tools.
 - /data/secrets/Canvas-Integrations.env contains integration secrets managed through Settings -> Integrations. Do not edit secret files directly and do not create ad-hoc secret files.
 
 Use workspace-relative paths for normal file operations. Use absolute paths only when a trusted tool result returned that exact runtime path.

--- a/app/lib/agents/base-system-prompt.ts
+++ b/app/lib/agents/base-system-prompt.ts
@@ -15,17 +15,18 @@ When in doubt, inspect the relevant workspace context first, then do the smalles
 
 ## Data Locations
 
-- /data/workspace is the user-visible workspace. Write final user-facing files and organized outputs here.
-- /data/user-uploads is an intake area for uploaded files. Copy anything the user should keep into /data/workspace.
+- Relative paths resolve inside the workspace bound to this chat session. Write final user-facing files and organized outputs there.
+- /data/workspace is a legacy alias only; do not treat it as a global workspace root.
+- /data/user-uploads is an intake area for uploaded files. Copy anything the user should keep into the active workspace using the file tools.
 - /data/agents/<agent-id> contains internal agent-managed files. Do not put user-facing deliverables there.
-- /data/skills contains installed skills. Create or update skills there, never inside /data/workspace.
+- /data/skills contains installed skills. Create or update skills there, never inside a user workspace.
 - /data/secrets/Canvas-Integrations.env contains integration secrets managed through Settings -> Integrations. Do not edit secret files directly and do not create ad-hoc secret files.
 
-Relative paths resolve from /data/workspace. Use absolute paths for internal runtime files only when needed.
+Use workspace-relative paths for normal file operations. Use absolute paths only when a trusted tool result returned that exact runtime path.
 
 ## Outputs
 
-When no specific output format is requested, create a Markdown document in /data/workspace. Clean up temporary files after completion when they are no longer useful.
+When no specific output format is requested, create a Markdown document in the active workspace. Clean up temporary files after completion when they are no longer useful.
 
 ## Memory
 
@@ -59,7 +60,7 @@ Use web_search for current public web lookup and web_fetch for known URLs. Treat
 
 ## Safe File Editing
 
-For existing file content edits, use \`edit_file\` for exact replacements or \`apply_patch\` for multiple coordinated replacements. Do not use shell commands such as \`sed -i\`, \`perl -pi\`, \`tee\`, or redirects to mutate file contents in \`/data/workspace\` or \`/data/agents\`.
+For existing file content edits, use \`edit_file\` for exact replacements or \`apply_patch\` for multiple coordinated replacements. Do not use shell commands such as \`sed -i\`, \`perl -pi\`, \`tee\`, or redirects to mutate workspace or agent-managed files.
 
 For copy, move, rename, and delete operations, prefer \`copy_path\`, \`move_path\`, and \`delete_path\` over shell commands so the UI can show clear file-operation activity. These path tools support single paths and multi-path batches through \`sourcePaths\` or \`paths\`; use \`recursive: true\` for directories and \`overwrite: true\` only when replacement is intended. The safe content-edit tools create undo snapshots, return diffs, validate supported file types, and verify the file after writing. Use \`write\` mainly for new files or intentional full rewrites. For large structural rewrites, briefly explain the intended approach before changing the file.
 
@@ -76,7 +77,7 @@ Avoid plain global pip installs. If system packages are required and command exe
 
 ## Outputs and Secrets
 
-Write final user-facing outputs under /data/workspace. Treat /data/user-uploads as intake only. Keep secrets in Settings -> Integrations so they are stored in /data/secrets/Canvas-Integrations.env. If a skill or integration needs a missing environment variable, tell the user which key is missing and point them to /settings?tab=integrations.
+Write final user-facing outputs under the active workspace. Treat /data/user-uploads as intake only. Keep secrets in Settings -> Integrations so they are stored in /data/secrets/Canvas-Integrations.env. If a skill or integration needs a missing environment variable, tell the user which key is missing and point them to /settings?tab=integrations.
 
 ## External Connectors
 

--- a/app/lib/agents/channel-system-prompt.ts
+++ b/app/lib/agents/channel-system-prompt.ts
@@ -11,7 +11,7 @@ Telegram can receive native attachments from local files. When a generated or sa
 
 \`MEDIA:/absolute/path/to/file\`
 
-- Use only exact absolute file paths that were returned by a trusted tool result, such as files under /data/studio/outputs, /data/user-uploads, or /data/workspace.
+- Use only exact absolute file paths that were returned by a trusted tool result, such as files under /data/studio/outputs, /data/user-uploads, or the active workspace.
 - For generated Studio images, videos, or audio, prefer \`MEDIA:\` with the absolute file path over Markdown image links.
 - Use \`[[audio_as_voice]]\` before \`MEDIA:\` only when an OGG/Opus audio file should be sent as a Telegram voice note.
 - Use \`[[as_document]]\` before \`MEDIA:\` when an image must be sent as an uncompressed file rather than as a Telegram photo.

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { promises as fs } from 'node:fs';
+import { existsSync, promises as fs, realpathSync } from 'node:fs';
 import type { Stats } from 'node:fs';
 import path from 'node:path';
 
@@ -145,18 +145,46 @@ function isPathWithin(candidatePath: string, basePath: string): boolean {
   return normalizedCandidate === normalizedBase || normalizedCandidate.startsWith(`${normalizedBase}${path.sep}`);
 }
 
-function getManagedWorkspaceRoots(): string[] {
+function rootPathVariants(rootPath: string): string[] {
+  const variants = new Set([path.resolve(rootPath)]);
+  try {
+    if (existsSync(rootPath)) {
+      variants.add(realpathSync(rootPath));
+    }
+  } catch {
+    // Keep the configured path variant when the root cannot be resolved synchronously.
+  }
+  return [...variants];
+}
+
+function isPathWithinRootVariants(candidatePath: string, rootPath: string): boolean {
+  return rootPathVariants(rootPath).some((rootVariant) => isPathWithin(candidatePath, rootVariant));
+}
+
+function isPathWithinAnyRootVariant(candidatePath: string, rootPaths: string[]): boolean {
+  return rootPaths.some((rootPath) => isPathWithinRootVariants(candidatePath, rootPath));
+}
+
+function getLegacyWorkspaceRoots(): string[] {
   const dataRoot = getAgentDataRoot();
   return [
     path.join(dataRoot, 'workspace'),
-    path.join(dataRoot, 'workspaces'),
     '/data/workspace',
-    '/data/workspaces',
   ];
 }
 
-function isManagedWorkspacePath(candidatePath: string): boolean {
-  return getManagedWorkspaceRoots().some((workspaceRoot) => isPathWithin(candidatePath, workspaceRoot));
+function getAllowedRuntimeReadRoots(): string[] {
+  const dataRoot = getAgentDataRoot();
+  return [
+    path.join(dataRoot, 'user-uploads'),
+    path.join(dataRoot, 'studio'),
+    '/data/user-uploads',
+    '/data/studio',
+  ];
+}
+
+function isAllowedRuntimeReadPath(candidatePath: string): boolean {
+  return isPathWithinAnyRootVariant(candidatePath, getAllowedRuntimeReadRoots());
 }
 
 function assertContextWorkspaceReadAllowed(candidatePath: string): void {
@@ -164,9 +192,11 @@ function assertContextWorkspaceReadAllowed(candidatePath: string): void {
   if (!executionContext) return;
 
   const resolvedPath = path.resolve(candidatePath);
-  if (isManagedWorkspacePath(resolvedPath) && !isPathWithin(resolvedPath, executionContext.workspaceRoot)) {
-    throw new Error('Agent file access is limited to the workspace bound to this chat session.');
+  if (isPathWithinRootVariants(resolvedPath, executionContext.workspaceRoot) || isAllowedRuntimeReadPath(resolvedPath)) {
+    return;
   }
+
+  throw new Error('Agent file access is limited to the workspace bound to this chat session or trusted runtime intake paths.');
 }
 
 async function assertContextWorkspaceWriteAllowed(candidatePath: string): Promise<void> {
@@ -281,8 +311,46 @@ export async function assertAgentWritablePathAllowed(candidatePath: string): Pro
   await assertNearestWritableParentAllowed(candidatePath);
 }
 
+function assertValidAgentPathInput(filePath: string): void {
+  if (typeof filePath !== 'string' || !filePath.trim()) {
+    throw new Error('Agent file path must be a non-empty string.');
+  }
+  if (filePath.includes('\0')) {
+    throw new Error('Agent file path contains an invalid null byte.');
+  }
+}
+
+function relativePathWithin(candidatePath: string, basePath: string): string | null {
+  const normalizedCandidate = path.resolve(candidatePath);
+  const normalizedBase = path.resolve(basePath);
+  const relativePath = path.relative(normalizedBase, normalizedCandidate);
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return normalizedCandidate === normalizedBase ? '.' : null;
+  }
+  return relativePath;
+}
+
+function resolveLegacyWorkspaceAlias(filePath: string): string | null {
+  const workspaceRoot = getAgentWorkspaceRoot();
+  for (const legacyRoot of getLegacyWorkspaceRoots()) {
+    const relativePath = relativePathWithin(filePath, legacyRoot);
+    if (relativePath) {
+      return relativePath === '.'
+        ? workspaceRoot
+        : path.join(workspaceRoot, relativePath);
+    }
+  }
+  return null;
+}
+
 export function resolveAgentPath(filePath: string): string {
-  return path.isAbsolute(filePath) ? filePath : path.join(getAgentWorkspaceRoot(), filePath);
+  assertValidAgentPathInput(filePath);
+  const trimmedPath = filePath.trim();
+  if (!path.isAbsolute(trimmedPath)) {
+    return path.join(getAgentWorkspaceRoot(), trimmedPath);
+  }
+
+  return resolveLegacyWorkspaceAlias(trimmedPath) ?? path.resolve(trimmedPath);
 }
 
 export function sha256Buffer(buffer: Buffer): string {
@@ -1186,7 +1254,7 @@ export async function moveAgentPaths(params: {
   const entries: AgentPathOperationEntry[] = [];
   for (const sourcePath of sourcePaths) {
     const sourceFullPath = resolveAgentPath(sourcePath);
-    await assertAgentPathAllowed(sourceFullPath);
+    await assertAgentWritablePathAllowed(sourceFullPath);
 
     const summary = await summarizePath(sourceFullPath);
     const entryDestinationPath = multipleSources
@@ -1340,6 +1408,44 @@ function isManagedDataPath(target: string): boolean {
   return candidateRoots.some((candidateRoot) => isPathWithin(normalized, candidateRoot));
 }
 
+function findShellDataPathMentions(command: string): string[] {
+  const mentions = new Set<string>();
+  const pathPattern = /(?:^|[\s"'`=(:])((?:\/data|[^\s"'`;&|()]*\/data)\/(?:workspaces|workspace|agents|user-uploads|studio)(?:\/[^\s"'`;&|()]*)?)/g;
+
+  for (const match of command.matchAll(pathPattern)) {
+    const mention = stripShellTokenQuotes(match[1] || '').trim();
+    if (mention) {
+      mentions.add(mention);
+    }
+  }
+
+  const executionContext = getAgentExecutionContext();
+  if (executionContext?.workspaceRoot) {
+    const escapedWorkspaceRoot = executionContext.workspaceRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const workspaceRootPattern = new RegExp(`(?:^|[\\s"'\\\`=(:])(${escapedWorkspaceRoot}(?:\\/[^\\s"'\\\`;&|()]*)?)`, 'g');
+    for (const match of command.matchAll(workspaceRootPattern)) {
+      const mention = stripShellTokenQuotes(match[1] || '').trim();
+      if (mention) {
+        mentions.add(mention);
+      }
+    }
+  }
+
+  return [...mentions];
+}
+
+function shellDataPathMentionViolatesContext(command: string): boolean {
+  const executionContext = getAgentExecutionContext();
+  if (!executionContext) return false;
+
+  return findShellDataPathMentions(command).some((mention) => {
+    const resolvedMention = path.resolve(mention);
+    if (isPathWithin(resolvedMention, executionContext.workspaceRoot)) return false;
+    if (resolveLegacyWorkspaceAlias(resolvedMention)) return false;
+    return true;
+  });
+}
+
 function stripShellTokenQuotes(token: string): string {
   const trimmed = token.trim();
   if (trimmed.length >= 2) {
@@ -1393,6 +1499,10 @@ export function detectUnsafeBashCommand(command: string): string | null {
   }
 
   const normalized = command.replace(/\s+/g, ' ').trim();
+  if (shellDataPathMentionViolatesContext(normalized)) {
+    return 'Shell commands are limited to the workspace bound to this chat session. Use dedicated file tools for allowed non-workspace inputs.';
+  }
+
   const executionContext = getAgentExecutionContext();
   const mentionsManagedPath = /\/data\/(?:workspace|workspaces|agents)(?:\/|$)/.test(normalized) ||
     Boolean(executionContext?.workspaceRoot && normalized.includes(executionContext.workspaceRoot));

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -1438,9 +1438,22 @@ function shellDataPathMentionViolatesContext(command: string): boolean {
   const executionContext = getAgentExecutionContext();
   if (!executionContext) return false;
 
+  const workspaceRootVariants = rootPathVariants(executionContext.workspaceRoot);
   return findShellDataPathMentions(command).some((mention) => {
     const resolvedMention = path.resolve(mention);
-    if (isPathWithin(resolvedMention, executionContext.workspaceRoot)) return false;
+    try {
+      if (existsSync(resolvedMention)) {
+        const realMention = realpathSync(resolvedMention);
+        if (workspaceRootVariants.some((rootVariant) => isPathWithin(realMention, rootVariant))) {
+          return false;
+        }
+        return true;
+      }
+    } catch {
+      return true;
+    }
+
+    if (workspaceRootVariants.some((rootVariant) => isPathWithin(resolvedMention, rootVariant))) return false;
     if (resolveLegacyWorkspaceAlias(resolvedMention)) return false;
     return true;
   });

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -877,9 +877,9 @@ export function createStudioGenerateImageTool(
         ...outputLines,
         '',
         'Important for the final answer: embed the generated image by copying the Markdown image line exactly. Do not invent, shorten, slugify, or rewrite the image URL; relative filenames like ente-statt-affe.jpg will not render in the chat.',
-        'Important for file operations: use the absolute copy source path when copying the generated file to /data/workspace. The browser render URL and thumbnail preview URL are not filesystem paths.',
+        'Important for file operations: use the absolute copy source path with copy_path when copying the generated file into the active workspace. The browser render URL and thumbnail preview URL are not filesystem paths.',
         '',
-        'To copy to workspace: bash cp <file-path> /data/workspace/<destination>',
+        'To copy to workspace: copy_path with sourcePath=<absolute copy source path> and destinationPath=<workspace-relative destination>.',
       ].join('\n');
       return {
         content: [{ type: 'text', text: summary }],
@@ -967,7 +967,7 @@ export function createStudioGenerateVideoTool(
         '',
         ...outputLines,
         '',
-        'To copy to workspace: bash cp <file-path> /data/workspace/<destination>',
+        'To copy to workspace: copy_path with sourcePath=<absolute copy source path> and destinationPath=<workspace-relative destination>.',
       ].join('\n');
       return {
         content: [{ type: 'text', text: summary }],
@@ -1031,7 +1031,7 @@ export function createStudioGenerateSoundTool(
         '',
         ...outputLines,
         '',
-        'To copy to workspace: bash cp <file-path> /data/workspace/<destination>',
+        'To copy to workspace: copy_path with sourcePath=<absolute copy source path> and destinationPath=<workspace-relative destination>.',
       ].join('\n');
       return {
         content: [{ type: 'text', text: summary }],
@@ -1687,7 +1687,7 @@ export function createRipgrepTool(): AgentTool {
     description: 'Searches file contents with ripgrep. Use this for fast text/content lookup across the workspace before falling back to bash.',
     parameters: Type.Object({
       pattern: Type.String({ description: 'Text or regex pattern to search for.' }),
-      path: Type.Optional(Type.String({ description: 'Directory or file to search in. Absolute or workspace-relative. Defaults to /data/workspace.' })),
+      path: Type.Optional(Type.String({ description: 'Directory or file to search in. Workspace-relative by default; trusted absolute runtime paths are validated server-side. Defaults to the active workspace.' })),
       glob: Type.Optional(Type.String({ description: 'Optional glob filter, for example "**/*.ts" or "*.md".' })),
       ignoreCase: Type.Optional(Type.Boolean({ description: 'Case-insensitive search when true.' })),
       hidden: Type.Optional(Type.Boolean({ description: 'Include hidden files when true.' })),
@@ -2007,14 +2007,14 @@ export const piTools: AgentTool[] = [
   {
     name: 'ls',
     label: 'Listing directory',
-    description: 'Lists files and directories. Use absolute paths (e.g. /data/agents/canvas-agent) or relative paths from /data/workspace.',
+    description: 'Lists files and directories in the active workspace. Prefer workspace-relative paths.',
     parameters: Type.Object({
-      path: Type.Optional(Type.String({ description: 'The path to list. Absolute or workspace-relative. Defaults to /data/workspace.' })),
+      path: Type.Optional(Type.String({ description: 'The path to list. Workspace-relative. Defaults to the active workspace root.' })),
     }),
     execute: async (toolCallId, params) => {
       try {
         const { path: dirPath } = params as { path?: string };
-        const effectiveDir = dirPath || '/data/workspace';
+        const effectiveDir = dirPath || '.';
         const fullPath = resolveAgentPath(effectiveDir);
         await assertAgentPathAllowed(fullPath);
         const entries = await fsPromises.readdir(fullPath, { withFileTypes: true });
@@ -2048,7 +2048,7 @@ export const piTools: AgentTool[] = [
   {
     name: 'read',
     label: 'Reading file',
-    description: 'Reads the content of a file. Use absolute paths (e.g. /data/agents/canvas-agent/AGENTS.md) or relative paths from /data/workspace. For PDFs, extracts text and can include limited rendered page images for vision-capable models.',
+    description: 'Reads the content of a file. Prefer workspace-relative paths. Trusted absolute Studio or upload paths returned by tools are validated server-side. For PDFs, extracts text and can include limited rendered page images for vision-capable models.',
     parameters: Type.Object({
       path: Type.String({ description: 'Absolute path or workspace-relative path.' }),
       maxChars: Type.Optional(Type.Number({ description: `Maximum text characters to return. Default ${DEFAULT_READ_TEXT_LIMIT}, max ${MAX_READ_TEXT_LIMIT}.` })),
@@ -2456,7 +2456,7 @@ export const piTools: AgentTool[] = [
     description: 'Legacy text search alias. Prefer the dedicated `rg` tool for new searches.',
     parameters: Type.Object({
       pattern: Type.String({ description: 'The regex pattern to search for.' }),
-      path: Type.Optional(Type.String({ description: 'The directory or file to search in. Absolute or workspace-relative. Defaults to /data/workspace.' })),
+      path: Type.Optional(Type.String({ description: 'The directory or file to search in. Workspace-relative by default. Defaults to the active workspace.' })),
     }),
     execute: async (toolCallId, params, signal) => {
       const { pattern, path: searchPath } = params as { pattern: string; path?: string };
@@ -2502,7 +2502,7 @@ export const piTools: AgentTool[] = [
     description: 'Finds files by name pattern. Use this or bash+find for path-based file discovery.',
     parameters: Type.Object({
       pattern: Type.String({ description: 'The glob pattern (e.g., "**/*.ts").' }),
-      path: Type.Optional(Type.String({ description: 'The directory to search in. Absolute or workspace-relative. Defaults to /data/workspace.' })),
+      path: Type.Optional(Type.String({ description: 'The directory to search in. Workspace-relative by default. Defaults to the active workspace.' })),
     }),
     execute: async (toolCallId, params, signal) => {
       const { pattern, path: searchPath } = params as { pattern: string; path?: string };
@@ -2636,7 +2636,7 @@ function createPublicShareTool(userId?: string, agentId?: string | null, session
         Type.Literal('create'),
         Type.Literal('revoke'),
       ], { description: 'Operation to perform.' }),
-      path: Type.Optional(Type.String({ description: 'Workspace-relative or /data/workspace file path for create.' })),
+      path: Type.Optional(Type.String({ description: 'Workspace-relative file path for create. Legacy /data/workspace aliases are mapped to the active workspace.' })),
       paths: Type.Optional(Type.Array(Type.String(), { description: 'Multiple concrete file paths for create. Folders are rejected.' })),
       shareId: Type.Optional(Type.String({ description: 'Public share ID for revoke.' })),
       status: Type.Optional(Type.String({ description: 'For list: all, active, expired, missing, stale, revoked.' })),

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -3224,7 +3224,7 @@ function getToolNotes(tool: AgentTool, group: PiToolGroup): string[] {
     notes.push('Starts another managed agent session and may call external models or tools through that agent.');
   }
   if (group === 'Memory') {
-    notes.push('May update durable agent or user memory files under /data/agents.');
+    notes.push('May update durable agent or user memory through the memory store. Direct /data/agents file access is not exposed through workspace file tools.');
   }
   if (group === 'Browser') {
     notes.push('Starts controlled headless Chromium and may interact with live webpages.');

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -536,7 +536,7 @@
     {
       "id": 31,
       "title": "Path Security fuer alle Workspace- und Agent-Dateioperationen erzwingen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/07-filesystem-migration-and-write-policy.md",

--- a/scripts/agent-session-workspace-context-test.ts
+++ b/scripts/agent-session-workspace-context-test.ts
@@ -97,6 +97,12 @@ async function main() {
       assert.equal(result.resolvedPath, path.join(workspace.rootPath, 'notes', 'context.md'));
       assert.equal(await fs.readFile(result.resolvedPath, 'utf8'), '# Session Workspace\n');
 
+      const symlinkWorkspaceRoot = path.join(dataRoot, 'workspaces', 'personal', userId, 'linked-files');
+      await fs.symlink(workspace.rootPath, symlinkWorkspaceRoot);
+      await runWithAgentExecutionContext({ ...executionContext, workspaceRoot: symlinkWorkspaceRoot }, async () => {
+        assert.equal(detectUnsafeBashCommand(`cat ${path.join(workspace.rootPath, 'notes', 'context.md')}`), null);
+      });
+
       const legacyAliasResult = await writeAgentTextFile({
         path: '/data/workspace/legacy-alias.md',
         content: '# Legacy Alias\n',

--- a/scripts/agent-session-workspace-context-test.ts
+++ b/scripts/agent-session-workspace-context-test.ts
@@ -23,6 +23,9 @@ async function main() {
     const {
       detectUnsafeBashCommand,
       getAgentWorkspaceRoot,
+      resolveAgentPath,
+      copyAgentPaths,
+      moveAgentPaths,
       writeAgentTextFile,
       assertAgentPathAllowed,
     } = await import('../app/lib/pi/agent-file-operations');
@@ -74,8 +77,18 @@ async function main() {
 
     await runWithAgentExecutionContext(executionContext, async () => {
       assert.equal(getAgentWorkspaceRoot(), workspace.rootPath);
+      assert.equal(resolveAgentPath('/data/workspace/legacy-alias.md'), path.join(workspace.rootPath, 'legacy-alias.md'));
       assert.equal(detectUnsafeBashCommand('./run-tests.sh > results.txt'), null);
       assert.equal(detectUnsafeBashCommand('npm run build 2>&1 | tee build.log'), null);
+      assert.equal(detectUnsafeBashCommand(`cat ${path.join(workspace.rootPath, 'notes', 'context.md')}`), null);
+      assert.match(
+        detectUnsafeBashCommand('cat /data/workspaces/personal/other-user/files/secret.md') || '',
+        /limited to the workspace bound/,
+      );
+      assert.match(
+        detectUnsafeBashCommand('cat /data/user-uploads/audio/input.ogg') || '',
+        /limited to the workspace bound/,
+      );
 
       const result = await writeAgentTextFile({
         path: 'notes/context.md',
@@ -84,8 +97,41 @@ async function main() {
       assert.equal(result.resolvedPath, path.join(workspace.rootPath, 'notes', 'context.md'));
       assert.equal(await fs.readFile(result.resolvedPath, 'utf8'), '# Session Workspace\n');
 
+      const legacyAliasResult = await writeAgentTextFile({
+        path: '/data/workspace/legacy-alias.md',
+        content: '# Legacy Alias\n',
+      });
+      assert.equal(legacyAliasResult.resolvedPath, path.join(workspace.rootPath, 'legacy-alias.md'));
+      assert.equal(await fs.readFile(path.join(workspace.rootPath, 'legacy-alias.md'), 'utf8'), '# Legacy Alias\n');
+
       await assert.rejects(
         () => assertAgentPathAllowed(path.join(dataRoot, 'workspaces', 'personal', 'other-user', 'files', 'secret.md')),
+        /limited to the workspace bound to this chat session/,
+      );
+
+      const userUploadPath = path.join(dataRoot, 'user-uploads', 'audio', 'voice.ogg');
+      await fs.mkdir(path.dirname(userUploadPath), { recursive: true });
+      await fs.writeFile(userUploadPath, 'audio input');
+      await assert.doesNotReject(() => assertAgentPathAllowed(userUploadPath));
+      const copiedUpload = await copyAgentPaths({
+        sourcePaths: [userUploadPath],
+        destinationPath: 'uploads/voice.ogg',
+      });
+      assert.equal(copiedUpload.destinationResolvedPath, path.join(workspace.rootPath, 'uploads', 'voice.ogg'));
+      assert.equal(await fs.readFile(path.join(workspace.rootPath, 'uploads', 'voice.ogg'), 'utf8'), 'audio input');
+      await assert.rejects(
+        () => moveAgentPaths({
+          sourcePaths: [userUploadPath],
+          destinationPath: 'uploads/moved-voice.ogg',
+        }),
+        /writes are limited to the workspace bound/,
+      );
+
+      const outsideReadRoot = path.join(tempRoot, 'outside-read');
+      await fs.mkdir(outsideReadRoot, { recursive: true });
+      await fs.writeFile(path.join(outsideReadRoot, 'private.txt'), 'blocked');
+      await assert.rejects(
+        () => assertAgentPathAllowed(path.join(outsideReadRoot, 'private.txt')),
         /limited to the workspace bound to this chat session/,
       );
 

--- a/server/terminal-service.js
+++ b/server/terminal-service.js
@@ -22,8 +22,9 @@ const SOCKET_PATH = process.env.CANVAS_TERMINAL_SOCKET || '/tmp/canvas-terminal.
 const TCP_PORT = parseInt(process.env.CANVAS_TERMINAL_PORT || '3457', 10);
 const AUTH_TOKEN = process.env.CANVAS_TERMINAL_TOKEN || generateToken();
 const USE_UNIX_SOCKET = process.env.CANVAS_TERMINAL_USE_UNIX_SOCKET !== 'false';
-const DATA = process.env.DATA || path.resolve(process.cwd(), 'data');
+const DATA = path.resolve(process.cwd(), process.env.DATA || 'data');
 const WORKSPACE_DIR = path.join(DATA, 'workspace');
+const WORKSPACES_DIR = path.join(DATA, 'workspaces');
 
 // State
 const sessions = new Map();
@@ -121,6 +122,72 @@ function generateToken() {
   return randomBytes(32).toString('hex');
 }
 
+function isPathWithin(candidatePath, basePath) {
+  const normalizedCandidate = path.resolve(candidatePath);
+  const normalizedBase = path.resolve(basePath);
+  return normalizedCandidate === normalizedBase || normalizedCandidate.startsWith(`${normalizedBase}${path.sep}`);
+}
+
+function terminalAllowedRootRealpaths() {
+  return [WORKSPACE_DIR, WORKSPACES_DIR]
+    .map((root) => fs.existsSync(root) ? fs.realpathSync(root) : path.resolve(root));
+}
+
+function deepestExistingTerminalPath(candidatePath) {
+  let currentPath = path.resolve(candidatePath);
+  while (true) {
+    try {
+      fs.lstatSync(currentPath);
+      return currentPath;
+    } catch {
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        return currentPath;
+      }
+      currentPath = parentPath;
+    }
+  }
+}
+
+function assertTerminalPathResolvesWithinAllowedRoots(candidatePath, allowedRoots) {
+  let realPath;
+  try {
+    realPath = fs.realpathSync(candidatePath);
+  } catch {
+    throw new Error('Terminal workspace path contains an unresolved filesystem link.');
+  }
+
+  if (!allowedRoots.some((root) => isPathWithin(realPath, root))) {
+    throw new Error('Terminal workspace path resolves outside managed workspace directories.');
+  }
+
+  return realPath;
+}
+
+function resolveTerminalWorkspaceCwd(cwd) {
+  const requestedCwd = cwd?.trim() || WORKSPACE_DIR;
+  if (!path.isAbsolute(requestedCwd) || requestedCwd.includes('\0')) {
+    throw new Error('Terminal workspace path must be an absolute path.');
+  }
+
+  const resolvedCwd = path.resolve(requestedCwd);
+  if (!isPathWithin(resolvedCwd, WORKSPACE_DIR) && !isPathWithin(resolvedCwd, WORKSPACES_DIR)) {
+    throw new Error('Terminal sessions are limited to managed workspace directories.');
+  }
+
+  const allowedRoots = terminalAllowedRootRealpaths();
+  assertTerminalPathResolvesWithinAllowedRoots(
+    deepestExistingTerminalPath(resolvedCwd),
+    allowedRoots
+  );
+
+  if (!fs.existsSync(resolvedCwd)) {
+    fs.mkdirSync(resolvedCwd, { recursive: true });
+  }
+
+  return assertTerminalPathResolvesWithinAllowedRoots(resolvedCwd, allowedRoots);
+}
+
 // Session Management
 function normalizeOwnerId(ownerId) {
   return ownerId?.trim() || 'anonymous';
@@ -192,7 +259,7 @@ function createSession(sessionId, ownerId, cwd) {
   }
   
   // Create PTY
-  const finalCwd = fs.existsSync(cwd) ? cwd : WORKSPACE_DIR;
+  const finalCwd = resolveTerminalWorkspaceCwd(cwd);
   const shell = resolveShell();
   
   log(`Creating session ${sessionId} for ${normalizedOwnerId} in ${finalCwd}`);

--- a/server/terminal-service.ts
+++ b/server/terminal-service.ts
@@ -161,6 +161,42 @@ function isPathWithin(candidatePath: string, basePath: string): boolean {
   return normalizedCandidate === normalizedBase || normalizedCandidate.startsWith(`${normalizedBase}${path.sep}`);
 }
 
+function terminalAllowedRootRealpaths(): string[] {
+  return [WORKSPACE_DIR, WORKSPACES_DIR]
+    .map((root) => fs.existsSync(root) ? fs.realpathSync(root) : path.resolve(root));
+}
+
+function deepestExistingTerminalPath(candidatePath: string): string {
+  let currentPath = path.resolve(candidatePath);
+  while (true) {
+    try {
+      fs.lstatSync(currentPath);
+      return currentPath;
+    } catch {
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        return currentPath;
+      }
+      currentPath = parentPath;
+    }
+  }
+}
+
+function assertTerminalPathResolvesWithinAllowedRoots(candidatePath: string, allowedRoots: string[]): string {
+  let realPath: string;
+  try {
+    realPath = fs.realpathSync(candidatePath);
+  } catch {
+    throw new Error('Terminal workspace path contains an unresolved filesystem link.');
+  }
+
+  if (!allowedRoots.some((root) => isPathWithin(realPath, root))) {
+    throw new Error('Terminal workspace path resolves outside managed workspace directories.');
+  }
+
+  return realPath;
+}
+
 function resolveTerminalWorkspaceCwd(cwd: string | undefined): string {
   const requestedCwd = cwd?.trim() || WORKSPACE_DIR;
   if (!path.isAbsolute(requestedCwd) || requestedCwd.includes('\0')) {
@@ -172,15 +208,17 @@ function resolveTerminalWorkspaceCwd(cwd: string | undefined): string {
     throw new Error('Terminal sessions are limited to managed workspace directories.');
   }
 
-  fs.mkdirSync(resolvedCwd, { recursive: true });
-  const realCwd = fs.realpathSync(resolvedCwd);
-  const allowedRoots = [WORKSPACE_DIR, WORKSPACES_DIR]
-    .map((root) => fs.existsSync(root) ? fs.realpathSync(root) : path.resolve(root));
-  if (!allowedRoots.some((root) => isPathWithin(realCwd, root))) {
-    throw new Error('Terminal workspace path resolves outside managed workspace directories.');
+  const allowedRoots = terminalAllowedRootRealpaths();
+  assertTerminalPathResolvesWithinAllowedRoots(
+    deepestExistingTerminalPath(resolvedCwd),
+    allowedRoots
+  );
+
+  if (!fs.existsSync(resolvedCwd)) {
+    fs.mkdirSync(resolvedCwd, { recursive: true });
   }
 
-  return realCwd;
+  return assertTerminalPathResolvesWithinAllowedRoots(resolvedCwd, allowedRoots);
 }
 
 // Session Management

--- a/server/terminal-service.ts
+++ b/server/terminal-service.ts
@@ -57,6 +57,7 @@ const AUTH_TOKEN = process.env.CANVAS_TERMINAL_TOKEN || generateToken();
 const USE_UNIX_SOCKET = process.env.CANVAS_TERMINAL_USE_UNIX_SOCKET !== 'false';
 const DATA = path.resolve(process.cwd(), process.env.DATA || 'data');
 const WORKSPACE_DIR = path.join(DATA, 'workspace');
+const WORKSPACES_DIR = path.join(DATA, 'workspaces');
 
 // State
 const sessions = new Map<string, TerminalSession>();
@@ -154,6 +155,34 @@ function generateToken(): string {
   return randomBytes(32).toString('hex');
 }
 
+function isPathWithin(candidatePath: string, basePath: string): boolean {
+  const normalizedCandidate = path.resolve(candidatePath);
+  const normalizedBase = path.resolve(basePath);
+  return normalizedCandidate === normalizedBase || normalizedCandidate.startsWith(`${normalizedBase}${path.sep}`);
+}
+
+function resolveTerminalWorkspaceCwd(cwd: string | undefined): string {
+  const requestedCwd = cwd?.trim() || WORKSPACE_DIR;
+  if (!path.isAbsolute(requestedCwd) || requestedCwd.includes('\0')) {
+    throw new Error('Terminal workspace path must be an absolute path.');
+  }
+
+  const resolvedCwd = path.resolve(requestedCwd);
+  if (!isPathWithin(resolvedCwd, WORKSPACE_DIR) && !isPathWithin(resolvedCwd, WORKSPACES_DIR)) {
+    throw new Error('Terminal sessions are limited to managed workspace directories.');
+  }
+
+  fs.mkdirSync(resolvedCwd, { recursive: true });
+  const realCwd = fs.realpathSync(resolvedCwd);
+  const allowedRoots = [WORKSPACE_DIR, WORKSPACES_DIR]
+    .map((root) => fs.existsSync(root) ? fs.realpathSync(root) : path.resolve(root));
+  if (!allowedRoots.some((root) => isPathWithin(realCwd, root))) {
+    throw new Error('Terminal workspace path resolves outside managed workspace directories.');
+  }
+
+  return realCwd;
+}
+
 // Session Management
 function normalizeOwnerId(ownerId: string): string {
   return ownerId?.trim() || 'anonymous';
@@ -225,7 +254,7 @@ function createSession(sessionId: string, ownerId: string, cwd: string): Termina
   }
   
   // Create PTY
-  const finalCwd = fs.existsSync(cwd) ? cwd : WORKSPACE_DIR;
+  const finalCwd = resolveTerminalWorkspaceCwd(cwd);
   const shell = resolveShell();
   
   log(`Creating session ${sessionId} for ${normalizedOwnerId} in ${finalCwd}`);


### PR DESCRIPTION
## Summary
- bind terminal creation to a server-resolved workspace root instead of accepting client-provided cwd
- harden agent file operations so reads/writes stay inside the session workspace, with trusted runtime intake paths read-only and legacy /data/workspace mapped to the active workspace
- update agent prompts/tool guidance away from global /data/workspace shell copies and mark Task 31 completed

## Verification
- npm run lint
- npx tsc --noEmit --pretty false
- npx tsx --conditions react-server scripts/agent-session-workspace-context-test.ts
- npx tsx --conditions react-server scripts/pi-tool-registry-test.ts
- npm run build

## Greptile
- Pending automatic first review after PR creation; no manual greploop triggered.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens workspace path security across the terminal and agent file-operation layers: terminal creation now resolves the working directory server-side from an authenticated workspace instead of accepting a client-supplied `cwd`, agent reads are gated to the active workspace plus explicitly trusted intake paths (`user-uploads`, `studio`), legacy `/data/workspace` references are mapped to the active workspace root, and shell commands that reference data paths outside the bound workspace are blocked.

- **Terminal API** (`route.ts`, `XTerminal.tsx`, `terminal-service.ts`): client no longer sends `cwd`; instead `workspaceId` is resolved through `resolveAgentSessionWorkspaceForUser`, and the terminal service enforces the resolved path with a pre- and post-symlink double-check before spawning the PTY.
- **Agent file operations** (`agent-file-operations.ts`): `assertContextWorkspaceReadAllowed` now allows trusted runtime intake paths read-only; `moveAgentPaths` source is upgraded from `assertAgentPathAllowed` to `assertAgentWritablePathAllowed`, correctly blocking moves out of user-uploads; `resolveAgentPath` transparently maps legacy `/data/workspace` prefixes to the active workspace.
- **Prompts & tool descriptions** (`base-system-prompt.ts`, `channel-system-prompt.ts`, `tool-registry.ts`): all hardcoded `/data/workspace` guidance replaced with workspace-relative or \"active workspace\" language, and Studio copy-to-workspace instructions now use `copy_path` instead of a raw `bash cp`.

<h3>Confidence Score: 4/5</h3>

The core security invariants are sound: the server always resolves and validates the workspace path before spawning a terminal or allowing file I/O, and a pre+post symlink double-check prevents directory-traversal bypass in the terminal service.

The workspace enforcement logic is well-structured and the new tests cover the main boundary cases. Three quality issues are worth addressing: status codes in the terminal create route are derived by scanning error message text, the terminal service creates directories on disk before completing its symlink check, and the write guard's initial boundary test doesn't expand symlink variants of the workspace root the way the read guard does.

`server/terminal-service.ts` and `app/api/terminal/create/route.ts` deserve a second look for the mkdirSync-before-realpath ordering and the string-based status code logic respectively.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/api/terminal/create/route.ts | Terminal creation now resolves the workspace server-side via `resolveAgentSessionWorkspaceForUser`; client-supplied `cwd` is gone. Status code determination via error-message string matching is fragile. |
| server/terminal-service.ts | New `resolveTerminalWorkspaceCwd` enforces that the PTY cwd lands inside `WORKSPACE_DIR` or `WORKSPACES_DIR` with a pre- and post-symlink double-check. `mkdirSync` runs before the `realpathSync` guard, leaving orphan dirs on rejection. |
| app/lib/pi/agent-file-operations.ts | Read path hardened with `rootPathVariants` + `isAllowedRuntimeReadPath` for user-uploads/studio; legacy `/data/workspace` alias now redirects writes to the active workspace root. Write guard uses `path.resolve` (no symlink expansion) for the initial check, inconsistently with the read guard. |
| app/components/terminal/XTerminal.tsx | Passes `workspaceId` from the workspace store (captured via ref to avoid stale closures) to the terminal create API instead of letting the client supply an arbitrary `cwd`. |
| app/lib/pi/tool-registry.ts | Tool descriptions updated to prefer workspace-relative paths; Studio copy-to-workspace guidance now uses `copy_path` instead of `bash cp /data/workspace`; `ls` default changed from `'/data/workspace'` literal to `'.'`. |
| scripts/agent-session-workspace-context-test.ts | Test coverage extended to cover legacy alias resolution, cross-workspace bash-command blocking (including user-uploads), copy from user-uploads, and rejection of move from user-uploads. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as XTerminal (client)
    participant R as /api/terminal/create
    participant WS as resolveAgentSessionWorkspaceForUser
    participant TS as terminal-service
    participant FS as Filesystem

    C->>R: "POST { sessionId, workspaceId }"
    R->>WS: resolve(userId, workspaceId, [canRead,canWrite])
    alt workspace not found / no permission
        WS-->>R: throws Error
        R-->>C: 403 / 404
    else resolved
        WS-->>R: "{ rootPath }"
        R->>TS: createSession(sessionId, ownerId, rootPath)
        TS->>TS: resolveTerminalWorkspaceCwd(rootPath)
        TS->>TS: path.resolve check vs WORKSPACE_DIR / WORKSPACES_DIR
        TS->>FS: mkdirSync(resolvedCwd, recursive)
        TS->>FS: realpathSync(resolvedCwd)
        TS->>TS: re-check realCwd vs allowedRoots
        alt realpath escapes allowed roots
            TS-->>R: throws Error
            R-->>C: 500
        else valid
            TS->>FS: spawn PTY in finalCwd
            TS-->>R: TerminalSession
            R-->>C: 200 session info
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as XTerminal (client)
    participant R as /api/terminal/create
    participant WS as resolveAgentSessionWorkspaceForUser
    participant TS as terminal-service
    participant FS as Filesystem

    C->>R: "POST { sessionId, workspaceId }"
    R->>WS: resolve(userId, workspaceId, [canRead,canWrite])
    alt workspace not found / no permission
        WS-->>R: throws Error
        R-->>C: 403 / 404
    else resolved
        WS-->>R: "{ rootPath }"
        R->>TS: createSession(sessionId, ownerId, rootPath)
        TS->>TS: resolveTerminalWorkspaceCwd(rootPath)
        TS->>TS: path.resolve check vs WORKSPACE_DIR / WORKSPACES_DIR
        TS->>FS: mkdirSync(resolvedCwd, recursive)
        TS->>FS: realpathSync(resolvedCwd)
        TS->>TS: re-check realCwd vs allowedRoots
        alt realpath escapes allowed roots
            TS-->>R: throws Error
            R-->>C: 500
        else valid
            TS->>FS: spawn PTY in finalCwd
            TS-->>R: TerminalSession
            R-->>C: 200 session info
        end
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/lib/pi/agent-file-operations.ts`, line 202-211 ([link](https://github.com/canvascoding/canvas-notebook/blob/e11db87beb15d97e0045e4864559aa0a8b5dc2ff/app/lib/pi/agent-file-operations.ts#L202-L211)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Write path uses `path.resolve` for workspace root; read path uses `rootPathVariants`**

   `assertContextWorkspaceReadAllowed` calls `isPathWithinRootVariants`, which tests both the configured path and its `realpathSync` variant when checking the workspace root. `assertContextWorkspaceWriteAllowed` only tests `path.resolve(executionContext.workspaceRoot)` for the first guard — if the workspace root itself is a symlink, any path expressed via the real destination would fail the first check and throw before reaching the async `realpath` verification. Because `resolveAgentPath` always anchors paths to `getAgentWorkspaceRoot()`, this doesn't bite in normal usage, but the asymmetry between the read and write guards is a latent footgun if the root-resolution path ever diverges.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fpath-security-file-ops%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fpath-security-file-ops%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Fpi%2Fagent-file-operations.ts%0ALine%3A%20202-211%0A%0AComment%3A%0A**Write%20path%20uses%20%60path.resolve%60%20for%20workspace%20root%3B%20read%20path%20uses%20%60rootPathVariants%60**%0A%0A%60assertContextWorkspaceReadAllowed%60%20calls%20%60isPathWithinRootVariants%60%2C%20which%20tests%20both%20the%20configured%20path%20and%20its%20%60realpathSync%60%20variant%20when%20checking%20the%20workspace%20root.%20%60assertContextWorkspaceWriteAllowed%60%20only%20tests%20%60path.resolve%28executionContext.workspaceRoot%29%60%20for%20the%20first%20guard%20%E2%80%94%20if%20the%20workspace%20root%20itself%20is%20a%20symlink%2C%20any%20path%20expressed%20via%20the%20real%20destination%20would%20fail%20the%20first%20check%20and%20throw%20before%20reaching%20the%20async%20%60realpath%60%20verification.%20Because%20%60resolveAgentPath%60%20always%20anchors%20paths%20to%20%60getAgentWorkspaceRoot%28%29%60%2C%20this%20doesn't%20bite%20in%20normal%20usage%2C%20but%20the%20asymmetry%20between%20the%20read%20and%20write%20guards%20is%20a%20latent%20footgun%20if%20the%20root-resolution%20path%20ever%20diverges.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=33&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fpath-security-file-ops%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fpath-security-file-ops%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapp%2Fapi%2Fterminal%2Fcreate%2Froute.ts%3A36-41%0A**Fragile%20string-matching%20for%20HTTP%20status%20code%20selection**%0A%0AThe%20%60status%60%20field%20is%20derived%20by%20scanning%20the%20error%20message%20for%20the%20substrings%20%60%22not%20found%22%60%20or%20%60%22inaccessible%22%60.%20If%20%60resolveAgentSessionWorkspaceForUser%60%20ever%20changes%20its%20error%20wording%20%28e.g.%20%22workspace%20does%20not%20exist%22%20or%20%22access%20denied%22%29%2C%20the%20handler%20will%20silently%20return%20a%20%60403%60%20where%20a%20%60404%60%20was%20intended%20%E2%80%94%20or%20vice%20versa.%20Additionally%2C%20passing%20%60message%60%20directly%20to%20the%20response%20body%20means%20any%20internal%20detail%20the%20upstream%20function%20includes%20in%20its%20error%20gets%20forwarded%20to%20the%20client%20as-is.%0A%0A%23%23%23%20Issue%202%20of%203%0Aserver%2Fterminal-service.ts%3A175-181%0A**Directory%20created%20on%20disk%20before%20symlink-bypass%20check%20completes**%0A%0A%60fs.mkdirSync%28resolvedCwd%2C%20%7B%20recursive%3A%20true%20%7D%29%60%20runs%20after%20the%20static%20%60path.resolve%60-based%20boundary%20check%2C%20but%20before%20%60fs.realpathSync%60%20resolves%20any%20symlinks.%20If%20the%20static%20check%20passes%20but%20the%20real-path%20check%20%28lines%20178-180%29%20fails%2C%20the%20directory%20has%20already%20been%20created%20at%20%60resolvedCwd%60.%20In%20a%20shared%20or%20container%20filesystem%20a%20path%20like%20%60%2Fdata%2Fworkspaces%2Fuser-a%2Finjected%60%20could%20be%20pre-created%20as%20a%20dangling%20symlink%20pointing%20outside%20the%20allowed%20roots%3B%20the%20error%20thrown%20by%20%60realpathSync%60%20would%20leave%20partially-created%20parent%20directories%20in%20place.%20The%20security%20invariant%20is%20upheld%2C%20but%20the%20side-effect%20is%20surprising%20and%20could%20interfere%20with%20cleanup%20logic.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Flib%2Fpi%2Fagent-file-operations.ts%3A202-211%0A**Write%20path%20uses%20%60path.resolve%60%20for%20workspace%20root%3B%20read%20path%20uses%20%60rootPathVariants%60**%0A%0A%60assertContextWorkspaceReadAllowed%60%20calls%20%60isPathWithinRootVariants%60%2C%20which%20tests%20both%20the%20configured%20path%20and%20its%20%60realpathSync%60%20variant%20when%20checking%20the%20workspace%20root.%20%60assertContextWorkspaceWriteAllowed%60%20only%20tests%20%60path.resolve%28executionContext.workspaceRoot%29%60%20for%20the%20first%20guard%20%E2%80%94%20if%20the%20workspace%20root%20itself%20is%20a%20symlink%2C%20any%20path%20expressed%20via%20the%20real%20destination%20would%20fail%20the%20first%20check%20and%20throw%20before%20reaching%20the%20async%20%60realpath%60%20verification.%20Because%20%60resolveAgentPath%60%20always%20anchors%20paths%20to%20%60getAgentWorkspaceRoot%28%29%60%2C%20this%20doesn't%20bite%20in%20normal%20usage%2C%20but%20the%20asymmetry%20between%20the%20read%20and%20write%20guards%20is%20a%20latent%20footgun%20if%20the%20root-resolution%20path%20ever%20diverges.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=33&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Enforce workspace path security"](https://github.com/canvascoding/canvas-notebook/commit/e11db87beb15d97e0045e4864559aa0a8b5dc2ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38938070)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->