### PR TITLE
Audit agent file mutations

### DIFF
--- a/app/lib/audit/audit-service.ts
+++ b/app/lib/audit/audit-service.ts
@@ -18,6 +18,8 @@ export type AuditStatus = 'success' | 'failure' | 'blocked' | 'queued' | 'starte
 
 export interface AuditEventInput {
   organizationId?: string | null;
+  customerId?: string | null;
+  projectId?: string | null;
   workspaceId?: string | null;
   userId?: string | null;
   sessionId?: string | null;
@@ -128,6 +130,8 @@ export async function recordAuditEvent(input: AuditEventInput): Promise<AuditEve
     await db.insert(auditEvents).values({
       id,
       organizationId: normalizeText(input.organizationId, 200),
+      customerId: normalizeText(input.customerId, 200),
+      projectId: normalizeText(input.projectId, 200),
       workspaceId: normalizeText(input.workspaceId, 200),
       userId: normalizeText(input.userId, 200),
       sessionId: normalizeText(input.sessionId, 500),

--- a/app/lib/automations/runner.ts
+++ b/app/lib/automations/runner.ts
@@ -209,6 +209,7 @@ export async function executeAutomationRun(runId: string): Promise<void> {
       workspace: automationWorkspace,
       userId: automationUserId,
       sessionId: piSessionId,
+      agentId: job.agentId,
     });
 
     await runWithAgentExecutionContext(executionContext, async () => {

--- a/app/lib/pi/agent-execution-context.ts
+++ b/app/lib/pi/agent-execution-context.ts
@@ -7,10 +7,13 @@ import type { WorkspaceType } from '@/app/lib/workspaces/types';
 export type AgentExecutionContext = {
   userId: string;
   sessionId: string;
+  agentId: string | null;
   workspaceId: string;
   workspaceType: WorkspaceType;
   workspaceName: string | null;
   organizationId: string | null;
+  customerId: string | null;
+  projectId: string | null;
   workspaceRoot: string;
   workspaceRootRelativePath: string | null;
   canWrite: boolean;

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -4,18 +4,20 @@ import type { Stats } from 'node:fs';
 import path from 'node:path';
 
 import { parseDocument } from 'yaml';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import {
   syncPublicSharesAfterDelete,
   syncPublicSharesAfterMove,
   syncPublicSharesAfterWrite,
 } from '@/app/lib/public-sharing/public-file-shares';
-import { getAgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
+import { getAgentExecutionContext, type AgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
 
 const SNAPSHOT_DIR_NAME = 'agent-file-snapshots';
 const MAX_DIFF_CHARS = 24_000;
 const DEFAULT_MAX_SNAPSHOT_COUNT = 500;
 const DEFAULT_MAX_SNAPSHOT_BYTES = 250 * 1024 * 1024;
 const MAX_PATH_SUMMARY_ENTRIES = 5_000;
+const MAX_AUDIT_PATH_ENTRIES = 100;
 
 export type AgentFileValidationCheck = {
   name: string;
@@ -328,6 +330,138 @@ function relativePathWithin(candidatePath: string, basePath: string): string | n
     return normalizedCandidate === normalizedBase ? '.' : null;
   }
   return relativePath;
+}
+
+function auditPathReference(fullPath: string, executionContext: AgentExecutionContext | null): string {
+  const resolvedPath = path.resolve(fullPath);
+  if (!executionContext?.workspaceRoot) {
+    return resolvedPath;
+  }
+
+  const workspaceRelativePath = relativePathWithin(resolvedPath, executionContext.workspaceRoot);
+  return workspaceRelativePath ?? resolvedPath;
+}
+
+function auditResolvedPathReference(value: string, executionContext: AgentExecutionContext | null): string {
+  return path.isAbsolute(value) ? auditPathReference(value, executionContext) : value;
+}
+
+function auditWorkspaceMetadata(executionContext: AgentExecutionContext | null) {
+  if (!executionContext) return null;
+  return {
+    workspaceId: executionContext.workspaceId,
+    workspaceType: executionContext.workspaceType,
+    workspaceName: executionContext.workspaceName,
+    workspaceRootRelativePath: executionContext.workspaceRootRelativePath,
+    legacy: executionContext.legacy,
+  };
+}
+
+async function recordAgentFileChangeAudit(result: AgentFileChangeResult, operation: string): Promise<void> {
+  if (!result.changed) return;
+
+  const executionContext = getAgentExecutionContext();
+  await recordAuditEvent({
+    organizationId: executionContext?.organizationId ?? null,
+    customerId: executionContext?.customerId ?? null,
+    projectId: executionContext?.projectId ?? null,
+    workspaceId: executionContext?.workspaceId ?? null,
+    userId: executionContext?.userId ?? null,
+    sessionId: executionContext?.sessionId ?? null,
+    agentId: executionContext?.agentId ?? null,
+    source: 'agent_tool',
+    eventType: 'file',
+    entityType: 'workspace_file',
+    entityId: result.path,
+    action: `agent_file.${operation}`,
+    status: 'success',
+    summary: `Agent file ${operation} changed ${result.path}.`,
+    metadata: {
+      path: result.path,
+      resolvedPath: auditPathReference(result.resolvedPath, executionContext),
+      workspace: auditWorkspaceMetadata(executionContext),
+      revision: {
+        snapshotId: result.snapshot?.id ?? null,
+        snapshotOperation: result.snapshot?.operation ?? null,
+        snapshotExisted: result.snapshot?.existed ?? null,
+        beforeSha256: result.beforeSha256,
+        afterSha256: result.afterSha256,
+      },
+      size: result.size,
+      validation: {
+        ok: result.validation.ok,
+        checks: result.validation.checks.map((check) => ({
+          name: check.name,
+          ok: check.ok,
+          message: check.message,
+        })),
+      },
+    },
+    inputHash: result.beforeSha256,
+    outputHash: result.afterSha256,
+    artifactRef: result.snapshot ? `agent-file-snapshot:${result.snapshot.id}` : null,
+  });
+}
+
+function summarizeAuditPathEntries(entries: AgentPathOperationEntry[], executionContext: AgentExecutionContext | null) {
+  return entries.slice(0, MAX_AUDIT_PATH_ENTRIES).map((entry) => ({
+    sourcePath: entry.sourcePath,
+    destinationPath: entry.destinationPath,
+    sourceResolvedPath: auditPathReference(entry.sourceResolvedPath, executionContext),
+    destinationResolvedPath: entry.destinationResolvedPath
+      ? auditPathReference(entry.destinationResolvedPath, executionContext)
+      : undefined,
+    type: entry.type,
+    changed: entry.changed,
+    overwritten: entry.overwritten,
+    bytes: entry.bytes,
+    files: entry.files,
+    directories: entry.directories,
+    truncated: entry.truncated,
+  }));
+}
+
+async function recordAgentPathOperationAudit(result: AgentPathOperationResult): Promise<void> {
+  if (!result.changed) return;
+
+  const executionContext = getAgentExecutionContext();
+  await recordAuditEvent({
+    organizationId: executionContext?.organizationId ?? null,
+    customerId: executionContext?.customerId ?? null,
+    projectId: executionContext?.projectId ?? null,
+    workspaceId: executionContext?.workspaceId ?? null,
+    userId: executionContext?.userId ?? null,
+    sessionId: executionContext?.sessionId ?? null,
+    agentId: executionContext?.agentId ?? null,
+    source: 'agent_tool',
+    eventType: 'file',
+    entityType: 'workspace_path',
+    entityId: result.destinationPath ?? result.sourcePath,
+    action: `agent_path.${result.operation}`,
+    status: 'success',
+    summary: `Agent path ${result.operation} changed ${result.destinationPath ?? result.sourcePath}.`,
+    metadata: {
+      operation: result.operation,
+      sourcePath: result.sourcePath,
+      sourcePaths: result.sourcePaths,
+      destinationPath: result.destinationPath,
+      sourceResolvedPath: auditResolvedPathReference(result.sourceResolvedPath, executionContext),
+      sourceResolvedPaths: result.sourceResolvedPaths.map((sourcePath) => auditPathReference(sourcePath, executionContext)),
+      destinationResolvedPath: result.destinationResolvedPath
+        ? auditPathReference(result.destinationResolvedPath, executionContext)
+        : null,
+      workspace: auditWorkspaceMetadata(executionContext),
+      type: result.type,
+      overwritten: result.overwritten,
+      bytes: result.bytes,
+      files: result.files,
+      directories: result.directories,
+      truncated: result.truncated,
+      entries: summarizeAuditPathEntries(result.entries, executionContext),
+      entriesTruncated: result.entries.length > MAX_AUDIT_PATH_ENTRIES,
+      totalEntries: result.entries.length,
+    },
+  });
 }
 
 function resolveLegacyWorkspaceAlias(filePath: string): string | null {
@@ -763,7 +897,7 @@ async function commitTextChange(params: {
   }
   await syncPublicSharesAfterWrite([params.fullPath]);
 
-  return {
+  const result: AgentFileChangeResult = {
     path: params.inputPath,
     resolvedPath: params.fullPath,
     changed: true,
@@ -774,6 +908,8 @@ async function commitTextChange(params: {
     diff: createUnifiedDiff(beforeContent, readBackText, `${params.inputPath} (before)`, `${params.inputPath} (after)`),
     validation,
   };
+  await recordAgentFileChangeAudit(result, params.operation);
+  return result;
 }
 
 export async function writeAgentTextFile(params: {
@@ -934,7 +1070,7 @@ export async function restoreAgentFileSnapshot(params: { snapshotId: string }): 
   if (!snapshot.existed) {
     await fs.rm(fullPath, { force: true });
     await syncPublicSharesAfterDelete([fullPath]);
-    return {
+    const result: AgentFileChangeResult = {
       path: snapshot.path,
       resolvedPath: fullPath,
       changed: before.existed,
@@ -947,6 +1083,8 @@ export async function restoreAgentFileSnapshot(params: { snapshotId: string }): 
         : '(file removed; textual diff unavailable)',
       validation: { ok: true, checks: [{ name: 'restore', ok: true, message: 'Restored snapshot by removing file that did not exist before the original edit.' }] },
     };
+    await recordAgentFileChangeAudit(result, 'restore_file_snapshot');
+    return result;
   }
 
   const content = await fs.readFile(snapshotContentPath(snapshot.id));
@@ -961,7 +1099,7 @@ export async function restoreAgentFileSnapshot(params: { snapshotId: string }): 
   const beforeText = before.buffer && !isProbablyBinary(before.buffer) ? before.buffer.toString('utf8') : null;
   const afterText = !isProbablyBinary(readBack) ? readBack.toString('utf8') : null;
 
-  return {
+  const result: AgentFileChangeResult = {
     path: snapshot.path,
     resolvedPath: fullPath,
     changed: true,
@@ -974,6 +1112,8 @@ export async function restoreAgentFileSnapshot(params: { snapshotId: string }): 
       : '(binary file restored; textual diff unavailable)',
     validation: validateAgentFileContent(snapshot.path, readBack.toString('utf8')),
   };
+  await recordAgentFileChangeAudit(result, 'restore_file_snapshot');
+  return result;
 }
 
 function getPathType(stats: Stats): AgentPathType {
@@ -1222,7 +1362,9 @@ export async function copyAgentPaths(params: {
   }
   await syncPublicSharesAfterWrite(entries.map((entry) => entry.destinationResolvedPath).filter((value): value is string => Boolean(value)));
 
-  return pathOperationSummary('copy_path', entries, params.destinationPath, destinationFullPath);
+  const result = pathOperationSummary('copy_path', entries, params.destinationPath, destinationFullPath);
+  await recordAgentPathOperationAudit(result);
+  return result;
 }
 
 export async function moveAgentPath(params: {
@@ -1312,7 +1454,9 @@ export async function moveAgentPaths(params: {
     }
   }
 
-  return pathOperationSummary('move_path', entries, params.destinationPath, destinationFullPath);
+  const result = pathOperationSummary('move_path', entries, params.destinationPath, destinationFullPath);
+  await recordAgentPathOperationAudit(result);
+  return result;
 }
 
 export async function deleteAgentPath(params: {
@@ -1387,7 +1531,9 @@ export async function deleteAgentPaths(params: {
   }
   await syncPublicSharesAfterDelete(deletableEntries.map((entry) => entry.sourceResolvedPath));
 
-  return pathOperationSummary('delete_path', entries);
+  const result = pathOperationSummary('delete_path', entries);
+  await recordAgentPathOperationAudit(result);
+  return result;
 }
 
 function isManagedDataPath(target: string): boolean {

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import { parseDocument } from 'yaml';
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
+import { logger } from '@/app/lib/logging';
 import {
   syncPublicSharesAfterDelete,
   syncPublicSharesAfterMove,
@@ -18,6 +19,8 @@ const DEFAULT_MAX_SNAPSHOT_COUNT = 500;
 const DEFAULT_MAX_SNAPSHOT_BYTES = 250 * 1024 * 1024;
 const MAX_PATH_SUMMARY_ENTRIES = 5_000;
 const MAX_AUDIT_PATH_ENTRIES = 100;
+const MAX_AUDIT_ENTITY_ID_LENGTH = 500;
+const agentFileAuditLogger = logger.module('AgentFileAudit');
 
 export type AgentFileValidationCheck = {
   name: string;
@@ -361,14 +364,22 @@ async function recordAgentFileChangeAudit(result: AgentFileChangeResult, operati
   if (!result.changed) return;
 
   const executionContext = getAgentExecutionContext();
+  if (!executionContext) {
+    agentFileAuditLogger.warn('Skipping agent file audit without execution context', {
+      operation,
+      path: result.path,
+    });
+    return;
+  }
+
   await recordAuditEvent({
-    organizationId: executionContext?.organizationId ?? null,
-    customerId: executionContext?.customerId ?? null,
-    projectId: executionContext?.projectId ?? null,
-    workspaceId: executionContext?.workspaceId ?? null,
-    userId: executionContext?.userId ?? null,
-    sessionId: executionContext?.sessionId ?? null,
-    agentId: executionContext?.agentId ?? null,
+    organizationId: executionContext.organizationId,
+    customerId: executionContext.customerId,
+    projectId: executionContext.projectId,
+    workspaceId: executionContext.workspaceId,
+    userId: executionContext.userId,
+    sessionId: executionContext.sessionId,
+    agentId: executionContext.agentId,
     source: 'agent_tool',
     eventType: 'file',
     entityType: 'workspace_file',
@@ -421,22 +432,43 @@ function summarizeAuditPathEntries(entries: AgentPathOperationEntry[], execution
   }));
 }
 
+function truncateAuditEntityId(entityId: string): string {
+  if (entityId.length <= MAX_AUDIT_ENTITY_ID_LENGTH) return entityId;
+  return `${entityId.slice(0, MAX_AUDIT_ENTITY_ID_LENGTH - 3)}...`;
+}
+
+function pathOperationEntityId(result: AgentPathOperationResult): string {
+  const paths = result.operation === 'delete_path'
+    ? result.entries.map((entry) => entry.sourcePath)
+    : result.entries.map((entry) => entry.destinationPath ?? entry.sourcePath);
+  return truncateAuditEntityId(paths.join(', '));
+}
+
 async function recordAgentPathOperationAudit(result: AgentPathOperationResult): Promise<void> {
   if (!result.changed) return;
 
   const executionContext = getAgentExecutionContext();
+  if (!executionContext) {
+    agentFileAuditLogger.warn('Skipping agent path audit without execution context', {
+      operation: result.operation,
+      sourcePath: result.sourcePath,
+      destinationPath: result.destinationPath,
+    });
+    return;
+  }
+
   await recordAuditEvent({
-    organizationId: executionContext?.organizationId ?? null,
-    customerId: executionContext?.customerId ?? null,
-    projectId: executionContext?.projectId ?? null,
-    workspaceId: executionContext?.workspaceId ?? null,
-    userId: executionContext?.userId ?? null,
-    sessionId: executionContext?.sessionId ?? null,
-    agentId: executionContext?.agentId ?? null,
+    organizationId: executionContext.organizationId,
+    customerId: executionContext.customerId,
+    projectId: executionContext.projectId,
+    workspaceId: executionContext.workspaceId,
+    userId: executionContext.userId,
+    sessionId: executionContext.sessionId,
+    agentId: executionContext.agentId,
     source: 'agent_tool',
     eventType: 'file',
     entityType: 'workspace_path',
-    entityId: result.destinationPath ?? result.sourcePath,
+    entityId: pathOperationEntityId(result),
     action: `agent_path.${result.operation}`,
     status: 'success',
     summary: `Agent path ${result.operation} changed ${result.destinationPath ?? result.sourcePath}.`,

--- a/app/lib/pi/session-workspace-context.ts
+++ b/app/lib/pi/session-workspace-context.ts
@@ -162,14 +162,18 @@ export function workspaceToAgentExecutionContext(input: {
   workspace: WorkspaceContext;
   userId: string;
   sessionId: string;
+  agentId?: string | null;
 }): AgentExecutionContext {
   return {
     userId: input.userId,
     sessionId: input.sessionId,
+    agentId: input.agentId ?? null,
     workspaceId: input.workspace.workspaceId,
     workspaceType: input.workspace.workspaceType,
     workspaceName: input.workspace.displayName ?? null,
     organizationId: input.workspace.organizationId ?? null,
+    customerId: input.workspace.customerId ?? null,
+    projectId: input.workspace.projectId ?? null,
     workspaceRoot: input.workspace.rootPath,
     workspaceRootRelativePath: input.workspace.rootRelativePath ?? null,
     canWrite: input.workspace.permissions.canWrite,
@@ -312,5 +316,6 @@ export async function resolveAgentExecutionContextForSession(input: {
     workspace,
     userId: input.userId,
     sessionId: input.sessionId,
+    agentId: input.agentId ?? null,
   });
 }

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -576,13 +576,29 @@
     {
       "id": 33,
       "title": "Agent-Dateiaenderungen mit User, Session, Workspace und Revision auditieren",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/05-actor-audit-retention.md",
         "docs/architecture/canvas-notebook/team-workspace/07-filesystem-migration-and-write-policy.md",
         "docs/architecture/canvas-notebook/team-workspace/08-user-scoped-secrets-runtime.md",
         "docs/architecture/canvas-notebook/team-workspace/10-agent-tool-execution-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/audit/audit-service.ts",
+        "app/lib/pi/agent-execution-context.ts",
+        "app/lib/pi/session-workspace-context.ts",
+        "app/lib/pi/agent-file-operations.ts",
+        "app/lib/automations/runner.ts",
+        "scripts/agent-session-workspace-context-test.ts",
+        "scripts/audit-service-test.ts"
+      ],
+      "verification": [
+        "npx tsx --conditions react-server scripts/agent-session-workspace-context-test.ts",
+        "npx tsx --conditions react-server scripts/audit-service-test.ts",
+        "npx tsc --noEmit --pretty false",
+        "npm run lint",
+        "npm run build"
       ]
     },
     {

--- a/scripts/agent-session-workspace-context-test.ts
+++ b/scripts/agent-session-workspace-context-test.ts
@@ -25,6 +25,7 @@ async function main() {
       getAgentWorkspaceRoot,
       resolveAgentPath,
       copyAgentPaths,
+      deleteAgentPaths,
       moveAgentPaths,
       writeAgentTextFile,
       assertAgentPathAllowed,
@@ -169,6 +170,20 @@ async function main() {
       assert.equal(copyAuditMetadata.files, 1);
       assert.equal(copyAuditMetadata.entries?.[0]?.destinationResolvedPath, 'uploads/voice.ogg');
       assert.doesNotMatch(copyAudit.metadataJson || '', /audio input/);
+
+      await writeAgentTextFile({ path: 'bulk/a.txt', content: 'A\n' });
+      await writeAgentTextFile({ path: 'bulk/b.txt', content: 'B\n' });
+      const deletedBulk = await deleteAgentPaths({
+        paths: ['bulk/a.txt', 'bulk/b.txt'],
+      });
+      assert.equal(deletedBulk.sourcePath, '2 paths');
+      const deleteAuditRows = await db.select().from(auditEvents);
+      const deleteAudit = deleteAuditRows.find((row) => row.action === 'agent_path.delete_path' && row.entityId === 'bulk/a.txt, bulk/b.txt');
+      assert.ok(deleteAudit, 'Expected bulk delete audit event with concrete path entityId');
+      assert.equal(deleteAudit.userId, userId);
+      assert.equal(deleteAudit.sessionId, sessionId);
+      assert.equal(deleteAudit.agentId, 'canvas-agent');
+      assert.notEqual(deleteAudit.entityId, '2 paths');
       await assert.rejects(
         () => moveAgentPaths({
           sourcePaths: [userUploadPath],

--- a/scripts/agent-session-workspace-context-test.ts
+++ b/scripts/agent-session-workspace-context-test.ts
@@ -14,7 +14,7 @@ async function main() {
     await fs.mkdir(dataRoot, { recursive: true });
 
     const { db } = await import('../app/lib/db');
-    const { user, piSessions } = await import('../app/lib/db/schema');
+    const { user, piSessions, auditEvents } = await import('../app/lib/db/schema');
     const {
       resolveAgentExecutionContextForSession,
       resolveAgentSessionWorkspaceForUser,
@@ -72,6 +72,7 @@ async function main() {
       userId,
       agentId: 'canvas-agent',
     });
+    assert.equal(executionContext.agentId, 'canvas-agent');
     assert.equal(executionContext.workspaceId, workspace.workspaceId);
     assert.equal(executionContext.workspaceRoot, workspace.rootPath);
 
@@ -96,6 +97,29 @@ async function main() {
       });
       assert.equal(result.resolvedPath, path.join(workspace.rootPath, 'notes', 'context.md'));
       assert.equal(await fs.readFile(result.resolvedPath, 'utf8'), '# Session Workspace\n');
+      const writeAuditRows = await db.select().from(auditEvents);
+      const writeAudit = writeAuditRows.find((row) => row.action === 'agent_file.write' && row.entityId === 'notes/context.md');
+      assert.ok(writeAudit, 'Expected write audit event for notes/context.md');
+      assert.equal(writeAudit.source, 'agent_tool');
+      assert.equal(writeAudit.userId, userId);
+      assert.equal(writeAudit.sessionId, sessionId);
+      assert.equal(writeAudit.agentId, 'canvas-agent');
+      assert.equal(writeAudit.workspaceId, workspace.workspaceId);
+      assert.equal(writeAudit.organizationId, workspace.organizationId);
+      assert.equal(writeAudit.inputHash, null);
+      assert.equal(writeAudit.outputHash, result.afterSha256);
+      assert.equal(writeAudit.artifactRef, `agent-file-snapshot:${result.snapshot?.id}`);
+      assert.ok(writeAudit.metadataJson);
+      const writeAuditMetadata = JSON.parse(writeAudit.metadataJson || '{}') as {
+        resolvedPath?: string;
+        workspace?: { workspaceType?: string };
+        revision?: { snapshotId?: string; afterSha256?: string };
+      };
+      assert.equal(writeAuditMetadata.resolvedPath, 'notes/context.md');
+      assert.equal(writeAuditMetadata.workspace?.workspaceType, 'personal');
+      assert.equal(writeAuditMetadata.revision?.snapshotId, result.snapshot?.id);
+      assert.equal(writeAuditMetadata.revision?.afterSha256, result.afterSha256);
+      assert.doesNotMatch(writeAudit.metadataJson || '', /Session Workspace/);
 
       const symlinkWorkspaceRoot = path.join(dataRoot, 'workspaces', 'personal', userId, 'linked-files');
       await fs.symlink(workspace.rootPath, symlinkWorkspaceRoot);
@@ -125,6 +149,26 @@ async function main() {
       });
       assert.equal(copiedUpload.destinationResolvedPath, path.join(workspace.rootPath, 'uploads', 'voice.ogg'));
       assert.equal(await fs.readFile(path.join(workspace.rootPath, 'uploads', 'voice.ogg'), 'utf8'), 'audio input');
+      const copyAuditRows = await db.select().from(auditEvents);
+      const copyAudit = copyAuditRows.find((row) => row.action === 'agent_path.copy_path' && row.entityId === 'uploads/voice.ogg');
+      assert.ok(copyAudit, 'Expected copy audit event for uploads/voice.ogg');
+      assert.equal(copyAudit.source, 'agent_tool');
+      assert.equal(copyAudit.userId, userId);
+      assert.equal(copyAudit.sessionId, sessionId);
+      assert.equal(copyAudit.agentId, 'canvas-agent');
+      assert.equal(copyAudit.workspaceId, workspace.workspaceId);
+      assert.ok(copyAudit.metadataJson);
+      const copyAuditMetadata = JSON.parse(copyAudit.metadataJson || '{}') as {
+        destinationResolvedPath?: string | null;
+        workspace?: { workspaceType?: string };
+        files?: number;
+        entries?: Array<{ destinationResolvedPath?: string }>;
+      };
+      assert.equal(copyAuditMetadata.destinationResolvedPath, 'uploads/voice.ogg');
+      assert.equal(copyAuditMetadata.workspace?.workspaceType, 'personal');
+      assert.equal(copyAuditMetadata.files, 1);
+      assert.equal(copyAuditMetadata.entries?.[0]?.destinationResolvedPath, 'uploads/voice.ogg');
+      assert.doesNotMatch(copyAudit.metadataJson || '', /audio input/);
       await assert.rejects(
         () => moveAgentPaths({
           sourcePaths: [userUploadPath],

--- a/scripts/audit-service-test.ts
+++ b/scripts/audit-service-test.ts
@@ -20,6 +20,8 @@ async function main() {
   const { hashAuditValue, recordAuditEvent } = await import('../app/lib/audit/audit-service');
   const event = await recordAuditEvent({
     organizationId: 'org-1',
+    customerId: 'customer-1',
+    projectId: 'project-1',
     workspaceId: 'ws-1',
     userId: 'user-1',
     sessionId: 'session-1',
@@ -46,6 +48,8 @@ async function main() {
   const verifyDb = new Database(path.join(dataRoot, 'sqlite.db'));
   try {
     const rows = verifyDb.prepare('SELECT * FROM audit_events').all() as Array<{
+      customer_id: string | null;
+      project_id: string | null;
       source: string;
       action: string;
       metadata_json: string;
@@ -53,6 +57,8 @@ async function main() {
       output_hash: string;
     }>;
     assert.equal(rows.length, 1);
+    assert.equal(rows[0].customer_id, 'customer-1');
+    assert.equal(rows[0].project_id, 'project-1');
     assert.equal(rows[0].source, 'test');
     assert.equal(rows[0].action, 'integration_secret.update');
     assert.equal(rows[0].input_hash, hashAuditValue({ value: 'input', password: 'hidden' }));


### PR DESCRIPTION
## Summary
- add agent/customer/project context to audit event recording
- attach agentId, customerId, and projectId to agent execution context, including automation runs
- audit successful agent file writes, edits, patches, restores, copies, moves, and deletes with workspace/session/user/revision metadata and without file contents
- mark Task 33 completed in docs/architecture/canvas-notebook/todo.json

## Verification
- npx tsx --conditions react-server scripts/agent-session-workspace-context-test.ts
- npx tsx --conditions react-server scripts/audit-service-test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build

Greptile score: 4/5; actionable comments addressed and resolved without a second trigger per user instruction

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `agentId`, `customerId`, and `projectId` into `AgentExecutionContext` and records that context in audit events for every successful agent file write, edit, patch, restore, copy, move, and delete — without capturing file contents.

- `agent-execution-context.ts` / `session-workspace-context.ts`: three new nullable fields (`agentId`, `customerId`, `projectId`) are read from the already-resolved `WorkspaceContext`, requiring no extra DB round-trips.
- `agent-file-operations.ts`: two new private helpers (`recordAgentFileChangeAudit`, `recordAgentPathOperationAudit`) fire after each successful operation; workspace-relative path normalization avoids leaking absolute filesystem paths into the audit metadata.
- `automations/runner.ts`: automation runs now thread `job.agentId` into the execution context so automated file mutations carry correct agent attribution.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the audit path is additive and failures are caught and logged without blocking file operations.

The core change is well-structured: context fields are read from already-resolved workspace data, path relativization prevents filesystem leakage in metadata, and file contents are never stored. Two data-quality gaps exist: bulk path operations record a synthetic "N paths" string as entityId, and a future call site outside an execution context would silently produce attribution-free audit rows. Neither affects current production paths.

app/lib/pi/agent-file-operations.ts — specifically the entityId value for multi-source path operations and the null-context guard in the two audit helpers.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/audit/audit-service.ts | Adds `customerId` and `projectId` to `AuditEventInput` interface and persists them via the existing `normalizeText` helper — straightforward schema extension, no issues found. |
| app/lib/pi/agent-execution-context.ts | Adds `agentId`, `customerId`, and `projectId` to the `AgentExecutionContext` type. All fields are optional/nullable and typed consistently with the rest of the context. |
| app/lib/pi/session-workspace-context.ts | Threads `agentId`, `customerId`, and `projectId` into `workspaceToAgentExecutionContext` and `resolveAgentExecutionContextForSession`. Fields are read from the already-populated `WorkspaceContext` type, requiring no extra DB queries. |
| app/lib/pi/agent-file-operations.ts | Adds audit recording after every successful file change and path operation. Paths are relativized against workspace root in metadata. One data-quality issue: bulk multi-source operations store a synthetic "N paths" string as the audit `entityId`, making per-file audit queries impossible for batch deletes/moves. |
| app/lib/automations/runner.ts | Propagates `agentId` from the automation job into `workspaceToAgentExecutionContext`, so automation-driven file mutations will now carry the correct `agentId` in their audit events. |
| scripts/agent-session-workspace-context-test.ts | Extends the integration test to verify that write and copy audit events are recorded with correct field values and that file contents are not leaked into the audit metadata. |
| scripts/audit-service-test.ts | Adds `customerId` and `projectId` to the round-trip test and verifies they are persisted correctly in the `audit_events` table. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as Agent Tool / Automation
    participant ALS as AsyncLocalStorage(AgentExecutionContext)
    participant FileOps as agent-file-operations
    participant AuditSvc as audit-service
    participant DB as SQLite (audit_events)

    Caller->>ALS: runWithAgentExecutionContext(ctx) ctx includes agentId, customerId, projectId
    ALS-->>FileOps: context available via getAgentExecutionContext()

    FileOps->>FileOps: writeAgentTextFile / editAgentFile / copyAgentPaths / moveAgentPaths / deleteAgentPaths / restoreAgentFileSnapshot

    alt "result.changed === true"
        FileOps->>AuditSvc: recordAuditEvent with organizationId, customerId, projectId, workspaceId, userId, sessionId, agentId
        Note over FileOps,AuditSvc: resolvedPaths workspace-relative, file contents never included
        AuditSvc->>DB: INSERT INTO audit_events
        DB-->>AuditSvc: ok or error (swallowed, logged)
    else "result.changed === false"
        FileOps->>FileOps: no audit (no-op operation)
    end

    FileOps-->>Caller: AgentFileChangeResult or AgentPathOperationResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as Agent Tool / Automation
    participant ALS as AsyncLocalStorage(AgentExecutionContext)
    participant FileOps as agent-file-operations
    participant AuditSvc as audit-service
    participant DB as SQLite (audit_events)

    Caller->>ALS: runWithAgentExecutionContext(ctx) ctx includes agentId, customerId, projectId
    ALS-->>FileOps: context available via getAgentExecutionContext()

    FileOps->>FileOps: writeAgentTextFile / editAgentFile / copyAgentPaths / moveAgentPaths / deleteAgentPaths / restoreAgentFileSnapshot

    alt "result.changed === true"
        FileOps->>AuditSvc: recordAuditEvent with organizationId, customerId, projectId, workspaceId, userId, sessionId, agentId
        Note over FileOps,AuditSvc: resolvedPaths workspace-relative, file contents never included
        AuditSvc->>DB: INSERT INTO audit_events
        DB-->>AuditSvc: ok or error (swallowed, logged)
    else "result.changed === false"
        FileOps->>FileOps: no audit (no-op operation)
    end

    FileOps-->>Caller: AgentFileChangeResult or AgentPathOperationResult
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fagent-file-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fagent-file-audit%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Flib%2Fpi%2Fagent-file-operations.ts%3A439%0A**%60entityId%60%20becomes%20%60%22N%20paths%22%60%20for%20bulk%20path%20operations**%0A%0A%60pathOperationSummary%60%20sets%20%60sourcePath%60%20to%20%60%22%24%7Bentries.length%7D%20paths%22%60%20when%20there%20are%20multiple%20entries%20%28line%201218%29.%20That%20synthetic%20string%20flows%20directly%20into%20%60entityId%60%20for%20delete%20and%20move%20audit%20events%2C%20so%20a%20batch%20delete%20of%20%60%5B%22notes%2Fa.md%22%2C%20%22notes%2Fb.md%22%5D%60%20is%20recorded%20with%20%60entityId%20%3D%20%222%20paths%22%60.%20Any%20downstream%20query%20looking%20up%20audit%20events%20by%20the%20actual%20file%20path%20will%20find%20nothing%20for%20those%20rows.%20The%20individual%20entries%20in%20%60metadata.entries%60%20do%20carry%20the%20real%20paths%2C%20but%20%60entityId%60%20is%20typically%20the%20primary%20lookup%20key%20for%20%22what%20happened%20to%20entity%20X%22.%20Consider%20using%20the%20first%20source%20path%20or%20a%20comma-joined%20list%20%28truncated%20to%20the%20%60entityId%60%20max%20of%20500%20chars%29%20for%20single-workspace%20bulk%20operations%2C%20or%20accept%20the%20limitation%20and%20document%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Flib%2Fpi%2Fagent-file-operations.ts%3A360-361%0A**Audit%20skipped%20silently%20when%20%60executionContext%60%20is%20null%20during%20an%20active%20file%20change**%0A%0A%60recordAgentFileChangeAudit%60%20%28and%20%60recordAgentPathOperationAudit%60%29%20call%20%60getAgentExecutionContext%28%29%60%20to%20fetch%20attribution%20fields%2C%20but%20if%20no%20context%20has%20been%20set%20%28i.e.%2C%20the%20call%20escapes%20%60runWithAgentExecutionContext%60%29%2C%20they%20still%20proceed%20and%20write%20an%20audit%20row%20with%20%60userId%60%2C%20%60sessionId%60%2C%20%60workspaceId%60%2C%20and%20%60agentId%60%20all%20%60null%60.%20The%20event%20is%20recorded%20but%20carries%20no%20actionable%20attribution%2C%20which%20may%20be%20worse%20than%20a%20clearly%20missing%20row.%20Since%20both%20callers%20currently%20always%20run%20inside%20a%20context%2C%20this%20is%20a%20latent%20concern%20for%20future%20call%20sites%20%E2%80%94%20but%20a%20defensive%20%60if%20%28!executionContext%29%20%7B%20log%20warning%3B%20return%3B%20%7D%60%20guard%20would%20prevent%20silent%20attribution-free%20records.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=35&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Audit agent file mutations"](https://github.com/canvascoding/canvas-notebook/commit/159759aa5e19b9acffa7d9b5705b4da70a2db3c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38946656)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->