### PR TITLE
Add knowledge parsing settings

### DIFF
--- a/app/api/admin/knowledge-settings/route.ts
+++ b/app/api/admin/knowledge-settings/route.ts
@@ -28,6 +28,7 @@ const SETTING_KEYS = [
   'perFileTimeoutSeconds',
   'minimumFreeMemoryMb',
 ] as const;
+const POLICY_BLOCK_ERROR_PREFIX = 'Knowledge settings update blocked:';
 
 function extractSettingsPatch(payload: PatchPayload): Record<string, unknown> {
   const source = payload.settings && typeof payload.settings === 'object' && !Array.isArray(payload.settings)
@@ -136,6 +137,8 @@ export async function PATCH(request: NextRequest) {
       },
     });
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to update Knowledge settings.';
+    const isPolicyBlock = message.startsWith(POLICY_BLOCK_ERROR_PREFIX);
     await recordAuditEvent({
       organizationId: admin.state.organizationId,
       userId: admin.session.user.id,
@@ -144,13 +147,18 @@ export async function PATCH(request: NextRequest) {
       entityType: 'knowledge_settings',
       entityId: admin.state.organizationId ?? 'system',
       action: 'knowledge_settings.update',
-      status: 'blocked',
-      summary: 'Knowledge and parsing settings update was blocked.',
+      status: isPolicyBlock ? 'blocked' : 'error',
+      summary: isPolicyBlock
+        ? 'Knowledge and parsing settings update was blocked.'
+        : 'Knowledge and parsing settings update failed.',
       metadata: {
-        error: error instanceof Error ? error.message : 'unknown',
+        error: message,
+        errorType: isPolicyBlock ? 'policy_block' : 'server_error',
       },
     });
-    const message = error instanceof Error ? error.message : 'Failed to update Knowledge settings.';
-    return NextResponse.json({ success: false, error: message }, { status: 400 });
+    return NextResponse.json(
+      { success: false, error: isPolicyBlock ? message : 'Failed to update Knowledge settings.' },
+      { status: isPolicyBlock ? 400 : 500 },
+    );
   }
 }

