### PR TITLE
Add installer database provider selection

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -18,6 +18,18 @@ CANVAS_INTERNAL_API_KEY=your-secret-genereate-please
 DATA=/data
 QMD_ENABLED=false
 
+# Database provider
+# sqlite is the single-user default. Team, RAG, and collaboration installs require postgres.
+CANVAS_DEPLOYMENT_MODE=single_user
+CANVAS_DATABASE_PROVIDER=sqlite
+# DATABASE_URL=postgresql://canvas:change-me@postgres:5432/canvas_notebook
+CANVAS_POSTGRES_VECTOR_ENABLED=false
+CANVAS_POSTGRES_IMAGE=pgvector/pgvector:0.8.3-pg18
+CANVAS_POSTGRES_DATA_VOLUME=canvas-postgres-data
+CANVAS_POSTGRES_DB=canvas_notebook
+CANVAS_POSTGRES_USER=canvas
+# CANVAS_POSTGRES_PASSWORD=change-me
+
 # License service
 # Defaults to https://api.canvasnotebook.app when unset.
 # CANVAS_LICENSE_CONTROL_PLANE_URL=https://api.canvasnotebook.app

--- a/compose.hub.yaml
+++ b/compose.hub.yaml
@@ -6,6 +6,10 @@ services:
       - "${HOST_PORT:-3456}:${CONTAINER_PORT:-3000}"
     env_file:
       - ${CANVAS_INSTALL_DIR:-/opt/canvas-notebook}/canvas-notebook.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+        required: false
     volumes:
       - ${DATA_DIR:-./data}:/data
     restart: unless-stopped

--- a/compose.hub.yaml
+++ b/compose.hub.yaml
@@ -9,3 +9,25 @@ services:
     volumes:
       - ${DATA_DIR:-./data}:/data
     restart: unless-stopped
