### PR TITLE
Add database provider abstraction

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,13 +1,30 @@
 import { NextResponse } from 'next/server';
 import { openDb } from '@/app/lib/db';
+import {
+  resolveDatabaseProviderGate,
+  toPublicDatabaseProviderStatus,
+} from '@/app/lib/db/provider';
+import {
+  areTeamFeaturesEnabled,
+  getDeploymentMode,
+} from '@/app/lib/organization/bootstrap';
 
 export async function GET() {
   const checks: Record<string, 'ok' | 'error'> = {
     app: 'ok',
+    databaseProvider: 'ok',
   };
 
   let status = 200;
   let connection: Awaited<ReturnType<typeof openDb>> | null = null;
+  const deploymentMode = getDeploymentMode();
+  const teamFeaturesEnabled = areTeamFeaturesEnabled(deploymentMode);
+  const providerGate = resolveDatabaseProviderGate({ teamFeaturesEnabled });
+
+  if (!providerGate.ok) {
+    checks.databaseProvider = 'error';
+    status = 503;
+  }
 
   try {
     connection = await openDb();
@@ -24,6 +41,11 @@ export async function GET() {
     {
       status: status === 200 ? 'healthy' : 'unhealthy',
       checks,
+      database: toPublicDatabaseProviderStatus(providerGate),
+      deployment: {
+        mode: deploymentMode,
+        teamFeaturesEnabled,
+      },
       timestamp: new Date().toISOString(),
     },
     { status }

--- a/app/api/setup/owner/route.ts
+++ b/app/api/setup/owner/route.ts
@@ -39,6 +39,8 @@ export async function POST(request: NextRequest) {
         ? 409
         : error.code === 'INVALID_INPUT'
           ? 400
+          : error.code === 'DATABASE_PROVIDER_BLOCKED'
+            ? 503
           : 500;
 
       return NextResponse.json(

--- a/app/lib/auth-setup.ts
+++ b/app/lib/auth-setup.ts
@@ -7,7 +7,17 @@ import { randomUUID } from 'node:crypto';
 import { hashPassword } from 'better-auth/crypto';
 
 import { runMigrations } from '@/app/lib/db/migrate';
-import { ensureOrganizationBootstrapForUser } from '@/app/lib/organization/bootstrap';
+import {
+  assertRuntimeDatabaseProviderSupported,
+  getDatabaseProviderProblemMessages,
+  resolveDatabaseProviderGate,
+  resolveSqlitePath,
+} from '@/app/lib/db/provider';
+import {
+  areTeamFeaturesEnabled,
+  ensureOrganizationBootstrapForUser,
+  getDeploymentMode,
+} from '@/app/lib/organization/bootstrap';
 
 export const SETUP_PASSWORD_MIN_LENGTH = 8;
 export const SETUP_PASSWORD_MAX_LENGTH = 128;
@@ -33,6 +43,7 @@ export class InitialOwnerSetupError extends Error {
     public readonly code:
       | 'INVALID_INPUT'
       | 'ALREADY_CONFIGURED'
+      | 'DATABASE_PROVIDER_BLOCKED'
       | 'DATABASE_ERROR',
     message: string,
     public readonly field?: keyof InitialOwnerInput,
@@ -42,12 +53,8 @@ export class InitialOwnerSetupError extends Error {
   }
 }
 
-function getDataDir(): string {
-  return process.env.DATA || path.resolve(process.cwd(), 'data');
-}
-
 function getSqlitePath(): string {
-  return path.join(getDataDir(), 'sqlite.db');
+  return resolveSqlitePath();
 }
 
 function normalizeEmail(email: unknown): string {
@@ -102,6 +109,22 @@ function openSetupDatabase() {
   return sqlite;
 }
 
+function assertSetupDatabaseProviderAllowed(): void {
+  const deploymentMode = getDeploymentMode();
+  const gate = resolveDatabaseProviderGate({
+    teamFeaturesEnabled: areTeamFeaturesEnabled(deploymentMode),
+  });
+
+  if (!gate.ok) {
+    throw new InitialOwnerSetupError(
+      'DATABASE_PROVIDER_BLOCKED',
+      getDatabaseProviderProblemMessages(gate.blockers).join(' '),
+    );
+  }
+
+  assertRuntimeDatabaseProviderSupported();
+}
+
 function countUsers(sqlite: Database.Database): number {
   const row = sqlite.prepare('SELECT COUNT(*) AS count FROM user').get() as { count?: number } | undefined;
   return Number(row?.count || 0);
@@ -127,6 +150,7 @@ export async function createInitialOwner(input: unknown): Promise<InitialOwner> 
   }
 
   const { name, email, password } = validation.value;
+  assertSetupDatabaseProviderAllowed();
   const passwordHash = await hashPassword(password);
   const userId = randomUUID();
   const accountId = randomUUID();

--- a/app/lib/auth-setup.ts
+++ b/app/lib/auth-setup.ts
@@ -8,7 +8,6 @@ import { hashPassword } from 'better-auth/crypto';
 
 import { runMigrations } from '@/app/lib/db/migrate';
 import {
-  assertRuntimeDatabaseProviderSupported,
   getDatabaseProviderProblemMessages,
   resolveDatabaseProviderGate,
   resolveSqlitePath,
@@ -121,8 +120,6 @@ function assertSetupDatabaseProviderAllowed(): void {
       getDatabaseProviderProblemMessages(gate.blockers).join(' '),
     );
   }
-
-  assertRuntimeDatabaseProviderSupported();
 }
 
 function countUsers(sqlite: Database.Database): number {

--- a/app/lib/db/index.ts
+++ b/app/lib/db/index.ts
@@ -4,13 +4,14 @@ import {mkdirSync} from 'fs';
 import path from 'path';
 import * as schema from './schema';
 import { runMigrations } from './migrate';
-
-function getDataDir(): string {
-  return process.env.DATA || path.resolve(/*turbopackIgnore: true*/ process.cwd(), 'data');
-}
+import {
+  assertRuntimeDatabaseProviderSupported,
+  getDatabaseProvider,
+  resolveSqlitePath,
+} from './provider';
 
 function getSqlitePath(): string {
-  return path.join(getDataDir(), 'sqlite.db');
+  return resolveSqlitePath();
 }
 
 const sqlitePath = getSqlitePath();
@@ -25,8 +26,10 @@ if (process.env.NEXT_PHASE !== 'phase-production-build') {
 }
 
 export const db = drizzle(sqlite, {schema});
+export { getDatabaseProvider, resolveSqlitePath };
 
 export async function openDb() {
+  assertRuntimeDatabaseProviderSupported();
   const freshSqlite = new Database(getSqlitePath());
   const bind = (statement: Database.Statement, params?: unknown[]) => (
     params === undefined ? statement : statement.bind(...params)

--- a/app/lib/db/provider.ts
+++ b/app/lib/db/provider.ts
@@ -48,9 +48,6 @@ export type PublicDatabaseProviderStatus = {
   provider: DatabaseProvider;
   requestedProvider: string | null;
   runtimeAdapter: DatabaseProviderConfig['runtimeAdapter'];
-  sqlite: {
-    pathConfigured: boolean;
-  };
   postgres: DatabaseProviderConfig['postgres'];
   blockers: DatabaseProviderProblemCode[];
   warnings: DatabaseProviderProblemCode[];
@@ -203,9 +200,6 @@ export function toPublicDatabaseProviderStatus(gate: DatabaseProviderGate): Publ
     provider: gate.provider,
     requestedProvider: gate.config.requestedProvider,
     runtimeAdapter: gate.runtimeAdapter,
-    sqlite: {
-      pathConfigured: Boolean(gate.config.sqlite.path),
-    },
     postgres: gate.config.postgres,
     blockers: gate.blockers.map((problem) => problem.code),
     warnings: gate.warnings.map((problem) => problem.code),

--- a/app/lib/db/provider.ts
+++ b/app/lib/db/provider.ts
@@ -1,0 +1,232 @@
+import path from 'node:path';
+
+export type DatabaseProvider = 'sqlite' | 'postgres';
+
+export type DatabaseProviderProblemCode =
+  | 'invalid_provider'
+  | 'team_requires_postgres'
+  | 'postgres_missing_database_url'
+  | 'postgres_invalid_database_url'
+  | 'postgres_runtime_adapter_unavailable'
+  | 'pgvector_required';
+
+export type DatabaseProviderProblem = {
+  code: DatabaseProviderProblemCode;
+  message: string;
+};
+
+export type DatabaseRuntimeAdapter = 'sqlite' | 'postgres' | 'postgres-unavailable';
+
+export type DatabaseProviderConfig = {
+  provider: DatabaseProvider;
+  requestedProvider: string | null;
+  runtimeAdapter: DatabaseRuntimeAdapter;
+  sqlite: {
+    dataDir: string;
+    path: string;
+  };
+  postgres: {
+    databaseUrlConfigured: boolean;
+    databaseUrlProtocol: string | null;
+    pgvectorEnabled: boolean;
+    imageConfigured: boolean;
+    dataVolumeConfigured: boolean;
+  };
+  problems: DatabaseProviderProblem[];
+};
+
+export type DatabaseProviderGate = {
+  ok: boolean;
+  provider: DatabaseProvider;
+  runtimeAdapter: DatabaseProviderConfig['runtimeAdapter'];
+  blockers: DatabaseProviderProblem[];
+  warnings: DatabaseProviderProblem[];
+  config: DatabaseProviderConfig;
+};
+
+export type PublicDatabaseProviderStatus = {
+  provider: DatabaseProvider;
+  requestedProvider: string | null;
+  runtimeAdapter: DatabaseProviderConfig['runtimeAdapter'];
+  sqlite: {
+    pathConfigured: boolean;
+  };
+  postgres: DatabaseProviderConfig['postgres'];
+  blockers: DatabaseProviderProblemCode[];
+  warnings: DatabaseProviderProblemCode[];
+};
+
+const VALID_PROVIDERS = new Set<DatabaseProvider>(['sqlite', 'postgres']);
+
+function normalizeEnvValue(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+function isTruthyEnv(value: string | null | undefined): boolean {
+  const normalized = normalizeEnvValue(value);
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
+}
+
+function createProblem(code: DatabaseProviderProblemCode, message: string): DatabaseProviderProblem {
+  return { code, message };
+}
+
+function getDatabaseUrlProtocol(databaseUrl: string | null | undefined): string | null {
+  const trimmed = databaseUrl?.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol.replace(/:$/u, '').toLowerCase() || null;
+  } catch {
+    return 'invalid';
+  }
+}
+
+export function resolveDataDir(): string {
+  return process.env.DATA || path.resolve(/*turbopackIgnore: true*/ process.cwd(), 'data');
+}
+
+export function resolveSqlitePath(): string {
+  return path.join(resolveDataDir(), 'sqlite.db');
+}
+
+export function normalizeDatabaseProvider(value?: string | null): DatabaseProvider {
+  const normalized = normalizeEnvValue(value);
+  if (!normalized) return 'sqlite';
+  return VALID_PROVIDERS.has(normalized as DatabaseProvider)
+    ? normalized as DatabaseProvider
+    : 'sqlite';
+}
+
+export function getDatabaseProvider(): DatabaseProvider {
+  return normalizeDatabaseProvider(process.env.CANVAS_DATABASE_PROVIDER);
+}
+
+export function resolveDatabaseProviderConfig(): DatabaseProviderConfig {
+  const requestedProvider = normalizeEnvValue(process.env.CANVAS_DATABASE_PROVIDER);
+  const provider = normalizeDatabaseProvider(requestedProvider);
+  const problems: DatabaseProviderProblem[] = [];
+  const sqlitePath = resolveSqlitePath();
+  const databaseUrlProtocol = getDatabaseUrlProtocol(process.env.DATABASE_URL);
+
+  if (requestedProvider && !VALID_PROVIDERS.has(requestedProvider as DatabaseProvider)) {
+    problems.push(createProblem(
+      'invalid_provider',
+      `Unsupported CANVAS_DATABASE_PROVIDER "${requestedProvider}". Use "sqlite" or "postgres".`,
+    ));
+  }
+
+  if (provider === 'postgres') {
+    if (!process.env.DATABASE_URL?.trim()) {
+      problems.push(createProblem(
+        'postgres_missing_database_url',
+        'Postgres mode requires DATABASE_URL.',
+      ));
+    } else if (databaseUrlProtocol !== 'postgres' && databaseUrlProtocol !== 'postgresql') {
+      problems.push(createProblem(
+        'postgres_invalid_database_url',
+        'DATABASE_URL must use postgres:// or postgresql:// in Postgres mode.',
+      ));
+    }
+  }
+
+  return {
+    provider,
+    requestedProvider,
+    runtimeAdapter: provider === 'postgres' ? 'postgres-unavailable' : 'sqlite',
+    sqlite: {
+      dataDir: resolveDataDir(),
+      path: sqlitePath,
+    },
+    postgres: {
+      databaseUrlConfigured: Boolean(process.env.DATABASE_URL?.trim()),
+      databaseUrlProtocol,
+      pgvectorEnabled: isTruthyEnv(process.env.CANVAS_POSTGRES_VECTOR_ENABLED),
+      imageConfigured: Boolean(process.env.CANVAS_POSTGRES_IMAGE?.trim()),
+      dataVolumeConfigured: Boolean(process.env.CANVAS_POSTGRES_DATA_VOLUME?.trim()),
+    },
+    problems,
+  };
+}
+
+export function resolveDatabaseProviderGate(options: {
+  teamFeaturesEnabled?: boolean;
+  requirePgvector?: boolean;
+  postgresRuntimeAdapterAvailable?: boolean;
+} = {}): DatabaseProviderGate {
+  const config = resolveDatabaseProviderConfig();
+  const blockers = [...config.problems];
+  const warnings: DatabaseProviderProblem[] = [];
+  const postgresRuntimeAdapterAvailable = options.postgresRuntimeAdapterAvailable === true;
+  const runtimeAdapter: DatabaseRuntimeAdapter = config.provider === 'postgres' && postgresRuntimeAdapterAvailable
+    ? 'postgres'
+    : config.runtimeAdapter;
+
+  if (options.teamFeaturesEnabled === true && config.provider !== 'postgres') {
+    blockers.push(createProblem(
+      'team_requires_postgres',
+      'Team features require CANVAS_DATABASE_PROVIDER=postgres.',
+    ));
+  }
+
+  if (config.provider === 'postgres' && !postgresRuntimeAdapterAvailable) {
+    blockers.push(createProblem(
+      'postgres_runtime_adapter_unavailable',
+      'Postgres provider is configured, but this build still uses the SQLite runtime adapter.',
+    ));
+  }
+
+  if (options.requirePgvector === true && config.provider === 'postgres' && !config.postgres.pgvectorEnabled) {
+    blockers.push(createProblem(
+      'pgvector_required',
+      'This feature requires CANVAS_POSTGRES_VECTOR_ENABLED=true.',
+    ));
+  }
+
+  return {
+    ok: blockers.length === 0,
+    provider: config.provider,
+    runtimeAdapter,
+    blockers,
+    warnings,
+    config,
+  };
+}
+
+export function getDatabaseProviderProblemMessages(problems: DatabaseProviderProblem[]): string[] {
+  return problems.map((problem) => problem.message);
+}
+
+export function toPublicDatabaseProviderStatus(gate: DatabaseProviderGate): PublicDatabaseProviderStatus {
+  return {
+    provider: gate.provider,
+    requestedProvider: gate.config.requestedProvider,
+    runtimeAdapter: gate.runtimeAdapter,
+    sqlite: {
+      pathConfigured: Boolean(gate.config.sqlite.path),
+    },
+    postgres: gate.config.postgres,
+    blockers: gate.blockers.map((problem) => problem.code),
+    warnings: gate.warnings.map((problem) => problem.code),
+  };
+}
+
+export class DatabaseProviderRuntimeError extends Error {
+  constructor(
+    public readonly code: DatabaseProviderProblemCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'DatabaseProviderRuntimeError';
+  }
+}
+
+export function assertRuntimeDatabaseProviderSupported(provider = getDatabaseProvider()): void {
+  if (provider !== 'sqlite') {
+    throw new DatabaseProviderRuntimeError(
+      'postgres_runtime_adapter_unavailable',
+      'Postgres mode is configured, but the Canvas Notebook runtime database adapter is not available yet.',
+    );
+  }
+}

--- a/app/lib/knowledge/settings-service.ts
+++ b/app/lib/knowledge/settings-service.ts
@@ -6,8 +6,9 @@ import { promises as fs } from 'node:fs';
 
 import {
   getDatabaseProvider,
-  type OrganizationPermissionState,
-} from '@/app/lib/organization/bootstrap';
+  normalizeDatabaseProvider,
+} from '@/app/lib/db/provider';
+import type { OrganizationPermissionState } from '@/app/lib/organization/bootstrap';
 import {
   resolveCanvasDataRoot,
   resolveOrganizationSettingsDir,
@@ -189,7 +190,7 @@ export async function resolveKnowledgeResourceStatus(
   settings: KnowledgeParsingSettings,
   state?: OrganizationPermissionState | null,
 ): Promise<KnowledgeResourceStatus> {
-  const databaseProvider = (state?.databaseProvider || getDatabaseProvider()).trim().toLowerCase() || 'sqlite';
+  const databaseProvider = normalizeDatabaseProvider(state?.databaseProvider || getDatabaseProvider());
   const postgresReady = databaseProvider === 'postgres';
   const pgvectorReady = process.env.CANVAS_POSTGRES_VECTOR_ENABLED === 'true';
   const totalMb = Math.round(os.totalmem() / 1024 / 1024);

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { getBootstrapAdminEmail } from '@/app/lib/bootstrap-admin';
 import { runMigrations } from '@/app/lib/db/migrate';
 import {
+  type DatabaseProvider,
   getDatabaseProvider as resolveConfiguredDatabaseProvider,
   getDatabaseProviderProblemMessages,
   resolveDatabaseProviderGate,
@@ -62,7 +63,7 @@ export type OrganizationBootstrapStatus = {
   ownerEmail: string | null;
   deploymentMode: string;
   teamFeaturesEnabled: boolean;
-  databaseProvider: string;
+  databaseProvider: DatabaseProvider;
   permission: OrganizationPermissionSnapshot | null;
   paths: {
     personalWorkspace: string | null;
@@ -80,7 +81,7 @@ export type OrganizationPermissionState = {
   organizationId: string | null;
   ownerUserId: string | null;
   teamFeaturesEnabled: boolean;
-  databaseProvider: string;
+  databaseProvider: DatabaseProvider;
   permission: OrganizationPermissionSnapshot | null;
 };
 
@@ -172,7 +173,7 @@ export function getConfiguredOrganizationId(): string | null {
   return value || null;
 }
 
-export function getDatabaseProvider(): string {
+export function getDatabaseProvider(): DatabaseProvider {
   return resolveConfiguredDatabaseProvider();
 }
 

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -8,6 +8,11 @@ import path from 'node:path';
 import { getBootstrapAdminEmail } from '@/app/lib/bootstrap-admin';
 import { runMigrations } from '@/app/lib/db/migrate';
 import {
+  getDatabaseProvider as resolveConfiguredDatabaseProvider,
+  getDatabaseProviderProblemMessages,
+  resolveDatabaseProviderGate,
+} from '@/app/lib/db/provider';
+import {
   resolveOrganizationAgentTemplatesDir,
   resolveOrganizationDataRoot,
   resolveOrganizationMcpTemplatesDir,
@@ -168,7 +173,7 @@ export function getConfiguredOrganizationId(): string | null {
 }
 
 export function getDatabaseProvider(): string {
-  return process.env.CANVAS_DATABASE_PROVIDER?.trim().toLowerCase() || 'sqlite';
+  return resolveConfiguredDatabaseProvider();
 }
 
 export function getDeploymentMode(): string {
@@ -487,6 +492,7 @@ function buildStatus(
     ? booleanFromDb(organization.team_features_enabled)
     : areTeamFeaturesEnabled(deploymentMode);
   const databaseProvider = getDatabaseProvider();
+  const databaseProviderGate = resolveDatabaseProviderGate({ teamFeaturesEnabled });
   const organizationId = organization?.organization_id || null;
   const ownerUserId = organization?.owner_user_id || ownerUser?.id || null;
   const paths = organizationId && ownerUserId
@@ -498,9 +504,7 @@ function buildStatus(
     warnings.push('CANVAS_TEAM_FEATURES_ENABLED is ignored for this single-user deployment mode.');
   }
 
-  if (teamFeaturesEnabled && databaseProvider !== 'postgres') {
-    warnings.push('Team features are enabled but CANVAS_DATABASE_PROVIDER is not postgres.');
-  }
+  warnings.push(...getDatabaseProviderProblemMessages(databaseProviderGate.blockers));
 
   const configuredOrganizationId = getConfiguredOrganizationId();
   if (configuredOrganizationId && organizationId && configuredOrganizationId !== organizationId) {

--- a/app/lib/organization/permissions.ts
+++ b/app/lib/organization/permissions.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 
 import { isAdminUser, type AdminUserCandidate } from '@/app/lib/admin-auth';
 import { auth } from '@/app/lib/auth';
+import { getDatabaseProvider } from '@/app/lib/db/provider';
 import {
   getOrganizationPermissionForUser,
   openOrganizationBootstrapDatabase,
@@ -149,7 +150,7 @@ function legacyFallbackState(): OrganizationPermissionState {
     organizationId: null,
     ownerUserId: null,
     teamFeaturesEnabled: false,
-    databaseProvider: process.env.CANVAS_DATABASE_PROVIDER?.trim().toLowerCase() || 'sqlite',
+    databaseProvider: getDatabaseProvider(),
     permission: LEGACY_ADMIN_PERMISSION,
   };
 }

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -718,11 +718,29 @@
     {
       "id": 38,
       "title": "Database-Provider-Abstraktion fuer SQLite und Postgres in Canvas Notebook einfuehren",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md",
         "docs/architecture/canvas-notebook/team-workspace/17-database-provider-postgres-rag-collaboration-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/db/provider.ts",
+        "app/lib/db/index.ts",
+        "app/api/health/route.ts",
+        "app/lib/auth-setup.ts",
+        "app/lib/organization/bootstrap.ts",
+        "app/lib/organization/permissions.ts",
+        "app/lib/knowledge/settings-service.ts",
+        "scripts/database-provider-abstraction-test.ts"
+      ],
+      "verification": [
+        "npm run test:db:provider",
+        "npm run test:auth:setup",
+        "npm run test:knowledge:settings",
+        "npx tsc --noEmit --pretty false",
+        "npm run lint",
+        "npm run build"
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:studio:organization-scope": "tsx --conditions react-server scripts/studio-organization-scope-test.ts",
     "test:knowledge:retrieval-scope": "tsx --conditions react-server scripts/knowledge-retrieval-scope-test.ts",
     "test:knowledge:settings": "tsx --conditions react-server scripts/knowledge-settings-test.ts",
+    "test:db:provider": "tsx scripts/database-provider-abstraction-test.ts",
     "test:skills:runtime": "tsx scripts/skills-runtime-test.ts",
     "test:skills:seed-bootstrap": "tsx scripts/default-seed-skills-test.ts",
     "test:plugins:seed-bootstrap": "tsx scripts/default-seed-plugins-test.ts",

--- a/scripts/database-provider-abstraction-test.ts
+++ b/scripts/database-provider-abstraction-test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+type EnvSnapshot = {
+  DATA?: string;
+  CANVAS_DATABASE_PROVIDER?: string;
+  CANVAS_POSTGRES_VECTOR_ENABLED?: string;
+  CANVAS_POSTGRES_IMAGE?: string;
+  CANVAS_POSTGRES_DATA_VOLUME?: string;
+  DATABASE_URL?: string;
+};
+
+function snapshotEnv(): EnvSnapshot {
+  return {
+    DATA: process.env.DATA,
+    CANVAS_DATABASE_PROVIDER: process.env.CANVAS_DATABASE_PROVIDER,
+    CANVAS_POSTGRES_VECTOR_ENABLED: process.env.CANVAS_POSTGRES_VECTOR_ENABLED,
+    CANVAS_POSTGRES_IMAGE: process.env.CANVAS_POSTGRES_IMAGE,
+    CANVAS_POSTGRES_DATA_VOLUME: process.env.CANVAS_POSTGRES_DATA_VOLUME,
+    DATABASE_URL: process.env.DATABASE_URL,
+  };
+}
+
+function restoreEnv(snapshot: EnvSnapshot): void {
+  for (const key of Object.keys(snapshot) as Array<keyof EnvSnapshot>) {
+    const value = snapshot[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function resetProviderEnv(dataDir: string): void {
+  process.env.DATA = dataDir;
+  delete process.env.CANVAS_DATABASE_PROVIDER;
+  delete process.env.CANVAS_POSTGRES_VECTOR_ENABLED;
+  delete process.env.CANVAS_POSTGRES_IMAGE;
+  delete process.env.CANVAS_POSTGRES_DATA_VOLUME;
+  delete process.env.DATABASE_URL;
+}
+
+async function main() {
+  const snapshot = snapshotEnv();
+  const dataDir = await mkdtemp(path.join(tmpdir(), 'canvas-db-provider-'));
+
+  try {
+    resetProviderEnv(dataDir);
+    const {
+      assertRuntimeDatabaseProviderSupported,
+      getDatabaseProvider,
+      resolveDatabaseProviderConfig,
+      resolveDatabaseProviderGate,
+      resolveSqlitePath,
+      toPublicDatabaseProviderStatus,
+    } = await import('../app/lib/db/provider');
+
+    assert.equal(getDatabaseProvider(), 'sqlite');
+    assert.equal(resolveSqlitePath(), path.join(dataDir, 'sqlite.db'));
+    let config = resolveDatabaseProviderConfig();
+    assert.equal(config.provider, 'sqlite');
+    assert.equal(config.runtimeAdapter, 'sqlite');
+    assert.deepEqual(config.problems, []);
+
+    let gate = resolveDatabaseProviderGate({ teamFeaturesEnabled: false });
+    assert.equal(gate.ok, true);
+    assert.deepEqual(gate.blockers, []);
+    assert.doesNotThrow(() => assertRuntimeDatabaseProviderSupported());
+
+    gate = resolveDatabaseProviderGate({ teamFeaturesEnabled: true });
+    assert.equal(gate.ok, false);
+    assert.ok(gate.blockers.some((problem) => problem.code === 'team_requires_postgres'));
+
+    process.env.CANVAS_DATABASE_PROVIDER = 'mysql';
+    config = resolveDatabaseProviderConfig();
+    assert.equal(config.provider, 'sqlite');
+    assert.equal(config.requestedProvider, 'mysql');
+    assert.ok(config.problems.some((problem) => problem.code === 'invalid_provider'));
+
+    process.env.CANVAS_DATABASE_PROVIDER = 'postgres';
+    delete process.env.DATABASE_URL;
+    gate = resolveDatabaseProviderGate({ teamFeaturesEnabled: true });
+    assert.equal(gate.ok, false);
+    assert.ok(gate.blockers.some((problem) => problem.code === 'postgres_missing_database_url'));
+    assert.ok(gate.blockers.some((problem) => problem.code === 'postgres_runtime_adapter_unavailable'));
+    assert.throws(
+      () => assertRuntimeDatabaseProviderSupported(),
+      /runtime database adapter is not available/u,
+    );
+
+    process.env.DATABASE_URL = 'mysql://canvas:secret@localhost/canvas';
+    gate = resolveDatabaseProviderGate({ teamFeaturesEnabled: true });
+    assert.ok(gate.blockers.some((problem) => problem.code === 'postgres_invalid_database_url'));
+
+    process.env.DATABASE_URL = 'postgresql://canvas:super-secret@postgres:5432/canvas_notebook';
+    process.env.CANVAS_POSTGRES_VECTOR_ENABLED = 'true';
+    process.env.CANVAS_POSTGRES_IMAGE = 'pgvector/postgres:18';
+    process.env.CANVAS_POSTGRES_DATA_VOLUME = 'canvas-postgres-data';
+    gate = resolveDatabaseProviderGate({
+      teamFeaturesEnabled: true,
+      requirePgvector: true,
+      postgresRuntimeAdapterAvailable: true,
+    });
+    assert.equal(gate.ok, true);
+    assert.equal(gate.runtimeAdapter, 'postgres');
+    assert.equal(gate.config.postgres.databaseUrlConfigured, true);
+    assert.equal(gate.config.postgres.databaseUrlProtocol, 'postgresql');
+    assert.equal(gate.config.postgres.pgvectorEnabled, true);
+    assert.equal(gate.config.postgres.imageConfigured, true);
+    assert.equal(gate.config.postgres.dataVolumeConfigured, true);
+
+    const publicStatus = toPublicDatabaseProviderStatus(gate);
+    const serializedStatus = JSON.stringify(publicStatus);
+    assert.equal(serializedStatus.includes('super-secret'), false);
+    assert.equal(serializedStatus.includes('canvas:super-secret'), false);
+    assert.equal(serializedStatus.includes('postgres:5432'), false);
+    assert.equal(publicStatus.postgres.databaseUrlConfigured, true);
+    assert.equal(publicStatus.postgres.databaseUrlProtocol, 'postgresql');
+    assert.equal(publicStatus.runtimeAdapter, 'postgres');
+
+    process.env.CANVAS_POSTGRES_VECTOR_ENABLED = 'false';
+    gate = resolveDatabaseProviderGate({
+      teamFeaturesEnabled: true,
+      requirePgvector: true,
+      postgresRuntimeAdapterAvailable: true,
+    });
+    assert.equal(gate.ok, false);
+    assert.ok(gate.blockers.some((problem) => problem.code === 'pgvector_required'));
+
+    console.log('database-provider-abstraction-test: ok');
+  } finally {
+    restoreEnv(snapshot);
+    await rm(dataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/knowledge-settings-test.ts
+++ b/scripts/knowledge-settings-test.ts
@@ -3,9 +3,10 @@ import { appendFile, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import type { DatabaseProvider } from '@/app/lib/db/provider';
 import type { OrganizationPermissionState } from '@/app/lib/organization/bootstrap';
 
-function testState(databaseProvider: string): OrganizationPermissionState {
+function testState(databaseProvider: DatabaseProvider): OrganizationPermissionState {
   return {
     configured: true,
     organizationId: 'org-knowledge-test',


### PR DESCRIPTION
## Summary
- add a central Canvas Notebook database provider abstraction for SQLite/Postgres selection, redacted public status, provider gates, and runtime adapter checks
- expose provider/deployment state in /api/health and block initial owner setup when the configured provider is not allowed for the deployment mode
- route bootstrap, permission, and knowledge gates through the shared provider logic and mark Task 38 completed in the todo index

## Verification
- npm run test:db:provider
- npm run test:auth:setup
- npm run test:knowledge:settings
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build

Greptile score: 4/5 automatic review. Addressed all 3 Greptile comments in c5939ce1; no manual re-trigger after fixes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a central `app/lib/db/provider.ts` abstraction that consolidates all database provider logic — environment normalization, validation, runtime adapter checks, and a gate mechanism — and threads it through health, auth setup, bootstrap, permissions, and knowledge settings.

- **New provider gate** (`resolveDatabaseProviderGate`) replaces scattered inline env-var reads with typed blocker/warning lists; `getDatabaseProvider()` now silently normalizes invalid values to `'sqlite'` while `resolveDatabaseProviderConfig` captures the raw `requestedProvider` for diagnostics.
- **Health endpoint** now returns 503 and exposes a redacted `database` object whenever the provider gate fails (team features + SQLite, missing/invalid `DATABASE_URL`, or any non-sqlite provider), introducing a deliberate behavior change for misconfigured deployments.
- **Initial owner setup** is blocked with a new `DATABASE_PROVIDER_BLOCKED` error code (mapped to HTTP 503) when the gate fails, preventing setup on an unsupported provider before any data is written.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the default SQLite single-user case; deployments with team features enabled or postgres configured will intentionally start returning 503 from /api/health.

The abstraction is well-structured, credentials are not leaked in the public status, and the test covers the important gate combinations. Two small issues are worth a follow-up: `sqlite.pathConfigured` in the public status is always `true` and carries no diagnostic value, and `assertRuntimeDatabaseProviderSupported()` at the end of `assertSetupDatabaseProviderAllowed` is unreachable under all current configurations (the gate already blocks postgres) and would conflict with gate semantics once actual postgres runtime support lands.

`app/lib/db/provider.ts` (trivially-true `pathConfigured` field) and `app/lib/auth-setup.ts` (dead `assertRuntimeDatabaseProviderSupported` call after the gate check).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/db/provider.ts | New central provider abstraction — well-structured with typed problems, gate logic, and redacted public status. `sqlite.pathConfigured` is always `true` and carries no diagnostic value. |
| app/api/health/route.ts | Adds provider gate check and deployment info to the health response; correctly propagates 503 on gate failure; database credentials are not leaked. |
| app/lib/auth-setup.ts | Adds `assertSetupDatabaseProviderAllowed` guard before initial owner creation; the trailing `assertRuntimeDatabaseProviderSupported()` is dead code under all current configurations. |
| app/lib/organization/bootstrap.ts | Gates bootstrap warnings through `resolveDatabaseProviderGate`; `getDatabaseProvider()` return type annotation is still `string` even though the delegate returns the narrower `DatabaseProvider` union. |
| app/lib/organization/permissions.ts | Replaces inline env-var reading in legacy fallback with the shared `getDatabaseProvider()` helper — clean, no issues. |
| app/lib/knowledge/settings-service.ts | Replaces manual `.trim().toLowerCase()` normalization with `normalizeDatabaseProvider`; functionally equivalent and correctly handles invalid provider values. |
| app/lib/db/index.ts | Delegates `getDataDir` / SQLite path resolution to the shared provider module; adds `assertRuntimeDatabaseProviderSupported` guard to `openDb`. |
| app/api/setup/owner/route.ts | Adds 503 mapping for the new `DATABASE_PROVIDER_BLOCKED` error code — correct and minimal. |
| scripts/database-provider-abstraction-test.ts | Comprehensive integration test covering default SQLite, invalid provider, missing/invalid DATABASE_URL, pgvector gate, and credential redaction. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ENV: CANVAS_DATABASE_PROVIDER and DATABASE_URL] --> B[resolveDatabaseProviderConfig]
    B --> C{provider valid?}
    C -- invalid --> D[add invalid_provider problem]
    C -- postgres --> E{DATABASE_URL set and valid?}
    E -- no --> F[add postgres_missing_database_url problem]
    E -- yes --> G[runtimeAdapter = postgres-unavailable]
    C -- sqlite --> H[runtimeAdapter = sqlite]

    B --> I[resolveDatabaseProviderGate]
    I --> J{teamFeaturesEnabled and provider != postgres?}
    J -- yes --> K[add team_requires_postgres blocker]
    I --> L{provider=postgres and postgresRuntimeAdapterAvailable=false?}
    L -- yes --> M[add postgres_runtime_adapter_unavailable blocker]
    I --> N{requirePgvector and pgvectorEnabled=false?}
    N -- yes --> O[add pgvector_required blocker]
    I --> P{blockers empty?}
    P -- yes --> Q[gate.ok = true]
    P -- no --> R[gate.ok = false]

    Q --> S[health endpoint returns 200]
    R --> T[health endpoint returns 503]
    R --> U[createInitialOwner throws DATABASE_PROVIDER_BLOCKED]
    Q --> V[createInitialOwner proceeds]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ENV: CANVAS_DATABASE_PROVIDER and DATABASE_URL] --> B[resolveDatabaseProviderConfig]
    B --> C{provider valid?}
    C -- invalid --> D[add invalid_provider problem]
    C -- postgres --> E{DATABASE_URL set and valid?}
    E -- no --> F[add postgres_missing_database_url problem]
    E -- yes --> G[runtimeAdapter = postgres-unavailable]
    C -- sqlite --> H[runtimeAdapter = sqlite]

    B --> I[resolveDatabaseProviderGate]
    I --> J{teamFeaturesEnabled and provider != postgres?}
    J -- yes --> K[add team_requires_postgres blocker]
    I --> L{provider=postgres and postgresRuntimeAdapterAvailable=false?}
    L -- yes --> M[add postgres_runtime_adapter_unavailable blocker]
    I --> N{requirePgvector and pgvectorEnabled=false?}
    N -- yes --> O[add pgvector_required blocker]
    I --> P{blockers empty?}
    P -- yes --> Q[gate.ok = true]
    P -- no --> R[gate.ok = false]

    Q --> S[health endpoint returns 200]
    R --> T[health endpoint returns 503]
    R --> U[createInitialOwner throws DATABASE_PROVIDER_BLOCKED]
    Q --> V[createInitialOwner proceeds]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Fdatabase-provider-abstraction%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdatabase-provider-abstraction%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapp%2Flib%2Fdb%2Fprovider.ts%3A206-209%0A**%60sqlite.pathConfigured%60%20is%20always%20%60true%60**%0A%0A%60Boolean%28gate.config.sqlite.path%29%60%20evaluates%20to%20%60true%60%20for%20every%20possible%20runtime%20state.%20%60resolveSqlitePath%28%29%60%20always%20returns%20a%20non-empty%20string%20%28either%20from%20%60process.env.DATA%60%20or%20from%20%60path.resolve%28process.cwd%28%29%2C%20'data'%29%60%29%2C%20so%20this%20field%20can%20never%20be%20%60false%60.%20As%20exposed%20in%20the%20public%20health%20endpoint%20it%20offers%20no%20diagnostic%20signal%20and%20may%20mislead%20operators%20into%20thinking%20there%20is%20meaningful%20state%20being%20reported%20here.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Flib%2Forganization%2Fbootstrap.ts%3A175-177%0AThe%20wrapper%20function's%20return%20type%20annotation%20is%20still%20%60string%60%2C%20but%20it%20now%20delegates%20to%20%60resolveConfiguredDatabaseProvider%28%29%60%20which%20returns%20the%20narrower%20%60DatabaseProvider%60%20union.%20Callers%20that%20check%20this%20value%20against%20%60'postgres'%60%20get%20no%20narrowing%20benefit%2C%20and%20the%20field%20%60databaseProvider%60%20on%20%60OrganizationBootstrapStatus%60%20and%20%60OrganizationPermissionState%60%20%28which%20both%20store%20this%20value%20as%20%60string%60%29%20could%20be%20tightened%20up%20from%20a%20single%20annotation%20here.%0A%0A%60%60%60suggestion%0Aexport%20function%20getDatabaseProvider%28%29%3A%20DatabaseProvider%20%7B%0A%20%20return%20resolveConfiguredDatabaseProvider%28%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Flib%2Fauth-setup.ts%3A112-126%0A**%60assertRuntimeDatabaseProviderSupported%28%29%60%20is%20unreachable%20when%20postgres%20is%20configured**%0A%0A%60resolveDatabaseProviderGate%60%20%28called%20without%20%60postgresRuntimeAdapterAvailable%3A%20true%60%29%20always%20adds%20a%20%60postgres_runtime_adapter_unavailable%60%20blocker%20whenever%20%60provider%20%3D%3D%3D%20'postgres'%60%2C%20so%20the%20gate%20throws%20before%20line%20125%20is%20reached.%20Conversely%2C%20when%20the%20provider%20is%20%60'sqlite'%60%20the%20gate%20passes%20and%20the%20runtime%20assert%20also%20passes%20silently.%20The%20call%20at%20line%20125%20is%20therefore%20dead%20code%20in%20all%20current%20configurations.%0A%0AThere%20is%20also%20a%20forward-compatibility%20hazard%3A%20if%20postgres%20runtime%20support%20is%20added%20in%20the%20future%20and%20the%20gate%20is%20updated%20to%20pass%20for%20postgres%20%28e.g.%20%60postgresRuntimeAdapterAvailable%3A%20true%60%29%2C%20this%20call%20would%20still%20unconditionally%20throw%2C%20overriding%20the%20gate's%20decision.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=39&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add database provider abstraction"](https://github.com/canvascoding/canvas-notebook/commit/6e35addec2a0f40240c3692878bf2226b372dbdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39008420)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->