--- a/app/api/admin/knowledge-settings/route.ts
+++ b/app/api/admin/knowledge-settings/route.ts
@@ -115,7 +115,7 @@ export async function PATCH(request: NextRequest) {
       status: 'success',
       summary: 'Knowledge and parsing settings updated.',
       metadata: {
-        changedKeys: Object.keys(patch),
+        changedKeys: result.changedKeys,
         resourceProfile: result.resourceStatus.resourceProfile,
         availability: result.resourceStatus.availability,
         blockers: result.resourceStatus.blockers,

--- a/app/api/admin/knowledge-settings/route.ts
+++ b/app/api/admin/knowledge-settings/route.ts
@@ -91,6 +91,12 @@ export async function PATCH(request: NextRequest) {
   try {
     const payload = await request.json().catch(() => ({})) as PatchPayload;
     const patch = extractSettingsPatch(payload);
+    if (Object.keys(patch).length === 0) {
+      return NextResponse.json(
+        { success: false, error: 'No recognized settings keys provided.' },
+        { status: 400 },
+      );
+    }
     const result = await updateKnowledgeParsingSettings({
       state: admin.state,
       actorUserId: admin.session.user.id,

--- a/app/api/admin/knowledge-settings/route.ts
+++ b/app/api/admin/knowledge-settings/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
+import {
+  readKnowledgeOperationalLogs,
+  readKnowledgeParsingSettings,
+  resolveKnowledgeResourceStatus,
+  updateKnowledgeParsingSettings,
+} from '@/app/lib/knowledge/settings-service';
+import { requireOrganizationPermission } from '@/app/lib/organization/permissions';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+type PatchPayload = {
+  settings?: Record<string, unknown>;
+};
+
+const SETTING_KEYS = [
+  'knowledgeAutoIngestionEnabled',
+  'heavyDocumentParsingEnabled',
+  'doclingEnabled',
+  'ocrEnabled',
+  'embeddingIndexingEnabled',
+  'remoteParsingEnabled',
+  'maxConcurrentHeavyJobs',
+  'maxDocumentSizeMb',
+  'maxPages',
+  'maxOcrPages',
+  'perFileTimeoutSeconds',
+  'minimumFreeMemoryMb',
+] as const;
+
+function extractSettingsPatch(payload: PatchPayload): Record<string, unknown> {
+  const source = payload.settings && typeof payload.settings === 'object' && !Array.isArray(payload.settings)
+    ? payload.settings
+    : {};
+  const patch: Record<string, unknown> = {};
+  for (const key of SETTING_KEYS) {
+    if (key in source) {
+      patch[key] = source[key];
+    }
+  }
+  return patch;
+}
+
+export async function GET(request: NextRequest) {
+  const admin = await requireOrganizationPermission(request, 'canEnableKnowledge', {
+    errorMessage: 'Only users with Knowledge administration permission can view Knowledge settings.',
+  });
+  if (!admin.ok) return admin.response;
+
+  const limited = rateLimit(request, {
+    limit: 120,
+    windowMs: 60_000,
+    keyPrefix: `knowledge-settings-get:${admin.session.user.id}`,
+  });
+  if (!limited.ok) return limited.response;
+
+  const { settings, storage } = await readKnowledgeParsingSettings(admin.state);
+  const resourceStatus = await resolveKnowledgeResourceStatus(settings, admin.state);
+  const logs = await readKnowledgeOperationalLogs({ organizationId: admin.state.organizationId ?? null });
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      settings,
+      resourceStatus,
+      logs,
+      storage: {
+        scope: storage.scope,
+      },
+      permission: {
+        canUpdate: admin.permission.canEnableKnowledge === true,
+      },
+    },
+  });
+}
+
+export async function PATCH(request: NextRequest) {
+  const admin = await requireOrganizationPermission(request, 'canEnableKnowledge', {
+    errorMessage: 'Only users with Knowledge administration permission can update Knowledge settings.',
+  });
+  if (!admin.ok) return admin.response;
+
+  const limited = rateLimit(request, {
+    limit: 20,
+    windowMs: 60_000,
+    keyPrefix: `knowledge-settings-patch:${admin.session.user.id}`,
+  });
+  if (!limited.ok) return limited.response;
+
+  try {
+    const payload = await request.json().catch(() => ({})) as PatchPayload;
+    const patch = extractSettingsPatch(payload);
+    const result = await updateKnowledgeParsingSettings({
+      state: admin.state,
+      actorUserId: admin.session.user.id,
+      updates: patch,
+    });
+
+    await recordAuditEvent({
+      organizationId: admin.state.organizationId,
+      userId: admin.session.user.id,
+      source: 'knowledge',
+      eventType: 'admin',
+      entityType: 'knowledge_settings',
+      entityId: admin.state.organizationId ?? 'system',
+      action: 'knowledge_settings.update',
+      status: 'success',
+      summary: 'Knowledge and parsing settings updated.',
+      metadata: {
+        changedKeys: Object.keys(patch),
+        resourceProfile: result.resourceStatus.resourceProfile,
+        availability: result.resourceStatus.availability,
+        blockers: result.resourceStatus.blockers,
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        settings: result.settings,
+        resourceStatus: result.resourceStatus,
+        logs: result.logs,
+        storage: {
+          scope: result.storage.scope,
+        },
+        permission: {
+          canUpdate: true,
+        },
+      },
+    });
+  } catch (error) {
+    await recordAuditEvent({
+      organizationId: admin.state.organizationId,
+      userId: admin.session.user.id,
+      source: 'knowledge',
+      eventType: 'admin',
+      entityType: 'knowledge_settings',
+      entityId: admin.state.organizationId ?? 'system',
+      action: 'knowledge_settings.update',
+      status: 'blocked',
+      summary: 'Knowledge and parsing settings update was blocked.',
+      metadata: {
+        error: error instanceof Error ? error.message : 'unknown',
+      },
+    });
+    const message = error instanceof Error ? error.message : 'Failed to update Knowledge settings.';
+    return NextResponse.json({ success: false, error: message }, { status: 400 });
+  }
+}

--- a/app/components/settings/IntegrationsSettingsClient.tsx
+++ b/app/components/settings/IntegrationsSettingsClient.tsx
@@ -269,6 +269,7 @@ const SETTINGS_TAB_ITEMS = [
   { value: 'integrations', labelKey: 'tabs.integrations' },
   { value: 'agent-settings', labelKey: 'tabs.agentSettings' },
   { value: 'workspace', labelKey: 'tabs.workspace' },
+  { value: 'knowledge', labelKey: 'tabs.knowledge' },
   { value: 'user-management', labelKey: 'tabs.userManagement' },
   { value: 'channels', labelKey: 'tabs.channels' },
   { value: 'usage', labelKey: 'tabs.usage' },
@@ -339,6 +340,11 @@ const SkillsPanel = dynamic(
 
 const WorkspaceSettingsPanel = dynamic(
   () => import('@/app/components/settings/WorkspaceSettingsPanel').then((module) => module.WorkspaceSettingsPanel),
+  { loading: SettingsTabLoader },
+);
+
+const KnowledgeSettingsPanel = dynamic(
+  () => import('@/app/components/settings/KnowledgeSettingsPanel').then((module) => module.KnowledgeSettingsPanel),
   { loading: SettingsTabLoader },
 );
 
@@ -2616,8 +2622,12 @@ export function IntegrationsSettingsClient({
 
   const effectiveTab = normalizeSettingsTab(activeTabOverride) ?? settingsTab;
   const visibleSettingsTabItems = useMemo(
-    () => SETTINGS_TAB_ITEMS.filter((tab) => tab.value !== 'user-management' || isAdmin),
-    [isAdmin],
+    () => SETTINGS_TAB_ITEMS.filter((tab) => {
+      if (tab.value === 'user-management') return isAdmin;
+      if (tab.value === 'knowledge') return isAdmin || organizationPermission?.canEnableKnowledge === true;
+      return true;
+    }),
+    [isAdmin, organizationPermission],
   );
   const visibleSettingsTabs = useMemo(
     () => new Set<SettingsTab>(visibleSettingsTabItems.map((tab) => tab.value)),
@@ -3404,6 +3414,8 @@ export function IntegrationsSettingsClient({
             organizationPermission={organizationPermission}
           />
         ))}
+
+        {renderLazyTabContent('knowledge', <KnowledgeSettingsPanel />)}
 
         {renderLazyTabContent('user-management',
           <UserManagementPanel currentUserId={currentUserId} isAdmin={isAdmin} />,

--- a/app/components/settings/KnowledgeSettingsPanel.tsx
+++ b/app/components/settings/KnowledgeSettingsPanel.tsx
@@ -1,0 +1,372 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  BookOpen,
+  Cpu,
+  Database,
+  FileText,
+  HardDrive,
+  Loader2,
+  MemoryStick,
+  RefreshCw,
+  Save,
+  ShieldCheck,
+} from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import type {
+  KnowledgeOperationalLogEntry,
+  KnowledgeParsingSettings,
+  KnowledgeSettingsResponse,
+} from '@/app/lib/knowledge/settings-types';
+
+const BOOLEAN_SETTING_KEYS = [
+  'knowledgeAutoIngestionEnabled',
+  'heavyDocumentParsingEnabled',
+  'doclingEnabled',
+  'ocrEnabled',
+  'embeddingIndexingEnabled',
+  'remoteParsingEnabled',
+] as const;
+
+const NUMBER_SETTING_KEYS = [
+  'maxConcurrentHeavyJobs',
+  'maxDocumentSizeMb',
+  'maxPages',
+  'maxOcrPages',
+  'perFileTimeoutSeconds',
+  'minimumFreeMemoryMb',
+] as const;
+
+type BooleanSettingKey = (typeof BOOLEAN_SETTING_KEYS)[number];
+type NumberSettingKey = (typeof NUMBER_SETTING_KEYS)[number];
+
+function cloneSettings(settings: KnowledgeParsingSettings): KnowledgeParsingSettings {
+  return { ...settings };
+}
+
+function availabilityVariant(availability: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (availability === 'available') return 'default';
+  if (availability === 'disabled') return 'destructive';
+  return 'secondary';
+}
+
+function logLevelVariant(level: KnowledgeOperationalLogEntry['level']): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (level === 'error') return 'destructive';
+  if (level === 'warn') return 'secondary';
+  return 'outline';
+}
+
+export function KnowledgeSettingsPanel() {
+  const t = useTranslations('settings.knowledge');
+  const [data, setData] = useState<KnowledgeSettingsResponse | null>(null);
+  const [draft, setDraft] = useState<KnowledgeParsingSettings | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const isDirty = useMemo(() => {
+    if (!data || !draft) return false;
+    return [...BOOLEAN_SETTING_KEYS, ...NUMBER_SETTING_KEYS].some((key) => data.settings[key] !== draft[key]);
+  }, [data, draft]);
+
+  const loadSettings = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/admin/knowledge-settings', {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || t('errors.load'));
+      }
+      const nextData = payload.data as KnowledgeSettingsResponse;
+      setData(nextData);
+      setDraft(cloneSettings(nextData.settings));
+      setMessage(null);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : t('errors.load'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      void loadSettings();
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [loadSettings]);
+
+  const updateBoolean = (key: BooleanSettingKey, value: boolean) => {
+    setDraft((current) => current ? { ...current, [key]: value } : current);
+  };
+
+  const updateNumber = (key: NumberSettingKey, value: string) => {
+    const parsed = Number(value);
+    setDraft((current) => current ? { ...current, [key]: Number.isFinite(parsed) ? parsed : current[key] } : current);
+  };
+
+  const saveSettings = async () => {
+    if (!draft) return;
+    setIsSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const response = await fetch('/api/admin/knowledge-settings', {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: draft }),
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || t('errors.save'));
+      }
+      const nextData = payload.data as KnowledgeSettingsResponse;
+      setData(nextData);
+      setDraft(cloneSettings(nextData.settings));
+      setMessage(t('saved'));
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : t('errors.save'));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading && !data) {
+    return (
+      <div className="flex items-center py-8 text-sm text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        {t('loading')}
+      </div>
+    );
+  }
+
+  if (!draft || !data) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('title')}</CardTitle>
+          <CardDescription>{t('description')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error || t('errors.load')}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const status = data.resourceStatus;
+  const canUpdate = data.permission.canUpdate && !isSaving;
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="px-4 sm:px-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <BookOpen className="h-5 w-5 text-muted-foreground" />
+            <CardTitle>{t('title')}</CardTitle>
+            <Badge variant={availabilityVariant(status.availability)}>
+              {t(`availability.${status.availability}`)}
+            </Badge>
+            <Badge variant="outline">{t(`profiles.${status.resourceProfile}`)}</Badge>
+          </div>
+          <CardDescription>{t('description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 px-4 pb-4 sm:px-6 sm:pb-6">
+          {error && <div className="border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div>}
+          {message && <div className="border border-border bg-muted px-3 py-2 text-sm text-muted-foreground">{message}</div>}
+          {!status.canEnableKnowledge && (
+            <div className="flex gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-900 dark:text-amber-200">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="space-y-1">
+                <p className="font-medium">{t('preflightBlocked')}</p>
+                <p>{t('preflightBlockedDescription')}</p>
+              </div>
+            </div>
+          )}
+
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <StatusTile icon={Database} label={t('status.database')} value={status.databaseProvider} detail={status.pgvectorReady ? t('status.pgvectorReady') : t('status.pgvectorMissing')} />
+            <StatusTile icon={MemoryStick} label={t('status.memory')} value={status.memory.totalMb === null ? t('unknown') : `${status.memory.totalMb} MB`} detail={t('status.freeMemory', { value: status.memory.freeMb ?? 0 })} />
+            <StatusTile icon={Cpu} label={t('status.cpu')} value={status.cpu.count === null ? t('unknown') : String(status.cpu.count)} detail={t('status.activeJobs', { value: status.queue.activeHeavyJobs })} />
+            <StatusTile icon={HardDrive} label={t('status.disk')} value={status.disk.freeGb === null ? t('unknown') : `${status.disk.freeGb} GB`} detail={t('status.diskThreshold', { value: status.disk.thresholdGb })} />
+          </div>
+
+          {(status.blockers.length > 0 || status.warnings.length > 0) && (
+            <div className="grid gap-3 md:grid-cols-2">
+              <StatusList title={t('blockers')} items={status.blockers} empty={t('none')} destructive />
+              <StatusList title={t('warnings')} items={status.warnings} empty={t('none')} />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="px-4 sm:px-6">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-muted-foreground" />
+            <CardTitle>{t('togglesTitle')}</CardTitle>
+          </div>
+          <CardDescription>{t('togglesDescription')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 px-4 pb-4 sm:px-6 sm:pb-6">
+          <div className="grid gap-3 md:grid-cols-2">
+            {BOOLEAN_SETTING_KEYS.map((key) => (
+              <ToggleRow
+                key={key}
+                label={t(`fields.${key}.label`)}
+                description={t(`fields.${key}.description`)}
+                checked={draft[key]}
+                disabled={!canUpdate}
+                onCheckedChange={(checked) => updateBoolean(key, checked)}
+              />
+            ))}
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {NUMBER_SETTING_KEYS.map((key) => (
+              <label key={key} className="space-y-2 rounded-md border border-border p-3">
+                <span className="text-sm font-medium">{t(`fields.${key}.label`)}</span>
+                <Input
+                  type="number"
+                  value={draft[key]}
+                  disabled={!canUpdate}
+                  onChange={(event) => updateNumber(key, event.target.value)}
+                />
+                <span className="block text-xs text-muted-foreground">{t(`fields.${key}.description`)}</span>
+              </label>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => void loadSettings()} disabled={isLoading || isSaving}>
+              {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+              {t('reload')}
+            </Button>
+            <Button type="button" onClick={() => void saveSettings()} disabled={!canUpdate || !isDirty}>
+              {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
+              {t('save')}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="px-4 sm:px-6">
+          <div className="flex items-center gap-2">
+            <FileText className="h-5 w-5 text-muted-foreground" />
+            <CardTitle>{t('logsTitle')}</CardTitle>
+          </div>
+          <CardDescription>{t('logsDescription')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 px-4 pb-4 sm:px-6 sm:pb-6">
+          {data.logs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t('logsEmpty')}</p>
+          ) : (
+            data.logs.map((entry) => (
+              <div key={`${entry.timestamp}:${entry.action}`} className="rounded-md border border-border p-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={logLevelVariant(entry.level)}>{entry.level}</Badge>
+                  <span className="text-sm font-medium">{entry.action}</span>
+                  <span className="text-xs text-muted-foreground">{new Date(entry.timestamp).toLocaleString()}</span>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">{entry.message}</p>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                  <span>{t('reasonCode')}: {entry.reasonCode}</span>
+                  <span>{t('changedKeys')}: {entry.changedKeys.length ? entry.changedKeys.join(', ') : t('none')}</span>
+                </div>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function StatusTile({
+  icon: Icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: typeof Database;
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-md border border-border p-3">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Icon className="h-4 w-4" />
+        <span>{label}</span>
+      </div>
+      <div className="mt-2 text-lg font-semibold">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{detail}</div>
+    </div>
+  );
+}
+
+function StatusList({
+  title,
+  items,
+  empty,
+  destructive = false,
+}: {
+  title: string;
+  items: string[];
+  empty: string;
+  destructive?: boolean;
+}) {
+  return (
+    <div className="rounded-md border border-border p-3">
+      <div className="text-sm font-medium">{title}</div>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {items.length === 0 ? (
+          <Badge variant="outline">{empty}</Badge>
+        ) : items.map((item) => (
+          <Badge key={item} variant={destructive ? 'destructive' : 'secondary'}>{item}</Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ToggleRow({
+  label,
+  description,
+  checked,
+  disabled,
+  onCheckedChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 rounded-md border border-border p-3">
+      <div className="space-y-1">
+        <Label className="text-sm font-medium">{label}</Label>
+        <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+      </div>
+      <Switch checked={checked} disabled={disabled} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}

--- a/app/components/settings/KnowledgeSettingsPanel.tsx
+++ b/app/components/settings/KnowledgeSettingsPanel.tsx
@@ -114,7 +114,7 @@ export function KnowledgeSettingsPanel() {
   };
 
   const updateNumber = (key: NumberSettingKey, value: string) => {
-    const parsed = Number(value);
+    const parsed = value.trim() === '' ? NaN : Number(value);
     setDraft((current) => current ? { ...current, [key]: Number.isFinite(parsed) ? parsed : current[key] } : current);
   };
 

--- a/app/components/settings/KnowledgeSettingsPanel.tsx
+++ b/app/components/settings/KnowledgeSettingsPanel.tsx
@@ -278,8 +278,8 @@ export function KnowledgeSettingsPanel() {
           {data.logs.length === 0 ? (
             <p className="text-sm text-muted-foreground">{t('logsEmpty')}</p>
           ) : (
-            data.logs.map((entry) => (
-              <div key={`${entry.timestamp}:${entry.action}`} className="rounded-md border border-border p-3">
+            data.logs.map((entry, index) => (
+              <div key={`${entry.timestamp}:${entry.action}:${index}`} className="rounded-md border border-border p-3">
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant={logLevelVariant(entry.level)}>{entry.level}</Badge>
                   <span className="text-sm font-medium">{entry.action}</span>

--- a/app/lib/audit/audit-service.ts
+++ b/app/lib/audit/audit-service.ts
@@ -14,7 +14,7 @@ const MAX_OBJECT_KEYS = 80;
 
 const SENSITIVE_KEY_PATTERN = /(secret|token|password|passphrase|credential|authorization|cookie|api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|private[_-]?key)/i;
 
-export type AuditStatus = 'success' | 'failure' | 'blocked' | 'queued' | 'started' | 'completed';
+export type AuditStatus = 'success' | 'failure' | 'error' | 'blocked' | 'queued' | 'started' | 'completed';
 
 export interface AuditEventInput {
   organizationId?: string | null;

--- a/app/lib/knowledge/settings-service.ts
+++ b/app/lib/knowledge/settings-service.ts
@@ -234,7 +234,7 @@ export async function resolveKnowledgeResourceStatus(
     },
     parser: {
       docling: settings.doclingEnabled ? 'not_checked' : 'disabled',
-      ocr: settings.ocrEnabled ? 'available' : 'disabled',
+      ocr: settings.ocrEnabled ? 'not_checked' : 'disabled',
       embeddings: settings.embeddingIndexingEnabled
         ? (postgresReady && pgvectorReady ? 'available' : 'requires_postgres')
         : 'disabled',

--- a/app/lib/knowledge/settings-service.ts
+++ b/app/lib/knowledge/settings-service.ts
@@ -1,0 +1,398 @@
+import 'server-only';
+
+import os from 'node:os';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+
+import {
+  getDatabaseProvider,
+  type OrganizationPermissionState,
+} from '@/app/lib/organization/bootstrap';
+import {
+  resolveCanvasDataRoot,
+  resolveOrganizationSettingsDir,
+  resolveSystemLogsDir,
+  resolveSystemSettingsDir,
+} from '@/app/lib/runtime-data-paths';
+import {
+  type KnowledgeOperationalLogEntry,
+  type KnowledgeParsingSettings,
+  type KnowledgeResourceAvailability,
+  type KnowledgeResourceProfile,
+  type KnowledgeResourceStatus,
+} from '@/app/lib/knowledge/settings-types';
+
+const SETTINGS_FILE = 'knowledge-parsing-settings.json';
+const LOG_FILE = 'knowledge-operational.jsonl';
+const DEFAULT_MINIMUM_FREE_MEMORY_MB = 512;
+const MIN_ENABLE_MEMORY_MB = 2048;
+const MIN_ENABLE_DISK_GB = 10;
+const MAX_LOG_ENTRIES = 50;
+
+type KnowledgeSettingsStorage = {
+  scope: 'organization' | 'system';
+  filePath: string;
+};
+
+type KnowledgeSettingsUpdate = Partial<Omit<
+  KnowledgeParsingSettings,
+  'updatedAt' | 'updatedByUserId'
+>>;
+
+const DEFAULT_KNOWLEDGE_SETTINGS: KnowledgeParsingSettings = {
+  knowledgeAutoIngestionEnabled: false,
+  heavyDocumentParsingEnabled: false,
+  doclingEnabled: false,
+  ocrEnabled: false,
+  embeddingIndexingEnabled: false,
+  remoteParsingEnabled: false,
+  maxConcurrentHeavyJobs: 1,
+  maxDocumentSizeMb: 25,
+  maxPages: 200,
+  maxOcrPages: 25,
+  perFileTimeoutSeconds: 120,
+  minimumFreeMemoryMb: DEFAULT_MINIMUM_FREE_MEMORY_MB,
+  updatedAt: null,
+  updatedByUserId: null,
+};
+
+const BOOLEAN_SETTING_KEYS = [
+  'knowledgeAutoIngestionEnabled',
+  'heavyDocumentParsingEnabled',
+  'doclingEnabled',
+  'ocrEnabled',
+  'embeddingIndexingEnabled',
+  'remoteParsingEnabled',
+] as const;
+
+const NUMBER_SETTING_LIMITS: Record<
+  Exclude<keyof KnowledgeSettingsUpdate, (typeof BOOLEAN_SETTING_KEYS)[number]>,
+  { min: number; max: number }
+> = {
+  maxConcurrentHeavyJobs: { min: 1, max: 4 },
+  maxDocumentSizeMb: { min: 1, max: 1024 },
+  maxPages: { min: 1, max: 5000 },
+  maxOcrPages: { min: 0, max: 500 },
+  perFileTimeoutSeconds: { min: 10, max: 3600 },
+  minimumFreeMemoryMb: { min: 128, max: 32768 },
+};
+
+function resolveKnowledgeSettingsStorage(state?: OrganizationPermissionState | null): KnowledgeSettingsStorage {
+  const organizationId = state?.organizationId?.trim();
+  if (organizationId) {
+    return {
+      scope: 'organization',
+      filePath: path.join(resolveOrganizationSettingsDir(organizationId), SETTINGS_FILE),
+    };
+  }
+
+  return {
+    scope: 'system',
+    filePath: path.join(resolveSystemSettingsDir(), SETTINGS_FILE),
+  };
+}
+
+async function ensurePrivateParent(filePath: string): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  await fs.chmod(dir, 0o700).catch(() => undefined);
+}
+
+async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+  await ensurePrivateParent(filePath);
+  const tmpPath = `${filePath}.tmp-${Date.now()}-${process.pid}-${Math.random().toString(16).slice(2)}`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  await fs.chmod(tmpPath, 0o600).catch(() => undefined);
+  await fs.rename(tmpPath, filePath);
+  await fs.chmod(filePath, 0o600).catch(() => undefined);
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function normalizeNumber(value: unknown, fallback: number, min: number, max: number): number {
+  const numeric = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+  return Math.min(max, Math.max(min, Math.round(numeric)));
+}
+
+function normalizeKnowledgeSettings(value: unknown): KnowledgeParsingSettings {
+  const record = value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Partial<KnowledgeParsingSettings>
+    : {};
+
+  const normalized: KnowledgeParsingSettings = {
+    ...DEFAULT_KNOWLEDGE_SETTINGS,
+    updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : null,
+    updatedByUserId: typeof record.updatedByUserId === 'string' ? record.updatedByUserId : null,
+  };
+
+  for (const key of BOOLEAN_SETTING_KEYS) {
+    normalized[key] = normalizeBoolean(record[key], DEFAULT_KNOWLEDGE_SETTINGS[key]);
+  }
+  for (const [key, limits] of Object.entries(NUMBER_SETTING_LIMITS) as Array<[keyof typeof NUMBER_SETTING_LIMITS, { min: number; max: number }]>) {
+    normalized[key] = normalizeNumber(record[key], DEFAULT_KNOWLEDGE_SETTINGS[key], limits.min, limits.max);
+  }
+
+  return normalized;
+}
+
+export async function readKnowledgeParsingSettings(
+  state?: OrganizationPermissionState | null,
+): Promise<{ settings: KnowledgeParsingSettings; storage: KnowledgeSettingsStorage }> {
+  const storage = resolveKnowledgeSettingsStorage(state);
+  try {
+    const raw = await fs.readFile(storage.filePath, 'utf8');
+    return {
+      settings: normalizeKnowledgeSettings(JSON.parse(raw)),
+      storage,
+    };
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code !== 'ENOENT') {
+      throw error;
+    }
+    return {
+      settings: { ...DEFAULT_KNOWLEDGE_SETTINGS },
+      storage,
+    };
+  }
+}
+
+async function getDiskFreeGb(): Promise<number | null> {
+  try {
+    const stats = await fs.statfs(resolveCanvasDataRoot());
+    return Math.floor((stats.bavail * stats.bsize) / 1024 / 1024 / 1024);
+  } catch {
+    return null;
+  }
+}
+
+function resolveMemoryProfile(totalMb: number | null): KnowledgeResourceProfile {
+  if (totalMb === null || totalMb < 1536) return 'disabled';
+  if (totalMb < 4096) return 'low';
+  if (totalMb < 8192) return 'standard';
+  return 'large';
+}
+
+function availabilityFor(
+  blockers: string[],
+  warnings: string[],
+  profile: KnowledgeResourceProfile,
+): KnowledgeResourceAvailability {
+  if (blockers.length > 0 || profile === 'disabled') return 'disabled';
+  if (warnings.length > 0 || profile === 'low') return 'degraded';
+  return 'available';
+}
+
+export async function resolveKnowledgeResourceStatus(
+  settings: KnowledgeParsingSettings,
+  state?: OrganizationPermissionState | null,
+): Promise<KnowledgeResourceStatus> {
+  const databaseProvider = (state?.databaseProvider || getDatabaseProvider()).trim().toLowerCase() || 'sqlite';
+  const postgresReady = databaseProvider === 'postgres';
+  const pgvectorReady = process.env.CANVAS_POSTGRES_VECTOR_ENABLED === 'true';
+  const totalMb = Math.round(os.totalmem() / 1024 / 1024);
+  const freeMb = Math.round(os.freemem() / 1024 / 1024);
+  const diskFreeGb = await getDiskFreeGb();
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+
+  if (!postgresReady) blockers.push('requires_postgres');
+  if (postgresReady && !pgvectorReady) blockers.push('requires_pgvector');
+  if (totalMb < MIN_ENABLE_MEMORY_MB) blockers.push('memory_below_2gb');
+  if (freeMb < settings.minimumFreeMemoryMb) warnings.push('free_memory_below_guard');
+  if (diskFreeGb !== null && diskFreeGb < MIN_ENABLE_DISK_GB) blockers.push('disk_below_10gb');
+  if (os.cpus().length < 2) warnings.push('single_cpu_serial_jobs');
+
+  const profile = resolveMemoryProfile(totalMb);
+  const availability = availabilityFor(blockers, warnings, profile);
+  const canEnableKnowledge = blockers.length === 0 && profile !== 'disabled';
+
+  return {
+    availability,
+    resourceProfile: profile,
+    databaseProvider,
+    postgresRequired: true,
+    postgresReady,
+    pgvectorReady,
+    memory: {
+      totalMb,
+      freeMb,
+      thresholdMb: MIN_ENABLE_MEMORY_MB,
+    },
+    cpu: {
+      count: os.cpus().length || null,
+    },
+    disk: {
+      freeGb: diskFreeGb,
+      thresholdGb: MIN_ENABLE_DISK_GB,
+    },
+    queue: {
+      depth: 0,
+      activeHeavyJobs: 0,
+    },
+    parser: {
+      docling: settings.doclingEnabled ? 'missing' : 'disabled',
+      ocr: settings.ocrEnabled ? 'available' : 'disabled',
+      embeddings: settings.embeddingIndexingEnabled
+        ? (postgresReady && pgvectorReady ? 'available' : 'requires_postgres')
+        : 'disabled',
+      remoteParsing: settings.remoteParsingEnabled ? 'enabled' : 'disabled',
+    },
+    canEnableKnowledge,
+    blockers,
+    warnings,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+function sanitizeLogString(value: string): string {
+  if (/(secret|token|password|credential|authorization|cookie|api[_-]?key|private[_-]?key)/iu.test(value)) {
+    return '[REDACTED]';
+  }
+  return value.length > 180 ? `${value.slice(0, 180)}...` : value;
+}
+
+function sanitizeLogValue(value: boolean | number | string | null): boolean | number | string | null {
+  return typeof value === 'string' ? sanitizeLogString(value) : value;
+}
+
+async function appendKnowledgeOperationalLog(entry: KnowledgeOperationalLogEntry): Promise<void> {
+  const logDir = resolveSystemLogsDir();
+  await fs.mkdir(logDir, { recursive: true, mode: 0o700 });
+  await fs.chmod(logDir, 0o700).catch(() => undefined);
+  const filePath = path.join(logDir, LOG_FILE);
+  await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
+  await fs.chmod(filePath, 0o600).catch(() => undefined);
+}
+
+export async function readKnowledgeOperationalLogs(input?: {
+  limit?: number;
+  organizationId?: string | null;
+}): Promise<KnowledgeOperationalLogEntry[]> {
+  const filePath = path.join(resolveSystemLogsDir(), LOG_FILE);
+  const limit = input?.limit ?? 12;
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return raw
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as KnowledgeOperationalLogEntry)
+      .filter((entry) => input?.organizationId === undefined || entry.organizationId === input.organizationId)
+      .slice(-Math.min(MAX_LOG_ENTRIES, Math.max(1, limit)))
+      .reverse();
+  } catch {
+    return [];
+  }
+}
+
+function collectChanges(
+  previous: KnowledgeParsingSettings,
+  next: KnowledgeParsingSettings,
+): KnowledgeOperationalLogEntry['changes'] {
+  const changes: KnowledgeOperationalLogEntry['changes'] = {};
+  const keys = [...BOOLEAN_SETTING_KEYS, ...Object.keys(NUMBER_SETTING_LIMITS)] as Array<keyof KnowledgeSettingsUpdate>;
+  for (const key of keys) {
+    if (previous[key] !== next[key]) {
+      changes[key] = {
+        from: sanitizeLogValue(previous[key] ?? null),
+        to: sanitizeLogValue(next[key] ?? null),
+      };
+    }
+  }
+  return changes;
+}
+
+function validateKnowledgeSettingsUpdate(
+  next: KnowledgeParsingSettings,
+  resourceStatus: KnowledgeResourceStatus,
+): string[] {
+  const errors: string[] = [];
+  if ((next.doclingEnabled || next.ocrEnabled) && !next.heavyDocumentParsingEnabled) {
+    errors.push('heavy_parsing_required_for_docling_or_ocr');
+  }
+  if (next.embeddingIndexingEnabled && !next.knowledgeAutoIngestionEnabled) {
+    errors.push('knowledge_required_for_embeddings');
+  }
+  if ((next.knowledgeAutoIngestionEnabled || next.embeddingIndexingEnabled) && !resourceStatus.canEnableKnowledge) {
+    errors.push(...resourceStatus.blockers);
+  }
+  if (next.heavyDocumentParsingEnabled && resourceStatus.memory.totalMb !== null && resourceStatus.memory.totalMb < MIN_ENABLE_MEMORY_MB) {
+    errors.push('memory_below_2gb');
+  }
+  return Array.from(new Set(errors));
+}
+
+export async function updateKnowledgeParsingSettings(input: {
+  state?: OrganizationPermissionState | null;
+  actorUserId: string;
+  updates: KnowledgeSettingsUpdate;
+}): Promise<{
+  settings: KnowledgeParsingSettings;
+  storage: KnowledgeSettingsStorage;
+  resourceStatus: KnowledgeResourceStatus;
+  logs: KnowledgeOperationalLogEntry[];
+}> {
+  const current = await readKnowledgeParsingSettings(input.state);
+  const next: KnowledgeParsingSettings = {
+    ...current.settings,
+    updatedAt: new Date().toISOString(),
+    updatedByUserId: input.actorUserId,
+  };
+
+  for (const key of BOOLEAN_SETTING_KEYS) {
+    if (key in input.updates) {
+      next[key] = Boolean(input.updates[key]);
+    }
+  }
+  for (const [key, limits] of Object.entries(NUMBER_SETTING_LIMITS) as Array<[keyof typeof NUMBER_SETTING_LIMITS, { min: number; max: number }]>) {
+    if (key in input.updates) {
+      next[key] = normalizeNumber(input.updates[key], current.settings[key], limits.min, limits.max);
+    }
+  }
+
+  const resourceStatus = await resolveKnowledgeResourceStatus(next, input.state);
+  const errors = validateKnowledgeSettingsUpdate(next, resourceStatus);
+  if (errors.length > 0) {
+    const logEntry: KnowledgeOperationalLogEntry = {
+      timestamp: new Date().toISOString(),
+      level: 'warn',
+      action: 'knowledge_settings.update_blocked',
+      actorUserId: input.actorUserId,
+      organizationId: input.state?.organizationId ?? null,
+      reasonCode: errors[0] ?? 'blocked',
+      changedKeys: Object.keys(collectChanges(current.settings, next)),
+      changes: collectChanges(current.settings, next),
+      resourceProfile: resourceStatus.resourceProfile,
+      blockers: errors,
+      message: 'Knowledge settings update blocked by policy or resource preflight.',
+    };
+    await appendKnowledgeOperationalLog(logEntry);
+    throw new Error(`Knowledge settings update blocked: ${errors.join(', ')}`);
+  }
+
+  await writeJsonAtomic(current.storage.filePath, next);
+  const changes = collectChanges(current.settings, next);
+  if (Object.keys(changes).length > 0) {
+    await appendKnowledgeOperationalLog({
+      timestamp: new Date().toISOString(),
+      level: 'info',
+      action: 'knowledge_settings.updated',
+      actorUserId: input.actorUserId,
+      organizationId: input.state?.organizationId ?? null,
+      reasonCode: resourceStatus.availability,
+      changedKeys: Object.keys(changes),
+      changes,
+      resourceProfile: resourceStatus.resourceProfile,
+      blockers: resourceStatus.blockers,
+      message: 'Knowledge and parsing settings updated.',
+    });
+  }
+
+  return {
+    settings: next,
+    storage: current.storage,
+    resourceStatus,
+    logs: await readKnowledgeOperationalLogs({ organizationId: input.state?.organizationId ?? null }),
+  };
+}

--- a/app/lib/knowledge/settings-service.ts
+++ b/app/lib/knowledge/settings-service.ts
@@ -28,6 +28,7 @@ const DEFAULT_MINIMUM_FREE_MEMORY_MB = 512;
 const MIN_ENABLE_MEMORY_MB = 2048;
 const MIN_ENABLE_DISK_GB = 10;
 const MAX_LOG_ENTRIES = 50;
+const MAX_LOG_FILE_LINES = 500;
 
 type KnowledgeSettingsStorage = {
   scope: 'organization' | 'system';
@@ -232,7 +233,7 @@ export async function resolveKnowledgeResourceStatus(
       activeHeavyJobs: 0,
     },
     parser: {
-      docling: settings.doclingEnabled ? 'missing' : 'disabled',
+      docling: settings.doclingEnabled ? 'not_checked' : 'disabled',
       ocr: settings.ocrEnabled ? 'available' : 'disabled',
       embeddings: settings.embeddingIndexingEnabled
         ? (postgresReady && pgvectorReady ? 'available' : 'requires_postgres')
@@ -264,6 +265,24 @@ async function appendKnowledgeOperationalLog(entry: KnowledgeOperationalLogEntry
   const filePath = path.join(logDir, LOG_FILE);
   await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
   await fs.chmod(filePath, 0o600).catch(() => undefined);
+  await trimKnowledgeOperationalLogFile(filePath);
+}
+
+async function trimKnowledgeOperationalLogFile(filePath: string): Promise<void> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const lines = raw.split('\n').filter(Boolean);
+    if (lines.length <= MAX_LOG_FILE_LINES) return;
+
+    const trimmed = `${lines.slice(-MAX_LOG_FILE_LINES).join('\n')}\n`;
+    const tmpPath = `${filePath}.tmp-${Date.now()}-${process.pid}-${Math.random().toString(16).slice(2)}`;
+    await fs.writeFile(tmpPath, trimmed, { mode: 0o600 });
+    await fs.chmod(tmpPath, 0o600).catch(() => undefined);
+    await fs.rename(tmpPath, filePath);
+    await fs.chmod(filePath, 0o600).catch(() => undefined);
+  } catch {
+    // Trimming failures must not block the settings update path.
+  }
 }
 
 export async function readKnowledgeOperationalLogs(input?: {

--- a/app/lib/knowledge/settings-service.ts
+++ b/app/lib/knowledge/settings-service.ts
@@ -356,6 +356,7 @@ export async function updateKnowledgeParsingSettings(input: {
   storage: KnowledgeSettingsStorage;
   resourceStatus: KnowledgeResourceStatus;
   logs: KnowledgeOperationalLogEntry[];
+  changedKeys: string[];
 }> {
   const current = await readKnowledgeParsingSettings(input.state);
   const next: KnowledgeParsingSettings = {
@@ -375,6 +376,8 @@ export async function updateKnowledgeParsingSettings(input: {
     }
   }
 
+  const changes = collectChanges(current.settings, next);
+  const changedKeys = Object.keys(changes);
   const resourceStatus = await resolveKnowledgeResourceStatus(next, input.state);
   const errors = validateKnowledgeSettingsUpdate(next, resourceStatus);
   if (errors.length > 0) {
@@ -385,8 +388,8 @@ export async function updateKnowledgeParsingSettings(input: {
       actorUserId: input.actorUserId,
       organizationId: input.state?.organizationId ?? null,
       reasonCode: errors[0] ?? 'blocked',
-      changedKeys: Object.keys(collectChanges(current.settings, next)),
-      changes: collectChanges(current.settings, next),
+      changedKeys,
+      changes,
       resourceProfile: resourceStatus.resourceProfile,
       blockers: errors,
       message: 'Knowledge settings update blocked by policy or resource preflight.',
@@ -395,9 +398,8 @@ export async function updateKnowledgeParsingSettings(input: {
     throw new Error(`Knowledge settings update blocked: ${errors.join(', ')}`);
   }
 
-  await writeJsonAtomic(current.storage.filePath, next);
-  const changes = collectChanges(current.settings, next);
-  if (Object.keys(changes).length > 0) {
+  if (changedKeys.length > 0) {
+    await writeJsonAtomic(current.storage.filePath, next);
     await appendKnowledgeOperationalLog({
       timestamp: new Date().toISOString(),
       level: 'info',
@@ -405,7 +407,7 @@ export async function updateKnowledgeParsingSettings(input: {
       actorUserId: input.actorUserId,
       organizationId: input.state?.organizationId ?? null,
       reasonCode: resourceStatus.availability,
-      changedKeys: Object.keys(changes),
+      changedKeys,
       changes,
       resourceProfile: resourceStatus.resourceProfile,
       blockers: resourceStatus.blockers,
@@ -414,9 +416,10 @@ export async function updateKnowledgeParsingSettings(input: {
   }
 
   return {
-    settings: next,
+    settings: changedKeys.length > 0 ? next : current.settings,
     storage: current.storage,
     resourceStatus,
     logs: await readKnowledgeOperationalLogs({ organizationId: input.state?.organizationId ?? null }),
+    changedKeys,
   };
 }

--- a/app/lib/knowledge/settings-service.ts
+++ b/app/lib/knowledge/settings-service.ts
@@ -293,10 +293,15 @@ export async function readKnowledgeOperationalLogs(input?: {
   const limit = input?.limit ?? 12;
   try {
     const raw = await fs.readFile(filePath, 'utf8');
-    return raw
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as KnowledgeOperationalLogEntry)
+    const entries: KnowledgeOperationalLogEntry[] = [];
+    for (const line of raw.split('\n').filter(Boolean)) {
+      try {
+        entries.push(JSON.parse(line) as KnowledgeOperationalLogEntry);
+      } catch {
+        // Keep readable entries visible if the process dies during appendFile.
+      }
+    }
+    return entries
       .filter((entry) => input?.organizationId === undefined || entry.organizationId === input.organizationId)
       .slice(-Math.min(MAX_LOG_ENTRIES, Math.max(1, limit)))
       .reverse();

--- a/app/lib/knowledge/settings-types.ts
+++ b/app/lib/knowledge/settings-types.ts
@@ -1,5 +1,6 @@
 export type KnowledgeResourceProfile = 'disabled' | 'low' | 'standard' | 'large';
 export type KnowledgeResourceAvailability = 'available' | 'degraded' | 'disabled';
+export type KnowledgeParserAvailability = 'available' | 'disabled' | 'missing' | 'not_checked';
 
 export interface KnowledgeParsingSettings {
   knowledgeAutoIngestionEnabled: boolean;
@@ -42,8 +43,8 @@ export interface KnowledgeResourceStatus {
     activeHeavyJobs: number;
   };
   parser: {
-    docling: 'available' | 'disabled' | 'missing';
-    ocr: 'available' | 'disabled' | 'missing';
+    docling: KnowledgeParserAvailability;
+    ocr: KnowledgeParserAvailability;
     embeddings: 'available' | 'disabled' | 'requires_postgres';
     remoteParsing: 'disabled' | 'enabled';
   };

--- a/app/lib/knowledge/settings-types.ts
+++ b/app/lib/knowledge/settings-types.ts
@@ -1,0 +1,80 @@
+export type KnowledgeResourceProfile = 'disabled' | 'low' | 'standard' | 'large';
+export type KnowledgeResourceAvailability = 'available' | 'degraded' | 'disabled';
+
+export interface KnowledgeParsingSettings {
+  knowledgeAutoIngestionEnabled: boolean;
+  heavyDocumentParsingEnabled: boolean;
+  doclingEnabled: boolean;
+  ocrEnabled: boolean;
+  embeddingIndexingEnabled: boolean;
+  remoteParsingEnabled: boolean;
+  maxConcurrentHeavyJobs: number;
+  maxDocumentSizeMb: number;
+  maxPages: number;
+  maxOcrPages: number;
+  perFileTimeoutSeconds: number;
+  minimumFreeMemoryMb: number;
+  updatedAt: string | null;
+  updatedByUserId: string | null;
+}
+
+export interface KnowledgeResourceStatus {
+  availability: KnowledgeResourceAvailability;
+  resourceProfile: KnowledgeResourceProfile;
+  databaseProvider: string;
+  postgresRequired: boolean;
+  postgresReady: boolean;
+  pgvectorReady: boolean;
+  memory: {
+    totalMb: number | null;
+    freeMb: number | null;
+    thresholdMb: number;
+  };
+  cpu: {
+    count: number | null;
+  };
+  disk: {
+    freeGb: number | null;
+    thresholdGb: number;
+  };
+  queue: {
+    depth: number;
+    activeHeavyJobs: number;
+  };
+  parser: {
+    docling: 'available' | 'disabled' | 'missing';
+    ocr: 'available' | 'disabled' | 'missing';
+    embeddings: 'available' | 'disabled' | 'requires_postgres';
+    remoteParsing: 'disabled' | 'enabled';
+  };
+  canEnableKnowledge: boolean;
+  blockers: string[];
+  warnings: string[];
+  checkedAt: string;
+}
+
+export interface KnowledgeOperationalLogEntry {
+  timestamp: string;
+  level: 'info' | 'warn' | 'error';
+  action: string;
+  actorUserId: string | null;
+  organizationId: string | null;
+  reasonCode: string;
+  changedKeys: string[];
+  changes: Record<string, { from: boolean | number | string | null; to: boolean | number | string | null }>;
+  resourceProfile: KnowledgeResourceProfile;
+  blockers: string[];
+  message: string;
+}
+
+export interface KnowledgeSettingsResponse {
+  settings: KnowledgeParsingSettings;
+  resourceStatus: KnowledgeResourceStatus;
+  logs: KnowledgeOperationalLogEntry[];
+  storage: {
+    scope: 'organization' | 'system';
+  };
+  permission: {
+    canUpdate: boolean;
+  };
+}

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -689,7 +689,7 @@
     {
       "id": 37,
       "title": "Knowledge-/Parsing-Settings mit Default-off Toggles, Resource-Status und redacted Logging umsetzen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/docling-knowledge-ingestion-plan.md",
@@ -697,6 +697,22 @@
         "docs/architecture/canvas-notebook/team-workspace/12-knowledge-ingestion-retrieval-policy.md",
         "docs/architecture/canvas-notebook/team-workspace/13-resource-aware-ingestion-and-job-backpressure.md",
         "docs/architecture/canvas-notebook/team-workspace/17-database-provider-postgres-rag-collaboration-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/knowledge/settings-types.ts",
+        "app/lib/knowledge/settings-service.ts",
+        "app/api/admin/knowledge-settings/route.ts",
+        "app/components/settings/KnowledgeSettingsPanel.tsx",
+        "app/components/settings/IntegrationsSettingsClient.tsx",
+        "messages/en.json",
+        "messages/de.json",
+        "scripts/knowledge-settings-test.ts"
+      ],
+      "verification": [
+        "npm run test:knowledge:settings",
+        "npx tsc --noEmit --pretty false",
+        "npm run lint",
+        "npm run build"
       ]
     },
     {

--- a/messages/de.json
+++ b/messages/de.json
@@ -1605,6 +1605,7 @@
       "integrations": "Integrationen",
       "agentSettings": "Agent-Einstellungen",
       "workspace": "Workspace",
+      "knowledge": "Knowledge",
       "userManagement": "Benutzer",
       "channels": "Channels",
       "usage": "Nutzung",
@@ -1758,6 +1759,103 @@
         "delete": "Benutzer konnte nicht gelöscht werden.",
         "offboardingPreflight": "Offboarding-Preflight konnte nicht geladen werden.",
         "offboarding": "Benutzer konnte nicht offboarded werden."
+      }
+    },
+    "knowledge": {
+      "title": "Knowledge / Parsing / Database",
+      "description": "Steuere automatische Knowledge-Ingestion, schwere Parser, OCR, Embeddings und Resource-Gates. Schwere Verarbeitung ist standardmäßig ausgeschaltet.",
+      "loading": "Knowledge-Einstellungen werden geladen...",
+      "unknown": "Unbekannt",
+      "reload": "Neu laden",
+      "save": "Einstellungen speichern",
+      "saved": "Knowledge-Einstellungen gespeichert.",
+      "none": "Keine",
+      "preflightBlocked": "Knowledge-Aktivierung ist blockiert",
+      "preflightBlockedDescription": "Postgres, pgvector, Arbeitsspeicher und Speicherplatz müssen den Preflight bestehen, bevor automatische Knowledge-Ingestion oder Embeddings laufen dürfen.",
+      "blockers": "Blocker",
+      "warnings": "Warnungen",
+      "reasonCode": "Grund",
+      "changedKeys": "Geändert",
+      "togglesTitle": "Feature-Schalter",
+      "togglesDescription": "Diese Schalter erlauben nur den Start von Jobs. Resource-Guards bleiben auch bei aktivierten Features aktiv.",
+      "logsTitle": "Operational Log",
+      "logsDescription": "Redacted Settings- und Resource-Entscheidungen. Dokumentinhalte, Prompts, Pfade und Secrets werden hier nie gespeichert.",
+      "logsEmpty": "Noch keine Knowledge-Operational-Events aufgezeichnet.",
+      "availability": {
+        "available": "Verfügbar",
+        "degraded": "Eingeschränkt",
+        "disabled": "Deaktiviert"
+      },
+      "profiles": {
+        "disabled": "Deaktiviertes Profil",
+        "low": "Wenig Ressourcen",
+        "standard": "Standard",
+        "large": "Groß"
+      },
+      "status": {
+        "database": "Datenbank",
+        "pgvectorReady": "pgvector bereit",
+        "pgvectorMissing": "pgvector fehlt",
+        "memory": "Arbeitsspeicher",
+        "freeMemory": "{value} MB frei",
+        "cpu": "CPU",
+        "activeJobs": "{value} aktive schwere Jobs",
+        "disk": "Speicherplatz",
+        "diskThreshold": "Benötigt {value} GB frei"
+      },
+      "fields": {
+        "knowledgeAutoIngestionEnabled": {
+          "label": "Knowledge Auto-Ingestion",
+          "description": "Geeignete Workspace-Dokumente nach Policy- und Resource-Prüfung automatisch registrieren und verarbeiten."
+        },
+        "heavyDocumentParsingEnabled": {
+          "label": "Schwere Dokumentenparser",
+          "description": "Ressourcenintensive Parser-Jobs erlauben. Normale Agent-Datei-Reads sind davon getrennt."
+        },
+        "doclingEnabled": {
+          "label": "Docling Parser",
+          "description": "Docling-basiertes Parsing erlauben, wenn der Provider verfügbar ist und schwere Parser aktiviert sind."
+        },
+        "ocrEnabled": {
+          "label": "OCR",
+          "description": "OCR für Dokumente ohne extrahierbaren Text erlauben. Auf kleinen Servern standardmäßig aus."
+        },
+        "embeddingIndexingEnabled": {
+          "label": "Embedding Indexing",
+          "description": "Embeddings nur erzeugen, wenn Scan, ACL, Postgres und pgvector-Gates bestanden sind."
+        },
+        "remoteParsingEnabled": {
+          "label": "Remote Parsing",
+          "description": "Remote Parser Provider erlauben. Bleibt standardmäßig aus, weil Dokumente die VM verlassen."
+        },
+        "maxConcurrentHeavyJobs": {
+          "label": "Max. schwere Jobs",
+          "description": "Maximale Anzahl schwerer Parser-Jobs, die gleichzeitig laufen dürfen."
+        },
+        "maxDocumentSizeMb": {
+          "label": "Max. Dokumentgröße (MB)",
+          "description": "Größere Dokumente werden deferred, metadata-only oder durch Policy blockiert."
+        },
+        "maxPages": {
+          "label": "Max. Seiten",
+          "description": "Seitenlimit für vollständiges Parsing."
+        },
+        "maxOcrPages": {
+          "label": "Max. OCR-Seiten",
+          "description": "Seitenlimit für OCR-Verarbeitung."
+        },
+        "perFileTimeoutSeconds": {
+          "label": "Timeout pro Datei (Sekunden)",
+          "description": "Hartes Timeout für einen Parser-Job."
+        },
+        "minimumFreeMemoryMb": {
+          "label": "Minimal freier Speicher (MB)",
+          "description": "Jobs werden degradiert oder deferred, wenn der freie Speicher unter diesen Guard fällt."
+        }
+      },
+      "errors": {
+        "load": "Knowledge-Einstellungen konnten nicht geladen werden.",
+        "save": "Knowledge-Einstellungen konnten nicht gespeichert werden."
       }
     },
     "scopes": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1606,6 +1606,7 @@
       "integrations": "Integrations",
       "agentSettings": "Agent Settings",
       "workspace": "Workspace",
+      "knowledge": "Knowledge",
       "userManagement": "Users",
       "channels": "Channels",
       "usage": "Usage",
@@ -1759,6 +1760,103 @@
         "delete": "Could not delete user.",
         "offboardingPreflight": "Could not load offboarding preflight.",
         "offboarding": "Could not offboard user."
+      }
+    },
+    "knowledge": {
+      "title": "Knowledge / Parsing / Database",
+      "description": "Control automatic Knowledge ingestion, heavy parsing, OCR, embeddings, and resource gates. Heavy processing starts disabled by default.",
+      "loading": "Loading Knowledge settings...",
+      "unknown": "Unknown",
+      "reload": "Reload",
+      "save": "Save settings",
+      "saved": "Knowledge settings saved.",
+      "none": "None",
+      "preflightBlocked": "Knowledge activation is blocked",
+      "preflightBlockedDescription": "Postgres, pgvector, memory, and disk preflight must pass before automatic Knowledge ingestion or embeddings can run.",
+      "blockers": "Blockers",
+      "warnings": "Warnings",
+      "reasonCode": "Reason",
+      "changedKeys": "Changed",
+      "togglesTitle": "Feature toggles",
+      "togglesDescription": "These controls only allow jobs to start. Resource guards remain active even when a feature is enabled.",
+      "logsTitle": "Operational log",
+      "logsDescription": "Redacted settings and resource decisions. Document contents, prompts, paths, and secrets are never written here.",
+      "logsEmpty": "No Knowledge operational events recorded yet.",
+      "availability": {
+        "available": "Available",
+        "degraded": "Degraded",
+        "disabled": "Disabled"
+      },
+      "profiles": {
+        "disabled": "Disabled profile",
+        "low": "Low resources",
+        "standard": "Standard",
+        "large": "Large"
+      },
+      "status": {
+        "database": "Database",
+        "pgvectorReady": "pgvector ready",
+        "pgvectorMissing": "pgvector missing",
+        "memory": "Memory",
+        "freeMemory": "{value} MB free",
+        "cpu": "CPU",
+        "activeJobs": "{value} active heavy jobs",
+        "disk": "Disk",
+        "diskThreshold": "Requires {value} GB free"
+      },
+      "fields": {
+        "knowledgeAutoIngestionEnabled": {
+          "label": "Knowledge auto-ingestion",
+          "description": "Automatically register and process eligible workspace documents after policy and resource checks."
+        },
+        "heavyDocumentParsingEnabled": {
+          "label": "Heavy document parsing",
+          "description": "Allow resource-intensive parsing jobs. Normal agent file reads are separate from this setting."
+        },
+        "doclingEnabled": {
+          "label": "Docling parser",
+          "description": "Allow Docling-based parsing when the provider is available and heavy parsing is enabled."
+        },
+        "ocrEnabled": {
+          "label": "OCR",
+          "description": "Allow OCR for documents without extractable text. Disabled by default on small servers."
+        },
+        "embeddingIndexingEnabled": {
+          "label": "Embedding indexing",
+          "description": "Generate embeddings only after scan, ACL, Postgres, and pgvector gates pass."
+        },
+        "remoteParsingEnabled": {
+          "label": "Remote parsing",
+          "description": "Allow remote parser providers. This stays off by default because documents leave the VM."
+        },
+        "maxConcurrentHeavyJobs": {
+          "label": "Max heavy jobs",
+          "description": "Maximum number of heavy parser jobs that may run at the same time."
+        },
+        "maxDocumentSizeMb": {
+          "label": "Max document size (MB)",
+          "description": "Documents above this size are deferred, metadata-only, or blocked by policy."
+        },
+        "maxPages": {
+          "label": "Max pages",
+          "description": "Page limit for full parsing."
+        },
+        "maxOcrPages": {
+          "label": "Max OCR pages",
+          "description": "Page limit for OCR processing."
+        },
+        "perFileTimeoutSeconds": {
+          "label": "Timeout per file (seconds)",
+          "description": "Hard timeout for one parser job."
+        },
+        "minimumFreeMemoryMb": {
+          "label": "Minimum free memory (MB)",
+          "description": "Jobs are degraded or deferred when free memory falls below this guard."
+        }
+      },
+      "errors": {
+        "load": "Could not load Knowledge settings.",
+        "save": "Could not save Knowledge settings."
       }
     },
     "scopes": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:studio:veo": "tsx scripts/veo-generation-test.ts",
     "test:studio:organization-scope": "tsx --conditions react-server scripts/studio-organization-scope-test.ts",
     "test:knowledge:retrieval-scope": "tsx --conditions react-server scripts/knowledge-retrieval-scope-test.ts",
+    "test:knowledge:settings": "tsx --conditions react-server scripts/knowledge-settings-test.ts",
     "test:skills:runtime": "tsx scripts/skills-runtime-test.ts",
     "test:skills:seed-bootstrap": "tsx scripts/default-seed-skills-test.ts",
     "test:plugins:seed-bootstrap": "tsx scripts/default-seed-plugins-test.ts",

--- a/scripts/knowledge-settings-test.ts
+++ b/scripts/knowledge-settings-test.ts
@@ -98,6 +98,10 @@ async function main() {
     assert.equal(safeUpdate.settings.minimumFreeMemoryMb, 768);
     assert.equal(safeUpdate.settings.remoteParsingEnabled, true);
     assert.equal(safeUpdate.settings.knowledgeAutoIngestionEnabled, false);
+    assert.deepEqual(
+      new Set(safeUpdate.changedKeys),
+      new Set(['remoteParsingEnabled', 'maxDocumentSizeMb', 'minimumFreeMemoryMb']),
+    );
 
     const logFile = path.join(dataRoot, 'system', 'logs', 'knowledge-operational.jsonl');
     const rawLogs = await readFile(logFile, 'utf8');

--- a/scripts/knowledge-settings-test.ts
+++ b/scripts/knowledge-settings-test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { appendFile, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -108,6 +108,10 @@ async function main() {
     const logs = await readKnowledgeOperationalLogs();
     assert.ok(logs.length >= 2);
     assert.ok(logs.every((entry) => Array.isArray(entry.changedKeys)));
+
+    await appendFile(logFile, '{broken-json\n');
+    const logsWithMalformedLine = await readKnowledgeOperationalLogs();
+    assert.ok(logsWithMalformedLine.length >= 2);
 
     for (let index = 0; index < 505; index += 1) {
       await assert.rejects(

--- a/scripts/knowledge-settings-test.ts
+++ b/scripts/knowledge-settings-test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import type { OrganizationPermissionState } from '@/app/lib/organization/bootstrap';
+
+function testState(databaseProvider: string): OrganizationPermissionState {
+  return {
+    configured: true,
+    organizationId: 'org-knowledge-test',
+    ownerUserId: 'owner-user',
+    teamFeaturesEnabled: true,
+    databaseProvider,
+    permission: {
+      role: 'owner',
+      status: 'active',
+      canWriteTeamWorkspace: true,
+      canCreatePublicLinks: true,
+      canCreateTeamAutomations: true,
+      canSharePluginsAndSkills: true,
+      canExport: true,
+      canDeleteTeamFiles: true,
+      canDeleteStudioAssets: true,
+      canManageBackups: true,
+      canMigrateDatabase: true,
+      canEnableKnowledge: true,
+      canRecoverWorkspaces: true,
+    },
+  };
+}
+
+async function main() {
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'canvas-knowledge-settings-'));
+  const previousData = process.env.DATA;
+  const previousCanvasDataRoot = process.env.CANVAS_DATA_ROOT;
+  const previousDatabaseProvider = process.env.CANVAS_DATABASE_PROVIDER;
+  const previousVectorEnabled = process.env.CANVAS_POSTGRES_VECTOR_ENABLED;
+
+  process.env.DATA = dataRoot;
+  process.env.CANVAS_DATA_ROOT = dataRoot;
+  process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
+  process.env.CANVAS_POSTGRES_VECTOR_ENABLED = 'false';
+
+  try {
+    const {
+      readKnowledgeOperationalLogs,
+      readKnowledgeParsingSettings,
+      resolveKnowledgeResourceStatus,
+      updateKnowledgeParsingSettings,
+    } = await import('../app/lib/knowledge/settings-service');
+
+    const sqliteState = testState('sqlite');
+    const { settings: defaults, storage } = await readKnowledgeParsingSettings(sqliteState);
+    assert.equal(storage.scope, 'organization');
+    assert.equal(defaults.knowledgeAutoIngestionEnabled, false);
+    assert.equal(defaults.heavyDocumentParsingEnabled, false);
+    assert.equal(defaults.doclingEnabled, false);
+    assert.equal(defaults.ocrEnabled, false);
+    assert.equal(defaults.embeddingIndexingEnabled, false);
+    assert.equal(defaults.remoteParsingEnabled, false);
+
+    const sqliteStatus = await resolveKnowledgeResourceStatus(defaults, sqliteState);
+    assert.equal(sqliteStatus.postgresReady, false);
+    assert.equal(sqliteStatus.canEnableKnowledge, false);
+    assert.ok(sqliteStatus.blockers.includes('requires_postgres'));
+
+    await assert.rejects(
+      () => updateKnowledgeParsingSettings({
+        state: sqliteState,
+        actorUserId: 'owner-user',
+        updates: {
+          knowledgeAutoIngestionEnabled: true,
+          embeddingIndexingEnabled: true,
+        },
+      }),
+      /requires_postgres/u,
+    );
+
+    const afterBlocked = await readKnowledgeParsingSettings(sqliteState);
+    assert.equal(afterBlocked.settings.knowledgeAutoIngestionEnabled, false);
+
+    const safeUpdate = await updateKnowledgeParsingSettings({
+      state: sqliteState,
+      actorUserId: 'owner-user',
+      updates: {
+        maxDocumentSizeMb: 64,
+        minimumFreeMemoryMb: 768,
+        remoteParsingEnabled: true,
+        secretToken: 'should-not-be-logged',
+      } as never,
+    });
+    assert.equal(safeUpdate.settings.maxDocumentSizeMb, 64);
+    assert.equal(safeUpdate.settings.minimumFreeMemoryMb, 768);
+    assert.equal(safeUpdate.settings.remoteParsingEnabled, true);
+    assert.equal(safeUpdate.settings.knowledgeAutoIngestionEnabled, false);
+
+    const logFile = path.join(dataRoot, 'system', 'logs', 'knowledge-operational.jsonl');
+    const rawLogs = await readFile(logFile, 'utf8');
+    assert.equal(rawLogs.includes('should-not-be-logged'), false);
+    assert.equal(rawLogs.includes('secretToken'), false);
+    assert.ok(rawLogs.includes('knowledge_settings.update_blocked'));
+    assert.ok(rawLogs.includes('knowledge_settings.updated'));
+    const logs = await readKnowledgeOperationalLogs();
+    assert.ok(logs.length >= 2);
+    assert.ok(logs.every((entry) => Array.isArray(entry.changedKeys)));
+
+    console.log('knowledge-settings-test: ok');
+  } finally {
+    if (previousData === undefined) delete process.env.DATA;
+    else process.env.DATA = previousData;
+    if (previousCanvasDataRoot === undefined) delete process.env.CANVAS_DATA_ROOT;
+    else process.env.CANVAS_DATA_ROOT = previousCanvasDataRoot;
+    if (previousDatabaseProvider === undefined) delete process.env.CANVAS_DATABASE_PROVIDER;
+    else process.env.CANVAS_DATABASE_PROVIDER = previousDatabaseProvider;
+    if (previousVectorEnabled === undefined) delete process.env.CANVAS_POSTGRES_VECTOR_ENABLED;
+    else process.env.CANVAS_POSTGRES_VECTOR_ENABLED = previousVectorEnabled;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/knowledge-settings-test.ts
+++ b/scripts/knowledge-settings-test.ts
@@ -65,6 +65,9 @@ async function main() {
     assert.equal(sqliteStatus.canEnableKnowledge, false);
     assert.ok(sqliteStatus.blockers.includes('requires_postgres'));
 
+    const doclingStatus = await resolveKnowledgeResourceStatus({ ...defaults, doclingEnabled: true }, sqliteState);
+    assert.equal(doclingStatus.parser.docling, 'not_checked');
+
     await assert.rejects(
       () => updateKnowledgeParsingSettings({
         state: sqliteState,
@@ -104,6 +107,21 @@ async function main() {
     const logs = await readKnowledgeOperationalLogs();
     assert.ok(logs.length >= 2);
     assert.ok(logs.every((entry) => Array.isArray(entry.changedKeys)));
+
+    for (let index = 0; index < 505; index += 1) {
+      await assert.rejects(
+        () => updateKnowledgeParsingSettings({
+          state: sqliteState,
+          actorUserId: 'owner-user',
+          updates: {
+            knowledgeAutoIngestionEnabled: true,
+          },
+        }),
+        /requires_postgres/u,
+      );
+    }
+    const cappedRawLogs = await readFile(logFile, 'utf8');
+    assert.ok(cappedRawLogs.split('\n').filter(Boolean).length <= 500);
 
     console.log('knowledge-settings-test: ok');
   } finally {

--- a/scripts/knowledge-settings-test.ts
+++ b/scripts/knowledge-settings-test.ts
@@ -65,8 +65,9 @@ async function main() {
     assert.equal(sqliteStatus.canEnableKnowledge, false);
     assert.ok(sqliteStatus.blockers.includes('requires_postgres'));
 
-    const doclingStatus = await resolveKnowledgeResourceStatus({ ...defaults, doclingEnabled: true }, sqliteState);
+    const doclingStatus = await resolveKnowledgeResourceStatus({ ...defaults, doclingEnabled: true, ocrEnabled: true }, sqliteState);
     assert.equal(doclingStatus.parser.docling, 'not_checked');
+    assert.equal(doclingStatus.parser.ocr, 'not_checked');
 
     await assert.rejects(
       () => updateKnowledgeParsingSettings({


### PR DESCRIPTION
## Summary
- add admin Knowledge/Parsing settings API with default-off toggles, resource preflight status, scope-limited redacted operational logs, and audit events
- add Settings UI tab for Knowledge controls, resource blockers/warnings, parser limits, and recent logs
- add focused settings regression test and mark task 37 complete in the architecture todo list

## Verification
- npm run test:knowledge:settings
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build

Greptile: 4/5 after 5 Greptile review cycles; zero unresolved actionable review threads.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a Knowledge/Parsing settings subsystem: a server-side service (`settings-service.ts`) with atomic writes, per-line JSONL operational logs and trimming, and resource preflight checks; a new `/api/admin/knowledge-settings` route guarded by `canEnableKnowledge`; and a `KnowledgeSettingsPanel` UI tab with feature toggles, resource-status tiles, and a log viewer.

- **Service layer** (`settings-service.ts`): all toggles default-off, settings are written atomically with mode `0o600`, log entries are parsed per-line (malformed lines are skipped), and log files are trimmed to 500 lines after each append.
- **API route** (`route.ts`): empty/unrecognized patches return 400 early; policy blocks and server errors are correctly distinguished in both the HTTP status and the audit record.
- **UI** (`KnowledgeSettingsPanel.tsx`): dirty-state detection, resource-profile badges, blocker/warning lists, and a read-only operational log viewer; the Knowledge tab is only shown to admins or users with `canEnableKnowledge`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: a no-op PATCH emits a false 'settings updated' audit record that should be resolved before this lands in production audit trails.

The route emits a success audit event with summary 'Knowledge and parsing settings updated.' even when updateKnowledgeParsingSettings returns an empty changedKeys array (all submitted values matched current settings). The operational log and settings file are correctly skipped, but the audit record falsely claims a successful update occurred. Since audit integrity is an explicit goal of this PR, a false-positive audit event on the no-op path is a real defect that should be addressed.

app/api/admin/knowledge-settings/route.ts — the audit event at lines 113-129 should be gated on result.changedKeys.length > 0

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/api/admin/knowledge-settings/route.ts | New admin PATCH/GET route; policy-block vs server-error distinction and empty-patch guard are correctly handled, but a no-op PATCH still emits a misleading 'success' audit event when all submitted values match current settings. |
| app/lib/knowledge/settings-service.ts | New service with atomic writes, per-line JSONL parsing, log trimming, and resource-status resolution; docling/ocr parser status correctly uses 'not_checked' sentinel; unbounded-growth and malformed-line issues from prior review are addressed. |
| app/components/settings/KnowledgeSettingsPanel.tsx | New settings panel with toggle/numeric inputs, resource-status tiles, and log viewer; React key now includes index preventing collision; draft cloning, dirty detection, and error states look correct. |
| app/lib/knowledge/settings-types.ts | New type definitions for settings, resource status, operational log entries, and the API response shape; types are well-structured with appropriate unions. |
| app/lib/audit/audit-service.ts | Adds 'error' to AuditStatus union to distinguish server faults from policy blocks; minimal, targeted change. |
| app/components/settings/IntegrationsSettingsClient.tsx | Adds Knowledge tab with correct visibility guard (isAdmin || canEnableKnowledge) and lazy-loads the new panel; no regressions to existing tabs. |
| scripts/knowledge-settings-test.ts | Regression test covers defaults, blocked updates, safe numeric updates, secret-key exclusion, malformed JSONL resilience, and log-file trimming at the 500-line cap. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `app/lib/knowledge/settings-service.ts`, line 848-875 ([link](https://github.com/canvascoding/canvas-notebook/blob/7b04846236dcd3994f500ab31e4d2cfccaabd9ad/app/lib/knowledge/settings-service.ts#L848-L875)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unbounded log file growth with full-file read on every request**

   `appendKnowledgeOperationalLog` unconditionally appends to the JSONL file with no rotation or truncation. `readKnowledgeOperationalLogs` then reads the _entire_ file into memory, parses every line, filters by org ID, and only _then_ slices to `MAX_LOG_ENTRIES`. In a multi-tenant deployment where admins save settings frequently, this file grows indefinitely — and every subsequent `GET` or `PATCH` response incurs a full read of an ever-larger file. The 50-entry cap is applied after the read, not at write time, so it provides no protection against file growth. A write-time trim (keep last N lines) or a simple line count check before appending would bound both file size and read cost.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fknowledge-parsing-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fknowledge-parsing-settings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Fknowledge%2Fsettings-service.ts%0ALine%3A%20848-875%0A%0AComment%3A%0A**Unbounded%20log%20file%20growth%20with%20full-file%20read%20on%20every%20request**%0A%0A%60appendKnowledgeOperationalLog%60%20unconditionally%20appends%20to%20the%20JSONL%20file%20with%20no%20rotation%20or%20truncation.%20%60readKnowledgeOperationalLogs%60%20then%20reads%20the%20_entire_%20file%20into%20memory%2C%20parses%20every%20line%2C%20filters%20by%20org%20ID%2C%20and%20only%20_then_%20slices%20to%20%60MAX_LOG_ENTRIES%60.%20In%20a%20multi-tenant%20deployment%20where%20admins%20save%20settings%20frequently%2C%20this%20file%20grows%20indefinitely%20%E2%80%94%20and%20every%20subsequent%20%60GET%60%20or%20%60PATCH%60%20response%20incurs%20a%20full%20read%20of%20an%20ever-larger%20file.%20The%2050-entry%20cap%20is%20applied%20after%20the%20read%2C%20not%20at%20write%20time%2C%20so%20it%20provides%20no%20protection%20against%20file%20growth.%20A%20write-time%20trim%20%28keep%20last%20N%20lines%29%20or%20a%20simple%20line%20count%20check%20before%20appending%20would%20bound%20both%20file%20size%20and%20read%20cost.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `app/lib/knowledge/settings-service.ts`, line 821-830 ([link](https://github.com/canvascoding/canvas-notebook/blob/7b04846236dcd3994f500ab31e4d2cfccaabd9ad/app/lib/knowledge/settings-service.ts#L821-L830)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Docling parser status is always `'missing'` when enabled**

   `docling: settings.doclingEnabled ? 'missing' : 'disabled'` hardcodes `'missing'` regardless of whether the Docling binary/provider is actually present. This means the resource status panel in the UI will always show "missing" for Docling when it's toggled on, even on systems where Docling is correctly installed. If availability detection is not yet implemented, the field should default to `'disabled'` or an explicit sentinel like `'not_checked'` rather than signalling a missing dependency that isn't actually checked.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fknowledge-parsing-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fknowledge-parsing-settings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Flib%2Fknowledge%2Fsettings-service.ts%0ALine%3A%20821-830%0A%0AComment%3A%0A**Docling%20parser%20status%20is%20always%20%60'missing'%60%20when%20enabled**%0A%0A%60docling%3A%20settings.doclingEnabled%20%3F%20'missing'%20%3A%20'disabled'%60%20hardcodes%20%60'missing'%60%20regardless%20of%20whether%20the%20Docling%20binary%2Fprovider%20is%20actually%20present.%20This%20means%20the%20resource%20status%20panel%20in%20the%20UI%20will%20always%20show%20%22missing%22%20for%20Docling%20when%20it's%20toggled%20on%2C%20even%20on%20systems%20where%20Docling%20is%20correctly%20installed.%20If%20availability%20detection%20is%20not%20yet%20implemented%2C%20the%20field%20should%20default%20to%20%60'disabled'%60%20or%20an%20explicit%20sentinel%20like%20%60'not_checked'%60%20rather%20than%20signalling%20a%20missing%20dependency%20that%20isn't%20actually%20checked.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fknowledge-parsing-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fknowledge-parsing-settings%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fapi%2Fadmin%2Fknowledge-settings%2Froute.ts%3A113-129%0A**Audit%20event%20emitted%20for%20no-op%20PATCH**%0A%0AWhen%20a%20PATCH%20body%20contains%20recognized%20keys%20but%20all%20values%20are%20identical%20to%20the%20current%20settings%2C%20%60updateKnowledgeParsingSettings%60%20skips%20the%20write%20and%20returns%20%60changedKeys%3A%20%5B%5D%60.%20The%20route%20unconditionally%20calls%20%60recordAuditEvent%60%20with%20%60status%3A%20'success'%60%20and%20%60summary%3A%20'Knowledge%20and%20parsing%20settings%20updated.'%60%20%E2%80%94%20creating%20an%20audit%20record%20that%20claims%20settings%20were%20changed%20when%20they%20weren't.%0A%0AAn%20admin%20reviewing%20the%20audit%20log%20will%20see%20spurious%20%22knowledge_settings.update%20%2F%20success%22%20events%20with%20%60changedKeys%3A%20%5B%5D%60%2C%20undermining%20the%20audit%20trail's%20reliability.%20Adding%20an%20early%20return%20%28or%20a%20no-op%20response%29%20when%20%60result.changedKeys.length%20%3D%3D%3D%200%60%20prevents%20the%20false%20record%20and%20avoids%20the%20redundant%20%60resolveKnowledgeResourceStatus%60%20%2F%20%60readKnowledgeOperationalLogs%60%20I%2FO%20that%20still%20runs%20inside%20%60updateKnowledgeParsingSettings%60%20for%20the%20no-op%20path.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["Report actual knowledge settings changes"](https://github.com/canvascoding/canvas-notebook/commit/a78337b70efaa61835e0903c2819acc6475eec8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38998427)</sub>

<!-- /greptile_comment -->