+
+  postgres:
+    profiles:
+      - postgres
+    container_name: canvas-notebook-postgres
+    image: ${CANVAS_POSTGRES_IMAGE:-pgvector/pgvector:0.8.3-pg18}
+    environment:
+      POSTGRES_DB: ${CANVAS_POSTGRES_DB:-canvas_notebook}
+      POSTGRES_USER: ${CANVAS_POSTGRES_USER:-canvas}
+      POSTGRES_PASSWORD: ${CANVAS_POSTGRES_PASSWORD:-unused-sqlite-profile-disabled}
+    volumes:
+      - canvas-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  canvas-postgres-data:
+    name: ${CANVAS_POSTGRES_DATA_VOLUME:-canvas-postgres-data}

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -746,11 +746,32 @@
     {
       "id": 39,
       "title": "Canvas Notebook CLI Installer um SQLite/Postgres-Auswahl und Team-Postgres-Zwang erweitern",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/02-execution-model.md",
         "docs/architecture/canvas-notebook/team-workspace/17-database-provider-postgres-rag-collaboration-policy.md"
+      ],
+      "implementationArtifacts": [
+        "install.sh",
+        "install/bin/canvas-notebook",
+        "install/lib/shared/config_json.sh",
+        "install/lib/shared/compose.sh",
+        "install/lib/commands/env.sh",
+        "install/lib/commands/config_cmd.sh",
+        "install/lib/commands/lifecycle.sh",
+        "install/lib/shared/ui.sh",
+        "compose.hub.yaml",
+        ".env.docker.example",
+        "scripts/cli-database-provider-test.sh"
+      ],
+      "verification": [
+        "npm run test:cli:database-provider",
+        "npm run test:cli:admin",
+        "bash -n install.sh install/bin/canvas-notebook install/lib/shared/config_json.sh install/lib/shared/compose.sh install/lib/commands/env.sh install/lib/commands/config_cmd.sh install/lib/commands/lifecycle.sh install/lib/shared/ui.sh scripts/cli-database-provider-test.sh scripts/cli-admin-command-test.sh",
+        "npx tsc --noEmit --pretty false",
+        "npm run lint",
+        "npm run build"
       ]
     },
     {

--- a/install.sh
+++ b/install.sh
@@ -267,6 +267,89 @@ configure_compose_values() {
   ok "Configuration is set"
 }
 
+configure_database_values() {
+  local current_deployment current_provider deployment_mode provider provider_choice deployment_choice team_features
+  local deployment_choice_default provider_choice_default database_env_key
+
+  current_deployment="$(config_json_read env.CANVAS_DEPLOYMENT_MODE)"
+  current_deployment="${current_deployment:-single_user}"
+  current_provider="$(config_json_read env.CANVAS_DATABASE_PROVIDER)"
+  current_provider="$(config_json_normalize_database_provider "${current_provider:-sqlite}")"
+
+  if [[ "$NONINTERACTIVE" == "true" ]]; then
+    deployment_mode="${CANVAS_DEPLOYMENT_MODE:-$current_deployment}"
+    provider="${CANVAS_DATABASE_PROVIDER:-$current_provider}"
+  else
+    section "Database"
+    echo "Choose the deployment scope:"
+    echo
+    echo "  1) Single-user / community  (SQLite allowed)"
+    echo "  2) Team / advanced          (Postgres + pgvector required)"
+    echo
+    if config_json_deployment_requires_postgres "$current_deployment" "$(config_json_read env.CANVAS_TEAM_FEATURES_ENABLED)"; then
+      deployment_choice_default="2"
+    else
+      deployment_choice_default="1"
+    fi
+    ask "Choice [1/2, default ${deployment_choice_default}]: " deployment_choice "$deployment_choice_default"
+    if [[ "$deployment_choice" == "2" ]]; then
+      deployment_mode="managed-team"
+      provider="postgres"
+      info "Team/advanced mode requires Postgres; configuring the local pgvector Postgres service."
+    else
+      deployment_mode="single_user"
+      echo
+      echo "Choose the database provider:"
+      echo
+      echo "  1) SQLite    (recommended for single-user installs)"
+      echo "  2) Postgres  (required later for team, RAG, and collaboration)"
+      echo
+      provider_choice_default="1"
+      [[ "$current_provider" == "postgres" ]] && provider_choice_default="2"
+      ask "Choice [1/2, default ${provider_choice_default}]: " provider_choice "$provider_choice_default"
+      if [[ "$provider_choice" == "2" ]]; then
+        provider="postgres"
+      else
+        provider="sqlite"
+      fi
+    fi
+  fi
+
+  provider="$(config_json_normalize_database_provider "$provider")"
+  team_features="${CANVAS_TEAM_FEATURES_ENABLED:-$(config_json_read env.CANVAS_TEAM_FEATURES_ENABLED)}"
+  if config_json_deployment_requires_postgres "$deployment_mode" "$team_features" && [[ "$provider" != "postgres" ]]; then
+    if [[ "$NONINTERACTIVE" == "true" ]]; then
+      info "Team/advanced deployment detected; forcing CANVAS_DATABASE_PROVIDER=postgres."
+    fi
+    provider="postgres"
+  fi
+
+  config_json_write env.CANVAS_DEPLOYMENT_MODE "$deployment_mode"
+  config_json_write env.CANVAS_DATABASE_PROVIDER "$provider"
+
+  for database_env_key in \
+    CANVAS_TEAM_FEATURES_ENABLED \
+    DATABASE_URL \
+    CANVAS_POSTGRES_IMAGE \
+    CANVAS_POSTGRES_DATA_VOLUME \
+    CANVAS_POSTGRES_DB \
+    CANVAS_POSTGRES_USER \
+    CANVAS_POSTGRES_PASSWORD; do
+    if [[ -n "${!database_env_key:-}" ]]; then
+      config_json_write "env.${database_env_key}" "${!database_env_key}"
+      ok "Set ${database_env_key}"
+    fi
+  done
+  unset database_env_key
+
+  config_json_ensure_database_config
+  ok "Database provider: $(config_json_read env.CANVAS_DATABASE_PROVIDER)"
+  if [[ "$(config_json_read env.CANVAS_DATABASE_PROVIDER)" == "postgres" ]]; then
+    ok "Postgres image: $(config_json_read env.CANVAS_POSTGRES_IMAGE)"
+    ok "Postgres volume: $(config_json_read env.CANVAS_POSTGRES_DATA_VOLUME)"
+  fi
+}
+
 apply_transient_admin_credentials() {
   if [[ -z "${ADMIN_EMAIL:-}" && -z "${ADMIN_PASSWORD:-}" ]]; then
     return 0
@@ -339,6 +422,7 @@ run_prebuilt_install() {
 
   configure_secrets
   configure_compose_values
+  configure_database_values
 
   if [[ -n "$DATA_DIR" ]]; then
     config_json_write dataDir "$DATA_DIR"

--- a/install/bin/canvas-notebook
+++ b/install/bin/canvas-notebook
@@ -211,4 +211,8 @@ if ! declare -f "$cmd_fn" >/dev/null 2>&1; then
   fail "Command '${cmd}' is defined in ${cmd_file}.sh but function ${cmd_fn}() not found"
 fi
 
-"$cmd_fn" "${CMD_ARGS[@]}"
+if [[ "${#CMD_ARGS[@]}" -gt 0 ]]; then
+  "$cmd_fn" "${CMD_ARGS[@]}"
+else
+  "$cmd_fn"
+fi

--- a/install/lib/commands/config_cmd.sh
+++ b/install/lib/commands/config_cmd.sh
@@ -3,10 +3,10 @@
 _mask_json_secrets() {
   local input="$1"
   local jq_expr
-  jq_expr='.env.BETTER_AUTH_SECRET = (if .env.BETTER_AUTH_SECRET == "" then "(not set)" else (.env.BETTER_AUTH_SECRET | .[0:4] + "***") end)
-    | .env.CANVAS_INTERNAL_API_KEY = (if .env.CANVAS_INTERNAL_API_KEY == "" then "(not set)" else (.env.CANVAS_INTERNAL_API_KEY | .[0:4] + "***") end)
-    | .env.DATABASE_URL = (if .env.DATABASE_URL == "" then "(not set)" else "postgresql://***" end)
-    | .env.CANVAS_POSTGRES_PASSWORD = (if .env.CANVAS_POSTGRES_PASSWORD == "" then "(not set)" else (.env.CANVAS_POSTGRES_PASSWORD | .[0:4] + "***") end)'
+  jq_expr='.env.BETTER_AUTH_SECRET = (if (.env.BETTER_AUTH_SECRET == null or .env.BETTER_AUTH_SECRET == "") then "(not set)" else (.env.BETTER_AUTH_SECRET | .[0:4] + "***") end)
+    | .env.CANVAS_INTERNAL_API_KEY = (if (.env.CANVAS_INTERNAL_API_KEY == null or .env.CANVAS_INTERNAL_API_KEY == "") then "(not set)" else (.env.CANVAS_INTERNAL_API_KEY | .[0:4] + "***") end)
+    | .env.DATABASE_URL = (if (.env.DATABASE_URL == null or .env.DATABASE_URL == "") then "(not set)" else "postgresql://***" end)
+    | .env.CANVAS_POSTGRES_PASSWORD = (if (.env.CANVAS_POSTGRES_PASSWORD == null or .env.CANVAS_POSTGRES_PASSWORD == "") then "(not set)" else (.env.CANVAS_POSTGRES_PASSWORD | .[0:4] + "***") end)'
   printf '%s' "$input" | jq "$jq_expr"
 }
 

--- a/install/lib/commands/config_cmd.sh
+++ b/install/lib/commands/config_cmd.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-_MASKED_JSON_KEYS=("BETTER_AUTH_SECRET" "CANVAS_INTERNAL_API_KEY")
-
 _mask_json_secrets() {
   local input="$1"
   local jq_expr
   jq_expr='.env.BETTER_AUTH_SECRET = (if .env.BETTER_AUTH_SECRET == "" then "(not set)" else (.env.BETTER_AUTH_SECRET | .[0:4] + "***") end)
-    | .env.CANVAS_INTERNAL_API_KEY = (if .env.CANVAS_INTERNAL_API_KEY == "" then "(not set)" else (.env.CANVAS_INTERNAL_API_KEY | .[0:4] + "***") end)'
+    | .env.CANVAS_INTERNAL_API_KEY = (if .env.CANVAS_INTERNAL_API_KEY == "" then "(not set)" else (.env.CANVAS_INTERNAL_API_KEY | .[0:4] + "***") end)
+    | .env.DATABASE_URL = (if .env.DATABASE_URL == "" then "(not set)" else "postgresql://***" end)
+    | .env.CANVAS_POSTGRES_PASSWORD = (if .env.CANVAS_POSTGRES_PASSWORD == "" then "(not set)" else (.env.CANVAS_POSTGRES_PASSWORD | .[0:4] + "***") end)'
   printf '%s' "$input" | jq "$jq_expr"
 }
 
@@ -43,8 +43,11 @@ cmd_config_set() {
 
   local display_value="$value"
   case "$key" in
-    env.BETTER_AUTH_SECRET|env.CANVAS_INTERNAL_API_KEY)
+    env.BETTER_AUTH_SECRET|env.CANVAS_INTERNAL_API_KEY|env.CANVAS_POSTGRES_PASSWORD)
       display_value="${value:0:4}***"
+      ;;
+    env.DATABASE_URL)
+      display_value="postgresql://***"
       ;;
   esac
   ok "Set ${key} = ${display_value}"

--- a/install/lib/commands/env.sh
+++ b/install/lib/commands/env.sh
@@ -22,7 +22,7 @@ cmd_env() {
     migrate_compose_file
     config_json_to_env
     sync_caddy
-    compose up -d --force-recreate "$SERVICE"
+    compose up -d --force-recreate
     follow_until_healthy
     return
   fi
@@ -51,7 +51,9 @@ cmd_env() {
     local env_key env_val
     while IFS= read -r env_key; do
       env_val="$(config_json_read "env.${env_key}")"
-      if [[ "$env_key" == *"SECRET"* || "$env_key" == *"PASSWORD"* || "$env_key" == *"API_KEY"* ]] && [[ -n "$env_val" ]]; then
+      if [[ "$env_key" == "DATABASE_URL" && -n "$env_val" ]]; then
+        env_val="postgresql://***"
+      elif [[ "$env_key" == *"SECRET"* || "$env_key" == *"PASSWORD"* || "$env_key" == *"API_KEY"* ]] && [[ -n "$env_val" ]]; then
         env_val="${env_val:0:4}***"
       fi
       printf '%-30s %s\n' "$env_key" "${env_val:-(not set)}"

--- a/install/lib/commands/lifecycle.sh
+++ b/install/lib/commands/lifecycle.sh
@@ -5,7 +5,7 @@ cmd_start() {
   migrate_compose_file
   config_json_to_env
   ensure_env_file
-  run_compose up -d "$SERVICE"
+  run_compose up -d
   wait_until_healthy
 }
 

--- a/install/lib/commands/lifecycle.sh
+++ b/install/lib/commands/lifecycle.sh
@@ -14,7 +14,7 @@ cmd_restart() {
   migrate_compose_file
   config_json_to_env
   ensure_env_file
-  run_compose restart "$SERVICE"
+  run_compose up -d --force-recreate
   wait_until_healthy
 }
 

--- a/install/lib/shared/compose.sh
+++ b/install/lib/shared/compose.sh
@@ -93,6 +93,10 @@ services:
       - "${HOST_PORT:-3456}:${CONTAINER_PORT:-3000}"
     env_file:
       - ${CANVAS_INSTALL_DIR:-/opt/canvas-notebook}/canvas-notebook.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+        required: false
     volumes:
       - ${DATA_DIR:-./data}:/data
     restart: unless-stopped

--- a/install/lib/shared/compose.sh
+++ b/install/lib/shared/compose.sh
@@ -81,6 +81,49 @@ ensure_env_file() {
   fi
 }
 
+write_managed_compose_file() {
+  local dest="$1" tmp
+  tmp="$(mktemp)"
+  cat > "$tmp" <<'EOCOMPOSE'
+services:
+  canvas-notebook:
+    container_name: canvas-notebook
+    image: ${CANVAS_IMAGE:-ghcr.io/canvascoding/canvas-notebook:latest}
+    ports:
+      - "${HOST_PORT:-3456}:${CONTAINER_PORT:-3000}"
+    env_file:
+      - ${CANVAS_INSTALL_DIR:-/opt/canvas-notebook}/canvas-notebook.env
+    volumes:
+      - ${DATA_DIR:-./data}:/data
+    restart: unless-stopped
+
+  postgres:
+    profiles:
+      - postgres
+    container_name: canvas-notebook-postgres
+    image: ${CANVAS_POSTGRES_IMAGE:-pgvector/pgvector:0.8.3-pg18}
+    environment:
+      POSTGRES_DB: ${CANVAS_POSTGRES_DB:-canvas_notebook}
+      POSTGRES_USER: ${CANVAS_POSTGRES_USER:-canvas}
+      POSTGRES_PASSWORD: ${CANVAS_POSTGRES_PASSWORD:-unused-sqlite-profile-disabled}
+    volumes:
+      - canvas-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  canvas-postgres-data:
+    name: ${CANVAS_POSTGRES_DATA_VOLUME:-canvas-postgres-data}
+EOCOMPOSE
+
+  _write_owned_file "$dest" "$tmp"
+  rm -f "$tmp"
+}
+
 host_port() {
   local port
   port="$(config_json_read hostPort 2>/dev/null || true)"
@@ -99,6 +142,10 @@ container_id() {
 
 migrate_compose_file() {
   if [[ ! -f "$COMPOSE_FILE" ]]; then
+    section "Compose file"
+    info "Creating ${COMPOSE_FILE}..."
+    write_managed_compose_file "$COMPOSE_FILE"
+    ok "Created ${COMPOSE_FILE} with managed app and optional Postgres services"
     return 0
   fi
 
@@ -112,6 +159,10 @@ migrate_compose_file() {
     needs_migration=true
   fi
 
+  if ! grep -q 'canvas-notebook-postgres' "$COMPOSE_FILE" 2>/dev/null; then
+    needs_migration=true
+  fi
+
   if [[ "$needs_migration" != "true" ]]; then
     return 0
   fi
@@ -119,36 +170,12 @@ migrate_compose_file() {
   section "Migrating Compose file"
   info "Updating ${COMPOSE_FILE} to new format..."
 
-  local tmp
-  tmp="$(mktemp)"
-
-  local install_dir_env="${CANVAS_INSTALL_DIR:-/opt/canvas-notebook}"
-  local data_dir_default="${CANVAS_DATA_DIR:-${HOME:-/opt}/canvas-notebook-data}"
-
-  cat > "$tmp" <<'EOCOMPOSE'
-services:
-  canvas-notebook:
-    container_name: canvas-notebook
-    image: ${CANVAS_IMAGE:-ghcr.io/canvascoding/canvas-notebook:latest}
-    ports:
-      - "${HOST_PORT:-3456}:${CONTAINER_PORT:-3000}"
-    env_file:
-      - __INSTALL_DIR__/canvas-notebook.env
-    volumes:
-      - ${DATA_DIR:-__DATA_DIR_DEFAULT__/data}:/data
-    restart: unless-stopped
-EOCOMPOSE
-
-  sed -i "s|__INSTALL_DIR__|${install_dir_env}|g" "$tmp"
-  sed -i "s|__DATA_DIR_DEFAULT__|${data_dir_default}|g" "$tmp"
-
   if [[ -f "$COMPOSE_FILE" ]]; then
     local backup="${COMPOSE_FILE}.bak"
     _write_owned_file "$backup" "$COMPOSE_FILE"
     ok "Backed up existing file to ${backup}"
   fi
 
-  _write_owned_file "$COMPOSE_FILE" "$tmp"
-  rm -f "$tmp"
-  ok "Updated ${COMPOSE_FILE} with container_name and env_file"
+  write_managed_compose_file "$COMPOSE_FILE"
+  ok "Updated ${COMPOSE_FILE} with managed app and optional Postgres services"
 }

--- a/install/lib/shared/config_json.sh
+++ b/install/lib/shared/config_json.sh
@@ -301,9 +301,18 @@ config_json_ensure_database_config() {
       pg_password="$(config_json_generate_secret)"
       config_json_write env.CANVAS_POSTGRES_PASSWORD "$pg_password"
     fi
-    if ! printf '%s' "$pg_password" | grep -qE '^[A-Za-z0-9._~-]+$'; then
-      fail "CANVAS_POSTGRES_PASSWORD contains URL-reserved characters. Set DATABASE_URL explicitly or use a URL-safe password."
-    fi
+    for postgres_url_part in \
+      "CANVAS_POSTGRES_USER:$pg_user" \
+      "CANVAS_POSTGRES_PASSWORD:$pg_password" \
+      "CANVAS_POSTGRES_DB:$pg_db"; do
+      local postgres_part_key postgres_part_value
+      postgres_part_key="${postgres_url_part%%:*}"
+      postgres_part_value="${postgres_url_part#*:}"
+      if ! printf '%s' "$postgres_part_value" | grep -qE '^[A-Za-z0-9._~-]+$'; then
+        fail "${postgres_part_key} contains URL-reserved characters. Set DATABASE_URL explicitly or use URL-safe Postgres credentials."
+      fi
+    done
+    unset postgres_url_part postgres_part_key postgres_part_value
     database_url="postgresql://${pg_user}:${pg_password}@postgres:5432/${pg_db}"
     config_json_write env.DATABASE_URL "$database_url"
   elif [[ ! "$database_url" =~ ^postgres(ql)?:// ]]; then

--- a/install/lib/shared/config_json.sh
+++ b/install/lib/shared/config_json.sh
@@ -37,7 +37,16 @@ CONFIG_JSON_DEFAULTS='{
     "ONBOARDING": true,
     "ONBOARDING_HINTS": false,
     "ALLOW_SIGNUP": false,
-    "OLLAMA_CLI_AUTO_INSTALL": true
+    "OLLAMA_CLI_AUTO_INSTALL": true,
+    "CANVAS_DEPLOYMENT_MODE": "single_user",
+    "CANVAS_DATABASE_PROVIDER": "sqlite",
+    "DATABASE_URL": "",
+    "CANVAS_POSTGRES_VECTOR_ENABLED": false,
+    "CANVAS_POSTGRES_IMAGE": "pgvector/pgvector:0.8.3-pg18",
+    "CANVAS_POSTGRES_DATA_VOLUME": "canvas-postgres-data",
+    "CANVAS_POSTGRES_DB": "canvas_notebook",
+    "CANVAS_POSTGRES_USER": "canvas",
+    "CANVAS_POSTGRES_PASSWORD": ""
   }
 }'
 
@@ -190,6 +199,20 @@ config_json_write() {
         return
       fi
       ;;
+    env.CANVAS_DATABASE_PROVIDER)
+      value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | xargs)"
+      if [[ "$value" != "sqlite" && "$value" != "postgres" ]]; then
+        fail "Invalid CANVAS_DATABASE_PROVIDER '${value}'. Expected sqlite or postgres."
+      fi
+      ;;
+    env.CANVAS_DEPLOYMENT_MODE)
+      value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | xargs)"
+      ;;
+    env.DATABASE_URL)
+      if [[ -n "$value" && ! "$value" =~ ^postgres(ql)?:// ]]; then
+        fail "DATABASE_URL must use postgres:// or postgresql://"
+      fi
+      ;;
     env.*)
       ;;
   esac
@@ -207,6 +230,91 @@ config_json_write() {
     _config_json_write_raw "env.BETTER_AUTH_BASE_URL" "\"$base_url\""
     _config_json_write_raw "env.BASE_URL" "\"$base_url\""
   fi
+}
+
+config_json_normalize_database_provider() {
+  local value="$1"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | xargs)"
+  case "$value" in
+    ""|sqlite) printf 'sqlite\n' ;;
+    postgres) printf 'postgres\n' ;;
+    *) fail "Invalid CANVAS_DATABASE_PROVIDER '${value}'. Expected sqlite or postgres." ;;
+  esac
+}
+
+config_json_deployment_requires_postgres() {
+  local deployment_mode="$1" team_features="${2:-}"
+  deployment_mode="$(printf '%s' "$deployment_mode" | tr '[:upper:]' '[:lower:]')"
+  team_features="$(printf '%s' "$team_features" | tr '[:upper:]' '[:lower:]')"
+
+  case "$deployment_mode" in
+    *team*|*enterprise*|*advanced*) return 0 ;;
+  esac
+
+  case "$team_features" in
+    true|1|yes|on) return 0 ;;
+  esac
+
+  return 1
+}
+
+config_json_generate_secret() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+    return
+  fi
+  date +%s%N | sha256sum | awk '{print $1}'
+}
+
+config_json_ensure_database_config() {
+  local deployment_mode team_features provider database_url pg_image pg_volume pg_db pg_user pg_password
+  deployment_mode="$(config_json_read env.CANVAS_DEPLOYMENT_MODE)"
+  deployment_mode="${deployment_mode:-single_user}"
+  team_features="$(config_json_read env.CANVAS_TEAM_FEATURES_ENABLED)"
+  provider="$(config_json_normalize_database_provider "$(config_json_read env.CANVAS_DATABASE_PROVIDER)")"
+
+  if config_json_deployment_requires_postgres "$deployment_mode" "$team_features" && [[ "$provider" != "postgres" ]]; then
+    fail "Deployment mode '${deployment_mode}' requires CANVAS_DATABASE_PROVIDER=postgres. Set the provider to postgres before syncing or starting."
+  fi
+
+  config_json_write env.CANVAS_DEPLOYMENT_MODE "$deployment_mode"
+  config_json_write env.CANVAS_DATABASE_PROVIDER "$provider"
+
+  if [[ "$provider" != "postgres" ]]; then
+    config_json_write env.CANVAS_POSTGRES_VECTOR_ENABLED false
+    return 0
+  fi
+
+  pg_image="$(config_json_read env.CANVAS_POSTGRES_IMAGE)"
+  pg_image="${pg_image:-pgvector/pgvector:0.8.3-pg18}"
+  pg_volume="$(config_json_read env.CANVAS_POSTGRES_DATA_VOLUME)"
+  pg_volume="${pg_volume:-canvas-postgres-data}"
+  pg_db="$(config_json_read env.CANVAS_POSTGRES_DB)"
+  pg_db="${pg_db:-canvas_notebook}"
+  pg_user="$(config_json_read env.CANVAS_POSTGRES_USER)"
+  pg_user="${pg_user:-canvas}"
+  pg_password="$(config_json_read env.CANVAS_POSTGRES_PASSWORD)"
+  database_url="$(config_json_read env.DATABASE_URL)"
+
+  if [[ -z "$database_url" ]]; then
+    if [[ -z "$pg_password" ]]; then
+      pg_password="$(config_json_generate_secret)"
+      config_json_write env.CANVAS_POSTGRES_PASSWORD "$pg_password"
+    fi
+    if ! printf '%s' "$pg_password" | grep -qE '^[A-Za-z0-9._~-]+$'; then
+      fail "CANVAS_POSTGRES_PASSWORD contains URL-reserved characters. Set DATABASE_URL explicitly or use a URL-safe password."
+    fi
+    database_url="postgresql://${pg_user}:${pg_password}@postgres:5432/${pg_db}"
+    config_json_write env.DATABASE_URL "$database_url"
+  elif [[ ! "$database_url" =~ ^postgres(ql)?:// ]]; then
+    fail "DATABASE_URL must use postgres:// or postgresql://"
+  fi
+
+  config_json_write env.CANVAS_POSTGRES_VECTOR_ENABLED true
+  config_json_write env.CANVAS_POSTGRES_IMAGE "$pg_image"
+  config_json_write env.CANVAS_POSTGRES_DATA_VOLUME "$pg_volume"
+  config_json_write env.CANVAS_POSTGRES_DB "$pg_db"
+  config_json_write env.CANVAS_POSTGRES_USER "$pg_user"
 }
 
 _config_json_write_raw() {
@@ -237,6 +345,8 @@ config_json_to_env() {
     config_json_init
   fi
 
+  config_json_ensure_database_config
+
   local domain image host_port container_port data_dir
   domain="$(config_json_read domain)"
   image="$(config_json_read image)"
@@ -256,6 +366,27 @@ config_json_to_env() {
       printf 'DATA_DIR=%s\n' "$data_dir"
     fi
   } > "$compose_tmp"
+  local database_provider postgres_profile postgres_image postgres_volume postgres_db postgres_user postgres_password
+  database_provider="$(config_json_normalize_database_provider "$(config_json_read env.CANVAS_DATABASE_PROVIDER)")"
+  if [[ "$database_provider" == "postgres" ]]; then
+    postgres_profile="postgres"
+  else
+    postgres_profile=""
+  fi
+  postgres_image="$(config_json_read env.CANVAS_POSTGRES_IMAGE)"
+  postgres_volume="$(config_json_read env.CANVAS_POSTGRES_DATA_VOLUME)"
+  postgres_db="$(config_json_read env.CANVAS_POSTGRES_DB)"
+  postgres_user="$(config_json_read env.CANVAS_POSTGRES_USER)"
+  postgres_password="$(config_json_read env.CANVAS_POSTGRES_PASSWORD)"
+  {
+    printf 'COMPOSE_PROFILES=%s\n' "$postgres_profile"
+    printf 'CANVAS_DATABASE_PROVIDER=%s\n' "$database_provider"
+    printf 'CANVAS_POSTGRES_IMAGE=%s\n' "${postgres_image:-pgvector/pgvector:0.8.3-pg18}"
+    printf 'CANVAS_POSTGRES_DATA_VOLUME=%s\n' "${postgres_volume:-canvas-postgres-data}"
+    printf 'CANVAS_POSTGRES_DB=%s\n' "${postgres_db:-canvas_notebook}"
+    printf 'CANVAS_POSTGRES_USER=%s\n' "${postgres_user:-canvas}"
+    printf 'CANVAS_POSTGRES_PASSWORD=%s\n' "$postgres_password"
+  } >> "$compose_tmp"
   _write_owned_file "$COMPOSE_ENV_PATH" "$compose_tmp"
   rm -f "$compose_tmp"
 

--- a/install/lib/shared/ui.sh
+++ b/install/lib/shared/ui.sh
@@ -124,7 +124,7 @@ recreate_container() {
   local recreate_log spin='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
   local i=0
   recreate_log="$(mktemp)"
-  compose up -d --force-recreate "$SERVICE" >"$recreate_log" 2>&1 &
+  compose up -d --force-recreate >"$recreate_log" 2>&1 &
   local rec_pid=$!
   while kill -0 "$rec_pid" 2>/dev/null; do
     printf "\r  ${spin:$((i % ${#spin})):1} Recreating container..."

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "test:organization:offboarding": "tsx --conditions react-server scripts/organization-offboarding-test.ts",
     "test:license": "tsx --conditions react-server scripts/license-security-test.ts",
     "test:cli:admin": "bash scripts/cli-admin-command-test.sh",
+    "test:cli:database-provider": "bash scripts/cli-database-provider-test.sh",
     "test:channels": "tsx scripts/channel-architecture-test.ts",
     "test:channels:media": "tsx scripts/channel-media-directives-test.ts",
     "test:channels:db": "tsx --conditions react-server scripts/channel-db-test.ts",

--- a/scripts/cli-database-provider-test.sh
+++ b/scripts/cli-database-provider-test.sh
@@ -78,6 +78,14 @@ if grep -Eq 'postgresql://canvas:[^*]' "$TMP_DIR/config-show.json"; then
   echo "DATABASE_URL was not masked in config-show output" >&2
   exit 1
 fi
+cp "$CANVAS_CONFIG_JSON" "$TMP_DIR/config-postgres.json"
+jq 'del(.env.DATABASE_URL, .env.CANVAS_POSTGRES_PASSWORD)' \
+  "$CANVAS_CONFIG_JSON" > "$TMP_DIR/config-legacy-missing-db-secrets.json"
+cp "$TMP_DIR/config-legacy-missing-db-secrets.json" "$CANVAS_CONFIG_JSON"
+"$cli" config-show --json --no-banner > "$TMP_DIR/config-show-legacy.json"
+grep -q '"DATABASE_URL": "(not set)"' "$TMP_DIR/config-show-legacy.json"
+grep -q '"CANVAS_POSTGRES_PASSWORD": "(not set)"' "$TMP_DIR/config-show-legacy.json"
+cp "$TMP_DIR/config-postgres.json" "$CANVAS_CONFIG_JSON"
 
 jq '.env.CANVAS_DATABASE_PROVIDER = "sqlite" | .env.CANVAS_DEPLOYMENT_MODE = "managed-team"' \
   "$CANVAS_CONFIG_JSON" > "$TMP_DIR/config-inconsistent.json"
@@ -93,6 +101,8 @@ grep -q 'requires CANVAS_DATABASE_PROVIDER=postgres' "$TMP_DIR/team-sqlite.txt"
 grep -q '^COMPOSE_PROFILES=postgres$' "$CANVAS_COMPOSE_ENV"
 
 grep -q 'canvas-notebook-postgres' "$CANVAS_COMPOSE_FILE"
+grep -q 'condition: service_healthy' "$CANVAS_COMPOSE_FILE"
+grep -q 'required: false' "$CANVAS_COMPOSE_FILE"
 grep -q 'profiles:' "$CANVAS_COMPOSE_FILE"
 grep -q 'pgvector/pgvector:0.8.3-pg18' "$CANVAS_COMPOSE_FILE"
 grep -q 'unused-sqlite-profile-disabled' "$CANVAS_COMPOSE_FILE"

--- a/scripts/cli-database-provider-test.sh
+++ b/scripts/cli-database-provider-test.sh
@@ -118,5 +118,21 @@ if "$cli" env --sync --no-banner > "$TMP_DIR/bad-password.txt" 2>&1; then
   exit 1
 fi
 grep -q 'URL-reserved characters' "$TMP_DIR/bad-password.txt"
+jq '.env.DATABASE_URL = "" | .env.CANVAS_POSTGRES_PASSWORD = "safe-password" | .env.CANVAS_POSTGRES_USER = "bad/user"' \
+  "$TMP_DIR/config-postgres.json" > "$TMP_DIR/config-bad-user.json"
+cp "$TMP_DIR/config-bad-user.json" "$CANVAS_CONFIG_JSON"
+if "$cli" env --sync --no-banner > "$TMP_DIR/bad-user.txt" 2>&1; then
+  echo "unsafe generated DATABASE_URL user was accepted" >&2
+  exit 1
+fi
+grep -q 'CANVAS_POSTGRES_USER contains URL-reserved characters' "$TMP_DIR/bad-user.txt"
+jq '.env.DATABASE_URL = "" | .env.CANVAS_POSTGRES_PASSWORD = "safe-password" | .env.CANVAS_POSTGRES_DB = "bad/db"' \
+  "$TMP_DIR/config-postgres.json" > "$TMP_DIR/config-bad-db.json"
+cp "$TMP_DIR/config-bad-db.json" "$CANVAS_CONFIG_JSON"
+if "$cli" env --sync --no-banner > "$TMP_DIR/bad-db.txt" 2>&1; then
+  echo "unsafe generated DATABASE_URL database name was accepted" >&2
+  exit 1
+fi
+grep -q 'CANVAS_POSTGRES_DB contains URL-reserved characters' "$TMP_DIR/bad-db.txt"
 
 echo "cli database provider tests passed"

--- a/scripts/cli-database-provider-test.sh
+++ b/scripts/cli-database-provider-test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/bin" "$TMP_DIR/install/lib" "$TMP_DIR/logs"
+cp -R "$ROOT_DIR/install/bin" "$TMP_DIR/install/"
+cp -R "$ROOT_DIR/install/lib/shared" "$TMP_DIR/install/lib/"
+cp -R "$ROOT_DIR/install/lib/commands" "$TMP_DIR/install/lib/"
+
+cat > "$TMP_DIR/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  info)
+    exit 0
+    ;;
+  compose)
+    shift
+    printf '%s\n' "$*" >> "${CANVAS_TEST_COMPOSE_LOG:?}"
+    exit 0
+    ;;
+  *)
+    echo "unexpected docker command: $*" >&2
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$TMP_DIR/bin/docker"
+
+cat > "$TMP_DIR/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+SH
+chmod +x "$TMP_DIR/bin/curl"
+
+export PATH="$TMP_DIR/bin:$PATH"
+export CANVAS_INSTALL_DIR="$TMP_DIR/install"
+export CANVAS_COMPOSE_FILE="$TMP_DIR/install/canvas-notebook-compose.yaml"
+export CANVAS_CONFIG_JSON="$TMP_DIR/config.json"
+export CANVAS_CONFIG_ENV="$TMP_DIR/canvas-notebook.env"
+export CANVAS_COMPOSE_ENV="$TMP_DIR/.env"
+export CANVAS_MANAGER_LOG_DIR="$TMP_DIR/logs"
+export CANVAS_TEST_COMPOSE_LOG="$TMP_DIR/compose.log"
+export CANVAS_USE_COLOR=false
+
+cli="$TMP_DIR/install/bin/canvas-notebook"
+
+"$cli" env --sync --no-banner > "$TMP_DIR/env-default-sync.txt"
+"$cli" env --no-banner > "$TMP_DIR/env-default.txt"
+grep -q 'CANVAS_DATABASE_PROVIDER[[:space:]]*sqlite' "$TMP_DIR/env-default.txt"
+grep -q '^COMPOSE_PROFILES=$' "$CANVAS_COMPOSE_ENV"
+grep -q '^CANVAS_DATABASE_PROVIDER=sqlite$' "$CANVAS_COMPOSE_ENV"
+grep -q '^CANVAS_POSTGRES_VECTOR_ENABLED=false$' "$CANVAS_CONFIG_ENV"
+
+"$cli" config-set env.CANVAS_DATABASE_PROVIDER postgres --no-banner > "$TMP_DIR/config-set-provider.txt"
+"$cli" env --sync --no-banner > "$TMP_DIR/env-sync-postgres.txt"
+"$cli" env --no-banner > "$TMP_DIR/env-postgres.txt"
+grep -q '^COMPOSE_PROFILES=postgres$' "$CANVAS_COMPOSE_ENV"
+grep -q '^CANVAS_DATABASE_PROVIDER=postgres$' "$CANVAS_COMPOSE_ENV"
+grep -q '^CANVAS_POSTGRES_VECTOR_ENABLED=true$' "$CANVAS_CONFIG_ENV"
+grep -q '^CANVAS_POSTGRES_PASSWORD=' "$CANVAS_COMPOSE_ENV"
+grep -q '^DATABASE_URL=postgresql://canvas:' "$CANVAS_CONFIG_ENV"
+grep -q 'postgresql://\*\*\*' "$TMP_DIR/env-postgres.txt"
+if grep -Eq 'DATABASE_URL[[:space:]]+postgresql://canvas:[^*]' "$TMP_DIR/env-postgres.txt"; then
+  echo "DATABASE_URL was not masked in env output" >&2
+  exit 1
+fi
+
+"$cli" config-show --json --no-banner > "$TMP_DIR/config-show.json"
+grep -q '"DATABASE_URL": "postgresql://\*\*\*"' "$TMP_DIR/config-show.json"
+grep -q '"CANVAS_POSTGRES_PASSWORD": ".*\*\*\*"' "$TMP_DIR/config-show.json"
+if grep -Eq 'postgresql://canvas:[^*]' "$TMP_DIR/config-show.json"; then
+  echo "DATABASE_URL was not masked in config-show output" >&2
+  exit 1
+fi
+
+jq '.env.CANVAS_DATABASE_PROVIDER = "sqlite" | .env.CANVAS_DEPLOYMENT_MODE = "managed-team"' \
+  "$CANVAS_CONFIG_JSON" > "$TMP_DIR/config-inconsistent.json"
+cp "$TMP_DIR/config-inconsistent.json" "$CANVAS_CONFIG_JSON"
+if "$cli" env --sync --no-banner > "$TMP_DIR/team-sqlite.txt" 2>&1; then
+  echo "managed-team accepted sqlite provider" >&2
+  exit 1
+fi
+grep -q 'requires CANVAS_DATABASE_PROVIDER=postgres' "$TMP_DIR/team-sqlite.txt"
+
+"$cli" config-set env.CANVAS_DATABASE_PROVIDER postgres --no-banner > /dev/null
+"$cli" env --sync --no-banner > /dev/null
+grep -q '^COMPOSE_PROFILES=postgres$' "$CANVAS_COMPOSE_ENV"
+
+grep -q 'canvas-notebook-postgres' "$CANVAS_COMPOSE_FILE"
+grep -q 'profiles:' "$CANVAS_COMPOSE_FILE"
+grep -q 'pgvector/pgvector:0.8.3-pg18' "$CANVAS_COMPOSE_FILE"
+grep -q 'unused-sqlite-profile-disabled' "$CANVAS_COMPOSE_FILE"
+
+jq '.env.DATABASE_URL = "" | .env.CANVAS_POSTGRES_PASSWORD = "bad/password+"' \
+  "$CANVAS_CONFIG_JSON" > "$TMP_DIR/config-bad-password.json"
+cp "$TMP_DIR/config-bad-password.json" "$CANVAS_CONFIG_JSON"
+if "$cli" env --sync --no-banner > "$TMP_DIR/bad-password.txt" 2>&1; then
+  echo "unsafe generated DATABASE_URL password was accepted" >&2
+  exit 1
+fi
+grep -q 'URL-reserved characters' "$TMP_DIR/bad-password.txt"
+
+echo "cli database provider tests passed"

--- a/scripts/cli-database-provider-test.sh
+++ b/scripts/cli-database-provider-test.sh
@@ -99,6 +99,9 @@ grep -q 'requires CANVAS_DATABASE_PROVIDER=postgres' "$TMP_DIR/team-sqlite.txt"
 "$cli" config-set env.CANVAS_DATABASE_PROVIDER postgres --no-banner > /dev/null
 "$cli" env --sync --no-banner > /dev/null
 grep -q '^COMPOSE_PROFILES=postgres$' "$CANVAS_COMPOSE_ENV"
+: > "$CANVAS_TEST_COMPOSE_LOG"
+"$cli" restart --no-banner > "$TMP_DIR/restart-postgres.txt"
+grep -q 'up -d --force-recreate' "$CANVAS_TEST_COMPOSE_LOG"
 
 grep -q 'canvas-notebook-postgres' "$CANVAS_COMPOSE_FILE"
 grep -q 'condition: service_healthy' "$CANVAS_COMPOSE_FILE"


### PR DESCRIPTION
## Summary
- add Canvas Notebook installer/CLI support for SQLite vs Postgres provider selection
- force Postgres for team/advanced deployments and generate pgvector Compose profile/env values
- mask Postgres secrets in CLI config/env output and add CLI coverage for provider sync guards
- mark Task 39 complete in the architecture todo list

## Verification
- npm run test:cli:database-provider
- npm run test:cli:admin
- bash -n install.sh install/bin/canvas-notebook install/lib/shared/config_json.sh install/lib/shared/compose.sh install/lib/commands/env.sh install/lib/commands/config_cmd.sh install/lib/commands/lifecycle.sh install/lib/shared/ui.sh scripts/cli-database-provider-test.sh scripts/cli-admin-command-test.sh
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build

Greptile score: 4/5 (latest Greptile review; all actionable Greptile feedback fixed in follow-up commits; no further Greptile trigger per user instruction)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds SQLite vs Postgres provider selection to the Canvas Notebook CLI installer, including interactive prompts, a team-mode postgres enforcement guard, pgvector compose profile generation, and secret masking for `DATABASE_URL` and `CANVAS_POSTGRES_PASSWORD`.

- **Provider selection & enforcement**: `configure_database_values` in `install.sh` and `config_json_ensure_database_config` in `config_json.sh` add interactive and non-interactive flows, normalize the provider value, auto-generate a URL-safe postgres password and `DATABASE_URL`, and hard-fail when a team/advanced deployment mode is configured with sqlite.
- **Compose profile wiring**: `write_managed_compose_file` emits the `postgres` profile service with a healthcheck and a profile-safe `depends_on` condition; `config_json_to_env` sets `COMPOSE_PROFILES=postgres` when the provider is postgres; `cmd_start` and `env --sync` drop the single-service scope so Docker Compose brings up all profile-active containers.
- **Secret masking**: `_mask_json_secrets` and the env display path now fully mask `DATABASE_URL` and partially mask `CANVAS_POSTGRES_PASSWORD`, with `null`/empty guards to avoid a false `"postgresql://***"` for missing keys.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one follow-up fix: cmd_restart won't start a postgres container that has never run, leaving the app unable to connect after a provider switch if the user runs restart instead of start.

The core install and env --sync paths are correct and well-tested. However, cmd_restart still calls run_compose restart "$SERVICE" rather than run_compose up -d, so a user who switches to postgres and then runs canvas-notebook restart will have the app restarted while postgres is never created, producing a database connection failure at boot.

install/lib/commands/lifecycle.sh — cmd_restart does not align with the profile-aware startup fix applied to cmd_start

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| install/lib/commands/lifecycle.sh | cmd_start fixed to use `up -d` for profile-aware postgres startup, but cmd_restart still uses `restart "$SERVICE"` and won't start a new postgres container |
| install/lib/shared/config_json.sh | Adds database provider normalization, postgres requirement guards, secret generation, and DATABASE_URL assembly; pg_user/pg_db lack URL-safety validation |
| install/lib/shared/compose.sh | Adds write_managed_compose_file helper that emits the postgres profile service and depends_on health gate; migration detection expanded to include canvas-notebook-postgres presence check |
| install/lib/commands/config_cmd.sh | Extends secret masking to DATABASE_URL (full mask) and CANVAS_POSTGRES_PASSWORD (prefix mask) with proper null/empty guards |
| install/lib/commands/env.sh | DATABASE_URL masking added to the env display path; --sync no longer scopes compose up to a single service |
| compose.hub.yaml | Adds postgres profile service with pgvector, healthcheck, and profile-safe depends_on on canvas-notebook |
| install.sh | Adds configure_database_values step with interactive provider/deployment-mode selection and team-mode postgres enforcement |
| scripts/cli-database-provider-test.sh | New integration test covering default sqlite profile, provider switch to postgres, masking checks, inconsistency guard, and bad-password rejection |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([canvas-notebook install / env --sync]) --> B[configure_database_values]
    B --> C{Interactive?}
    C -- Yes --> D[Prompt: deployment scope\n1=single-user / 2=team]
    D -- Team --> E[deployment_mode=managed-team\nprovider=postgres]
    D -- Single --> F[Prompt: provider\n1=sqlite / 2=postgres]
    F --> G[provider=sqlite or postgres]
    C -- No\nNONINTERACTIVE=true --> H[Use env vars /\ncurrent config defaults]
    E --> I[config_json_ensure_database_config]
    G --> I
    H --> I
    I --> J{deployment requires\npostgres?}
    J -- Yes + provider!=postgres --> K[FAIL: team mode\nrequires postgres]
    J -- No or provider=postgres --> L{provider=postgres?}
    L -- No --> M[Write CANVAS_POSTGRES_VECTOR_ENABLED=false\nCOMPOSE_PROFILES empty]
    L -- Yes --> N{DATABASE_URL\nalready set?}
    N -- No --> O[Generate URL-safe password\nBuild DATABASE_URL\nStore both in config.json]
    N -- Yes --> P[Use existing DATABASE_URL]
    O --> Q[Write CANVAS_POSTGRES_VECTOR_ENABLED=true\nCOMPOSE_PROFILES=postgres\nAll PG env vars to .env]
    P --> Q
    M --> R[config_json_to_env\nwrites compose .env + container env]
    Q --> R
    R --> S[compose up -d\nstarts app + postgres profile]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([canvas-notebook install / env --sync]) --> B[configure_database_values]
    B --> C{Interactive?}
    C -- Yes --> D[Prompt: deployment scope\n1=single-user / 2=team]
    D -- Team --> E[deployment_mode=managed-team\nprovider=postgres]
    D -- Single --> F[Prompt: provider\n1=sqlite / 2=postgres]
    F --> G[provider=sqlite or postgres]
    C -- No\nNONINTERACTIVE=true --> H[Use env vars /\ncurrent config defaults]
    E --> I[config_json_ensure_database_config]
    G --> I
    H --> I
    I --> J{deployment requires\npostgres?}
    J -- Yes + provider!=postgres --> K[FAIL: team mode\nrequires postgres]
    J -- No or provider=postgres --> L{provider=postgres?}
    L -- No --> M[Write CANVAS_POSTGRES_VECTOR_ENABLED=false\nCOMPOSE_PROFILES empty]
    L -- Yes --> N{DATABASE_URL\nalready set?}
    N -- No --> O[Generate URL-safe password\nBuild DATABASE_URL\nStore both in config.json]
    N -- Yes --> P[Use existing DATABASE_URL]
    O --> Q[Write CANVAS_POSTGRES_VECTOR_ENABLED=true\nCOMPOSE_PROFILES=postgres\nAll PG env vars to .env]
    P --> Q
    M --> R[config_json_to_env\nwrites compose .env + container env]
    Q --> R
    R --> S[compose up -d\nstarts app + postgres profile]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `install/lib/commands/lifecycle.sh`, line 17 ([link](https://github.com/canvascoding/canvas-notebook/blob/5555fcaadd31c245c8006ece68b03bbaa20e6e96/install/lib/commands/lifecycle.sh#L17)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`restart` won't start a postgres container that isn't already running**

   `cmd_start` was deliberately changed to `run_compose up -d` (without `$SERVICE`) so that an active postgres profile causes the postgres container to be created and started. `cmd_restart`, however, still calls `run_compose restart "$SERVICE"` — `compose restart` only restarts **already-running** containers; it will not create or start a new one. A user who switches to postgres and then runs `canvas-notebook restart` (instead of `start`) will have the app container restarted without ever starting postgres, causing a database connection failure on boot.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Finstaller-database-provider-choice%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Finstaller-database-provider-choice%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20install%2Flib%2Fcommands%2Flifecycle.sh%0ALine%3A%2017%0A%0AComment%3A%0A**%60restart%60%20won't%20start%20a%20postgres%20container%20that%20isn't%20already%20running**%0A%0A%60cmd_start%60%20was%20deliberately%20changed%20to%20%60run_compose%20up%20-d%60%20%28without%20%60%24SERVICE%60%29%20so%20that%20an%20active%20postgres%20profile%20causes%20the%20postgres%20container%20to%20be%20created%20and%20started.%20%60cmd_restart%60%2C%20however%2C%20still%20calls%20%60run_compose%20restart%20%22%24SERVICE%22%60%20%E2%80%94%20%60compose%20restart%60%20only%20restarts%20**already-running**%20containers%3B%20it%20will%20not%20create%20or%20start%20a%20new%20one.%20A%20user%20who%20switches%20to%20postgres%20and%20then%20runs%20%60canvas-notebook%20restart%60%20%28instead%20of%20%60start%60%29%20will%20have%20the%20app%20container%20restarted%20without%20ever%20starting%20postgres%2C%20causing%20a%20database%20connection%20failure%20on%20boot.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=canvascoding%2Fcanvas-notebook&pr=40&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Finstaller-database-provider-choice%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Finstaller-database-provider-choice%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ainstall%2Flib%2Fcommands%2Flifecycle.sh%3A17%0A**%60restart%60%20won't%20start%20a%20postgres%20container%20that%20isn't%20already%20running**%0A%0A%60cmd_start%60%20was%20deliberately%20changed%20to%20%60run_compose%20up%20-d%60%20%28without%20%60%24SERVICE%60%29%20so%20that%20an%20active%20postgres%20profile%20causes%20the%20postgres%20container%20to%20be%20created%20and%20started.%20%60cmd_restart%60%2C%20however%2C%20still%20calls%20%60run_compose%20restart%20%22%24SERVICE%22%60%20%E2%80%94%20%60compose%20restart%60%20only%20restarts%20**already-running**%20containers%3B%20it%20will%20not%20create%20or%20start%20a%20new%20one.%20A%20user%20who%20switches%20to%20postgres%20and%20then%20runs%20%60canvas-notebook%20restart%60%20%28instead%20of%20%60start%60%29%20will%20have%20the%20app%20container%20restarted%20without%20ever%20starting%20postgres%2C%20causing%20a%20database%20connection%20failure%20on%20boot.%0A%0A%23%23%23%20Issue%202%20of%202%0Ainstall%2Flib%2Fshared%2Fconfig_json.sh%3A304-307%0A**%60pg_user%60%20and%20%60pg_db%60%20not%20validated%20for%20URL-reserved%20characters**%0A%0AThe%20auto-generated%20%60DATABASE_URL%60%20is%20built%20by%20string-interpolating%20%60pg_user%60%2C%20%60pg_password%60%2C%20and%20%60pg_db%60.%20%60pg_password%60%20is%20checked%20against%20a%20URL-safe%20character%20class%20%28line%20304%29%2C%20but%20no%20equivalent%20guard%20exists%20for%20%60pg_user%60%20or%20%60pg_db%60.%20A%20custom%20%60CANVAS_POSTGRES_USER%60%20or%20%60CANVAS_POSTGRES_DB%60%20containing%20%60%40%60%2C%20%60%3A%60%2C%20%60%2F%60%2C%20or%20%60%3F%60%20would%20silently%20produce%20a%20malformed%20URL%2C%20causing%20every%20subsequent%20connection%20attempt%20to%20fail.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=40&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address greptile installer feedback"](https://github.com/canvascoding/canvas-notebook/commit/5555fcaadd31c245c8006ece68b03bbaa20e6e96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39023529)</sub>

<!-- /greptile_comment -->
