### PR TITLE
Add shared workspace revision guards

### DIFF
--- a/app/api/files/create/route.ts
+++ b/app/api/files/create/route.ts
@@ -3,6 +3,11 @@ import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { createDirectory, writeFile } from '@/app/lib/filesystem/workspace-files';
 import { createEmptyExcalidrawFileContent, isExcalidrawFilePath } from '@/app/lib/excalidraw-file';
 import {
+  WorkspaceFileRevisionError,
+  assertWorkspaceFileRevisionAllowed,
+  workspaceRequiresRevisionCheck,
+} from '@/app/lib/files/revision-guard';
+import {
   applyRateLimit,
   invalidateWorkspaceFileViews,
   jsonError,
@@ -39,6 +44,11 @@ export async function POST(request: NextRequest) {
     if (type === 'directory') {
       await createDirectory(path, fileOptions);
     } else if (type === 'file') {
+      await assertWorkspaceFileRevisionAllowed({
+        path,
+        options: fileOptions,
+        requireExpectedRevision: workspaceRequiresRevisionCheck(workspaceResult.workspace),
+      });
       await writeFile(
         path,
         template === 'excalidraw' || isExcalidrawFilePath(path)
@@ -72,6 +82,15 @@ export async function POST(request: NextRequest) {
 
     return jsonSuccess();
   } catch (error) {
+    if (error instanceof WorkspaceFileRevisionError) {
+      return jsonError(error.message, error.status, {
+        code: error.code,
+        path: error.path,
+        expectedSha256: error.expectedSha256,
+        currentSha256: error.currentSha256,
+        currentStats: error.currentStats,
+      });
+    }
     return jsonServerError('[API] File create error:', error, 'Failed to create path');
   }
 }

--- a/app/api/files/read/route.ts
+++ b/app/api/files/read/route.ts
@@ -42,8 +42,6 @@ export async function GET(request: NextRequest) {
     const metaOnly = searchParams.get('meta') === '1';
 
     if (metaOnly) {
-      const revisionContent = stats.size <= sizeLimit ? await readFile(path, fileOptions) : null;
-      const sha256 = revisionContent ? sha256Buffer(revisionContent) : undefined;
       return NextResponse.json({
         success: true,
         data: {
@@ -53,7 +51,6 @@ export async function GET(request: NextRequest) {
             size: stats.size,
             modified: stats.modified,
             permissions: stats.permissions,
-            sha256,
           },
         },
       });

--- a/app/api/files/read/route.ts
+++ b/app/api/files/read/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readFile, getFileStats } from '@/app/lib/filesystem/workspace-files';
+import { sha256Buffer } from '@/app/lib/files/revision-guard';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 import { isExcalidrawFilePath } from '@/app/lib/excalidraw-file';
 import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
@@ -37,9 +38,12 @@ export async function GET(request: NextRequest) {
     }
     
     const stats = await getFileStats(path, fileOptions);
+    const sizeLimit = isExcalidrawFilePath(path) ? EXCALIDRAW_READ_SIZE_LIMIT : READ_SIZE_LIMIT;
     const metaOnly = searchParams.get('meta') === '1';
 
     if (metaOnly) {
+      const revisionContent = stats.size <= sizeLimit ? await readFile(path, fileOptions) : null;
+      const sha256 = revisionContent ? sha256Buffer(revisionContent) : undefined;
       return NextResponse.json({
         success: true,
         data: {
@@ -49,12 +53,12 @@ export async function GET(request: NextRequest) {
             size: stats.size,
             modified: stats.modified,
             permissions: stats.permissions,
+            sha256,
           },
         },
       });
     }
     
-    const sizeLimit = isExcalidrawFilePath(path) ? EXCALIDRAW_READ_SIZE_LIMIT : READ_SIZE_LIMIT;
     if (stats.size > sizeLimit) {
         return NextResponse.json(
             { success: false, error: 'File is too large to read' },
@@ -63,6 +67,7 @@ export async function GET(request: NextRequest) {
     }
 
     const content = await readFile(path, fileOptions);
+    const sha256 = sha256Buffer(content);
     
     return NextResponse.json({
       success: true,
@@ -73,6 +78,7 @@ export async function GET(request: NextRequest) {
           size: stats.size,
           modified: stats.modified,
           permissions: stats.permissions,
+          sha256,
         },
       },
     });

--- a/app/api/files/write/route.ts
+++ b/app/api/files/write/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from 'next/server';
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
-import { writeFile } from '@/app/lib/filesystem/workspace-files';
+import { getFileStats, writeFile } from '@/app/lib/filesystem/workspace-files';
+import {
+  WorkspaceFileRevisionError,
+  assertWorkspaceFileRevisionAllowed,
+  sha256Buffer,
+  workspaceRequiresRevisionCheck,
+} from '@/app/lib/files/revision-guard';
 import { queuePublicSharesAfterWrite } from '@/app/lib/public-sharing/public-file-shares';
 import { getParentDirectory } from '@/app/lib/files/path-utils';
 import {
@@ -26,8 +32,8 @@ export async function POST(request: NextRequest) {
     });
     if (rateLimitResponse) return rateLimitResponse;
 
-    const body = await readJsonBody<{ path?: string; content?: string }>(request);
-    const { path, content } = body;
+    const body = await readJsonBody<{ path?: string; content?: string; expectedSha256?: string | null }>(request);
+    const { path, content, expectedSha256 } = body;
 
     if (!path || content === undefined) {
       return jsonError('Path and content are required', 400);
@@ -39,7 +45,17 @@ export async function POST(request: NextRequest) {
       finalContent = Buffer.from(content.substring(7), 'base64');
     }
 
+    await assertWorkspaceFileRevisionAllowed({
+      path,
+      expectedSha256,
+      options: fileOptions,
+      requireExpectedRevision: workspaceRequiresRevisionCheck(workspaceResult.workspace),
+    });
+
     await writeFile(path, finalContent, fileOptions);
+    const contentBuffer = Buffer.isBuffer(finalContent) ? finalContent : Buffer.from(finalContent);
+    const afterSha256 = sha256Buffer(contentBuffer);
+    const stats = await getFileStats(path, fileOptions);
     invalidateWorkspaceFileViews({ fileOptions, subtreeDirs: [getParentDirectory(path)] });
     queuePublicSharesAfterWrite([path], workspaceResult.workspace);
     await recordAuditEvent({
@@ -58,6 +74,8 @@ export async function POST(request: NextRequest) {
         workspaceType: workspaceResult.workspace.workspaceType,
         contentBytes: Buffer.isBuffer(finalContent) ? finalContent.byteLength : Buffer.byteLength(finalContent),
         encoded: typeof content === 'string' && content.startsWith('base64:'),
+        expectedSha256: expectedSha256 ?? null,
+        afterSha256,
       },
       input: {
         path,
@@ -65,8 +83,27 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    return jsonSuccess();
+    return jsonSuccess({
+      data: {
+        path,
+        stats: {
+          size: stats.size,
+          modified: stats.modified,
+          permissions: stats.permissions,
+          sha256: afterSha256,
+        },
+      },
+    });
   } catch (error) {
+    if (error instanceof WorkspaceFileRevisionError) {
+      return jsonError(error.message, error.status, {
+        code: error.code,
+        path: error.path,
+        expectedSha256: error.expectedSha256,
+        currentSha256: error.currentSha256,
+        currentStats: error.currentStats,
+      });
+    }
     return jsonServerError('[API] File write error:', error, 'Failed to write file');
   }
 }

--- a/app/api/files/write/route.ts
+++ b/app/api/files/write/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest } from 'next/server';
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
-import { getFileStats, writeFile } from '@/app/lib/filesystem/workspace-files';
+import { writeFile } from '@/app/lib/filesystem/workspace-files';
 import {
   WorkspaceFileRevisionError,
   assertWorkspaceFileRevisionAllowed,
-  sha256Buffer,
+  getWorkspaceFileRevision,
   workspaceRequiresRevisionCheck,
 } from '@/app/lib/files/revision-guard';
 import { queuePublicSharesAfterWrite } from '@/app/lib/public-sharing/public-file-shares';
@@ -54,8 +54,12 @@ export async function POST(request: NextRequest) {
 
     await writeFile(path, finalContent, fileOptions);
     const contentBuffer = Buffer.isBuffer(finalContent) ? finalContent : Buffer.from(finalContent);
-    const afterSha256 = sha256Buffer(contentBuffer);
-    const stats = await getFileStats(path, fileOptions);
+    const afterRevision = await getWorkspaceFileRevision(path, fileOptions);
+    if (!afterRevision) {
+      return jsonError('Written file could not be read after save', 500);
+    }
+    const afterSha256 = afterRevision.sha256;
+    const stats = afterRevision.stats;
     invalidateWorkspaceFileViews({ fileOptions, subtreeDirs: [getParentDirectory(path)] });
     queuePublicSharesAfterWrite([path], workspaceResult.workspace);
     await recordAuditEvent({
@@ -72,7 +76,7 @@ export async function POST(request: NextRequest) {
       metadata: {
         path,
         workspaceType: workspaceResult.workspace.workspaceType,
-        contentBytes: Buffer.isBuffer(finalContent) ? finalContent.byteLength : Buffer.byteLength(finalContent),
+        contentBytes: contentBuffer.byteLength,
         encoded: typeof content === 'string' && content.startsWith('base64:'),
         expectedSha256: expectedSha256 ?? null,
         afterSha256,

--- a/app/lib/files/client.ts
+++ b/app/lib/files/client.ts
@@ -1,7 +1,7 @@
 import type { ConvertParams } from '@/app/components/shared/ImagePreprocessDialog';
 import { WORKSPACE_ID_HEADER } from '@/app/lib/workspaces/constants';
 import { useWorkspaceStore } from '@/app/store/workspace-store';
-import type { CurrentFile, FileNode } from './types';
+import type { CurrentFile, FileNode, FileStats } from './types';
 
 interface ApiErrorPayload {
   error?: unknown;
@@ -26,6 +26,11 @@ export interface WorkspacePathConflictError extends Error {
   type?: string;
   sourcePath?: string;
   destPath?: string;
+}
+
+export interface WriteWorkspaceFileResult {
+  path: string;
+  stats?: FileStats;
 }
 
 interface UploadWorkspaceFilesParams {
@@ -141,17 +146,24 @@ export async function readWorkspaceFile(
   return data;
 }
 
-export async function writeWorkspaceFile(path: string, content: string): Promise<void> {
+export async function writeWorkspaceFile(
+  path: string,
+  content: string,
+  options: { expectedSha256?: string | null } = {}
+): Promise<WriteWorkspaceFileResult> {
   const response = await fetch('/api/files/write', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...workspaceHeaders() },
     credentials: 'include',
-    body: JSON.stringify({ path, content }),
+    body: JSON.stringify({ path, content, expectedSha256: options.expectedSha256 ?? null }),
   });
 
   if (!response.ok) {
     throw new Error(await readApiError(response, 'Failed to save file'));
   }
+
+  const { data } = await readApiJson<{ data: WriteWorkspaceFileResult }>(response, 'Failed to save file');
+  return data;
 }
 
 export async function createWorkspacePath(

--- a/app/lib/files/revision-guard.ts
+++ b/app/lib/files/revision-guard.ts
@@ -98,7 +98,7 @@ export async function assertWorkspaceFileRevisionAllowed(params: {
   const currentRevision = await getWorkspaceFileRevision(params.path, params.options);
 
   if (!currentRevision) {
-    if (expectedSha256) {
+    if (params.requireExpectedRevision && expectedSha256) {
       throw new WorkspaceFileRevisionError({
         code: 'FILE_REVISION_CONFLICT',
         status: 409,
@@ -110,6 +110,10 @@ export async function assertWorkspaceFileRevisionAllowed(params: {
       });
     }
     return null;
+  }
+
+  if (!params.requireExpectedRevision) {
+    return currentRevision;
   }
 
   if (expectedSha256 && expectedSha256 !== currentRevision.sha256) {

--- a/app/lib/files/revision-guard.ts
+++ b/app/lib/files/revision-guard.ts
@@ -1,0 +1,140 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+
+import {
+  getFileStats,
+  readFile,
+  type WorkspaceFileOperationOptions,
+} from '@/app/lib/filesystem/workspace-files';
+import type { FileStats } from '@/app/lib/files/types';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
+
+export interface WorkspaceFileRevision {
+  path: string;
+  sha256: string;
+  stats: FileStats;
+}
+
+export class WorkspaceFileRevisionError extends Error {
+  readonly code: 'FILE_REVISION_REQUIRED' | 'FILE_REVISION_CONFLICT';
+  readonly status: 409 | 428;
+  readonly path: string;
+  readonly expectedSha256: string | null;
+  readonly currentSha256: string | null;
+  readonly currentStats: FileStats | null;
+
+  constructor(params: {
+    code: 'FILE_REVISION_REQUIRED' | 'FILE_REVISION_CONFLICT';
+    status: 409 | 428;
+    message: string;
+    path: string;
+    expectedSha256?: string | null;
+    currentSha256?: string | null;
+    currentStats?: FileStats | null;
+  }) {
+    super(params.message);
+    this.name = 'WorkspaceFileRevisionError';
+    this.code = params.code;
+    this.status = params.status;
+    this.path = params.path;
+    this.expectedSha256 = params.expectedSha256 ?? null;
+    this.currentSha256 = params.currentSha256 ?? null;
+    this.currentStats = params.currentStats ?? null;
+  }
+}
+
+export function sha256Buffer(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+export function normalizeExpectedSha256(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().replace(/^sha256:/i, '').toLowerCase();
+  return /^[a-f0-9]{64}$/.test(normalized) ? normalized : null;
+}
+
+export function workspaceRequiresRevisionCheck(workspace: WorkspaceContext): boolean {
+  return workspace.workspaceType === 'team' || workspace.workspaceType === 'project';
+}
+
+function isEnoent(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT');
+}
+
+export async function getWorkspaceFileRevision(
+  filePath: string,
+  options?: WorkspaceFileOperationOptions,
+): Promise<WorkspaceFileRevision | null> {
+  try {
+    const [stats, content] = await Promise.all([
+      getFileStats(filePath, options),
+      readFile(filePath, options),
+    ]);
+    const sha256 = sha256Buffer(content);
+    return {
+      path: filePath,
+      sha256,
+      stats: {
+        size: stats.size,
+        modified: stats.modified,
+        permissions: stats.permissions,
+        sha256,
+      },
+    };
+  } catch (error) {
+    if (isEnoent(error)) return null;
+    throw error;
+  }
+}
+
+export async function assertWorkspaceFileRevisionAllowed(params: {
+  path: string;
+  expectedSha256?: unknown;
+  options?: WorkspaceFileOperationOptions;
+  requireExpectedRevision?: boolean;
+}): Promise<WorkspaceFileRevision | null> {
+  const expectedSha256 = normalizeExpectedSha256(params.expectedSha256);
+  const currentRevision = await getWorkspaceFileRevision(params.path, params.options);
+
+  if (!currentRevision) {
+    if (expectedSha256) {
+      throw new WorkspaceFileRevisionError({
+        code: 'FILE_REVISION_CONFLICT',
+        status: 409,
+        message: 'File revision conflict: the file no longer exists.',
+        path: params.path,
+        expectedSha256,
+        currentSha256: null,
+        currentStats: null,
+      });
+    }
+    return null;
+  }
+
+  if (expectedSha256 && expectedSha256 !== currentRevision.sha256) {
+    throw new WorkspaceFileRevisionError({
+      code: 'FILE_REVISION_CONFLICT',
+      status: 409,
+      message: 'File revision conflict: this file changed after it was loaded. Reload the latest version before saving.',
+      path: params.path,
+      expectedSha256,
+      currentSha256: currentRevision.sha256,
+      currentStats: currentRevision.stats,
+    });
+  }
+
+  if (params.requireExpectedRevision && !expectedSha256) {
+    throw new WorkspaceFileRevisionError({
+      code: 'FILE_REVISION_REQUIRED',
+      status: 428,
+      message: 'A current file revision is required before saving shared workspace files.',
+      path: params.path,
+      expectedSha256: null,
+      currentSha256: currentRevision.sha256,
+      currentStats: currentRevision.stats,
+    });
+  }
+
+  return currentRevision;
+}

--- a/app/lib/files/types.ts
+++ b/app/lib/files/types.ts
@@ -26,6 +26,7 @@ export interface FileStats {
   size: number;
   modified: number;
   permissions: string;
+  sha256?: string;
 }
 
 export interface CurrentFile {

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { parseDocument } from 'yaml';
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { logger } from '@/app/lib/logging';
+import { normalizeExpectedSha256 as normalizeAgentExpectedSha256 } from '@/app/lib/files/revision-guard';
 import {
   syncPublicSharesAfterDelete,
   syncPublicSharesAfterMove,
@@ -363,12 +364,6 @@ function auditWorkspaceMetadata(executionContext: AgentExecutionContext | null) 
 function activeWorkspaceRequiresRevisionGuard(): boolean {
   const executionContext = getAgentExecutionContext();
   return executionContext?.workspaceType === 'team' || executionContext?.workspaceType === 'project';
-}
-
-function normalizeAgentExpectedSha256(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const normalized = value.trim().replace(/^sha256:/i, '').toLowerCase();
-  return /^[a-f0-9]{64}$/.test(normalized) ? normalized : null;
 }
 
 function assertAgentSharedWorkspaceRevision(params: {

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -365,6 +365,12 @@ function activeWorkspaceRequiresRevisionGuard(): boolean {
   return executionContext?.workspaceType === 'team' || executionContext?.workspaceType === 'project';
 }
 
+function normalizeAgentExpectedSha256(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().replace(/^sha256:/i, '').toLowerCase();
+  return /^[a-f0-9]{64}$/.test(normalized) ? normalized : null;
+}
+
 function assertAgentSharedWorkspaceRevision(params: {
   operation: string;
   path: string;
@@ -372,7 +378,7 @@ function assertAgentSharedWorkspaceRevision(params: {
   expectedSha256?: string | null;
 }): void {
   if (!params.beforeExisted || !activeWorkspaceRequiresRevisionGuard()) return;
-  if (params.expectedSha256?.trim()) return;
+  if (normalizeAgentExpectedSha256(params.expectedSha256)) return;
 
   throw new Error(
     `Refusing to ${params.operation} ${params.path}: existing shared workspace files require expectedSha256. Read the file first and retry with the current SHA-256 hash.`,
@@ -973,14 +979,15 @@ export async function writeAgentTextFile(params: {
   await assertAgentWritablePathAllowed(fullPath);
   const before = await readExistingFile(fullPath);
   const beforeSha256 = before.buffer ? sha256Buffer(before.buffer) : null;
+  const expectedSha256 = normalizeAgentExpectedSha256(params.expectedSha256);
   assertAgentSharedWorkspaceRevision({
     operation: params.operation ?? 'write',
     path: params.path,
     beforeExisted: before.existed,
-    expectedSha256: params.expectedSha256,
+    expectedSha256,
   });
 
-  if (params.expectedSha256 && beforeSha256 !== params.expectedSha256) {
+  if (expectedSha256 && beforeSha256 !== expectedSha256) {
     throw new Error(`Refusing to write ${params.path}: expectedSha256 did not match current file hash.`);
   }
 
@@ -1010,7 +1017,15 @@ export async function editAgentFile(params: {
   }
 
   const beforeSha256 = sha256Buffer(before.buffer);
-  if (params.expectedSha256 && beforeSha256 !== params.expectedSha256) {
+  const expectedSha256 = normalizeAgentExpectedSha256(params.expectedSha256);
+  assertAgentSharedWorkspaceRevision({
+    operation: 'edit_file',
+    path: params.path,
+    beforeExisted: before.existed,
+    expectedSha256,
+  });
+
+  if (expectedSha256 && beforeSha256 !== expectedSha256) {
     throw new Error(`Refusing to edit ${params.path}: expectedSha256 did not match current file hash.`);
   }
 
@@ -1059,7 +1074,15 @@ export async function applyAgentFilePatch(params: { files: AgentPatchFileInput[]
     }
 
     const beforeSha256 = sha256Buffer(before.buffer);
-    if (file.expectedSha256 && beforeSha256 !== file.expectedSha256) {
+    const expectedSha256 = normalizeAgentExpectedSha256(file.expectedSha256);
+    assertAgentSharedWorkspaceRevision({
+      operation: 'patch',
+      path: file.path,
+      beforeExisted: before.existed,
+      expectedSha256,
+    });
+
+    if (expectedSha256 && beforeSha256 !== expectedSha256) {
       throw new Error(`Refusing to patch ${file.path}: expectedSha256 did not match current file hash.`);
     }
 

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -360,6 +360,25 @@ function auditWorkspaceMetadata(executionContext: AgentExecutionContext | null) 
   };
 }
 
+function activeWorkspaceRequiresRevisionGuard(): boolean {
+  const executionContext = getAgentExecutionContext();
+  return executionContext?.workspaceType === 'team' || executionContext?.workspaceType === 'project';
+}
+
+function assertAgentSharedWorkspaceRevision(params: {
+  operation: string;
+  path: string;
+  beforeExisted: boolean;
+  expectedSha256?: string | null;
+}): void {
+  if (!params.beforeExisted || !activeWorkspaceRequiresRevisionGuard()) return;
+  if (params.expectedSha256?.trim()) return;
+
+  throw new Error(
+    `Refusing to ${params.operation} ${params.path}: existing shared workspace files require expectedSha256. Read the file first and retry with the current SHA-256 hash.`,
+  );
+}
+
 async function recordAgentFileChangeAudit(result: AgentFileChangeResult, operation: string): Promise<void> {
   if (!result.changed) return;
 
@@ -954,6 +973,12 @@ export async function writeAgentTextFile(params: {
   await assertAgentWritablePathAllowed(fullPath);
   const before = await readExistingFile(fullPath);
   const beforeSha256 = before.buffer ? sha256Buffer(before.buffer) : null;
+  assertAgentSharedWorkspaceRevision({
+    operation: params.operation ?? 'write',
+    path: params.path,
+    beforeExisted: before.existed,
+    expectedSha256: params.expectedSha256,
+  });
 
   if (params.expectedSha256 && beforeSha256 !== params.expectedSha256) {
     throw new Error(`Refusing to write ${params.path}: expectedSha256 did not match current file hash.`);

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -2106,7 +2106,7 @@ export const piTools: AgentTool[] = [
                   displayPath: resolvedPath.displayPath,
                   mimeType: image.mimeType,
                   size: buffer.length,
-                }),
+                }) + `\nSHA-256: ${sha256}`,
               },
               image,
             ],
@@ -2189,7 +2189,7 @@ export const piTools: AgentTool[] = [
   {
     name: 'edit_file',
     label: 'Editing file safely',
-    description: 'Safely edits an existing text file by exact oldText -> newText replacement. Refuses ambiguous matches, creates an undo snapshot, returns a diff, validates supported file types, and verifies the file after writing. Use this instead of sed, perl -pi, tee, or shell redirects.',
+    description: 'Safely edits an existing text file by exact oldText -> newText replacement. Refuses ambiguous matches, creates an undo snapshot, returns a diff, validates supported file types, and verifies the file after writing. Existing shared workspace files require expectedSha256 from the read tool output. Use this instead of sed, perl -pi, tee, or shell redirects.',
     parameters: Type.Object({
       path: Type.String({ description: 'Absolute path or workspace-relative path.' }),
       oldText: Type.String({ description: 'Exact text to replace. Must match expectedOccurrences.' }),
@@ -2229,7 +2229,7 @@ export const piTools: AgentTool[] = [
   {
     name: 'apply_patch',
     label: 'Applying safe patch',
-    description: 'Safely applies multiple exact text replacements across one or more existing files. All replacements are preflighted before any write. Creates undo snapshots, returns diffs, validates supported file types, and verifies files after writing.',
+    description: 'Safely applies multiple exact text replacements across one or more existing files. All replacements are preflighted before any write. Creates undo snapshots, returns diffs, validates supported file types, and verifies files after writing. Existing shared workspace files require expectedSha256 from the read tool output.',
     parameters: Type.Object({
       files: Type.Array(Type.Object({
         path: Type.String({ description: 'Absolute path or workspace-relative path.' }),

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -25,6 +25,7 @@ import {
   moveAgentPaths,
   resolveAgentPath,
   restoreAgentFileSnapshot,
+  sha256Buffer,
   type AgentFileChangeResult,
   type AgentFileValidationResult,
   type AgentPathOperationResult,
@@ -2093,6 +2094,7 @@ export const piTools: AgentTool[] = [
           };
         }
         const buffer = await fsPromises.readFile(fullPath);
+        const sha256 = sha256Buffer(buffer);
         const image = imageContentForBuffer(fullPath, buffer);
         if (image) {
           return {
@@ -2113,6 +2115,7 @@ export const piTools: AgentTool[] = [
               requestedPath: filePath,
               resolvedPath: fullPath,
               size: buffer.length,
+              sha256,
               type: 'image',
               mimeType: image.mimeType,
               source: resolvedPath.source,
@@ -2140,8 +2143,8 @@ export const piTools: AgentTool[] = [
         const text = buffer.toString('utf8');
         const truncated = truncateReadText(text, readTextLimit);
         return {
-          content: [{ type: 'text', text: truncated.text }],
-          details: { filePath, size: buffer.length, type: 'text', textLength: text.length, truncated: truncated.truncated },
+          content: [{ type: 'text', text: `SHA-256: ${sha256}\n\n${truncated.text}` }],
+          details: { filePath, size: buffer.length, sha256, type: 'text', textLength: text.length, truncated: truncated.truncated },
         };
       } catch (error: unknown) {
         const message = getErrorMessage(error);
@@ -2155,7 +2158,7 @@ export const piTools: AgentTool[] = [
   {
     name: 'write',
     label: 'Writing file',
-    description: 'Writes text content to a file. Creates an undo snapshot, returns a diff, validates supported file types, and verifies the file after writing. Prefer edit_file or apply_patch for existing files when possible.',
+    description: 'Writes text content to a file. Creates an undo snapshot, returns a diff, validates supported file types, and verifies the file after writing. Prefer edit_file or apply_patch for existing files when possible. Existing shared workspace files require expectedSha256 from the read tool output.',
     parameters: Type.Object({
       path: Type.String({ description: 'Absolute path or workspace-relative path.' }),
       content: Type.String({ description: 'The content to write.' }),

--- a/app/store/file-store.ts
+++ b/app/store/file-store.ts
@@ -128,7 +128,8 @@ function areFileStatsEqual(left?: FileStats, right?: FileStats) {
   return (
     left?.size === right?.size &&
     left?.modified === right?.modified &&
-    left?.permissions === right?.permissions
+    left?.permissions === right?.permissions &&
+    left?.sha256 === right?.sha256
   );
 }
 
@@ -658,7 +659,10 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
     set({ fileError: null });
 
     try {
-      await writeWorkspaceFile(path, content);
+      const currentFileBeforeSave = get().currentFile;
+      const result = await writeWorkspaceFile(path, content, {
+        expectedSha256: currentFileBeforeSave?.path === path ? currentFileBeforeSave.stats?.sha256 ?? null : null,
+      });
 
       // Update current file if it's the same path
       const { currentFile } = get();
@@ -667,6 +671,7 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
           currentFile: {
             ...currentFile,
             content,
+            stats: result.stats ?? currentFile.stats,
           },
         });
       }

--- a/app/store/file-store.ts
+++ b/app/store/file-store.ts
@@ -133,6 +133,44 @@ function areFileStatsEqual(left?: FileStats, right?: FileStats) {
   );
 }
 
+function updateFileRevision(
+  revisions: Record<string, string>,
+  filePath: string,
+  stats?: FileStats,
+): Record<string, string> {
+  if (!stats?.sha256 || revisions[filePath] === stats.sha256) return revisions;
+  return {
+    ...revisions,
+    [filePath]: stats.sha256,
+  };
+}
+
+function removeFileRevisions(
+  revisions: Record<string, string>,
+  paths: string[],
+): Record<string, string> {
+  const entries = Object.entries(revisions).filter(([filePath]) => (
+    !paths.some((removedPath) => isSameOrDescendantPath(filePath, removedPath))
+  ));
+  return entries.length === Object.keys(revisions).length ? revisions : Object.fromEntries(entries);
+}
+
+function remapFileRevisions(
+  revisions: Record<string, string>,
+  oldPath: string,
+  newPath: string,
+): Record<string, string> {
+  let changed = false;
+  const remapped = Object.fromEntries(
+    Object.entries(revisions).map(([filePath, sha256]) => {
+      if (!isSameOrDescendantPath(filePath, oldPath)) return [filePath, sha256];
+      changed = true;
+      return [remapDescendantPath(filePath, oldPath, newPath), sha256];
+    }),
+  );
+  return changed ? remapped : revisions;
+}
+
 interface FileStoreState {
   // File tree
   fileTree: FileNode[];
@@ -148,6 +186,7 @@ interface FileStoreState {
   loadingFilePath: string | null;
   fileLoadRequestId: number;
   fileError: string | null;
+  fileRevisions: Record<string, string>;
 
   // Browser mode
   browserMode: BrowserMode;
@@ -241,6 +280,7 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
   selectedNode: null,
 
   currentFile: null,
+  fileRevisions: {},
 
   browserMode: 'tree',
   setBrowserMode: (mode: BrowserMode) => {
@@ -528,7 +568,7 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
       if (get().fileLoadRequestId !== requestId) return;
 
       const fileName = path.split('/').pop() || path;
-      set({
+      set((state) => ({
         selectedNode: { path, type: 'file', name: fileName },
         currentFile: {
           path,
@@ -537,7 +577,8 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
         },
         isLoadingFile: false,
         loadingFilePath: null,
-      });
+        fileRevisions: updateFileRevision(state.fileRevisions, path, data.stats),
+      }));
     } catch (error) {
       if (error instanceof Response && error.status === 404) {
         if (get().fileLoadRequestId === requestId) {
@@ -586,14 +627,17 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
         content: data.content,
         stats: data.stats,
       };
+      const nextFileRevisions = updateFileRevision(get().fileRevisions, path, data.stats);
 
       if (
         currentFile.content !== refreshedFile.content ||
-        !areFileStatsEqual(currentFile.stats, refreshedFile.stats)
+        !areFileStatsEqual(currentFile.stats, refreshedFile.stats) ||
+        nextFileRevisions !== get().fileRevisions
       ) {
         set({
           currentFile: refreshedFile,
           fileError: null,
+          fileRevisions: nextFileRevisions,
         });
       }
 
@@ -659,21 +703,28 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
     set({ fileError: null });
 
     try {
-      const currentFileBeforeSave = get().currentFile;
+      const { currentFile: currentFileBeforeSave, fileRevisions } = get();
+      const expectedSha256 = fileRevisions[path]
+        ?? (currentFileBeforeSave?.path === path ? currentFileBeforeSave.stats?.sha256 ?? null : null);
       const result = await writeWorkspaceFile(path, content, {
-        expectedSha256: currentFileBeforeSave?.path === path ? currentFileBeforeSave.stats?.sha256 ?? null : null,
+        expectedSha256,
       });
 
       // Update current file if it's the same path
       const { currentFile } = get();
       if (currentFile?.path === path) {
-        set({
+        set((state) => ({
           currentFile: {
             ...currentFile,
             content,
             stats: result.stats ?? currentFile.stats,
           },
-        });
+          fileRevisions: updateFileRevision(state.fileRevisions, path, result.stats),
+        }));
+      } else if (result.stats?.sha256) {
+        set((state) => ({
+          fileRevisions: updateFileRevision(state.fileRevisions, path, result.stats),
+        }));
       }
     } catch (error) {
       const message =
@@ -781,7 +832,11 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
         }
       }
 
-      set({ multiSelectPaths: new Set(), isMultiSelectMode: false });
+      set((state) => ({
+        multiSelectPaths: new Set(),
+        isMultiSelectMode: false,
+        fileRevisions: removeFileRevisions(state.fileRevisions, pathsToDelete),
+      }));
 
       const parentDirs = new Set(pathsToDelete.map((deletedPath) => getParentDirectory(deletedPath)));
       for (const parentDir of parentDirs) {
@@ -819,10 +874,11 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
       const updatedCurrentFile = currentFile && isSameOrDescendantPath(currentFile.path, oldPath)
         ? { ...currentFile, path: remapDescendantPath(currentFile.path, oldPath, newPath) }
         : currentFile;
-      set({
+      set((state) => ({
         selectedNode: updatedSelectedNode,
         ...(updatedCurrentFile !== currentFile ? { currentFile: updatedCurrentFile, fileError: null } : {}),
-      });
+        fileRevisions: remapFileRevisions(state.fileRevisions, oldPath, newPath),
+      }));
 
       const parentDirs = new Set([
         getParentDirectory(oldPath),
@@ -905,6 +961,7 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
   clearCurrentFile: () => {
     set((state) => ({
       currentFile: null,
+      fileRevisions: {},
       isLoadingFile: false,
       loadingFilePath: null,
       fileError: null,
@@ -919,6 +976,7 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
       treeError: null,
       selectedNode: null,
       currentFile: null,
+      fileRevisions: {},
       isLoadingFile: false,
       loadingFilePath: null,
       fileLoadRequestId: state.fileLoadRequestId + 1,

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -604,12 +604,31 @@
     {
       "id": 34,
       "title": "Einfache Locks oder Revision-Checks fuer Team-Dateien einfuehren",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/05-actor-audit-retention.md",
         "docs/architecture/canvas-notebook/team-workspace/17-database-provider-postgres-rag-collaboration-policy.md",
         "docs/architecture/canvas-notebook/team-workspace/18-collaboration-and-file-conflict-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/files/revision-guard.ts",
+        "app/lib/files/types.ts",
+        "app/api/files/create/route.ts",
+        "app/api/files/read/route.ts",
+        "app/api/files/write/route.ts",
+        "app/lib/files/client.ts",
+        "app/store/file-store.ts",
+        "app/lib/pi/agent-file-operations.ts",
+        "app/lib/pi/tool-registry.ts",
+        "scripts/file-revision-guard-test.ts"
+      ],
+      "verification": [
+        "npx tsx --conditions react-server scripts/file-revision-guard-test.ts",
+        "npx tsx --conditions react-server scripts/agent-session-workspace-context-test.ts",
+        "npx tsc --noEmit --pretty false",
+        "npm run lint",
+        "npm run build"
       ]
     },
     {

--- a/scripts/file-revision-guard-test.ts
+++ b/scripts/file-revision-guard-test.ts
@@ -63,7 +63,7 @@ async function main() {
     } = await import('../app/lib/files/revision-guard');
     const { writeFile } = await import('../app/lib/filesystem/workspace-files');
     const { runWithAgentExecutionContext } = await import('../app/lib/pi/agent-execution-context');
-    const { writeAgentTextFile } = await import('../app/lib/pi/agent-file-operations');
+    const { editAgentFile, writeAgentTextFile } = await import('../app/lib/pi/agent-file-operations');
 
     await writeFile('notes.md', 'personal v1\n', { workspace: personalWorkspace });
     await assert.doesNotReject(() => assertWorkspaceFileRevisionAllowed({
@@ -137,9 +137,17 @@ async function main() {
       const updated = await writeAgentTextFile({
         path: 'agent-created.md',
         content: 'agent v2\n',
-        expectedSha256: created.afterSha256,
+        expectedSha256: `sha256:${created.afterSha256.toUpperCase()}`,
       });
       assert.equal(updated.changed, true);
+
+      const edited = await editAgentFile({
+        path: 'agent-created.md',
+        oldText: 'agent v2\n',
+        newText: 'agent v3\n',
+        expectedSha256: updated.afterSha256,
+      });
+      assert.equal(edited.changed, true);
     });
 
     console.log('file-revision-guard-test: ok');

--- a/scripts/file-revision-guard-test.ts
+++ b/scripts/file-revision-guard-test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { WorkspaceContext } from '../app/lib/workspaces/types';
+
+function workspaceContext(params: {
+  rootPath: string;
+  workspaceId: string;
+  workspaceType: WorkspaceContext['workspaceType'];
+  organizationId?: string | null;
+}): WorkspaceContext {
+  return {
+    workspaceId: params.workspaceId,
+    workspaceType: params.workspaceType,
+    rootPath: params.rootPath,
+    rootRelativePath: path.relative(path.dirname(params.rootPath), params.rootPath),
+    displayName: params.workspaceType,
+    status: 'active',
+    organizationId: params.organizationId ?? null,
+    permissions: {
+      canRead: true,
+      canWrite: true,
+      canDelete: true,
+      canCreatePublicLinks: true,
+      canManageWorkspace: true,
+      canRunAgent: true,
+    },
+    legacy: false,
+  };
+}
+
+async function main() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-file-revision-guard-'));
+  const dataRoot = path.join(tempRoot, 'data');
+  process.env.DATA = dataRoot;
+
+  try {
+    const personalRoot = path.join(dataRoot, 'workspaces', 'personal', 'user-1', 'files');
+    const teamRoot = path.join(dataRoot, 'workspaces', 'team', 'org-1', 'files');
+    await fs.mkdir(personalRoot, { recursive: true });
+    await fs.mkdir(teamRoot, { recursive: true });
+
+    const personalWorkspace = workspaceContext({
+      rootPath: personalRoot,
+      workspaceId: 'ws-personal',
+      workspaceType: 'personal',
+      organizationId: 'org-1',
+    });
+    const teamWorkspace = workspaceContext({
+      rootPath: teamRoot,
+      workspaceId: 'ws-team',
+      workspaceType: 'team',
+      organizationId: 'org-1',
+    });
+
+    const {
+      WorkspaceFileRevisionError,
+      assertWorkspaceFileRevisionAllowed,
+      getWorkspaceFileRevision,
+      workspaceRequiresRevisionCheck,
+    } = await import('../app/lib/files/revision-guard');
+    const { writeFile } = await import('../app/lib/filesystem/workspace-files');
+    const { runWithAgentExecutionContext } = await import('../app/lib/pi/agent-execution-context');
+    const { writeAgentTextFile } = await import('../app/lib/pi/agent-file-operations');
+
+    await writeFile('notes.md', 'personal v1\n', { workspace: personalWorkspace });
+    await assert.doesNotReject(() => assertWorkspaceFileRevisionAllowed({
+      path: 'notes.md',
+      options: { workspace: personalWorkspace },
+      requireExpectedRevision: workspaceRequiresRevisionCheck(personalWorkspace),
+    }));
+
+    await writeFile('team.md', 'team v1\n', { workspace: teamWorkspace });
+    const teamRevision = await getWorkspaceFileRevision('team.md', { workspace: teamWorkspace });
+    assert.ok(teamRevision?.sha256);
+
+    await assert.rejects(
+      () => assertWorkspaceFileRevisionAllowed({
+        path: 'team.md',
+        options: { workspace: teamWorkspace },
+        requireExpectedRevision: workspaceRequiresRevisionCheck(teamWorkspace),
+      }),
+      (error) => error instanceof WorkspaceFileRevisionError && error.code === 'FILE_REVISION_REQUIRED' && error.status === 428,
+    );
+
+    await assert.rejects(
+      () => assertWorkspaceFileRevisionAllowed({
+        path: 'team.md',
+        expectedSha256: '0'.repeat(64),
+        options: { workspace: teamWorkspace },
+        requireExpectedRevision: workspaceRequiresRevisionCheck(teamWorkspace),
+      }),
+      (error) => error instanceof WorkspaceFileRevisionError && error.code === 'FILE_REVISION_CONFLICT' && error.status === 409,
+    );
+
+    await assert.doesNotReject(() => assertWorkspaceFileRevisionAllowed({
+      path: 'team.md',
+      expectedSha256: teamRevision.sha256,
+      options: { workspace: teamWorkspace },
+      requireExpectedRevision: workspaceRequiresRevisionCheck(teamWorkspace),
+    }));
+
+    const agentContext = {
+      userId: 'user-1',
+      sessionId: 'session-1',
+      agentId: 'canvas-agent',
+      workspaceId: teamWorkspace.workspaceId,
+      workspaceType: teamWorkspace.workspaceType,
+      workspaceName: teamWorkspace.displayName ?? null,
+      organizationId: teamWorkspace.organizationId ?? null,
+      customerId: null,
+      projectId: null,
+      workspaceRoot: teamWorkspace.rootPath,
+      workspaceRootRelativePath: teamWorkspace.rootRelativePath ?? null,
+      canWrite: true,
+      canShare: true,
+      legacy: false,
+    };
+
+    await runWithAgentExecutionContext(agentContext, async () => {
+      const created = await writeAgentTextFile({
+        path: 'agent-created.md',
+        content: 'agent v1\n',
+      });
+      assert.equal(created.changed, true);
+
+      await assert.rejects(
+        () => writeAgentTextFile({
+          path: 'agent-created.md',
+          content: 'agent v2\n',
+        }),
+        /existing shared workspace files require expectedSha256/i,
+      );
+
+      const updated = await writeAgentTextFile({
+        path: 'agent-created.md',
+        content: 'agent v2\n',
+        expectedSha256: created.afterSha256,
+      });
+      assert.equal(updated.changed, true);
+    });
+
+    console.log('file-revision-guard-test: ok');
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+void main();

--- a/scripts/file-revision-guard-test.ts
+++ b/scripts/file-revision-guard-test.ts
@@ -71,6 +71,12 @@ async function main() {
       options: { workspace: personalWorkspace },
       requireExpectedRevision: workspaceRequiresRevisionCheck(personalWorkspace),
     }));
+    await assert.doesNotReject(() => assertWorkspaceFileRevisionAllowed({
+      path: 'notes.md',
+      expectedSha256: '0'.repeat(64),
+      options: { workspace: personalWorkspace },
+      requireExpectedRevision: workspaceRequiresRevisionCheck(personalWorkspace),
+    }));
 
     await writeFile('team.md', 'team v1\n', { workspace: teamWorkspace });
     const teamRevision = await getWorkspaceFileRevision('team.md', { workspace: teamWorkspace });


### PR DESCRIPTION
## Summary
- add a server-side file revision guard based on SHA-256 hashes
- return `stats.sha256` from file reads and pass it back on editor saves
- block stale or missing base revisions for existing Team/Project workspace file writes and creates
- require `expectedSha256` for agent full-file writes to existing shared workspace files, while preserving exact edit/patch flows
- mark Task 34 completed in docs/architecture/canvas-notebook/todo.json

## Verification
- npx tsx --conditions react-server scripts/file-revision-guard-test.ts
- npx tsx --conditions react-server scripts/agent-session-workspace-context-test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build

Greptile score: pending automatic review

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a server-side SHA-256 revision guard to prevent stale-write conflicts on Team/Project workspace files. The server can now reject writes where the client's `expectedSha256` doesn't match the current file content, and team/project workspace writes without any revision token are blocked with a 428.

- **`revision-guard.ts`**: new module with `getWorkspaceFileRevision`, `assertWorkspaceFileRevisionAllowed`, and `WorkspaceFileRevisionError`; wired into all three file API routes.
- **`file-store.ts`**: adds a `fileRevisions` map keyed by file path that is populated on every successful read and updated on every successful write, then sent as `expectedSha256` on subsequent saves.
- **`agent-file-operations.ts` / `tool-registry.ts`**: agent write/edit/patch tools now enforce `expectedSha256` for existing files in shared workspaces, and the read tool prepends the SHA-256 hash to file output so agents can supply it.

<h3>Confidence Score: 4/5</h3>

Safe to merge for team/project workspaces; personal workspace saves will now 409 when files are externally modified after loading, which is an unintended scope expansion of the guard.

The revision guard logic and the server-side enforcement are sound. The one concrete defect is that the client unconditionally populates expectedSha256 from fileRevisions regardless of workspace type. Since the server applies the mismatch check to all workspaces when a hash is provided, personal workspace users whose files change between load and save (agent writes, build tools, VCS) will hit a 409 that they cannot explain or recover from without reloading. The PR description explicitly limits the guard to Team/Project workspaces, so this appears to be an accidental scope expansion.

app/store/file-store.ts — the expectedSha256 lookup in saveFile needs to be conditional on workspace type.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/lib/files/revision-guard.ts | New file: clean implementation of the revision guard with proper error types, normalization, and ENOENT handling |
| app/store/file-store.ts | Adds fileRevisions map and unconditionally sends expectedSha256 for all workspace types, including personal — causing 409 conflicts for personal workspace users when files are externally modified |
| app/api/files/write/route.ts | Correctly integrates revision guard pre-write and returns afterSha256 from a full post-write disk read; TOCTOU window between guard and write is inherent to optimistic locking |
| app/api/files/create/route.ts | Correctly blocks overwriting existing files in team workspaces via the revision guard; new files (ENOENT path) pass through cleanly |
| app/api/files/read/route.ts | sha256 added to full-read response only; metaOnly and over-limit paths correctly omit it |
| app/lib/pi/agent-file-operations.ts | Adds assertAgentSharedWorkspaceRevision guard to write/edit/patch; normalizeAgentExpectedSha256 duplicates the identical function already exported from revision-guard.ts |
| app/lib/pi/tool-registry.ts | Prepends SHA-256 to read tool output for both text and image files so agents can supply expectedSha256; sha256 also stored in details for internal tracking |
| app/lib/files/client.ts | writeWorkspaceFile signature extended with expectedSha256 option and now returns WriteWorkspaceFileResult with stats; backward-compatible since only file-store.ts is the caller |
| scripts/file-revision-guard-test.ts | Comprehensive integration test covering personal vs team workspace behaviors, 428/409 cases, and agent write/edit flows |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client: saveFile] --> B{fileRevisions has sha256?}
    B -- yes --> C[send expectedSha256]
    B -- no --> D[send null]
    C --> E[POST /api/files/write]
    D --> E

    E --> F[assertWorkspaceFileRevisionAllowed]
    F --> G[getWorkspaceFileRevision - reads full file]
    G --> H{file exists?}
    H -- no --> I{expectedSha256 set?}
    I -- yes --> J[409 FILE_REVISION_CONFLICT - file gone]
    I -- no --> K[return null - no-op]
    H -- yes --> L{expectedSha256 set?}
    L -- yes --> M{sha256 matches?}
    M -- no --> N[409 FILE_REVISION_CONFLICT]
    M -- yes --> O{requireExpectedRevision?}
    L -- no --> O
    O -- true --> P{expectedSha256 set?}
    P -- no --> Q[428 FILE_REVISION_REQUIRED]
    P -- yes --> R[return currentRevision]
    O -- false --> R

    K --> S[writeFile]
    R --> S
    S --> T[getWorkspaceFileRevision - reads file again]
    T --> U[return stats + afterSha256 to client]
    U --> V[client updates fileRevisions map]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Client: saveFile] --> B{fileRevisions has sha256?}
    B -- yes --> C[send expectedSha256]
    B -- no --> D[send null]
    C --> E[POST /api/files/write]
    D --> E

    E --> F[assertWorkspaceFileRevisionAllowed]
    F --> G[getWorkspaceFileRevision - reads full file]
    G --> H{file exists?}
    H -- no --> I{expectedSha256 set?}
    I -- yes --> J[409 FILE_REVISION_CONFLICT - file gone]
    I -- no --> K[return null - no-op]
    H -- yes --> L{expectedSha256 set?}
    L -- yes --> M{sha256 matches?}
    M -- no --> N[409 FILE_REVISION_CONFLICT]
    M -- yes --> O{requireExpectedRevision?}
    L -- no --> O
    O -- true --> P{expectedSha256 set?}
    P -- no --> Q[428 FILE_REVISION_REQUIRED]
    P -- yes --> R[return currentRevision]
    O -- false --> R

    K --> S[writeFile]
    R --> S
    S --> T[getWorkspaceFileRevision - reads file again]
    T --> U[return stats + afterSha256 to client]
    U --> V[client updates fileRevisions map]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/lib/pi/tool-registry.ts`, line 2097-2124 ([link](https://github.com/canvascoding/canvas-notebook/blob/6a362f5271ae38f1b431d5b75e2d030fd64adf65/app/lib/pi/tool-registry.ts#L2097-L2124)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Image sha256 is available in details but not visible to the agent**

   For text files, sha256 is prepended directly to the `content` block so the model can copy it into `expectedSha256` on a subsequent write. For image files the hash is computed and stored in `details.sha256`, but `details` is not exposed to the model as tool-call output — only `content` is. If an agent reads an image file and then needs to overwrite it in a team workspace, it cannot supply `expectedSha256`, so `assertAgentSharedWorkspaceRevision` will throw. Consider adding a short sha256 line to the text content block alongside the existing image-info text.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fteam-file-revision-guards%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fteam-file-revision-guards%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Fpi%2Ftool-registry.ts%0ALine%3A%202097-2124%0A%0AComment%3A%0A**Image%20sha256%20is%20available%20in%20details%20but%20not%20visible%20to%20the%20agent**%0A%0AFor%20text%20files%2C%20sha256%20is%20prepended%20directly%20to%20the%20%60content%60%20block%20so%20the%20model%20can%20copy%20it%20into%20%60expectedSha256%60%20on%20a%20subsequent%20write.%20For%20image%20files%20the%20hash%20is%20computed%20and%20stored%20in%20%60details.sha256%60%2C%20but%20%60details%60%20is%20not%20exposed%20to%20the%20model%20as%20tool-call%20output%20%E2%80%94%20only%20%60content%60%20is.%20If%20an%20agent%20reads%20an%20image%20file%20and%20then%20needs%20to%20overwrite%20it%20in%20a%20team%20workspace%2C%20it%20cannot%20supply%20%60expectedSha256%60%2C%20so%20%60assertAgentSharedWorkspaceRevision%60%20will%20throw.%20Consider%20adding%20a%20short%20sha256%20line%20to%20the%20text%20content%20block%20alongside%20the%20existing%20image-info%20text.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fteam-file-revision-guards%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fteam-file-revision-guards%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fstore%2Ffile-store.ts%3A706-711%0A**expectedSha256%20sent%20unconditionally%20for%20personal%20workspaces**%0A%0A%60fileRevisions%5Bpath%5D%60%20is%20populated%20for%20every%20workspace%20type%20on%20every%20successful%20file%20read%2C%20so%20personal%20workspace%20saves%20always%20include%20%60expectedSha256%60.%20The%20server's%20%60assertWorkspaceFileRevisionAllowed%60%20checks%20%60expectedSha256%20!%3D%3D%20currentRevision.sha256%60%20unconditionally%20%E2%80%94%20the%20%60requireExpectedRevision%60%20flag%20only%20controls%20the%20%22missing%20hash%22%20428%2C%20not%20the%20%22mismatched%20hash%22%20409.%20Consequently%2C%20if%20any%20other%20process%20%28the%20agent%2C%20a%20build%20tool%2C%20VCS%29%20writes%20to%20a%20personal%20workspace%20file%20after%20it%20was%20last%20loaded%2C%20the%20next%20UI%20save%20returns%20a%20409%20conflict%20even%20though%20personal%20workspaces%20have%20no%20sharing%20semantics.%20The%20PR%20description%20explicitly%20scopes%20the%20revision%20guard%20to%20%22Team%2FProject%20workspace%20file%20writes%22%2C%20so%20this%20appears%20unintentional.%0A%0ATo%20fix%2C%20either%20gate%20the%20%60expectedSha256%60%20lookup%20on%20workspace%20type%20%28if%20the%20workspace%20type%20is%20accessible%20in%20the%20store%29%2C%20or%20on%20the%20server%20side%2C%20skip%20the%20hash-mismatch%20check%20for%20non-shared%20workspaces.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Flib%2Fpi%2Fagent-file-operations.ts%3A368-372%0A%60normalizeAgentExpectedSha256%60%20is%20character-for-character%20identical%20to%20%60normalizeExpectedSha256%60%20already%20exported%20from%20%60revision-guard.ts%60.%20Since%20both%20files%20are%20server-only%2C%20the%20local%20copy%20can%20be%20replaced%20with%20a%20direct%20import.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20normalizeExpectedSha256%20as%20normalizeAgentExpectedSha256%20%7D%20from%20'%40%2Fapp%2Flib%2Ffiles%2Frevision-guard'%3B%0A%60%60%60%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Track file revisions per path"](https://github.com/canvascoding/canvas-notebook/commit/cb0de24dd5b8b125f0650bb3a5e7a2ad4166dc83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38949426)</sub>

<!-- /greptile_comment -->