### PR TITLE
Make backups and migration manifests provider aware

### DIFF
--- a/app/lib/backups/full-backup-service.ts
+++ b/app/lib/backups/full-backup-service.ts
@@ -631,6 +631,15 @@ async function unzipText(args: string[], maxBuffer = 100 * 1024 * 1024): Promise
   return stdout;
 }
 
+async function unzipBuffer(args: string[], maxBuffer = 500 * 1024 * 1024): Promise<Buffer> {
+  const { stdout } = await execFileAsync('unzip', args, { encoding: 'buffer', maxBuffer });
+  return stdout;
+}
+
+function sha256Buffer(buffer: Buffer): string {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
 function parseManifest(raw: string): CanvasFullBackupManifest | null {
   let parsed: unknown;
   try {
@@ -685,6 +694,22 @@ export async function inspectFullBackupArchive(archivePath: string): Promise<Ful
   }
   if (!manifest.database.artifactPath || !manifest.database.artifactSha256) {
     risks.push('Backup database artifact is missing or has no checksum.');
+  } else {
+    try {
+      const artifactBytes = await unzipBuffer(['-p', archivePath, manifest.database.artifactPath]);
+      const actualSha256 = sha256Buffer(artifactBytes);
+      if (actualSha256 !== manifest.database.artifactSha256) {
+        risks.push('Backup database artifact checksum does not match the manifest.');
+      }
+    } catch (error) {
+      risks.push(`Backup database artifact could not be read: ${error instanceof Error ? error.message : 'unknown error'}`);
+    }
+  }
+  if (sourceProvider === 'sqlite' && manifest.database.backupKind !== 'sqlite_snapshot') {
+    risks.push('SQLite full backup manifest does not point to a SQLite snapshot.');
+  }
+  if (sourceProvider === 'postgres' && manifest.database.backupKind !== 'postgres_dump') {
+    risks.push('Postgres full backup manifest does not point to a Postgres dump.');
   }
 
   return {

--- a/app/lib/backups/full-backup-service.ts
+++ b/app/lib/backups/full-backup-service.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import crypto from 'crypto';
-import { execFile } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import path from 'path';
 import { createReadStream, createWriteStream, promises as fs, type WriteStream } from 'fs';
 import { promisify } from 'util';
@@ -631,13 +631,44 @@ async function unzipText(args: string[], maxBuffer = 100 * 1024 * 1024): Promise
   return stdout;
 }
 
-async function unzipBuffer(args: string[], maxBuffer = 500 * 1024 * 1024): Promise<Buffer> {
-  const { stdout } = await execFileAsync('unzip', args, { encoding: 'buffer', maxBuffer });
-  return stdout;
-}
+async function sha256ZipEntry(archivePath: string, entryPath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256');
+    const child = spawn('unzip', ['-p', archivePath, entryPath], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const stderrChunks: Buffer[] = [];
+    let stderrBytes = 0;
+    let settled = false;
 
-function sha256Buffer(buffer: Buffer): string {
-  return crypto.createHash('sha256').update(buffer).digest('hex');
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      hash.update(chunk);
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      if (stderrBytes >= 4096) return;
+      const remaining = 4096 - stderrBytes;
+      stderrChunks.push(chunk.subarray(0, remaining));
+      stderrBytes += Math.min(chunk.length, remaining);
+    });
+    child.stdout.on('error', fail);
+    child.stderr.on('error', fail);
+    child.on('error', fail);
+    child.on('close', (code, signal) => {
+      if (settled) return;
+      if (code === 0) {
+        settled = true;
+        resolve(hash.digest('hex'));
+        return;
+      }
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+      const exitReason = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`;
+      fail(new Error(`unzip exited with ${exitReason}${stderr ? `: ${stderr}` : ''}`));
+    });
+  });
 }
 
 function parseManifest(raw: string): CanvasFullBackupManifest | null {
@@ -696,8 +727,7 @@ export async function inspectFullBackupArchive(archivePath: string): Promise<Ful
     risks.push('Backup database artifact is missing or has no checksum.');
   } else {
     try {
-      const artifactBytes = await unzipBuffer(['-p', archivePath, manifest.database.artifactPath]);
-      const actualSha256 = sha256Buffer(artifactBytes);
+      const actualSha256 = await sha256ZipEntry(archivePath, manifest.database.artifactPath);
       if (actualSha256 !== manifest.database.artifactSha256) {
         risks.push('Backup database artifact checksum does not match the manifest.');
       }

--- a/app/lib/migration/export-service.ts
+++ b/app/lib/migration/export-service.ts
@@ -16,6 +16,8 @@ import {
   type CanvasMigrationManifest,
   type MigrationComponentKey,
   type MigrationComponents,
+  type MigrationExportDatabase,
+  type MigrationExportFeatures,
   type MigrationExportJob,
   type MigrationExportOptions,
   type MigrationExportProfile,
@@ -335,6 +337,17 @@ async function maybeStat(pathname: string): Promise<import('fs').Stats | null> {
   }
 }
 
+async function sha256File(filePath: string): Promise<string> {
+  const hash = crypto.createHash('sha256');
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(filePath, { highWaterMark: 1024 * 1024 });
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', resolve);
+  });
+  return hash.digest('hex');
+}
+
 function extractEnvKeys(raw: string): string[] {
   const keys = new Set<string>();
   for (const line of raw.split(/\r?\n/u)) {
@@ -420,6 +433,7 @@ async function buildReconnectManifest(params: {
 async function createSqliteSnapshot(dataRoot: string, exportDir: string): Promise<{
   filePath: string;
   entry: MigrationFileEntry;
+  sha256: string;
 }> {
   const sourcePath = path.join(dataRoot, SQLITE_FILE_NAME);
   const snapshotPath = path.join(exportDir, 'snapshot', SQLITE_FILE_NAME);
@@ -445,14 +459,64 @@ async function createSqliteSnapshot(dataRoot: string, exportDir: string): Promis
   }
 
   const stats = await fs.stat(snapshotPath);
+  const sha256 = await sha256File(snapshotPath);
   return {
     filePath: snapshotPath,
+    sha256,
     entry: {
       component: 'database',
       archivePath: `data/${SQLITE_FILE_NAME}`,
       size: stats.size,
       modifiedAt: stats.mtime.toISOString(),
     },
+  };
+}
+
+function normalizeDatabaseProvider(value: string | null | undefined): MigrationExportDatabase['provider'] {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === 'sqlite' || normalized === 'postgres') return normalized;
+  return 'unknown';
+}
+
+function buildFeatures(source: MigrationExportSource): MigrationExportFeatures {
+  const truthy = (value: string | undefined) => value === 'true' || value === '1' || value === 'yes';
+  return {
+    teamWorkspaceEnabled: source.teamFeaturesEnabled || truthy(process.env.CANVAS_TEAM_WORKSPACE_ENABLED),
+    knowledgeEnabled: truthy(process.env.CANVAS_KNOWLEDGE_ENABLED) || truthy(process.env.CANVAS_TEAM_KNOWLEDGE_BASE_ENABLED),
+    embeddingsEnabled: truthy(process.env.CANVAS_EMBEDDINGS_ENABLED) || truthy(process.env.CANVAS_POSTGRES_VECTOR_ENABLED),
+    collaborationEnabled: truthy(process.env.CANVAS_COLLABORATION_ENABLED),
+  };
+}
+
+function buildDatabaseManifest(params: {
+  source: MigrationExportSource;
+  sqliteSnapshot: { entry: MigrationFileEntry; sha256: string } | null;
+}): MigrationExportDatabase {
+  const provider = normalizeDatabaseProvider(params.source.databaseProvider);
+  if (provider === 'sqlite' && params.sqliteSnapshot) {
+    return {
+      provider,
+      logicalSchemaVersion: null,
+      migrationVersion: MIGRATION_BUNDLE_SCHEMA_VERSION,
+      backupKind: 'sqlite_snapshot',
+      artifactPath: params.sqliteSnapshot.entry.archivePath,
+      artifactSha256: params.sqliteSnapshot.sha256,
+      pgvectorEnabled: null,
+      pgvectorVersion: null,
+      postgresVersion: null,
+    };
+  }
+
+  return {
+    provider,
+    logicalSchemaVersion: null,
+    migrationVersion: MIGRATION_BUNDLE_SCHEMA_VERSION,
+    backupKind: 'none',
+    artifactPath: null,
+    artifactSha256: null,
+    pgvectorEnabled: provider === 'postgres' ? process.env.CANVAS_POSTGRES_VECTOR_ENABLED === 'true' : null,
+    pgvectorVersion: provider === 'postgres' ? process.env.CANVAS_POSTGRES_VECTOR_VERSION?.trim() || null : null,
+    postgresVersion: provider === 'postgres' ? process.env.CANVAS_POSTGRES_VERSION?.trim() || null : null,
   };
 }
 
@@ -463,6 +527,8 @@ function buildManifest(params: {
   selection: MigrationExportSelection;
   source: MigrationExportSource;
   security: MigrationExportSecurity;
+  database: MigrationExportDatabase;
+  features: MigrationExportFeatures;
   files: MigrationFileEntry[];
 }): CanvasMigrationManifest {
   const warnings: string[] = [
@@ -494,6 +560,9 @@ function buildManifest(params: {
   } else {
     warnings.push('Only a redacted reconnect manifest is included for secrets; raw secret files and OAuth tokens are excluded.');
   }
+  if (params.database.provider === 'postgres' && params.components.database) {
+    warnings.push('Postgres database contents are not embedded in normal migration exports. Use Full Backup for a Postgres dump.');
+  }
 
   return {
     format: 'canvas-notebook-migration',
@@ -506,6 +575,14 @@ function buildManifest(params: {
     selection: params.selection,
     source: params.source,
     security: params.security,
+    database: params.database,
+    features: params.features,
+    restore: {
+      requiresPostgres: params.database.provider === 'postgres',
+      requiresReindex: params.database.provider === 'postgres' || params.features.knowledgeEnabled || params.features.embeddingsEnabled,
+      preservesTargetInstanceAndLicense: true,
+      publicLinksIncluded: false,
+    },
     fileCount: params.files.length,
     totalBytes: params.files.reduce((sum, entry) => sum + entry.size, 0),
     warnings,
@@ -540,13 +617,16 @@ async function runExport(job: MigrationExportJob): Promise<void> {
 
     await ensureMigrationDir(exportDir);
     const files: MigrationFileEntry[] = [];
-    let sqliteSnapshot: { filePath: string; entry: MigrationFileEntry } | null = null;
+    let sqliteSnapshot: { filePath: string; entry: MigrationFileEntry; sha256: string } | null = null;
 
-    if (job.components.database) {
+    if (job.components.database && job.source.databaseProvider === 'sqlite') {
       job.phase = 'Creating SQLite backup';
       await persist(true);
       sqliteSnapshot = await createSqliteSnapshot(dataRoot, exportDir);
       files.push(sqliteSnapshot.entry);
+    } else if (job.components.database) {
+      job.phase = 'Recording database provider metadata';
+      await persist(true);
     }
 
     const componentRoots = getSelectedMigrationExportComponentPaths(job.components, {
@@ -577,6 +657,8 @@ async function runExport(job: MigrationExportJob): Promise<void> {
       selection: job.selection,
       source: job.source,
       security: buildExportSecurity(job.components),
+      database: buildDatabaseManifest({ source: job.source, sqliteSnapshot }),
+      features: buildFeatures(job.source),
       files,
     });
     job.manifest = manifest;

--- a/app/lib/migration/inspect-service.ts
+++ b/app/lib/migration/inspect-service.ts
@@ -11,7 +11,10 @@ import {
   type CanvasMigrationManifest,
   type MigrationComponentKey,
   type MigrationComponents,
+  type MigrationExportDatabase,
+  type MigrationExportFeatures,
   type MigrationExportProfile,
+  type MigrationExportRestore,
   type MigrationExportSecurity,
   type MigrationExportSelection,
   type MigrationExportSource,
@@ -114,6 +117,51 @@ function parseExportSecurity(value: unknown): MigrationExportSecurity | undefine
   };
 }
 
+function parseExportDatabase(value: unknown): MigrationExportDatabase | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const database = value as Record<string, unknown>;
+  const provider = database.provider === 'sqlite' || database.provider === 'postgres' || database.provider === 'unknown'
+    ? database.provider
+    : 'unknown';
+  const backupKind = database.backupKind === 'sqlite_snapshot' || database.backupKind === 'postgres_dump' || database.backupKind === 'none'
+    ? database.backupKind
+    : 'none';
+  return {
+    provider,
+    logicalSchemaVersion: typeof database.logicalSchemaVersion === 'number' ? database.logicalSchemaVersion : null,
+    migrationVersion: typeof database.migrationVersion === 'number' ? database.migrationVersion : null,
+    backupKind,
+    artifactPath: optionalString(database.artifactPath),
+    artifactSha256: optionalString(database.artifactSha256),
+    compressedBytes: typeof database.compressedBytes === 'number' ? database.compressedBytes : null,
+    pgvectorEnabled: typeof database.pgvectorEnabled === 'boolean' ? database.pgvectorEnabled : null,
+    pgvectorVersion: optionalString(database.pgvectorVersion),
+    postgresVersion: optionalString(database.postgresVersion),
+  };
+}
+
+function parseExportFeatures(value: unknown): MigrationExportFeatures | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const features = value as Record<string, unknown>;
+  return {
+    teamWorkspaceEnabled: features.teamWorkspaceEnabled === true,
+    knowledgeEnabled: features.knowledgeEnabled === true,
+    embeddingsEnabled: features.embeddingsEnabled === true,
+    collaborationEnabled: features.collaborationEnabled === true,
+  };
+}
+
+function parseExportRestore(value: unknown): MigrationExportRestore | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const restore = value as Record<string, unknown>;
+  return {
+    requiresPostgres: restore.requiresPostgres === true,
+    requiresReindex: restore.requiresReindex === true,
+    preservesTargetInstanceAndLicense: true,
+    publicLinksIncluded: false,
+  };
+}
+
 function parseManifest(raw: string): CanvasMigrationManifest | null {
   let parsed: unknown;
   try {
@@ -148,6 +196,9 @@ function parseManifest(raw: string): CanvasMigrationManifest | null {
     selection: parseExportSelection(record.selection),
     source: parseExportSource(record.source),
     security: parseExportSecurity(record.security),
+    database: parseExportDatabase(record.database),
+    features: parseExportFeatures(record.features),
+    restore: parseExportRestore(record.restore),
     fileCount: record.fileCount,
     totalBytes: record.totalBytes,
     warnings: Array.isArray(record.warnings) ? record.warnings.filter((item): item is string => typeof item === 'string') : [],
@@ -501,13 +552,34 @@ function buildDryRun(params: {
   const blockers: string[] = [];
 
   if (params.manifest.components.database) {
-    const sourceProvider = params.manifest.source?.databaseProvider ?? 'sqlite';
-    if (sourceProvider !== 'sqlite') {
-      blockers.push(`Source database provider ${sourceProvider} is not supported by the V1 restore engine.`);
+    const sourceProvider = params.manifest.database?.provider ?? params.manifest.source?.databaseProvider ?? 'sqlite';
+    const backupKind = params.manifest.database?.backupKind ?? 'sqlite_snapshot';
+    const artifactPath = params.manifest.database?.artifactPath ?? 'data/sqlite.db';
+    if (sourceProvider === 'postgres') {
+      if (target.databaseProvider !== 'postgres') {
+        blockers.push('This export requires a Postgres target before database restore can be staged.');
+      }
+      blockers.push('Postgres database restore is not supported by the migration restore engine; use Full Backup restore or the SQLite-to-Postgres migration flow.');
+    } else if (sourceProvider !== 'sqlite') {
+      blockers.push(`Source database provider ${sourceProvider} is not supported by the restore engine.`);
+    } else {
+      if (backupKind !== 'sqlite_snapshot' || artifactPath !== 'data/sqlite.db') {
+        blockers.push('SQLite database restore requires a sanitized data/sqlite.db snapshot in the migration archive.');
+      }
+      if (target.databaseProvider !== 'sqlite') {
+        blockers.push(`Target database provider ${target.databaseProvider} requires a provider-aware import path before SQLite database restore.`);
+      }
     }
-    if (target.databaseProvider !== 'sqlite') {
-      blockers.push(`Target database provider ${target.databaseProvider} requires a provider-aware import path before database restore.`);
-    }
+  }
+
+  if (params.manifest.restore?.requiresPostgres && target.databaseProvider !== 'postgres') {
+    blockers.push('Manifest restore metadata requires Postgres on the target instance.');
+  }
+  if (
+    target.databaseProvider !== 'postgres' &&
+    (params.manifest.features?.knowledgeEnabled || params.manifest.features?.embeddingsEnabled || params.manifest.features?.collaborationEnabled)
+  ) {
+    blockers.push('Knowledge, embeddings, or collaboration metadata requires a Postgres target and reindex before restore.');
   }
 
   for (const mapping of users) {
@@ -583,6 +655,12 @@ function buildRisks(manifest: CanvasMigrationManifest | null): string[] {
   if (!manifest.components.secrets) {
     risks.push('Secrets are not included. API keys and local integration credentials must be configured again.');
   }
+  if (manifest.database?.provider === 'postgres') {
+    risks.push('Postgres database data cannot be restored by the V1 migration restore script; use Full Backup restore or a dedicated provider migration.');
+  }
+  if (manifest.restore?.requiresReindex) {
+    risks.push('Knowledge or embedding indexes require reindexing after restore.');
+  }
 
   return risks;
 }
@@ -616,7 +694,7 @@ export async function inspectMigrationArchive(params: {
   }
 
   const currentAppVersion = getCurrentAppVersion();
-  const bundleSchemaSupported = manifest?.bundleSchemaVersion === MIGRATION_BUNDLE_SCHEMA_VERSION;
+  const bundleSchemaSupported = Boolean(manifest && manifest.bundleSchemaVersion >= 1 && manifest.bundleSchemaVersion <= MIGRATION_BUNDLE_SCHEMA_VERSION);
   const compatibility = formatVersionCompatibilityMessage({
     exportVersion: manifest?.appVersion ?? null,
     currentVersion: currentAppVersion,

--- a/app/lib/migration/inspect-service.ts
+++ b/app/lib/migration/inspect-service.ts
@@ -572,7 +572,11 @@ function buildDryRun(params: {
     }
   }
 
-  if (params.manifest.restore?.requiresPostgres && target.databaseProvider !== 'postgres') {
+  if (
+    params.manifest.restore?.requiresPostgres &&
+    !params.manifest.components.database &&
+    target.databaseProvider !== 'postgres'
+  ) {
     blockers.push('Manifest restore metadata requires Postgres on the target instance.');
   }
   if (

--- a/app/lib/migration/types.ts
+++ b/app/lib/migration/types.ts
@@ -1,4 +1,4 @@
-export const MIGRATION_BUNDLE_SCHEMA_VERSION = 1;
+export const MIGRATION_BUNDLE_SCHEMA_VERSION = 2;
 
 export const MIGRATION_COMPONENT_KEYS = [
   'database',
@@ -61,6 +61,9 @@ export interface CanvasMigrationManifest {
   selection?: MigrationExportSelection;
   source?: MigrationExportSource;
   security?: MigrationExportSecurity;
+  database?: MigrationExportDatabase;
+  features?: MigrationExportFeatures;
+  restore?: MigrationExportRestore;
   fileCount: number;
   totalBytes: number;
   warnings: string[];
@@ -90,6 +93,37 @@ export interface MigrationExportSecurity {
   rawSecretsIncluded: false;
   secretsMode: 'excluded' | 'reconnect_manifest';
   unencryptedArchive: true;
+}
+
+export type MigrationExportDatabaseProvider = 'sqlite' | 'postgres' | 'unknown';
+
+export type MigrationExportDatabaseBackupKind = 'sqlite_snapshot' | 'postgres_dump' | 'none';
+
+export interface MigrationExportDatabase {
+  provider: MigrationExportDatabaseProvider;
+  logicalSchemaVersion: number | null;
+  migrationVersion: number | null;
+  backupKind: MigrationExportDatabaseBackupKind;
+  artifactPath: string | null;
+  artifactSha256: string | null;
+  compressedBytes?: number | null;
+  pgvectorEnabled: boolean | null;
+  pgvectorVersion: string | null;
+  postgresVersion: string | null;
+}
+
+export interface MigrationExportFeatures {
+  teamWorkspaceEnabled: boolean;
+  knowledgeEnabled: boolean;
+  embeddingsEnabled: boolean;
+  collaborationEnabled: boolean;
+}
+
+export interface MigrationExportRestore {
+  requiresPostgres: boolean;
+  requiresReindex: boolean;
+  preservesTargetInstanceAndLicense: true;
+  publicLinksIncluded: false;
 }
 
 export interface MigrationExportOptions {

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -794,10 +794,11 @@
     {
       "id": 41,
       "title": "SQLite-zu-Postgres-Migrationstool mit Maintenance Mode, Snapshot, Referenzpruefung und Reindex-Status bauen",
-      "status": "pending",
+      "status": "completed",
       "repo": "cross-repo",
-      "blockedBy": [
-        "https://github.com/canvascoding/canvas-control-plane/pull/7"
+      "completedBy": [
+        "https://github.com/canvascoding/canvas-control-plane/pull/7",
+        "https://github.com/canvascoding/canvas-notebook/pull/41"
       ],
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/09-initial-setup-and-update-migration.md",
@@ -833,11 +834,28 @@
     {
       "id": 42,
       "title": "Export, Import, Backup und Restore provider-aware machen inklusive Postgres-Dump",
-      "status": "pending",
+      "status": "completed",
       "repo": "cross-repo",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/15-export-import-backup-restore-policy.md",
         "docs/architecture/canvas-notebook/team-workspace/17-database-provider-postgres-rag-collaboration-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/migration/types.ts",
+        "app/lib/migration/export-service.ts",
+        "app/lib/migration/inspect-service.ts",
+        "app/lib/migration/restore-service.ts",
+        "scripts/apply-pending-migration-restore.ts",
+        "app/lib/backups/full-backup-service.ts",
+        "scripts/full-backup-service-test.ts",
+        "scripts/migration-export-policy-test.ts",
+        "scripts/migration-import-dry-run-test.ts"
+      ],
+      "verification": [
+        "npm run test:backup:full",
+        "tsx --conditions react-server scripts/migration-export-policy-test.ts",
+        "tsx --conditions react-server scripts/migration-import-dry-run-test.ts",
+        "npm run build"
       ]
     },
     {

--- a/scripts/apply-pending-migration-restore.ts
+++ b/scripts/apply-pending-migration-restore.ts
@@ -79,6 +79,10 @@ async function validateArchive(archivePath: string): Promise<CanvasMigrationMani
   if (manifest.format !== 'canvas-notebook-migration' || !manifest.components) {
     throw new Error('Archive manifest is not a Canvas migration manifest.');
   }
+  const sourceProvider = manifest.database?.provider ?? manifest.source?.databaseProvider ?? 'sqlite';
+  if (manifest.components.database && sourceProvider !== 'sqlite') {
+    throw new Error(`Database restore for provider ${sourceProvider} is not supported by this migration restore script.`);
+  }
   return manifest;
 }
 

--- a/scripts/full-backup-service-test.ts
+++ b/scripts/full-backup-service-test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -51,8 +51,12 @@ async function main() {
   const previousData = process.env.DATA;
   const previousCanvasDataRoot = process.env.CANVAS_DATA_ROOT;
   const previousDatabaseProvider = process.env.CANVAS_DATABASE_PROVIDER;
+  const previousDatabaseUrl = process.env.DATABASE_URL;
   const previousDeploymentMode = process.env.CANVAS_DEPLOYMENT_MODE;
   const previousTeamFeatures = process.env.CANVAS_TEAM_FEATURES_ENABLED;
+  const previousVectorEnabled = process.env.CANVAS_POSTGRES_VECTOR_ENABLED;
+  const previousVectorVersion = process.env.CANVAS_POSTGRES_VECTOR_VERSION;
+  const previousPath = process.env.PATH;
 
   process.env.DATA = dataRoot;
   process.env.CANVAS_DATA_ROOT = dataRoot;
@@ -145,6 +149,71 @@ async function main() {
     assert.ok(inspection.warnings.some((warning) => warning.includes('unencrypted')));
     assert.equal('archivePath' in serializeFullBackupInspection(inspection), false);
 
+    const fakeBin = path.join(dataRoot, 'fake-bin');
+    await mkdir(fakeBin, { recursive: true });
+    const fakePgDump = path.join(fakeBin, 'pg_dump');
+    await writeFile(fakePgDump, `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "--version" ]]; then
+  echo "pg_dump (PostgreSQL) 18.1"
+  exit 0
+fi
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --file)
+      shift
+      out="$1"
+      ;;
+  esac
+  shift || true
+done
+if [[ -z "$out" ]]; then
+  echo "missing --file" >&2
+  exit 2
+fi
+printf 'fake-postgres-dump\\n' > "$out"
+`);
+    await chmod(fakePgDump, 0o700);
+    process.env.PATH = `${fakeBin}:${previousPath || ''}`;
+    process.env.CANVAS_DATABASE_PROVIDER = 'postgres';
+    process.env.DATABASE_URL = 'postgresql://canvas:secret@localhost:5432/canvas_notebook';
+    process.env.CANVAS_POSTGRES_VECTOR_ENABLED = 'true';
+    process.env.CANVAS_POSTGRES_VECTOR_VERSION = '0.8.3';
+
+    const postgresJob = await createFullBackupJob({
+      source: {
+        organizationId: 'org-backup',
+        createdByUserId: 'user-admin',
+        createdByEmail: 'admin@example.test',
+        createdByRole: 'admin',
+      },
+    });
+    const completedPostgres = await waitForBackup(getFullBackupJob, postgresJob.id);
+    assert.ok(completedPostgres.filePath);
+    const postgresEntries = await unzipList(completedPostgres.filePath);
+    assert.ok(postgresEntries.includes('manifest.json'));
+    assert.ok(postgresEntries.includes('database/postgres.dump'));
+    assert.equal(postgresEntries.includes('database/sqlite.db'), false);
+    assert.equal(postgresEntries.includes('data/sqlite.db'), false);
+    const postgresManifest = JSON.parse(await unzipEntryText(completedPostgres.filePath, 'manifest.json'));
+    assert.equal(postgresManifest.database.provider, 'postgres');
+    assert.equal(postgresManifest.database.backupKind, 'postgres_dump');
+    assert.equal(postgresManifest.database.artifactPath, 'database/postgres.dump');
+    assert.equal(postgresManifest.database.pgvectorEnabled, true);
+    assert.equal(postgresManifest.database.pgvectorVersion, '0.8.3');
+    assert.match(postgresManifest.database.postgresVersion, /PostgreSQL/u);
+    const dumpBytes = await unzipEntryBuffer(completedPostgres.filePath, 'database/postgres.dump');
+    assert.equal(createHash('sha256').update(dumpBytes).digest('hex'), postgresManifest.database.artifactSha256);
+    const postgresInspection = await inspectFullBackupArchive(completedPostgres.filePath);
+    assert.equal(postgresInspection.canRestore, true);
+    assert.equal(postgresInspection.sourceDatabaseProvider, 'postgres');
+    process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
+    const sqliteTargetInspection = await inspectFullBackupArchive(completedPostgres.filePath);
+    assert.equal(sqliteTargetInspection.canRestore, false);
+    assert.ok(sqliteTargetInspection.risks.some((risk) => risk.includes('SQLite target')));
+    process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
+
     await new Promise((resolve) => setTimeout(resolve, 50));
     const lockPath = path.join(dataRoot, 'system', 'backups', '.full-backup.lock');
     await writeFile(lockPath, `${JSON.stringify({
@@ -217,10 +286,18 @@ async function main() {
     else process.env.CANVAS_DATA_ROOT = previousCanvasDataRoot;
     if (previousDatabaseProvider === undefined) delete process.env.CANVAS_DATABASE_PROVIDER;
     else process.env.CANVAS_DATABASE_PROVIDER = previousDatabaseProvider;
+    if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = previousDatabaseUrl;
     if (previousDeploymentMode === undefined) delete process.env.CANVAS_DEPLOYMENT_MODE;
     else process.env.CANVAS_DEPLOYMENT_MODE = previousDeploymentMode;
     if (previousTeamFeatures === undefined) delete process.env.CANVAS_TEAM_FEATURES_ENABLED;
     else process.env.CANVAS_TEAM_FEATURES_ENABLED = previousTeamFeatures;
+    if (previousVectorEnabled === undefined) delete process.env.CANVAS_POSTGRES_VECTOR_ENABLED;
+    else process.env.CANVAS_POSTGRES_VECTOR_ENABLED = previousVectorEnabled;
+    if (previousVectorVersion === undefined) delete process.env.CANVAS_POSTGRES_VECTOR_VERSION;
+    else process.env.CANVAS_POSTGRES_VECTOR_VERSION = previousVectorVersion;
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
     await rm(dataRoot, { recursive: true, force: true });
   }
 }

--- a/scripts/full-backup-service-test.ts
+++ b/scripts/full-backup-service-test.ts
@@ -212,7 +212,6 @@ printf 'fake-postgres-dump\\n' > "$out"
     const sqliteTargetInspection = await inspectFullBackupArchive(completedPostgres.filePath);
     assert.equal(sqliteTargetInspection.canRestore, false);
     assert.ok(sqliteTargetInspection.risks.some((risk) => risk.includes('SQLite target')));
-    process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
 
     await new Promise((resolve) => setTimeout(resolve, 50));
     const lockPath = path.join(dataRoot, 'system', 'backups', '.full-backup.lock');

--- a/scripts/migration-export-policy-test.ts
+++ b/scripts/migration-export-policy-test.ts
@@ -53,11 +53,15 @@ async function main() {
   const previousCanvasDataRoot = process.env.CANVAS_DATA_ROOT;
   const previousDatabaseProvider = process.env.CANVAS_DATABASE_PROVIDER;
   const previousDeploymentMode = process.env.CANVAS_DEPLOYMENT_MODE;
+  const previousTeamFeatures = process.env.CANVAS_TEAM_FEATURES_ENABLED;
+  const previousKnowledgeEnabled = process.env.CANVAS_KNOWLEDGE_ENABLED;
+  const previousVectorEnabled = process.env.CANVAS_POSTGRES_VECTOR_ENABLED;
 
   process.env.DATA = dataRoot;
   process.env.CANVAS_DATA_ROOT = dataRoot;
   process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
   process.env.CANVAS_DEPLOYMENT_MODE = 'team';
+  process.env.CANVAS_TEAM_FEATURES_ENABLED = 'true';
 
   try {
     await mkdir(path.join(dataRoot, 'workspace'), { recursive: true });
@@ -158,6 +162,7 @@ async function main() {
     assert.ok(entries.includes('data/reconnect-manifest.json'));
 
     const manifest = JSON.parse(await unzipEntryText(completedStandard.filePath!, 'manifest.json'));
+    assert.equal(manifest.bundleSchemaVersion, 2);
     assert.equal(manifest.exportProfile, 'standard');
     assert.equal(manifest.selection.includePersonalWorkspaces, false);
     assert.equal(manifest.selection.includePublicLinks, false);
@@ -168,6 +173,14 @@ async function main() {
     assert.equal(manifest.security.secretsMode, 'reconnect_manifest');
     assert.equal(manifest.source.organizationId, 'org-export');
     assert.equal(manifest.source.createdByUserId, 'user-admin');
+    assert.equal(manifest.database.provider, 'sqlite');
+    assert.equal(manifest.database.backupKind, 'sqlite_snapshot');
+    assert.equal(manifest.database.artifactPath, 'data/sqlite.db');
+    assert.match(manifest.database.artifactSha256, /^[a-f0-9]{64}$/u);
+    assert.equal(manifest.features.teamWorkspaceEnabled, true);
+    assert.equal(manifest.restore.requiresPostgres, false);
+    assert.equal(manifest.restore.preservesTargetInstanceAndLicense, true);
+    assert.equal(manifest.restore.publicLinksIncluded, false);
 
     const reconnectManifest = JSON.parse(await unzipEntryText(completedStandard.filePath!, 'data/reconnect-manifest.json'));
     assert.equal(reconnectManifest.rawSecretsIncluded, false);
@@ -219,6 +232,36 @@ async function main() {
       .filter(Boolean);
     assert.ok(fullAdminEntries.includes('data/workspaces/personal/user-export/files/private.md'));
 
+    process.env.CANVAS_DATABASE_PROVIDER = 'postgres';
+    process.env.CANVAS_POSTGRES_VECTOR_ENABLED = 'true';
+    process.env.CANVAS_KNOWLEDGE_ENABLED = 'true';
+    const postgresJob = await createMigrationExportJob({
+      components,
+      profile: 'standard',
+      includePersonalWorkspaces: false,
+      source: {
+        organizationId: 'org-export',
+        createdByUserId: 'user-admin',
+        createdByEmail: 'admin@example.test',
+        createdByRole: 'admin',
+      },
+    });
+    const completedPostgres = await waitForExport(getMigrationExportJob, postgresJob.id);
+    assert.ok(completedPostgres.filePath);
+    const postgresEntries = (await unzipList(completedPostgres.filePath))
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    assert.equal(postgresEntries.includes('data/sqlite.db'), false);
+    const postgresManifest = JSON.parse(await unzipEntryText(completedPostgres.filePath, 'manifest.json'));
+    assert.equal(postgresManifest.database.provider, 'postgres');
+    assert.equal(postgresManifest.database.backupKind, 'none');
+    assert.equal(postgresManifest.database.artifactPath, null);
+    assert.equal(postgresManifest.database.pgvectorEnabled, true);
+    assert.equal(postgresManifest.restore.requiresPostgres, true);
+    assert.equal(postgresManifest.restore.requiresReindex, true);
+    assert.ok(postgresManifest.warnings.some((warning: string) => warning.includes('Full Backup')));
+
     console.log('migration-export-policy-test: ok');
   } finally {
     if (previousData === undefined) delete process.env.DATA;
@@ -229,6 +272,12 @@ async function main() {
     else process.env.CANVAS_DATABASE_PROVIDER = previousDatabaseProvider;
     if (previousDeploymentMode === undefined) delete process.env.CANVAS_DEPLOYMENT_MODE;
     else process.env.CANVAS_DEPLOYMENT_MODE = previousDeploymentMode;
+    if (previousTeamFeatures === undefined) delete process.env.CANVAS_TEAM_FEATURES_ENABLED;
+    else process.env.CANVAS_TEAM_FEATURES_ENABLED = previousTeamFeatures;
+    if (previousKnowledgeEnabled === undefined) delete process.env.CANVAS_KNOWLEDGE_ENABLED;
+    else process.env.CANVAS_KNOWLEDGE_ENABLED = previousKnowledgeEnabled;
+    if (previousVectorEnabled === undefined) delete process.env.CANVAS_POSTGRES_VECTOR_ENABLED;
+    else process.env.CANVAS_POSTGRES_VECTOR_ENABLED = previousVectorEnabled;
     await rm(dataRoot, { recursive: true, force: true });
   }
 }

--- a/scripts/migration-import-dry-run-test.ts
+++ b/scripts/migration-import-dry-run-test.ts
@@ -262,7 +262,7 @@ async function main() {
     assert.equal(postgresInspection.dryRun?.status, 'blocked');
     assert.ok(postgresInspection.dryRun?.blockers.some((blocker) => blocker.includes('Postgres target')));
     assert.ok(postgresInspection.dryRun?.blockers.some((blocker) => blocker.includes('Full Backup')));
-    assert.ok(postgresInspection.dryRun?.blockers.some((blocker) => blocker.includes('requires Postgres')));
+    assert.ok(postgresInspection.dryRun?.blockers.some((blocker) => blocker.includes('reindex')));
     assert.ok(postgresInspection.risks.some((risk) => risk.includes('Postgres database data')));
 
     console.log('migration-import-dry-run-test: ok');

--- a/scripts/migration-import-dry-run-test.ts
+++ b/scripts/migration-import-dry-run-test.ts
@@ -134,6 +134,29 @@ async function main() {
         secretsMode: 'reconnect_manifest',
         unencryptedArchive: true,
       },
+      database: {
+        provider: 'sqlite',
+        logicalSchemaVersion: null,
+        migrationVersion: MIGRATION_BUNDLE_SCHEMA_VERSION,
+        backupKind: 'sqlite_snapshot',
+        artifactPath: 'data/sqlite.db',
+        artifactSha256: '0'.repeat(64),
+        pgvectorEnabled: null,
+        pgvectorVersion: null,
+        postgresVersion: null,
+      },
+      features: {
+        teamWorkspaceEnabled: true,
+        knowledgeEnabled: false,
+        embeddingsEnabled: false,
+        collaborationEnabled: false,
+      },
+      restore: {
+        requiresPostgres: false,
+        requiresReindex: false,
+        preservesTargetInstanceAndLicense: true,
+        publicLinksIncluded: false,
+      },
       fileCount: 4,
       totalBytes: 4,
       warnings: [],
@@ -202,6 +225,45 @@ async function main() {
     assert.ok(blockedInspection.dryRun?.blockers.some((blocker) => blocker.includes('source-user')));
     assert.ok(blockedInspection.dryRun?.blockers.some((blocker) => blocker.includes('data/workspaces/team/org-source/files')));
     assert.ok(blockedInspection.dryRun?.blockers.some((blocker) => blocker.includes('data/workspaces/project/project-source/files')));
+
+    const postgresManifest: CanvasMigrationManifest = {
+      ...matchingManifest,
+      exportId: 'export-postgres',
+      database: {
+        provider: 'postgres',
+        logicalSchemaVersion: null,
+        migrationVersion: MIGRATION_BUNDLE_SCHEMA_VERSION,
+        backupKind: 'none',
+        artifactPath: null,
+        artifactSha256: null,
+        pgvectorEnabled: true,
+        pgvectorVersion: '0.8.3',
+        postgresVersion: 'PostgreSQL 18.1',
+      },
+      features: {
+        teamWorkspaceEnabled: true,
+        knowledgeEnabled: true,
+        embeddingsEnabled: true,
+        collaborationEnabled: true,
+      },
+      restore: {
+        requiresPostgres: true,
+        requiresReindex: true,
+        preservesTargetInstanceAndLicense: true,
+        publicLinksIncluded: false,
+      },
+      files: [],
+      fileCount: 0,
+      totalBytes: 0,
+    };
+    const postgresArchive = await createZipArchive(archiveRoot, 'postgres', postgresManifest, {});
+    const postgresInspection = await inspectMigrationArchive({ uploadId: 'postgres-upload', archivePath: postgresArchive });
+    assert.equal(postgresInspection.canRestore, false);
+    assert.equal(postgresInspection.dryRun?.status, 'blocked');
+    assert.ok(postgresInspection.dryRun?.blockers.some((blocker) => blocker.includes('Postgres target')));
+    assert.ok(postgresInspection.dryRun?.blockers.some((blocker) => blocker.includes('Full Backup')));
+    assert.ok(postgresInspection.dryRun?.blockers.some((blocker) => blocker.includes('requires Postgres')));
+    assert.ok(postgresInspection.risks.some((risk) => risk.includes('Postgres database data')));
 
     console.log('migration-import-dry-run-test: ok');
   } finally {


### PR DESCRIPTION
## Summary
- mark Task 41 complete now that the dependent Control Plane PR has merged, and mark Task 42 complete with implementation artifacts
- upgrade migration exports to schema v2 with database, feature, and restore metadata while keeping v1 archive inspection compatible
- make migration import dry runs block unsafe provider mismatches and harden full-backup inspection with database artifact checksum validation
- add Postgres full-backup dump coverage with a fake pg_dump and provider-aware export/import tests

## Verification
- npm run test:backup:full
- tsx --conditions react-server scripts/migration-export-policy-test.ts
- tsx --conditions react-server scripts/migration-import-dry-run-test.ts
- npm run build

Greptile score: 5/5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the migration export/import pipeline and full-backup service provider-aware by introducing a schema v2 manifest with `database`, `features`, and `restore` metadata sections, adding streaming SHA-256 checksum verification for full-backup database artifacts, and blocking unsafe provider mismatches during dry-run inspection and restore.

- **Schema v2 migration manifests** (`types.ts`, `export-service.ts`, `inspect-service.ts`): adds `MigrationExportDatabase` (provider, backupKind, SHA-256), `MigrationExportFeatures`, and `MigrationExportRestore` to `CanvasMigrationManifest`; the `bundleSchemaVersion` range check is widened to `[1, 2]` so v1 archives remain importable.
- **Full-backup checksum hardening** (`full-backup-service.ts`): replaces the buffered approach with a new `sha256ZipEntry` that streams `unzip -p` stdout through `crypto.createHash`, eliminating the 500 MB buffer ceiling that previously caused large Postgres dumps to fail inspection.
- **Provider-mismatch blocking** (`inspect-service.ts`, `apply-pending-migration-restore.ts`): dry-run now emits distinct blockers for Postgres-source exports and the restore script validates the provider before running, preventing silent partial restores.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are well-tested with end-to-end script coverage for both SQLite and Postgres paths, and v1 archive compatibility is preserved.

The core logic changes are thorough and backed by dedicated test scripts. The streaming checksum approach for full-backup inspection correctly eliminates the memory ceiling from the previous implementation. Dry-run blocker logic is carefully guarded to avoid the triple-blocker issue noted in prior review comments. The one noteworthy inconsistency (pgvectorEnabled strictness vs. the truthy() helper) affects only manifest metadata and not restore-engine decisions.

app/lib/migration/export-service.ts — minor inconsistency between pgvectorEnabled and embeddingsEnabled normalization.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/backups/full-backup-service.ts | Adds streaming sha256ZipEntry to verify database artifact checksums without loading the entire archive into memory, plus provider-aware backupKind validation for both SQLite and Postgres full backups. |
| app/lib/migration/export-service.ts | Upgrades export manifests to schema v2 with database, features, and restore metadata; computes SHA-256 of SQLite snapshots. Minor: pgvectorEnabled uses strict === 'true' while buildFeatures uses a truthy() helper accepting '1'/'yes', creating a potential metadata inconsistency. |
| app/lib/migration/inspect-service.ts | Adds parsers for new v2 manifest fields (database, features, restore), extends dry-run logic with Postgres and feature-based blockers, widens bundleSchemaVersion check to accept v1–v2 archives. |
| app/lib/migration/types.ts | Bumps MIGRATION_BUNDLE_SCHEMA_VERSION to 2 and adds MigrationExportDatabase, MigrationExportFeatures, and MigrationExportRestore interfaces with literal-typed fields. |
| scripts/apply-pending-migration-restore.ts | Adds an early-exit guard in validateArchive that blocks non-SQLite database restores, preventing the V1 restore script from running against a Postgres-sourced archive. |
| scripts/full-backup-service-test.ts | Adds Postgres full-backup coverage using a fake pg_dump binary, verifies archive structure, manifest fields, SHA-256 checksum, and provider-mismatch inspection behaviour. |
| scripts/migration-export-policy-test.ts | Extends export policy tests to assert v2 manifest fields for both SQLite and Postgres providers, verifying bundleSchemaVersion, database, features, and restore sections. |
| scripts/migration-import-dry-run-test.ts | Adds a Postgres manifest dry-run test that verifies all expected blockers (Postgres target, Full Backup, reindex) are present when importing a Postgres export onto a SQLite target. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Migration Export Job] --> B{database provider?}
    B -->|sqlite| C[createSqliteSnapshot\nsha256File]
    B -->|postgres| D[Record provider metadata only\nno artifact]
    C --> E[buildDatabaseManifest\nprovider=sqlite, backupKind=sqlite_snapshot]
    D --> F[buildDatabaseManifest\nprovider=postgres, backupKind=none]
    E --> G[buildManifest v2\n+ database + features + restore]
    F --> G
    G --> H[inspectMigrationArchive]
    H --> I{bundleSchemaVersion 1..2?}
    I -->|yes| J[buildDryRun]
    I -->|no| K[warn: unsupported schema]
    J --> L{sourceProvider?}
    L -->|postgres| M[Blocker: engine unsupported\nBlocker: target mismatch if SQLite]
    L -->|sqlite| N{backupKind == sqlite_snapshot?}
    N -->|yes| O{target == sqlite?}
    N -->|no| P[Blocker: invalid backup kind]
    O -->|yes| Q[ready / attention]
    O -->|no| R[Blocker: target mismatch]
    J --> S{features: knowledge or embeddings or collab?}
    S -->|yes + non-postgres target| T[Blocker: reindex required]
    subgraph Full Backup
        FB1[createFullBackupJob] --> FB2{provider?}
        FB2 -->|sqlite| FB3[createSqliteFullSnapshot]
        FB2 -->|postgres| FB4[createPostgresDump\npg_dump --format=custom]
        FB3 --> FB5[sha256File]
        FB4 --> FB5
        FB5 --> FB6[inspectFullBackupArchive]
        FB6 --> FB7[sha256ZipEntry\nstreaming hash]
        FB7 -->|mismatch| FB8[risk: checksum mismatch]
        FB7 -->|ok| FB9[canRestore: true if no risks]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Migration Export Job] --> B{database provider?}
    B -->|sqlite| C[createSqliteSnapshot\nsha256File]
    B -->|postgres| D[Record provider metadata only\nno artifact]
    C --> E[buildDatabaseManifest\nprovider=sqlite, backupKind=sqlite_snapshot]
    D --> F[buildDatabaseManifest\nprovider=postgres, backupKind=none]
    E --> G[buildManifest v2\n+ database + features + restore]
    F --> G
    G --> H[inspectMigrationArchive]
    H --> I{bundleSchemaVersion 1..2?}
    I -->|yes| J[buildDryRun]
    I -->|no| K[warn: unsupported schema]
    J --> L{sourceProvider?}
    L -->|postgres| M[Blocker: engine unsupported\nBlocker: target mismatch if SQLite]
    L -->|sqlite| N{backupKind == sqlite_snapshot?}
    N -->|yes| O{target == sqlite?}
    N -->|no| P[Blocker: invalid backup kind]
    O -->|yes| Q[ready / attention]
    O -->|no| R[Blocker: target mismatch]
    J --> S{features: knowledge or embeddings or collab?}
    S -->|yes + non-postgres target| T[Blocker: reindex required]
    subgraph Full Backup
        FB1[createFullBackupJob] --> FB2{provider?}
        FB2 -->|sqlite| FB3[createSqliteFullSnapshot]
        FB2 -->|postgres| FB4[createPostgresDump\npg_dump --format=custom]
        FB3 --> FB5[sha256File]
        FB4 --> FB5
        FB5 --> FB6[inspectFullBackupArchive]
        FB6 --> FB7[sha256ZipEntry\nstreaming hash]
        FB7 -->|mismatch| FB8[risk: checksum mismatch]
        FB7 -->|ok| FB9[canRestore: true if no risks]
    end
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Ftask-42-provider-aware-backups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ftask-42-provider-aware-backups%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Flib%2Fmigration%2Fexport-service.ts%3A517%0AThe%20%60pgvectorEnabled%60%20field%20is%20set%20with%20a%20strict%20%60%3D%3D%3D%20'true'%60%20check%2C%20but%20%60buildFeatures%60%20uses%20the%20local%20%60truthy%28%29%60%20helper%20which%20also%20accepts%20%60'1'%60%20and%20%60'yes'%60.%20If%20an%20operator%20sets%20%60CANVAS_POSTGRES_VECTOR_ENABLED%3D1%60%2C%20the%20manifest%20would%20have%20%60database.pgvectorEnabled%3A%20false%60%20while%20%60features.embeddingsEnabled%3A%20true%60%20%E2%80%94%20contradictory%20metadata%20that%20could%20confuse%20tooling%20or%20support%20diagnostics.%20The%20same%20strict%20check%20is%20also%20present%20in%20%60createPostgresDump%60%20in%20%60full-backup-service.ts%60%20at%20line%20372.%0A%0A%60%60%60suggestion%0A%20%20%20%20pgvectorEnabled%3A%20provider%20%3D%3D%3D%20'postgres'%20%3F%20truthy%28process.env.CANVAS_POSTGRES_VECTOR_ENABLED%29%20%3A%20null%2C%0A%60%60%60%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=42&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address provider-aware backup review fee..."](https://github.com/canvascoding/canvas-notebook/commit/7502948a297b7c5de1db35985bac568691fc718b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39077068)</sub>

<!-- /greptile_comment -->
