### PR TITLE
Implement file collaboration lock policy

### DIFF
--- a/app/api/files/create/route.ts
+++ b/app/api/files/create/route.ts
@@ -5,8 +5,14 @@ import { createEmptyExcalidrawFileContent, isExcalidrawFilePath } from '@/app/li
 import {
   WorkspaceFileRevisionError,
   assertWorkspaceFileRevisionAllowed,
+  getWorkspaceFileRevision,
   workspaceRequiresRevisionCheck,
 } from '@/app/lib/files/revision-guard';
+import {
+  FileCollaborationPolicyError,
+  assertFileCollaborationWriteAllowed,
+  ensureFileRevisionForCurrentContent,
+} from '@/app/lib/files/collaboration-policy';
 import {
   applyRateLimit,
   invalidateWorkspaceFileViews,
@@ -49,6 +55,13 @@ export async function POST(request: NextRequest) {
         options: fileOptions,
         requireExpectedRevision: workspaceRequiresRevisionCheck(workspaceResult.workspace),
       });
+      assertFileCollaborationWriteAllowed({
+        workspace: workspaceResult.workspace,
+        path,
+        actorUserId: workspaceResult.session.user.id,
+        actorSessionId: null,
+        actorType: 'user',
+      });
       await writeFile(
         path,
         template === 'excalidraw' || isExcalidrawFilePath(path)
@@ -56,6 +69,18 @@ export async function POST(request: NextRequest) {
           : '',
         fileOptions
       );
+      const revision = await getWorkspaceFileRevision(path, fileOptions);
+      if (revision) {
+        ensureFileRevisionForCurrentContent({
+          workspace: workspaceResult.workspace,
+          path,
+          contentHash: revision.sha256,
+          sizeBytes: revision.stats.size,
+          actorUserId: workspaceResult.session.user.id,
+          actorType: 'user',
+          sourceSessionId: null,
+        });
+      }
     } else {
       return jsonError('Invalid type', 400);
     }
@@ -89,6 +114,15 @@ export async function POST(request: NextRequest) {
         expectedSha256: error.expectedSha256,
         currentSha256: error.currentSha256,
         currentStats: error.currentStats,
+      });
+    }
+    if (error instanceof FileCollaborationPolicyError) {
+      return jsonError(error.message, error.status, {
+        code: error.code,
+        path: error.path,
+        currentRevisionId: error.currentRevisionId,
+        baseRevisionId: error.baseRevisionId,
+        activeLock: error.activeLock,
       });
     }
     return jsonServerError('[API] File create error:', error, 'Failed to create path');

--- a/app/api/files/locks/route.ts
+++ b/app/api/files/locks/route.ts
@@ -1,0 +1,176 @@
+import { NextRequest } from 'next/server';
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
+import {
+  FileCollaborationPolicyError,
+  acquireFileLock,
+  getFileCollaborationState,
+  releaseFileLock,
+  type FileLockType,
+} from '@/app/lib/files/collaboration-policy';
+import {
+  applyRateLimit,
+  jsonError,
+  jsonServerError,
+  jsonSuccess,
+  readJsonBody,
+} from '@/app/lib/api/route-helpers';
+import { requireRequestWorkspace } from '@/app/lib/workspaces/request';
+
+function isFileLockType(value: unknown): value is FileLockType {
+  return value === 'edit' || value === 'upload' || value === 'agent_write';
+}
+
+function collaborationPolicyError(error: FileCollaborationPolicyError) {
+  return jsonError(error.message, error.status, {
+    code: error.code,
+    path: error.path,
+    currentRevisionId: error.currentRevisionId,
+    baseRevisionId: error.baseRevisionId,
+    activeLock: error.activeLock,
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
+  if (workspaceResult.response) return workspaceResult.response;
+
+  try {
+    const rateLimitResponse = applyRateLimit(request, {
+      limit: 120,
+      windowMs: 60_000,
+      keyPrefix: 'files-locks-read',
+    });
+    if (rateLimitResponse) return rateLimitResponse;
+
+    const path = request.nextUrl.searchParams.get('path')?.trim();
+    if (!path) return jsonError('Path parameter is required', 400);
+
+    return jsonSuccess({
+      data: getFileCollaborationState({
+        workspace: workspaceResult.workspace,
+        path,
+      }),
+    });
+  } catch (error) {
+    return jsonServerError('[API] File lock state error:', error, 'Failed to read file lock state');
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canWrite' });
+  if (workspaceResult.response) return workspaceResult.response;
+
+  try {
+    const rateLimitResponse = applyRateLimit(request, {
+      limit: 60,
+      windowMs: 60_000,
+      keyPrefix: 'files-locks-acquire',
+    });
+    if (rateLimitResponse) return rateLimitResponse;
+
+    const body = await readJsonBody<{
+      path?: string;
+      lockType?: string;
+      ttlMs?: number;
+      baseRevisionId?: string | null;
+    }>(request);
+    if (!body.path) return jsonError('Path is required', 400);
+    const lockType = isFileLockType(body.lockType) ? body.lockType : 'edit';
+
+    const result = acquireFileLock({
+      workspace: workspaceResult.workspace,
+      path: body.path,
+      lockedByUserId: workspaceResult.session.user.id,
+      lockedBySessionId: null,
+      lockType,
+      ttlMs: body.ttlMs,
+      baseRevisionId: body.baseRevisionId ?? null,
+    });
+
+    await recordAuditEvent({
+      organizationId: workspaceResult.workspace.organizationId,
+      customerId: workspaceResult.workspace.customerId,
+      projectId: workspaceResult.workspace.projectId,
+      workspaceId: workspaceResult.workspace.workspaceId,
+      userId: workspaceResult.session.user.id,
+      source: 'files',
+      eventType: 'file',
+      entityType: 'workspace_path',
+      entityId: body.path,
+      action: 'file.lock.acquire',
+      status: 'success',
+      summary: `File lock acquired for ${body.path}.`,
+      metadata: {
+        path: body.path,
+        lockId: result.lock.id,
+        lockType,
+        expiresAt: result.lock.expiresAt,
+      },
+    });
+
+    return jsonSuccess({ data: result });
+  } catch (error) {
+    if (error instanceof FileCollaborationPolicyError) return collaborationPolicyError(error);
+    return jsonServerError('[API] File lock acquire error:', error, 'Failed to acquire file lock');
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canWrite' });
+  if (workspaceResult.response) return workspaceResult.response;
+
+  try {
+    const rateLimitResponse = applyRateLimit(request, {
+      limit: 60,
+      windowMs: 60_000,
+      keyPrefix: 'files-locks-release',
+    });
+    if (rateLimitResponse) return rateLimitResponse;
+
+    const body = await readJsonBody<{
+      path?: string;
+      lockId?: string;
+      force?: boolean;
+    }>(request);
+    if (!body.path && !body.lockId) return jsonError('Path or lockId is required', 400);
+
+    if (body.force && !workspaceResult.workspace.permissions.canManageWorkspace) {
+      return jsonError('Only workspace managers can force release file locks', 403);
+    }
+
+    const lock = releaseFileLock({
+      workspace: workspaceResult.workspace,
+      path: body.path,
+      lockId: body.lockId,
+      actorUserId: workspaceResult.session.user.id,
+      actorSessionId: null,
+      force: Boolean(body.force),
+    });
+
+    await recordAuditEvent({
+      organizationId: workspaceResult.workspace.organizationId,
+      customerId: workspaceResult.workspace.customerId,
+      projectId: workspaceResult.workspace.projectId,
+      workspaceId: workspaceResult.workspace.workspaceId,
+      userId: workspaceResult.session.user.id,
+      source: 'files',
+      eventType: 'file',
+      entityType: 'workspace_path',
+      entityId: lock.path,
+      action: body.force ? 'file.lock.force_release' : 'file.lock.release',
+      status: 'success',
+      summary: `File lock released for ${lock.path}.`,
+      metadata: {
+        path: lock.path,
+        lockId: lock.id,
+        lockType: lock.lockType,
+        finalStatus: lock.status,
+      },
+    });
+
+    return jsonSuccess({ data: { lock } });
+  } catch (error) {
+    if (error instanceof FileCollaborationPolicyError) return collaborationPolicyError(error);
+    return jsonServerError('[API] File lock release error:', error, 'Failed to release file lock');
+  }
+}

--- a/app/api/files/read/route.ts
+++ b/app/api/files/read/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readFile, getFileStats } from '@/app/lib/filesystem/workspace-files';
 import { sha256Buffer } from '@/app/lib/files/revision-guard';
+import {
+  ensureFileRevisionForCurrentContent,
+  getFileCollaborationState,
+} from '@/app/lib/files/collaboration-policy';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 import { isExcalidrawFilePath } from '@/app/lib/excalidraw-file';
 import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
@@ -42,6 +46,10 @@ export async function GET(request: NextRequest) {
     const metaOnly = searchParams.get('meta') === '1';
 
     if (metaOnly) {
+      const collaboration = getFileCollaborationState({
+        workspace: workspaceResult.workspace,
+        path,
+      });
       return NextResponse.json({
         success: true,
         data: {
@@ -52,6 +60,7 @@ export async function GET(request: NextRequest) {
             modified: stats.modified,
             permissions: stats.permissions,
           },
+          collaboration,
         },
       });
     }
@@ -65,6 +74,20 @@ export async function GET(request: NextRequest) {
 
     const content = await readFile(path, fileOptions);
     const sha256 = sha256Buffer(content);
+    const revision = ensureFileRevisionForCurrentContent({
+      workspace: workspaceResult.workspace,
+      path,
+      contentHash: sha256,
+      sizeBytes: stats.size,
+      actorUserId: workspaceResult.session.user.id,
+      actorType: 'user',
+      sourceSessionId: null,
+    });
+    const collaboration = getFileCollaborationState({
+      workspace: workspaceResult.workspace,
+      path,
+      ensureDocument: true,
+    });
     
     return NextResponse.json({
       success: true,
@@ -77,6 +100,8 @@ export async function GET(request: NextRequest) {
           permissions: stats.permissions,
           sha256,
         },
+        revision,
+        collaboration,
       },
     });
   } catch (error) {

--- a/app/api/files/upload/route.ts
+++ b/app/api/files/upload/route.ts
@@ -177,6 +177,7 @@ export async function POST(request: NextRequest) {
             path: targetPath,
           });
           if (!currentState.activeLock) {
+            // acquireFileLock re-checks in its own write transaction; a raced lock becomes FILE_LOCKED.
             const acquired = acquireFileLock({
               workspace: workspaceResult.workspace,
               path: targetPath,

--- a/app/api/files/upload/route.ts
+++ b/app/api/files/upload/route.ts
@@ -10,6 +10,17 @@ import { getImageConversionErrorMessage } from '@/app/lib/images/convert';
 import { normalizeUploadImageBuffer, parseUploadConvertParams } from '@/app/lib/images/upload-conversion';
 import { syncPublicSharesAfterWrite } from '@/app/lib/public-sharing/public-file-shares';
 import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
+import { getWorkspaceFileRevision } from '@/app/lib/files/revision-guard';
+import {
+  FileCollaborationPolicyError,
+  acquireFileLock,
+  assertFileCollaborationWriteAllowed,
+  detectFileCollaborationStrategy,
+  ensureFileRevisionForCurrentContent,
+  getFileCollaborationState,
+  releaseFileLock,
+  workspaceRequiresCollaborationPolicy,
+} from '@/app/lib/files/collaboration-policy';
 
 const MAX_FILE_SIZE = 100 * 1024 * 1024;
 const MAX_TOTAL_SIZE = 500 * 1024 * 1024;
@@ -144,7 +155,76 @@ export async function POST(request: NextRequest) {
         await createDirectory(parentDir, fileOptions);
       }
 
-      await writeFile(targetPath, normalized.buffer, fileOptions);
+      const beforeRevision = await getWorkspaceFileRevision(targetPath, fileOptions);
+      const storedBaseRevision = beforeRevision
+        ? ensureFileRevisionForCurrentContent({
+            workspace: workspaceResult.workspace,
+            path: targetPath,
+            contentHash: beforeRevision.sha256,
+            sizeBytes: beforeRevision.stats.size,
+            actorType: 'system',
+          })
+        : null;
+      let transientUploadLockId: string | null = null;
+      try {
+        const shouldAutoLockUpload =
+          Boolean(beforeRevision)
+          && workspaceRequiresCollaborationPolicy(workspaceResult.workspace)
+          && detectFileCollaborationStrategy(targetPath) === 'exclusive_lock';
+        if (shouldAutoLockUpload) {
+          const currentState = getFileCollaborationState({
+            workspace: workspaceResult.workspace,
+            path: targetPath,
+          });
+          if (!currentState.activeLock) {
+            const acquired = acquireFileLock({
+              workspace: workspaceResult.workspace,
+              path: targetPath,
+              lockedByUserId: workspaceResult.session.user.id,
+              lockedBySessionId: null,
+              lockType: 'upload',
+              ttlMs: 5 * 60 * 1000,
+              baseRevisionId: storedBaseRevision?.id ?? null,
+            });
+            transientUploadLockId = acquired.lock.id;
+          }
+        }
+
+        assertFileCollaborationWriteAllowed({
+          workspace: workspaceResult.workspace,
+          path: targetPath,
+          actorUserId: workspaceResult.session.user.id,
+          actorType: 'user',
+          baseRevisionId: storedBaseRevision?.id ?? null,
+        });
+
+        await writeFile(targetPath, normalized.buffer, fileOptions);
+        const afterRevision = await getWorkspaceFileRevision(targetPath, fileOptions);
+        if (afterRevision) {
+          ensureFileRevisionForCurrentContent({
+            workspace: workspaceResult.workspace,
+            path: targetPath,
+            contentHash: afterRevision.sha256,
+            sizeBytes: afterRevision.stats.size,
+            actorUserId: workspaceResult.session.user.id,
+            actorType: 'user',
+            sourceSessionId: null,
+            baseRevisionId: storedBaseRevision?.id ?? null,
+          });
+        }
+      } finally {
+        if (transientUploadLockId) {
+          try {
+            releaseFileLock({
+              workspace: workspaceResult.workspace,
+              lockId: transientUploadLockId,
+              actorUserId: workspaceResult.session.user.id,
+            });
+          } catch (releaseError) {
+            console.warn('[API] Failed to release transient upload lock:', releaseError);
+          }
+        }
+      }
       uploadedFiles.push(filename);
       uploadedPaths.push(targetPath);
     }
@@ -175,6 +255,20 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ success: true, count: files.length, files: uploadedFiles });
   } catch (error) {
+    if (error instanceof FileCollaborationPolicyError) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: error.message,
+          code: error.code,
+          path: error.path,
+          currentRevisionId: error.currentRevisionId,
+          baseRevisionId: error.baseRevisionId,
+          activeLock: error.activeLock,
+        },
+        { status: error.status }
+      );
+    }
     console.error('[API] File upload error:', error);
     const message = error instanceof Error ? error.message : 'Failed to upload file';
     return NextResponse.json(

--- a/app/api/files/write/route.ts
+++ b/app/api/files/write/route.ts
@@ -7,6 +7,12 @@ import {
   getWorkspaceFileRevision,
   workspaceRequiresRevisionCheck,
 } from '@/app/lib/files/revision-guard';
+import {
+  FileCollaborationPolicyError,
+  assertFileCollaborationWriteAllowed,
+  ensureFileRevisionForCurrentContent,
+  getFileCollaborationState,
+} from '@/app/lib/files/collaboration-policy';
 import { queuePublicSharesAfterWrite } from '@/app/lib/public-sharing/public-file-shares';
 import { getParentDirectory } from '@/app/lib/files/path-utils';
 import {
@@ -32,8 +38,13 @@ export async function POST(request: NextRequest) {
     });
     if (rateLimitResponse) return rateLimitResponse;
 
-    const body = await readJsonBody<{ path?: string; content?: string; expectedSha256?: string | null }>(request);
-    const { path, content, expectedSha256 } = body;
+    const body = await readJsonBody<{
+      path?: string;
+      content?: string;
+      expectedSha256?: string | null;
+      baseRevisionId?: string | null;
+    }>(request);
+    const { path, content, expectedSha256, baseRevisionId } = body;
 
     if (!path || content === undefined) {
       return jsonError('Path and content are required', 400);
@@ -45,11 +56,29 @@ export async function POST(request: NextRequest) {
       finalContent = Buffer.from(content.substring(7), 'base64');
     }
 
-    await assertWorkspaceFileRevisionAllowed({
+    const beforeRevision = await assertWorkspaceFileRevisionAllowed({
       path,
       expectedSha256,
       options: fileOptions,
       requireExpectedRevision: workspaceRequiresRevisionCheck(workspaceResult.workspace),
+    });
+    const storedBaseRevision = beforeRevision
+      ? ensureFileRevisionForCurrentContent({
+          workspace: workspaceResult.workspace,
+          path,
+          contentHash: beforeRevision.sha256,
+          sizeBytes: beforeRevision.stats.size,
+          actorType: 'system',
+        })
+      : null;
+
+    assertFileCollaborationWriteAllowed({
+      workspace: workspaceResult.workspace,
+      path,
+      actorUserId: workspaceResult.session.user.id,
+      actorSessionId: null,
+      actorType: 'user',
+      baseRevisionId: baseRevisionId ?? null,
     });
 
     await writeFile(path, finalContent, fileOptions);
@@ -60,6 +89,21 @@ export async function POST(request: NextRequest) {
     }
     const afterSha256 = afterRevision.sha256;
     const stats = afterRevision.stats;
+    const revision = ensureFileRevisionForCurrentContent({
+      workspace: workspaceResult.workspace,
+      path,
+      contentHash: afterSha256,
+      sizeBytes: stats.size,
+      actorUserId: workspaceResult.session.user.id,
+      actorType: 'user',
+      sourceSessionId: null,
+      baseRevisionId: baseRevisionId ?? storedBaseRevision?.id ?? null,
+    });
+    const collaboration = getFileCollaborationState({
+      workspace: workspaceResult.workspace,
+      path,
+      ensureDocument: true,
+    });
     invalidateWorkspaceFileViews({ fileOptions, subtreeDirs: [getParentDirectory(path)] });
     queuePublicSharesAfterWrite([path], workspaceResult.workspace);
     await recordAuditEvent({
@@ -80,6 +124,8 @@ export async function POST(request: NextRequest) {
         encoded: typeof content === 'string' && content.startsWith('base64:'),
         expectedSha256: expectedSha256 ?? null,
         afterSha256,
+        baseRevisionId: baseRevisionId ?? storedBaseRevision?.id ?? null,
+        revisionId: revision.id,
       },
       input: {
         path,
@@ -96,6 +142,8 @@ export async function POST(request: NextRequest) {
           permissions: stats.permissions,
           sha256: afterSha256,
         },
+        revision,
+        collaboration,
       },
     });
   } catch (error) {
@@ -106,6 +154,15 @@ export async function POST(request: NextRequest) {
         expectedSha256: error.expectedSha256,
         currentSha256: error.currentSha256,
         currentStats: error.currentStats,
+      });
+    }
+    if (error instanceof FileCollaborationPolicyError) {
+      return jsonError(error.message, error.status, {
+        code: error.code,
+        path: error.path,
+        currentRevisionId: error.currentRevisionId,
+        baseRevisionId: error.baseRevisionId,
+        activeLock: error.activeLock,
       });
     }
     return jsonServerError('[API] File write error:', error, 'Failed to write file');

--- a/app/components/editor/FileEditor.tsx
+++ b/app/components/editor/FileEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { AlertCircle, CheckCircle2, ChevronLeft, ChevronRight, Code2, Download, Eye, FileText, Loader2, MoreVertical, Presentation, RefreshCw, Save, Share2, X } from 'lucide-react';
+import { AlertCircle, CheckCircle2, ChevronLeft, ChevronRight, Code2, Download, Eye, FileText, GitBranch, Loader2, Lock, MoreVertical, Presentation, RefreshCw, Save, Share2, UsersRound, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -421,6 +421,19 @@ export function FileEditor({ onClosePreview }: FileEditorProps = {}) {
   const isVideo = VIDEO_EXTENSIONS.has(extension);
   const isText = extension === '' || TEXT_EXTENSIONS.has(extension);
   const isBinary = !isText && !isImage && !isPdf && !isMarkdown && !isHtml && !isExcalidraw && !isAudio && !isVideo && !isOffice;
+  const collaboration = currentFile?.collaboration ?? null;
+  const collaborationLabel = useMemo(() => {
+    if (!collaboration) return null;
+    if (collaboration.activeLock) return t('collaboration.locked');
+    if (collaboration.strategy === 'crdt_text') return t('collaboration.crdtText');
+    if (collaboration.strategy === 'exclusive_lock') return t('collaboration.lockRequired');
+    return collaboration.requiresRevisionCheck ? t('collaboration.revisionCheck') : null;
+  }, [collaboration, t]);
+  const revisionLabel = currentFile?.revision?.id
+    ? t('collaboration.revisionShort', { revision: currentFile.revision.id.slice(-8) })
+    : collaboration?.latestRevision?.id
+      ? t('collaboration.revisionShort', { revision: collaboration.latestRevision.id.slice(-8) })
+      : null;
   const markdownViewMode = isMarpMarkdownFile
     ? (markdownViewOverride.path === activePath ? markdownViewOverride.mode : 'slides')
     : 'markdown';
@@ -734,6 +747,30 @@ export function FileEditor({ onClosePreview }: FileEditorProps = {}) {
             </>
           )}
           {isImage && <span className="bg-muted px-2 py-0.5 text-foreground shrink-0">{t('readOnly')}</span>}
+          {collaborationLabel ? (
+            <span
+              className="flex items-center gap-1 rounded-sm border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground shrink-0"
+              title={collaborationLabel}
+            >
+              {collaboration?.activeLock ? (
+                <Lock className="h-3.5 w-3.5" />
+              ) : collaboration?.strategy === 'crdt_text' ? (
+                <UsersRound className="h-3.5 w-3.5" />
+              ) : (
+                <GitBranch className="h-3.5 w-3.5" />
+              )}
+              <span className="hidden lg:inline">{collaborationLabel}</span>
+            </span>
+          ) : null}
+          {revisionLabel ? (
+            <span
+              className="hidden xl:flex items-center gap-1 rounded-sm border border-border bg-background px-2 py-0.5 text-xs text-muted-foreground shrink-0"
+              title={revisionLabel}
+            >
+              <GitBranch className="h-3.5 w-3.5" />
+              <span>{revisionLabel}</span>
+            </span>
+          ) : null}
           {(isMarkdown || isHtml || isPdf) && (
             <Button
               variant="ghost"

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -213,6 +213,68 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       FOREIGN KEY (workspace_id) REFERENCES canvas_workspaces(id) ON DELETE CASCADE
     );
 
+    CREATE TABLE IF NOT EXISTS file_revisions (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      customer_id TEXT,
+      project_id TEXT,
+      workspace_id TEXT NOT NULL,
+      workspace_type TEXT NOT NULL,
+      path TEXT NOT NULL,
+      content_hash TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL DEFAULT 0,
+      created_by_user_id TEXT,
+      created_by_actor_type TEXT NOT NULL DEFAULT 'user',
+      source_session_id TEXT,
+      base_revision_id TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS file_locks (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      customer_id TEXT,
+      project_id TEXT,
+      workspace_id TEXT NOT NULL,
+      workspace_type TEXT NOT NULL,
+      path TEXT NOT NULL,
+      revision_id TEXT,
+      locked_by_user_id TEXT,
+      locked_by_session_id TEXT,
+      lock_type TEXT NOT NULL DEFAULT 'edit',
+      status TEXT NOT NULL DEFAULT 'active',
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS collaboration_documents (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      customer_id TEXT,
+      project_id TEXT,
+      workspace_id TEXT NOT NULL,
+      workspace_type TEXT NOT NULL,
+      path TEXT NOT NULL,
+      provider TEXT NOT NULL DEFAULT 'yjs',
+      state_version INTEGER NOT NULL DEFAULT 0,
+      snapshot_revision_id TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS collaboration_events (
+      id TEXT PRIMARY KEY NOT NULL,
+      document_id TEXT NOT NULL,
+      actor_user_id TEXT,
+      actor_session_id TEXT,
+      sequence INTEGER NOT NULL,
+      payload_ref TEXT,
+      payload_hash TEXT,
+      created_at INTEGER NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS organization_user_permissions (
       organization_id TEXT NOT NULL,
       user_id TEXT NOT NULL,
@@ -1772,6 +1834,21 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_workspace_trash_project_status ON workspace_trash_entries (project_id, status, deleted_at);
     CREATE INDEX IF NOT EXISTS idx_workspace_trash_deleted_by ON workspace_trash_entries (deleted_by_user_id, deleted_at);
     CREATE INDEX IF NOT EXISTS idx_workspace_trash_original_path ON workspace_trash_entries (workspace_id, original_path, status);
+    CREATE INDEX IF NOT EXISTS idx_file_revisions_workspace_path_created ON file_revisions (workspace_id, path, created_at);
+    CREATE INDEX IF NOT EXISTS idx_file_revisions_workspace_path_hash ON file_revisions (workspace_id, path, content_hash);
+    CREATE INDEX IF NOT EXISTS idx_file_revisions_org_created ON file_revisions (organization_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_file_revisions_project_created ON file_revisions (project_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_file_revisions_actor_created ON file_revisions (created_by_user_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_file_locks_active_path ON file_locks (workspace_id, path, status, expires_at);
+    CREATE INDEX IF NOT EXISTS idx_file_locks_user_status ON file_locks (locked_by_user_id, status, updated_at);
+    CREATE INDEX IF NOT EXISTS idx_file_locks_org_status ON file_locks (organization_id, status, updated_at);
+    CREATE INDEX IF NOT EXISTS idx_file_locks_project_status ON file_locks (project_id, status, updated_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_collab_documents_workspace_path_provider ON collaboration_documents (workspace_id, path, provider);
+    CREATE INDEX IF NOT EXISTS idx_collab_documents_org_status ON collaboration_documents (organization_id, status, updated_at);
+    CREATE INDEX IF NOT EXISTS idx_collab_documents_project_status ON collaboration_documents (project_id, status, updated_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_collab_events_document_sequence ON collaboration_events (document_id, sequence);
+    CREATE INDEX IF NOT EXISTS idx_collab_events_document_created ON collaboration_events (document_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_collab_events_actor_created ON collaboration_events (actor_user_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_user ON organization_user_permissions (user_id);
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_role ON organization_user_permissions (organization_id, role);
     CREATE INDEX IF NOT EXISTS idx_org_user_permissions_status ON organization_user_permissions (organization_id, status);

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -191,7 +191,7 @@ export const workspaceTrashEntries = sqliteTable("workspace_trash_entries", {
   organizationId: text("organization_id"),
   customerId: text("customer_id"),
   projectId: text("project_id"),
-  workspaceId: text("workspace_id").notNull(),
+  workspaceId: text("workspace_id").notNull().references(() => canvasWorkspaces.id, { onDelete: 'cascade' }),
   workspaceType: text("workspace_type").notNull(),
   ownerUserId: text("owner_user_id"),
   originalPath: text("original_path").notNull(),
@@ -219,12 +219,14 @@ export const workspaceTrashEntries = sqliteTable("workspace_trash_entries", {
   originalPathIdx: index("idx_workspace_trash_original_path").on(table.workspaceId, table.originalPath, table.status),
 }));
 
+// Collaboration metadata mirrors the manual SQLite migration: workspace/document
+// IDs are logical IDs without FK constraints, and timestamp values are epoch ms.
 export const fileRevisions = sqliteTable("file_revisions", {
   id: text("id").primaryKey(),
   organizationId: text("organization_id"),
   customerId: text("customer_id"),
   projectId: text("project_id"),
-  workspaceId: text("workspace_id").notNull().references(() => canvasWorkspaces.id, { onDelete: 'cascade' }),
+  workspaceId: text("workspace_id").notNull(),
   workspaceType: text("workspace_type").notNull(),
   path: text("path").notNull(),
   contentHash: text("content_hash").notNull(),

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -191,7 +191,7 @@ export const workspaceTrashEntries = sqliteTable("workspace_trash_entries", {
   organizationId: text("organization_id"),
   customerId: text("customer_id"),
   projectId: text("project_id"),
-  workspaceId: text("workspace_id").notNull().references(() => canvasWorkspaces.id, { onDelete: 'cascade' }),
+  workspaceId: text("workspace_id").notNull(),
   workspaceType: text("workspace_type").notNull(),
   ownerUserId: text("owner_user_id"),
   originalPath: text("original_path").notNull(),
@@ -217,6 +217,87 @@ export const workspaceTrashEntries = sqliteTable("workspace_trash_entries", {
   projectStatusIdx: index("idx_workspace_trash_project_status").on(table.projectId, table.status, table.deletedAt),
   deletedByIdx: index("idx_workspace_trash_deleted_by").on(table.deletedByUserId, table.deletedAt),
   originalPathIdx: index("idx_workspace_trash_original_path").on(table.workspaceId, table.originalPath, table.status),
+}));
+
+export const fileRevisions = sqliteTable("file_revisions", {
+  id: text("id").primaryKey(),
+  organizationId: text("organization_id"),
+  customerId: text("customer_id"),
+  projectId: text("project_id"),
+  workspaceId: text("workspace_id").notNull().references(() => canvasWorkspaces.id, { onDelete: 'cascade' }),
+  workspaceType: text("workspace_type").notNull(),
+  path: text("path").notNull(),
+  contentHash: text("content_hash").notNull(),
+  sizeBytes: integer("size_bytes").notNull().default(0),
+  createdByUserId: text("created_by_user_id"),
+  createdByActorType: text("created_by_actor_type").notNull().default("user"),
+  sourceSessionId: text("source_session_id"),
+  baseRevisionId: text("base_revision_id"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  workspacePathCreatedIdx: index("idx_file_revisions_workspace_path_created").on(table.workspaceId, table.path, table.createdAt),
+  workspacePathHashIdx: index("idx_file_revisions_workspace_path_hash").on(table.workspaceId, table.path, table.contentHash),
+  orgCreatedIdx: index("idx_file_revisions_org_created").on(table.organizationId, table.createdAt),
+  projectCreatedIdx: index("idx_file_revisions_project_created").on(table.projectId, table.createdAt),
+  actorCreatedIdx: index("idx_file_revisions_actor_created").on(table.createdByUserId, table.createdAt),
+}));
+
+export const fileLocks = sqliteTable("file_locks", {
+  id: text("id").primaryKey(),
+  organizationId: text("organization_id"),
+  customerId: text("customer_id"),
+  projectId: text("project_id"),
+  workspaceId: text("workspace_id").notNull(),
+  workspaceType: text("workspace_type").notNull(),
+  path: text("path").notNull(),
+  revisionId: text("revision_id"),
+  lockedByUserId: text("locked_by_user_id"),
+  lockedBySessionId: text("locked_by_session_id"),
+  lockType: text("lock_type").notNull().default("edit"),
+  status: text("status").notNull().default("active"),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  activePathIdx: index("idx_file_locks_active_path").on(table.workspaceId, table.path, table.status, table.expiresAt),
+  userStatusIdx: index("idx_file_locks_user_status").on(table.lockedByUserId, table.status, table.updatedAt),
+  orgStatusIdx: index("idx_file_locks_org_status").on(table.organizationId, table.status, table.updatedAt),
+  projectStatusIdx: index("idx_file_locks_project_status").on(table.projectId, table.status, table.updatedAt),
+}));
+
+export const collaborationDocuments = sqliteTable("collaboration_documents", {
+  id: text("id").primaryKey(),
+  organizationId: text("organization_id"),
+  customerId: text("customer_id"),
+  projectId: text("project_id"),
+  workspaceId: text("workspace_id").notNull(),
+  workspaceType: text("workspace_type").notNull(),
+  path: text("path").notNull(),
+  provider: text("provider").notNull().default("yjs"),
+  stateVersion: integer("state_version").notNull().default(0),
+  snapshotRevisionId: text("snapshot_revision_id"),
+  status: text("status").notNull().default("active"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  workspacePathProviderIdx: uniqueIndex("idx_collab_documents_workspace_path_provider").on(table.workspaceId, table.path, table.provider),
+  orgStatusIdx: index("idx_collab_documents_org_status").on(table.organizationId, table.status, table.updatedAt),
+  projectStatusIdx: index("idx_collab_documents_project_status").on(table.projectId, table.status, table.updatedAt),
+}));
+
+export const collaborationEvents = sqliteTable("collaboration_events", {
+  id: text("id").primaryKey(),
+  documentId: text("document_id").notNull(),
+  actorUserId: text("actor_user_id"),
+  actorSessionId: text("actor_session_id"),
+  sequence: integer("sequence").notNull(),
+  payloadRef: text("payload_ref"),
+  payloadHash: text("payload_hash"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  documentSequenceIdx: uniqueIndex("idx_collab_events_document_sequence").on(table.documentId, table.sequence),
+  documentCreatedIdx: index("idx_collab_events_document_created").on(table.documentId, table.createdAt),
+  actorCreatedIdx: index("idx_collab_events_actor_created").on(table.actorUserId, table.createdAt),
 }));
 
 export const organizationUserPermissions = sqliteTable("organization_user_permissions", {

--- a/app/lib/files/client.ts
+++ b/app/lib/files/client.ts
@@ -1,7 +1,7 @@
 import type { ConvertParams } from '@/app/components/shared/ImagePreprocessDialog';
 import { WORKSPACE_ID_HEADER } from '@/app/lib/workspaces/constants';
 import { useWorkspaceStore } from '@/app/store/workspace-store';
-import type { CurrentFile, FileNode, FileStats } from './types';
+import type { CurrentFile, FileCollaborationState, FileNode, FileRevisionRecord, FileStats } from './types';
 
 interface ApiErrorPayload {
   error?: unknown;
@@ -31,6 +31,8 @@ export interface WorkspacePathConflictError extends Error {
 export interface WriteWorkspaceFileResult {
   path: string;
   stats?: FileStats;
+  revision?: FileRevisionRecord | null;
+  collaboration?: FileCollaborationState | null;
 }
 
 interface UploadWorkspaceFilesParams {
@@ -149,13 +151,18 @@ export async function readWorkspaceFile(
 export async function writeWorkspaceFile(
   path: string,
   content: string,
-  options: { expectedSha256?: string | null } = {}
+  options: { expectedSha256?: string | null; baseRevisionId?: string | null } = {}
 ): Promise<WriteWorkspaceFileResult> {
   const response = await fetch('/api/files/write', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...workspaceHeaders() },
     credentials: 'include',
-    body: JSON.stringify({ path, content, expectedSha256: options.expectedSha256 ?? null }),
+    body: JSON.stringify({
+      path,
+      content,
+      expectedSha256: options.expectedSha256 ?? null,
+      baseRevisionId: options.baseRevisionId ?? null,
+    }),
   });
 
   if (!response.ok) {

--- a/app/lib/files/collaboration-policy.ts
+++ b/app/lib/files/collaboration-policy.ts
@@ -81,7 +81,7 @@ export class FileCollaborationPolicyError extends Error {
     | 'FILE_REVISION_ID_CONFLICT'
     | 'FILE_LOCK_NOT_FOUND'
     | 'FILE_LOCK_PERMISSION_DENIED';
-  readonly status: 404 | 409 | 423;
+  readonly status: 403 | 404 | 409 | 423;
   readonly path: string;
   readonly currentRevisionId: string | null;
   readonly baseRevisionId: string | null;
@@ -701,7 +701,7 @@ export function releaseFileLock(params: {
     if (!params.force && !isSameActor(lock, params.actorUserId, params.actorSessionId)) {
       throw new FileCollaborationPolicyError({
         code: 'FILE_LOCK_PERMISSION_DENIED',
-        status: 423,
+        status: 403,
         message: 'Only the lock owner or an owner/admin force release can release this file lock.',
         path: lock.path,
         activeLock: lock,

--- a/app/lib/files/collaboration-policy.ts
+++ b/app/lib/files/collaboration-policy.ts
@@ -1,0 +1,738 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+
+import type Database from 'better-sqlite3';
+import { openOrganizationBootstrapDatabase } from '@/app/lib/organization/bootstrap';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
+
+export type FileCollaborationStrategy = 'crdt_text' | 'revision_check' | 'exclusive_lock';
+export type FileActorType = 'user' | 'agent' | 'automation' | 'system';
+export type FileLockType = 'edit' | 'upload' | 'agent_write';
+export type FileLockStatus = 'active' | 'released' | 'expired' | 'force_released';
+
+export interface FileRevisionRecord {
+  id: string;
+  organizationId: string | null;
+  customerId: string | null;
+  projectId: string | null;
+  workspaceId: string;
+  workspaceType: WorkspaceContext['workspaceType'];
+  path: string;
+  contentHash: string;
+  sizeBytes: number;
+  createdByUserId: string | null;
+  createdByActorType: FileActorType;
+  sourceSessionId: string | null;
+  baseRevisionId: string | null;
+  createdAt: number;
+}
+
+export interface FileLockRecord {
+  id: string;
+  organizationId: string | null;
+  customerId: string | null;
+  projectId: string | null;
+  workspaceId: string;
+  workspaceType: WorkspaceContext['workspaceType'];
+  path: string;
+  revisionId: string | null;
+  lockedByUserId: string | null;
+  lockedBySessionId: string | null;
+  lockType: FileLockType;
+  status: FileLockStatus;
+  expiresAt: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CollaborationDocumentRecord {
+  id: string;
+  organizationId: string | null;
+  customerId: string | null;
+  projectId: string | null;
+  workspaceId: string;
+  workspaceType: WorkspaceContext['workspaceType'];
+  path: string;
+  provider: 'yjs';
+  stateVersion: number;
+  snapshotRevisionId: string | null;
+  status: 'active' | 'archived';
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface FileCollaborationState {
+  path: string;
+  strategy: FileCollaborationStrategy;
+  crdtCapable: boolean;
+  lockRequired: boolean;
+  requiresRevisionCheck: boolean;
+  latestRevision: FileRevisionRecord | null;
+  activeLock: FileLockRecord | null;
+  document: CollaborationDocumentRecord | null;
+}
+
+export class FileCollaborationPolicyError extends Error {
+  readonly code:
+    | 'FILE_LOCKED'
+    | 'FILE_LOCK_REQUIRED'
+    | 'FILE_REVISION_ID_CONFLICT'
+    | 'FILE_LOCK_NOT_FOUND'
+    | 'FILE_LOCK_PERMISSION_DENIED';
+  readonly status: 404 | 409 | 423;
+  readonly path: string;
+  readonly currentRevisionId: string | null;
+  readonly baseRevisionId: string | null;
+  readonly activeLock: FileLockRecord | null;
+
+  constructor(params: {
+    code: FileCollaborationPolicyError['code'];
+    status: FileCollaborationPolicyError['status'];
+    message: string;
+    path: string;
+    currentRevisionId?: string | null;
+    baseRevisionId?: string | null;
+    activeLock?: FileLockRecord | null;
+  }) {
+    super(params.message);
+    this.name = 'FileCollaborationPolicyError';
+    this.code = params.code;
+    this.status = params.status;
+    this.path = params.path;
+    this.currentRevisionId = params.currentRevisionId ?? null;
+    this.baseRevisionId = params.baseRevisionId ?? null;
+    this.activeLock = params.activeLock ?? null;
+  }
+}
+
+const CRDT_TEXT_EXTENSIONS = new Set(['md', 'markdown', 'txt']);
+const EXCLUSIVE_LOCK_EXTENSIONS = new Set([
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx',
+  'pdf',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'svg',
+  'bmp',
+  'ico',
+  'mp4',
+  'webm',
+  'ogv',
+  'mov',
+  'wav',
+  'mp3',
+  'm4a',
+  'aac',
+  'ogg',
+  'opus',
+  'flac',
+  'zip',
+  'tar',
+  'gz',
+  '7z',
+]);
+
+const DEFAULT_LOCK_TTL_MS = 15 * 60 * 1000;
+const MAX_LOCK_TTL_MS = 4 * 60 * 60 * 1000;
+
+type Sqlite = InstanceType<typeof Database>;
+
+type FileRevisionRow = {
+  id: string;
+  organization_id: string | null;
+  customer_id: string | null;
+  project_id: string | null;
+  workspace_id: string;
+  workspace_type: WorkspaceContext['workspaceType'];
+  path: string;
+  content_hash: string;
+  size_bytes: number;
+  created_by_user_id: string | null;
+  created_by_actor_type: FileActorType;
+  source_session_id: string | null;
+  base_revision_id: string | null;
+  created_at: number;
+};
+
+type FileLockRow = {
+  id: string;
+  organization_id: string | null;
+  customer_id: string | null;
+  project_id: string | null;
+  workspace_id: string;
+  workspace_type: WorkspaceContext['workspaceType'];
+  path: string;
+  revision_id: string | null;
+  locked_by_user_id: string | null;
+  locked_by_session_id: string | null;
+  lock_type: FileLockType;
+  status: FileLockStatus;
+  expires_at: number;
+  created_at: number;
+  updated_at: number;
+};
+
+type CollaborationDocumentRow = {
+  id: string;
+  organization_id: string | null;
+  customer_id: string | null;
+  project_id: string | null;
+  workspace_id: string;
+  workspace_type: WorkspaceContext['workspaceType'];
+  path: string;
+  provider: 'yjs';
+  state_version: number;
+  snapshot_revision_id: string | null;
+  status: 'active' | 'archived';
+  created_at: number;
+  updated_at: number;
+};
+
+function normalizeWorkspacePath(filePath: string): string {
+  const normalized = path.posix.normalize(filePath.replace(/\\/g, '/')).replace(/^\/+/u, '');
+  if (!normalized || normalized === '.' || normalized.split('/').includes('..')) {
+    throw new Error(`Invalid workspace file path: ${filePath}`);
+  }
+  return normalized;
+}
+
+function fileExtension(filePath: string): string {
+  const base = path.posix.basename(filePath).toLowerCase();
+  const dotIndex = base.lastIndexOf('.');
+  return dotIndex > 0 ? base.slice(dotIndex + 1) : '';
+}
+
+export function detectFileCollaborationStrategy(filePath: string): FileCollaborationStrategy {
+  const extension = fileExtension(filePath);
+  if (CRDT_TEXT_EXTENSIONS.has(extension)) return 'crdt_text';
+  if (EXCLUSIVE_LOCK_EXTENSIONS.has(extension)) return 'exclusive_lock';
+  return 'revision_check';
+}
+
+export function workspaceRequiresCollaborationPolicy(workspace: WorkspaceContext): boolean {
+  return workspace.workspaceType === 'team' || workspace.workspaceType === 'project';
+}
+
+function mapRevision(row: FileRevisionRow | undefined): FileRevisionRecord | null {
+  if (!row) return null;
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    customerId: row.customer_id,
+    projectId: row.project_id,
+    workspaceId: row.workspace_id,
+    workspaceType: row.workspace_type,
+    path: row.path,
+    contentHash: row.content_hash,
+    sizeBytes: row.size_bytes,
+    createdByUserId: row.created_by_user_id,
+    createdByActorType: row.created_by_actor_type,
+    sourceSessionId: row.source_session_id,
+    baseRevisionId: row.base_revision_id,
+    createdAt: row.created_at,
+  };
+}
+
+function mapLock(row: FileLockRow | undefined): FileLockRecord | null {
+  if (!row) return null;
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    customerId: row.customer_id,
+    projectId: row.project_id,
+    workspaceId: row.workspace_id,
+    workspaceType: row.workspace_type,
+    path: row.path,
+    revisionId: row.revision_id,
+    lockedByUserId: row.locked_by_user_id,
+    lockedBySessionId: row.locked_by_session_id,
+    lockType: row.lock_type,
+    status: row.status,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapDocument(row: CollaborationDocumentRow | undefined): CollaborationDocumentRecord | null {
+  if (!row) return null;
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    customerId: row.customer_id,
+    projectId: row.project_id,
+    workspaceId: row.workspace_id,
+    workspaceType: row.workspace_type,
+    path: row.path,
+    provider: row.provider,
+    stateVersion: row.state_version,
+    snapshotRevisionId: row.snapshot_revision_id,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function withCollaborationDatabase<T>(write: boolean, callback: (sqlite: Sqlite) => T): T {
+  const sqlite = openOrganizationBootstrapDatabase();
+  try {
+    if (write) sqlite.exec('BEGIN IMMEDIATE');
+    const result = callback(sqlite);
+    if (write) sqlite.exec('COMMIT');
+    return result;
+  } catch (error) {
+    if (write && sqlite.inTransaction) sqlite.exec('ROLLBACK');
+    throw error;
+  } finally {
+    sqlite.close();
+  }
+}
+
+function expireStaleLocks(sqlite: Sqlite, workspaceId: string, filePath: string, nowMs: number): void {
+  sqlite.prepare(`
+    UPDATE file_locks
+    SET status = 'expired', updated_at = ?
+    WHERE workspace_id = ?
+      AND path = ?
+      AND status = 'active'
+      AND expires_at <= ?
+  `).run(nowMs, workspaceId, filePath, nowMs);
+}
+
+function getLatestRevision(sqlite: Sqlite, workspaceId: string, filePath: string): FileRevisionRecord | null {
+  const row = sqlite.prepare(`
+    SELECT *
+    FROM file_revisions
+    WHERE workspace_id = ? AND path = ?
+    ORDER BY created_at DESC, rowid DESC
+    LIMIT 1
+  `).get(workspaceId, filePath) as FileRevisionRow | undefined;
+  return mapRevision(row);
+}
+
+function getActiveLock(sqlite: Sqlite, workspaceId: string, filePath: string, nowMs: number): FileLockRecord | null {
+  expireStaleLocks(sqlite, workspaceId, filePath, nowMs);
+  const row = sqlite.prepare(`
+    SELECT *
+    FROM file_locks
+    WHERE workspace_id = ?
+      AND path = ?
+      AND status = 'active'
+      AND expires_at > ?
+    ORDER BY updated_at DESC, rowid DESC
+    LIMIT 1
+  `).get(workspaceId, filePath, nowMs) as FileLockRow | undefined;
+  return mapLock(row);
+}
+
+function getCollaborationDocument(
+  sqlite: Sqlite,
+  workspaceId: string,
+  filePath: string,
+): CollaborationDocumentRecord | null {
+  const row = sqlite.prepare(`
+    SELECT *
+    FROM collaboration_documents
+    WHERE workspace_id = ?
+      AND path = ?
+      AND provider = 'yjs'
+      AND status = 'active'
+    LIMIT 1
+  `).get(workspaceId, filePath) as CollaborationDocumentRow | undefined;
+  return mapDocument(row);
+}
+
+function ensureCollaborationDocument(
+  sqlite: Sqlite,
+  workspace: WorkspaceContext,
+  filePath: string,
+  snapshotRevisionId: string | null,
+  nowMs: number,
+): CollaborationDocumentRecord {
+  const existing = getCollaborationDocument(sqlite, workspace.workspaceId, filePath);
+  if (existing) return existing;
+
+  const id = `collab-doc-${randomUUID()}`;
+  sqlite.prepare(`
+    INSERT INTO collaboration_documents (
+      id, organization_id, customer_id, project_id, workspace_id, workspace_type, path,
+      provider, state_version, snapshot_revision_id, status, created_at, updated_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, 'yjs', 0, ?, 'active', ?, ?)
+  `).run(
+    id,
+    workspace.organizationId ?? null,
+    workspace.customerId ?? null,
+    workspace.projectId ?? null,
+    workspace.workspaceId,
+    workspace.workspaceType,
+    filePath,
+    snapshotRevisionId,
+    nowMs,
+    nowMs,
+  );
+
+  const created = getCollaborationDocument(sqlite, workspace.workspaceId, filePath);
+  if (!created) {
+    throw new Error(`Failed to create collaboration document for ${filePath}.`);
+  }
+  return created;
+}
+
+function buildState(params: {
+  sqlite: Sqlite;
+  workspace: WorkspaceContext;
+  path: string;
+  nowMs: number;
+  latestRevision?: FileRevisionRecord | null;
+  ensureDocument?: boolean;
+}): FileCollaborationState {
+  const strategy = detectFileCollaborationStrategy(params.path);
+  const requiresPolicy = workspaceRequiresCollaborationPolicy(params.workspace);
+  const latestRevision = params.latestRevision ?? getLatestRevision(params.sqlite, params.workspace.workspaceId, params.path);
+  const activeLock = requiresPolicy ? getActiveLock(params.sqlite, params.workspace.workspaceId, params.path, params.nowMs) : null;
+  const crdtCapable = requiresPolicy && strategy === 'crdt_text';
+  const document = crdtCapable
+    ? params.ensureDocument
+      ? ensureCollaborationDocument(params.sqlite, params.workspace, params.path, latestRevision?.id ?? null, params.nowMs)
+      : getCollaborationDocument(params.sqlite, params.workspace.workspaceId, params.path)
+    : null;
+
+  return {
+    path: params.path,
+    strategy,
+    crdtCapable,
+    lockRequired: requiresPolicy && strategy === 'exclusive_lock',
+    requiresRevisionCheck: requiresPolicy,
+    latestRevision,
+    activeLock,
+    document,
+  };
+}
+
+export function getFileCollaborationState(params: {
+  workspace: WorkspaceContext;
+  path: string;
+  ensureDocument?: boolean;
+  nowMs?: number;
+}): FileCollaborationState {
+  const normalizedPath = normalizeWorkspacePath(params.path);
+  return withCollaborationDatabase(Boolean(params.ensureDocument), (sqlite) => buildState({
+    sqlite,
+    workspace: params.workspace,
+    path: normalizedPath,
+    nowMs: params.nowMs ?? Date.now(),
+    ensureDocument: params.ensureDocument,
+  }));
+}
+
+export function ensureFileRevisionForCurrentContent(params: {
+  workspace: WorkspaceContext;
+  path: string;
+  contentHash: string;
+  sizeBytes: number;
+  actorUserId?: string | null;
+  actorType?: FileActorType;
+  sourceSessionId?: string | null;
+  baseRevisionId?: string | null;
+  nowMs?: number;
+}): FileRevisionRecord {
+  const normalizedPath = normalizeWorkspacePath(params.path);
+  const nowMs = params.nowMs ?? Date.now();
+
+  return withCollaborationDatabase(true, (sqlite) => {
+    const latest = getLatestRevision(sqlite, params.workspace.workspaceId, normalizedPath);
+    if (latest?.contentHash === params.contentHash && latest.sizeBytes === params.sizeBytes) {
+      return latest;
+    }
+
+    const id = `file-rev-${randomUUID()}`;
+    sqlite.prepare(`
+      INSERT INTO file_revisions (
+        id, organization_id, customer_id, project_id, workspace_id, workspace_type, path,
+        content_hash, size_bytes, created_by_user_id, created_by_actor_type,
+        source_session_id, base_revision_id, created_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id,
+      params.workspace.organizationId ?? null,
+      params.workspace.customerId ?? null,
+      params.workspace.projectId ?? null,
+      params.workspace.workspaceId,
+      params.workspace.workspaceType,
+      normalizedPath,
+      params.contentHash,
+      params.sizeBytes,
+      params.actorUserId ?? null,
+      params.actorType ?? 'system',
+      params.sourceSessionId ?? null,
+      params.baseRevisionId ?? latest?.id ?? null,
+      nowMs,
+    );
+
+    const created = getLatestRevision(sqlite, params.workspace.workspaceId, normalizedPath);
+    if (!created) {
+      throw new Error(`Failed to create file revision for ${normalizedPath}.`);
+    }
+
+    if (detectFileCollaborationStrategy(normalizedPath) === 'crdt_text' && workspaceRequiresCollaborationPolicy(params.workspace)) {
+      ensureCollaborationDocument(sqlite, params.workspace, normalizedPath, created.id, nowMs);
+    }
+
+    return created;
+  });
+}
+
+function isSameActor(lock: FileLockRecord, userId?: string | null, sessionId?: string | null): boolean {
+  if (sessionId && lock.lockedBySessionId && lock.lockedBySessionId === sessionId) return true;
+  return Boolean(userId && lock.lockedByUserId && lock.lockedByUserId === userId);
+}
+
+export function assertFileCollaborationWriteAllowed(params: {
+  workspace: WorkspaceContext;
+  path: string;
+  actorUserId?: string | null;
+  actorSessionId?: string | null;
+  actorType?: FileActorType;
+  baseRevisionId?: string | null;
+  nowMs?: number;
+}): FileCollaborationState {
+  const normalizedPath = normalizeWorkspacePath(params.path);
+  const nowMs = params.nowMs ?? Date.now();
+
+  return withCollaborationDatabase(true, (sqlite) => {
+    const latestRevision = getLatestRevision(sqlite, params.workspace.workspaceId, normalizedPath);
+    const state = buildState({
+      sqlite,
+      workspace: params.workspace,
+      path: normalizedPath,
+      nowMs,
+      latestRevision,
+      ensureDocument: false,
+    });
+
+    if (
+      params.baseRevisionId
+      && latestRevision?.id
+      && params.baseRevisionId !== latestRevision.id
+    ) {
+      throw new FileCollaborationPolicyError({
+        code: 'FILE_REVISION_ID_CONFLICT',
+        status: 409,
+        message: 'File revision conflict: this file changed after it was loaded. Reload the latest version before saving.',
+        path: normalizedPath,
+        currentRevisionId: latestRevision.id,
+        baseRevisionId: params.baseRevisionId,
+      });
+    }
+
+    if (state.activeLock && !isSameActor(state.activeLock, params.actorUserId, params.actorSessionId)) {
+      throw new FileCollaborationPolicyError({
+        code: 'FILE_LOCKED',
+        status: 423,
+        message: 'File is locked by another active editor. Wait for the lock to expire or ask an owner/admin to release it.',
+        path: normalizedPath,
+        currentRevisionId: latestRevision?.id ?? null,
+        baseRevisionId: params.baseRevisionId ?? null,
+        activeLock: state.activeLock,
+      });
+    }
+
+    if (state.lockRequired && latestRevision?.id && !state.activeLock) {
+      throw new FileCollaborationPolicyError({
+        code: 'FILE_LOCK_REQUIRED',
+        status: 423,
+        message: 'File requires an active edit lock before it can be changed.',
+        path: normalizedPath,
+        currentRevisionId: latestRevision.id,
+        baseRevisionId: params.baseRevisionId ?? null,
+      });
+    }
+
+    return state;
+  });
+}
+
+function normalizeLockTtl(ttlMs?: number): number {
+  if (!ttlMs || !Number.isFinite(ttlMs)) return DEFAULT_LOCK_TTL_MS;
+  return Math.max(30_000, Math.min(Math.trunc(ttlMs), MAX_LOCK_TTL_MS));
+}
+
+export function acquireFileLock(params: {
+  workspace: WorkspaceContext;
+  path: string;
+  lockedByUserId: string;
+  lockedBySessionId?: string | null;
+  lockType?: FileLockType;
+  ttlMs?: number;
+  baseRevisionId?: string | null;
+  nowMs?: number;
+}): { lock: FileLockRecord; state: FileCollaborationState } {
+  const normalizedPath = normalizeWorkspacePath(params.path);
+  const nowMs = params.nowMs ?? Date.now();
+  const expiresAt = nowMs + normalizeLockTtl(params.ttlMs);
+
+  return withCollaborationDatabase(true, (sqlite) => {
+    const latestRevision = getLatestRevision(sqlite, params.workspace.workspaceId, normalizedPath);
+    const activeLock = getActiveLock(sqlite, params.workspace.workspaceId, normalizedPath, nowMs);
+
+    if (
+      params.baseRevisionId
+      && latestRevision?.id
+      && params.baseRevisionId !== latestRevision.id
+    ) {
+      throw new FileCollaborationPolicyError({
+        code: 'FILE_REVISION_ID_CONFLICT',
+        status: 409,
+        message: 'File revision conflict: this file changed after it was loaded. Reload the latest version before locking.',
+        path: normalizedPath,
+        currentRevisionId: latestRevision.id,
+        baseRevisionId: params.baseRevisionId,
+      });
+    }
+
+    if (activeLock) {
+      if (!isSameActor(activeLock, params.lockedByUserId, params.lockedBySessionId)) {
+        throw new FileCollaborationPolicyError({
+          code: 'FILE_LOCKED',
+          status: 423,
+          message: 'File is already locked by another active editor.',
+          path: normalizedPath,
+          currentRevisionId: latestRevision?.id ?? null,
+          baseRevisionId: params.baseRevisionId ?? null,
+          activeLock,
+        });
+      }
+
+      sqlite.prepare(`
+        UPDATE file_locks
+        SET expires_at = ?, updated_at = ?
+        WHERE id = ?
+      `).run(expiresAt, nowMs, activeLock.id);
+      const refreshed = getActiveLock(sqlite, params.workspace.workspaceId, normalizedPath, nowMs);
+      if (!refreshed) {
+        throw new Error(`Failed to refresh active lock for ${normalizedPath}.`);
+      }
+      return {
+        lock: refreshed,
+        state: buildState({ sqlite, workspace: params.workspace, path: normalizedPath, nowMs, latestRevision }),
+      };
+    }
+
+    const id = `file-lock-${randomUUID()}`;
+    sqlite.prepare(`
+      INSERT INTO file_locks (
+        id, organization_id, customer_id, project_id, workspace_id, workspace_type, path,
+        revision_id, locked_by_user_id, locked_by_session_id, lock_type, status,
+        expires_at, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?)
+    `).run(
+      id,
+      params.workspace.organizationId ?? null,
+      params.workspace.customerId ?? null,
+      params.workspace.projectId ?? null,
+      params.workspace.workspaceId,
+      params.workspace.workspaceType,
+      normalizedPath,
+      params.baseRevisionId ?? latestRevision?.id ?? null,
+      params.lockedByUserId,
+      params.lockedBySessionId ?? null,
+      params.lockType ?? 'edit',
+      expiresAt,
+      nowMs,
+      nowMs,
+    );
+
+    const lock = getActiveLock(sqlite, params.workspace.workspaceId, normalizedPath, nowMs);
+    if (!lock) {
+      throw new Error(`Failed to create active lock for ${normalizedPath}.`);
+    }
+
+    return {
+      lock,
+      state: buildState({ sqlite, workspace: params.workspace, path: normalizedPath, nowMs, latestRevision }),
+    };
+  });
+}
+
+export function releaseFileLock(params: {
+  workspace: WorkspaceContext;
+  path?: string;
+  lockId?: string;
+  actorUserId: string;
+  actorSessionId?: string | null;
+  force?: boolean;
+  nowMs?: number;
+}): FileLockRecord {
+  const nowMs = params.nowMs ?? Date.now();
+
+  return withCollaborationDatabase(true, (sqlite) => {
+    const lock = params.lockId
+      ? mapLock(sqlite.prepare(`
+          SELECT *
+          FROM file_locks
+          WHERE id = ? AND workspace_id = ?
+          LIMIT 1
+        `).get(params.lockId, params.workspace.workspaceId) as FileLockRow | undefined)
+      : params.path
+        ? getActiveLock(sqlite, params.workspace.workspaceId, normalizeWorkspacePath(params.path), nowMs)
+        : null;
+
+    if (!lock) {
+      throw new FileCollaborationPolicyError({
+        code: 'FILE_LOCK_NOT_FOUND',
+        status: 404,
+        message: 'File lock was not found.',
+        path: params.path ? normalizeWorkspacePath(params.path) : '',
+      });
+    }
+
+    if (!params.force && !isSameActor(lock, params.actorUserId, params.actorSessionId)) {
+      throw new FileCollaborationPolicyError({
+        code: 'FILE_LOCK_PERMISSION_DENIED',
+        status: 423,
+        message: 'Only the lock owner or an owner/admin force release can release this file lock.',
+        path: lock.path,
+        activeLock: lock,
+      });
+    }
+
+    const nextStatus: FileLockStatus = params.force && !isSameActor(lock, params.actorUserId, params.actorSessionId)
+      ? 'force_released'
+      : 'released';
+    sqlite.prepare(`
+      UPDATE file_locks
+      SET status = ?, updated_at = ?
+      WHERE id = ?
+    `).run(nextStatus, nowMs, lock.id);
+
+    return {
+      ...lock,
+      status: nextStatus,
+      updatedAt: nowMs,
+    };
+  });
+}
+
+export function expireActiveFileLocks(params: {
+  workspace: WorkspaceContext;
+  path: string;
+  nowMs?: number;
+}): void {
+  const normalizedPath = normalizeWorkspacePath(params.path);
+  const nowMs = params.nowMs ?? Date.now();
+  withCollaborationDatabase(true, (sqlite) => {
+    expireStaleLocks(sqlite, params.workspace.workspaceId, normalizedPath, nowMs);
+  });
+}

--- a/app/lib/files/types.ts
+++ b/app/lib/files/types.ts
@@ -29,8 +29,49 @@ export interface FileStats {
   sha256?: string;
 }
 
+export type FileCollaborationStrategy = 'crdt_text' | 'revision_check' | 'exclusive_lock';
+
+export interface FileRevisionRecord {
+  id: string;
+  contentHash: string;
+  baseRevisionId: string | null;
+  createdAt: number;
+  createdByActorType: string;
+  createdByUserId: string | null;
+}
+
+export interface FileLockState {
+  id: string;
+  lockedByUserId: string | null;
+  lockedBySessionId: string | null;
+  lockType: string;
+  status: string;
+  expiresAt: number;
+}
+
+export interface CollaborationDocumentState {
+  id: string;
+  provider: 'yjs';
+  stateVersion: number;
+  snapshotRevisionId: string | null;
+  status: string;
+}
+
+export interface FileCollaborationState {
+  path: string;
+  strategy: FileCollaborationStrategy;
+  crdtCapable: boolean;
+  lockRequired: boolean;
+  requiresRevisionCheck: boolean;
+  latestRevision: FileRevisionRecord | null;
+  activeLock: FileLockState | null;
+  document: CollaborationDocumentState | null;
+}
+
 export interface CurrentFile {
   path: string;
   content: string;
   stats?: FileStats;
+  revision?: FileRevisionRecord | null;
+  collaboration?: FileCollaborationState | null;
 }

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -8,11 +8,16 @@ import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { logger } from '@/app/lib/logging';
 import { normalizeExpectedSha256 as normalizeAgentExpectedSha256 } from '@/app/lib/files/revision-guard';
 import {
+  assertFileCollaborationWriteAllowed,
+  ensureFileRevisionForCurrentContent,
+} from '@/app/lib/files/collaboration-policy';
+import {
   syncPublicSharesAfterDelete,
   syncPublicSharesAfterMove,
   syncPublicSharesAfterWrite,
 } from '@/app/lib/public-sharing/public-file-shares';
 import { getAgentExecutionContext, type AgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
 
 const SNAPSHOT_DIR_NAME = 'agent-file-snapshots';
 const MAX_DIFF_CHARS = 24_000;
@@ -364,6 +369,31 @@ function auditWorkspaceMetadata(executionContext: AgentExecutionContext | null) 
 function activeWorkspaceRequiresRevisionGuard(): boolean {
   const executionContext = getAgentExecutionContext();
   return executionContext?.workspaceType === 'team' || executionContext?.workspaceType === 'project';
+}
+
+function getAgentWorkspaceContext(): WorkspaceContext | null {
+  const executionContext = getAgentExecutionContext();
+  if (!executionContext) return null;
+
+  return {
+    workspaceId: executionContext.workspaceId,
+    workspaceType: executionContext.workspaceType,
+    rootPath: executionContext.workspaceRoot,
+    rootRelativePath: executionContext.workspaceRootRelativePath ?? undefined,
+    displayName: executionContext.workspaceName ?? undefined,
+    organizationId: executionContext.organizationId,
+    customerId: executionContext.customerId,
+    projectId: executionContext.projectId,
+    permissions: {
+      canRead: true,
+      canWrite: executionContext.canWrite,
+      canDelete: executionContext.canWrite,
+      canCreatePublicLinks: executionContext.canShare,
+      canManageWorkspace: false,
+      canRunAgent: true,
+    },
+    legacy: executionContext.legacy,
+  };
 }
 
 function assertAgentSharedWorkspaceRevision(params: {
@@ -933,6 +963,29 @@ async function commitTextChange(params: {
 
   await assertAgentWritablePathAllowed(params.fullPath);
   await fs.mkdir(path.dirname(params.fullPath), { recursive: true });
+  const executionContext = getAgentExecutionContext();
+  const workspaceContext = getAgentWorkspaceContext();
+  const baseRevision = workspaceContext && params.beforeBuffer
+    ? ensureFileRevisionForCurrentContent({
+        workspace: workspaceContext,
+        path: params.inputPath,
+        contentHash: sha256Buffer(params.beforeBuffer),
+        sizeBytes: params.beforeBuffer.length,
+        actorType: 'system',
+      })
+    : null;
+
+  if (workspaceContext) {
+    assertFileCollaborationWriteAllowed({
+      workspace: workspaceContext,
+      path: params.inputPath,
+      actorUserId: executionContext?.userId ?? null,
+      actorSessionId: executionContext?.sessionId ?? null,
+      actorType: 'agent',
+      baseRevisionId: baseRevision?.id ?? null,
+    });
+  }
+
   const snapshot = await createSnapshotFromBuffer({
     inputPath: params.inputPath,
     fullPath: params.fullPath,
@@ -946,6 +999,18 @@ async function commitTextChange(params: {
   const readBackText = readBack.toString('utf8');
   if (readBackText !== params.nextContent) {
     throw new Error(`Read-after-write verification failed for ${params.inputPath}.`);
+  }
+  if (workspaceContext) {
+    ensureFileRevisionForCurrentContent({
+      workspace: workspaceContext,
+      path: params.inputPath,
+      contentHash: sha256Buffer(readBack),
+      sizeBytes: readBack.length,
+      actorUserId: executionContext?.userId ?? null,
+      actorType: 'agent',
+      sourceSessionId: executionContext?.sessionId ?? null,
+      baseRevisionId: baseRevision?.id ?? null,
+    });
   }
   await syncPublicSharesAfterWrite([params.fullPath]);
 

--- a/app/store/file-store.ts
+++ b/app/store/file-store.ts
@@ -574,6 +574,8 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
           path,
           content: data.content,
           stats: data.stats,
+          revision: data.revision ?? data.collaboration?.latestRevision ?? null,
+          collaboration: data.collaboration ?? null,
         },
         isLoadingFile: false,
         loadingFilePath: null,
@@ -626,6 +628,8 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
         ...currentFile,
         content: data.content,
         stats: data.stats,
+        revision: data.revision ?? data.collaboration?.latestRevision ?? currentFile.revision ?? null,
+        collaboration: data.collaboration ?? currentFile.collaboration ?? null,
       };
       const nextFileRevisions = updateFileRevision(get().fileRevisions, path, data.stats);
 
@@ -708,6 +712,9 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
         ?? (currentFileBeforeSave?.path === path ? currentFileBeforeSave.stats?.sha256 ?? null : null);
       const result = await writeWorkspaceFile(path, content, {
         expectedSha256,
+        baseRevisionId: currentFileBeforeSave?.path === path
+          ? currentFileBeforeSave.revision?.id ?? currentFileBeforeSave.collaboration?.latestRevision?.id ?? null
+          : null,
       });
 
       // Update current file if it's the same path
@@ -718,6 +725,8 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
             ...currentFile,
             content,
             stats: result.stats ?? currentFile.stats,
+            revision: result.revision ?? result.collaboration?.latestRevision ?? currentFile.revision ?? null,
+            collaboration: result.collaboration ?? currentFile.collaboration ?? null,
           },
           fileRevisions: updateFileRevision(state.fileRevisions, path, result.stats),
         }));

--- a/docs/architecture/canvas-notebook/todo.json
+++ b/docs/architecture/canvas-notebook/todo.json
@@ -892,11 +892,36 @@
     {
       "id": 44,
       "title": "Markdown-/Text-Collaboration mit CRDT/Yjs und Lock-/Revision-Policy fuer Office/PDF/Assets bauen",
-      "status": "pending",
+      "status": "completed",
       "repo": "canvasstudios-notebook",
       "planningArtifacts": [
         "docs/architecture/canvas-notebook/team-workspace/10-agent-tool-execution-policy.md",
         "docs/architecture/canvas-notebook/team-workspace/18-collaboration-and-file-conflict-policy.md"
+      ],
+      "implementationArtifacts": [
+        "app/lib/db/schema.ts",
+        "app/lib/db/migrate.ts",
+        "app/lib/files/collaboration-policy.ts",
+        "app/api/files/locks/route.ts",
+        "app/api/files/read/route.ts",
+        "app/api/files/write/route.ts",
+        "app/api/files/create/route.ts",
+        "app/api/files/upload/route.ts",
+        "app/lib/pi/agent-file-operations.ts",
+        "app/lib/files/client.ts",
+        "app/lib/files/types.ts",
+        "app/store/file-store.ts",
+        "app/components/editor/FileEditor.tsx",
+        "scripts/file-collaboration-policy-test.ts"
+      ],
+      "verification": [
+        "npm run test:files:collaboration",
+        "tsx --conditions react-server scripts/file-revision-guard-test.ts",
+        "npm run test:agent:session-workspace",
+        "npm run test:workspace:foundation",
+        "npm run lint",
+        "npx tsc --noEmit --pretty false",
+        "npm run build"
       ]
     }
   ]

--- a/messages/de.json
+++ b/messages/de.json
@@ -687,6 +687,13 @@
     "unsavedChanges": "Ungespeicherte Änderungen",
     "saved": "Gespeichert",
     "savedAt": "Gespeichert {time}",
+    "collaboration": {
+      "crdtText": "Live-Text vorbereitet",
+      "revisionCheck": "Revision geprüft",
+      "lockRequired": "Lock erforderlich",
+      "locked": "Gesperrt",
+      "revisionShort": "Revision {revision}"
+    },
     "binaryPreviewUnavailable": "Für Binärdateien ist keine Vorschau verfügbar.",
     "downloadFile": "Datei herunterladen",
     "pdfLoading": "PDF wird geladen...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -688,6 +688,13 @@
     "unsavedChanges": "Unsaved changes",
     "saved": "Saved",
     "savedAt": "Saved {time}",
+    "collaboration": {
+      "crdtText": "Live text-ready",
+      "revisionCheck": "Revision checked",
+      "lockRequired": "Lock required",
+      "locked": "Locked",
+      "revisionShort": "Revision {revision}"
+    },
     "binaryPreviewUnavailable": "Binary file preview is not available.",
     "downloadFile": "Download file",
     "pdfLoading": "Loading PDF...",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "test:workspace:switcher-ui": "tsx scripts/workspace-switcher-ui-test.ts",
     "test:workspace:cross-copy": "tsx --conditions react-server scripts/workspace-cross-copy-test.ts",
     "test:public-share:workspace": "tsx --conditions react-server scripts/public-share-workspace-scope-test.ts",
+    "test:files:collaboration": "tsx --conditions react-server scripts/file-collaboration-policy-test.ts",
     "test:agent:session-workspace": "tsx --conditions react-server scripts/agent-session-workspace-context-test.ts",
     "test:e2e": "playwright test --pass-with-no-tests",
     "test:all": "node scripts/test-all.mjs",

--- a/scripts/file-collaboration-policy-test.ts
+++ b/scripts/file-collaboration-policy-test.ts
@@ -55,6 +55,7 @@ async function main() {
       ensureFileRevisionForCurrentContent,
       expireActiveFileLocks,
       getFileCollaborationState,
+      releaseFileLock,
     } = await import('../app/lib/files/collaboration-policy');
     const { writeFile } = await import('../app/lib/filesystem/workspace-files');
     const { sha256Buffer } = await import('../app/lib/files/revision-guard');
@@ -161,6 +162,17 @@ async function main() {
       baseRevisionId: pdfRevision.id,
       nowMs: 20_002,
     }));
+    assert.throws(
+      () => releaseFileLock({
+        workspace,
+        lockId: firstLock.lock.id,
+        actorUserId: 'user-b',
+        nowMs: 20_003,
+      }),
+      (error) => error instanceof FileCollaborationPolicyError
+        && error.code === 'FILE_LOCK_PERMISSION_DENIED'
+        && error.status === 403,
+    );
 
     assert.throws(
       () => assertFileCollaborationWriteAllowed({
@@ -168,7 +180,7 @@ async function main() {
         path: 'brief.pdf',
         actorUserId: 'user-b',
         baseRevisionId: pdfRevision.id,
-        nowMs: 20_003,
+        nowMs: 20_004,
       }),
       (error) => error instanceof FileCollaborationPolicyError && error.code === 'FILE_LOCKED',
     );

--- a/scripts/file-collaboration-policy-test.ts
+++ b/scripts/file-collaboration-policy-test.ts
@@ -1,0 +1,259 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { WorkspaceContext } from '../app/lib/workspaces/types';
+
+function workspaceContext(params: {
+  rootPath: string;
+  workspaceId: string;
+  workspaceType: WorkspaceContext['workspaceType'];
+  organizationId?: string | null;
+}): WorkspaceContext {
+  return {
+    workspaceId: params.workspaceId,
+    workspaceType: params.workspaceType,
+    rootPath: params.rootPath,
+    rootRelativePath: path.relative(path.dirname(params.rootPath), params.rootPath),
+    displayName: params.workspaceType,
+    status: 'active',
+    organizationId: params.organizationId ?? null,
+    permissions: {
+      canRead: true,
+      canWrite: true,
+      canDelete: true,
+      canCreatePublicLinks: true,
+      canManageWorkspace: true,
+      canRunAgent: true,
+    },
+    legacy: false,
+  };
+}
+
+async function main() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-file-collab-'));
+  const dataRoot = path.join(tempRoot, 'data');
+  process.env.DATA = dataRoot;
+
+  try {
+    const teamRoot = path.join(dataRoot, 'workspaces', 'team', 'org-collab', 'files');
+    await fs.mkdir(teamRoot, { recursive: true });
+
+    const workspace = workspaceContext({
+      rootPath: teamRoot,
+      workspaceId: 'ws-collab',
+      workspaceType: 'team',
+      organizationId: 'org-collab',
+    });
+
+    const {
+      FileCollaborationPolicyError,
+      acquireFileLock,
+      assertFileCollaborationWriteAllowed,
+      detectFileCollaborationStrategy,
+      ensureFileRevisionForCurrentContent,
+      expireActiveFileLocks,
+      getFileCollaborationState,
+    } = await import('../app/lib/files/collaboration-policy');
+    const { writeFile } = await import('../app/lib/filesystem/workspace-files');
+    const { sha256Buffer } = await import('../app/lib/files/revision-guard');
+    const { runWithAgentExecutionContext } = await import('../app/lib/pi/agent-execution-context');
+    const { writeAgentTextFile } = await import('../app/lib/pi/agent-file-operations');
+
+    assert.equal(detectFileCollaborationStrategy('notes.md'), 'crdt_text');
+    assert.equal(detectFileCollaborationStrategy('notes.txt'), 'crdt_text');
+    assert.equal(detectFileCollaborationStrategy('data.json'), 'revision_check');
+    assert.equal(detectFileCollaborationStrategy('brief.pdf'), 'exclusive_lock');
+    assert.equal(detectFileCollaborationStrategy('slides.pptx'), 'exclusive_lock');
+
+    await writeFile('notes.md', '# V1\n', { workspace });
+    const notesBuffer = Buffer.from('# V1\n');
+    const initialRevision = ensureFileRevisionForCurrentContent({
+      workspace,
+      path: 'notes.md',
+      contentHash: sha256Buffer(notesBuffer),
+      sizeBytes: notesBuffer.length,
+      actorUserId: 'user-a',
+      actorType: 'user',
+      nowMs: 10_000,
+    });
+
+    const markdownState = getFileCollaborationState({
+      workspace,
+      path: 'notes.md',
+      ensureDocument: true,
+      nowMs: 10_001,
+    });
+    assert.equal(markdownState.strategy, 'crdt_text');
+    assert.equal(markdownState.crdtCapable, true);
+    assert.equal(markdownState.requiresRevisionCheck, true);
+    assert.equal(markdownState.document?.provider, 'yjs');
+    assert.equal(markdownState.document?.snapshotRevisionId, initialRevision.id);
+
+    assert.doesNotThrow(() => assertFileCollaborationWriteAllowed({
+      workspace,
+      path: 'notes.md',
+      actorUserId: 'user-a',
+      baseRevisionId: initialRevision.id,
+      nowMs: 10_002,
+    }));
+
+    const secondBuffer = Buffer.from('# V2\n');
+    const secondRevision = ensureFileRevisionForCurrentContent({
+      workspace,
+      path: 'notes.md',
+      contentHash: sha256Buffer(secondBuffer),
+      sizeBytes: secondBuffer.length,
+      actorUserId: 'user-a',
+      actorType: 'user',
+      baseRevisionId: initialRevision.id,
+      nowMs: 10_003,
+    });
+    assert.notEqual(secondRevision.id, initialRevision.id);
+
+    assert.throws(
+      () => assertFileCollaborationWriteAllowed({
+        workspace,
+        path: 'notes.md',
+        actorUserId: 'user-b',
+        baseRevisionId: initialRevision.id,
+        nowMs: 10_004,
+      }),
+      (error) => error instanceof FileCollaborationPolicyError && error.code === 'FILE_REVISION_ID_CONFLICT',
+    );
+
+    await writeFile('brief.pdf', Buffer.from('%PDF-locked\n'), { workspace });
+    const pdfBuffer = Buffer.from('%PDF-locked\n');
+    const pdfRevision = ensureFileRevisionForCurrentContent({
+      workspace,
+      path: 'brief.pdf',
+      contentHash: sha256Buffer(pdfBuffer),
+      sizeBytes: pdfBuffer.length,
+      actorType: 'system',
+      nowMs: 20_000,
+    });
+    assert.throws(
+      () => assertFileCollaborationWriteAllowed({
+        workspace,
+        path: 'brief.pdf',
+        actorUserId: 'user-a',
+        baseRevisionId: pdfRevision.id,
+        nowMs: 20_000,
+      }),
+      (error) => error instanceof FileCollaborationPolicyError && error.code === 'FILE_LOCK_REQUIRED',
+    );
+    const firstLock = acquireFileLock({
+      workspace,
+      path: 'brief.pdf',
+      lockedByUserId: 'user-a',
+      lockType: 'edit',
+      ttlMs: 60_000,
+      baseRevisionId: pdfRevision.id,
+      nowMs: 20_001,
+    });
+    assert.equal(firstLock.lock.lockedByUserId, 'user-a');
+    assert.equal(firstLock.state.activeLock?.id, firstLock.lock.id);
+    assert.doesNotThrow(() => assertFileCollaborationWriteAllowed({
+      workspace,
+      path: 'brief.pdf',
+      actorUserId: 'user-a',
+      baseRevisionId: pdfRevision.id,
+      nowMs: 20_002,
+    }));
+
+    assert.throws(
+      () => assertFileCollaborationWriteAllowed({
+        workspace,
+        path: 'brief.pdf',
+        actorUserId: 'user-b',
+        baseRevisionId: pdfRevision.id,
+        nowMs: 20_003,
+      }),
+      (error) => error instanceof FileCollaborationPolicyError && error.code === 'FILE_LOCKED',
+    );
+
+    expireActiveFileLocks({ workspace, path: 'brief.pdf', nowMs: 90_002 });
+    assert.throws(
+      () => assertFileCollaborationWriteAllowed({
+        workspace,
+        path: 'brief.pdf',
+        actorUserId: 'user-b',
+        baseRevisionId: pdfRevision.id,
+        nowMs: 90_003,
+      }),
+      (error) => error instanceof FileCollaborationPolicyError && error.code === 'FILE_LOCK_REQUIRED',
+    );
+    acquireFileLock({
+      workspace,
+      path: 'brief.pdf',
+      lockedByUserId: 'user-b',
+      lockType: 'edit',
+      ttlMs: 60_000,
+      baseRevisionId: pdfRevision.id,
+      nowMs: 90_004,
+    });
+    assert.doesNotThrow(() => assertFileCollaborationWriteAllowed({
+      workspace,
+      path: 'brief.pdf',
+      actorUserId: 'user-b',
+      baseRevisionId: pdfRevision.id,
+      nowMs: 90_005,
+    }));
+
+    const agentNow = Date.now();
+    await writeFile('agent.md', 'agent v1\n', { workspace });
+    const agentBuffer = Buffer.from('agent v1\n');
+    const agentRevision = ensureFileRevisionForCurrentContent({
+      workspace,
+      path: 'agent.md',
+      contentHash: sha256Buffer(agentBuffer),
+      sizeBytes: agentBuffer.length,
+      actorType: 'system',
+      nowMs: agentNow,
+    });
+    acquireFileLock({
+      workspace,
+      path: 'agent.md',
+      lockedByUserId: 'human-editor',
+      lockType: 'edit',
+      ttlMs: 60_000,
+      baseRevisionId: agentRevision.id,
+      nowMs: agentNow + 1,
+    });
+
+    const agentContext = {
+      userId: 'agent-owner',
+      sessionId: 'agent-session',
+      agentId: 'canvas-agent',
+      workspaceId: workspace.workspaceId,
+      workspaceType: workspace.workspaceType,
+      workspaceName: workspace.displayName ?? null,
+      organizationId: workspace.organizationId ?? null,
+      customerId: null,
+      projectId: null,
+      workspaceRoot: workspace.rootPath,
+      workspaceRootRelativePath: workspace.rootRelativePath ?? null,
+      canWrite: true,
+      canShare: true,
+      legacy: false,
+    };
+
+    await runWithAgentExecutionContext(agentContext, async () => {
+      await assert.rejects(
+        () => writeAgentTextFile({
+          path: 'agent.md',
+          content: 'agent v2\n',
+          expectedSha256: sha256Buffer(agentBuffer),
+        }),
+        /locked by another active editor/i,
+      );
+    });
+
+    console.log('file-collaboration-policy-test: ok');
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add collaboration metadata tables for file revisions, locks, Yjs document state, and collaboration events
- enforce revision conflicts and active lock ownership across file create/read/write/upload APIs and agent file writes
- add `/api/files/locks` plus editor badges for CRDT-ready text, lock-required files, active locks, and revision ids
- mark Task 44 complete in `docs/architecture/canvas-notebook/todo.json`

## Verification
- npm run test:files:collaboration
- tsx --conditions react-server scripts/file-revision-guard-test.ts
- npm run test:agent:session-workspace
- npm run test:workspace:foundation
- npm run lint
- npx tsc --noEmit --pretty false
- npm run build

## Notes
- Browser/Playwright UI testing was not run because this repository asks for explicit approval before using it.
- Greptile score: pending automatic initial review.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a file collaboration lock policy for team and project workspaces, adding four new SQLite tables (`file_revisions`, `file_locks`, `collaboration_documents`, `collaboration_events`), a `collaboration-policy.ts` enforcement module, and a new `/api/files/locks` REST endpoint.

- **Core policy enforcement**: All file create/read/write/upload routes and agent writes now call `assertFileCollaborationWriteAllowed`, which enforces revision-conflict detection (409), exclusive-lock blocking (423), and lock-required checks (423) based on file extension strategy (`crdt_text` / `revision_check` / `exclusive_lock`).
- **Lock lifecycle**: `POST /api/files/locks` acquires locks (with auto-renewal for existing owners), `DELETE` releases them (with force-release guarded by `canManageWorkspace`), and the editor surfaces active-lock, CRDT-capable, and revision badges.
- **Agent integration**: `commitTextChange` in `agent-file-operations.ts` now participates in the same policy, recording pre- and post-write revisions and respecting active locks set by human editors.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all collaboration checks are additive and the enforcement logic is well-tested by the accompanying integration script.

The write-path enforcement logic (revision conflict, lock-required, lock-blocked) is correct and exercised end-to-end in the test script. The three flagged items are all non-blocking: a missing collaboration-policy guard on reads causes unnecessary write-transaction overhead but no incorrect behavior; the collaboration_events sequence constraint is future infrastructure that no existing code writes to; and the hardcoded null session ID in the locks API is a known limitation of HTTP session granularity.

app/api/files/read/route.ts — every full file read now opens a SQLite write transaction regardless of workspace type; worth adding a policy guard before shipping to high-traffic environments.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/files/collaboration-policy.ts | Core collaboration engine: revision dedup, lock acquire/release, write enforcement. Logic is sound; 403/409/423 status codes are correctly assigned. |
| app/api/files/read/route.ts | Every full file read now unconditionally opens a SQLite write transaction (ensureFileRevisionForCurrentContent + getFileCollaborationState with ensureDocument:true), regardless of workspace type. |
| app/lib/db/migrate.ts | Adds four new tables with appropriate indexes. collaboration_events carries a UNIQUE (document_id, sequence) index that requires per-document sequence management before any rows can be inserted — no such logic exists in this PR. |
| app/api/files/locks/route.ts | New REST endpoint for lock lifecycle (GET state, POST acquire, DELETE release). Force-release permission guard is present. lockedBySessionId is always null, making session-level isolation unused for API callers. |
| app/api/files/write/route.ts | Pre-write state is recorded as storedBaseRevision, then assertFileCollaborationWriteAllowed uses the client-provided baseRevisionId for conflict detection, and post-write state is recorded with the correct actor attribution. Logic is correct. |
| app/api/files/upload/route.ts | Auto-acquires a transient upload lock for exclusive_lock files with existing content; releases it in a finally block. Correctly delegates concurrency safety to acquireFileLock's own transaction rather than the outer state read. |
| app/lib/pi/agent-file-operations.ts | Agent writes now participate in collaboration policy: pre-write snapshot + assertFileCollaborationWriteAllowed + post-write revision recording. Session and user IDs are correctly pulled from AgentExecutionContext. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Client
  participant WriteAPI as /api/files/write
  participant RevGuard as revision-guard
  participant CollabPolicy as collaboration-policy
  participant SQLite

  Client->>WriteAPI: "POST {path, content, baseRevisionId}"
  WriteAPI->>RevGuard: assertWorkspaceFileRevisionAllowed(expectedSha256)
  RevGuard->>SQLite: read file stats from disk
  RevGuard-->>WriteAPI: beforeRevision (sha256, size)

  WriteAPI->>CollabPolicy: ensureFileRevisionForCurrentContent(beforeRevision)
  CollabPolicy->>SQLite: BEGIN IMMEDIATE
  CollabPolicy->>SQLite: SELECT latest revision
  CollabPolicy->>SQLite: INSERT if content changed — storedBaseRevision
  CollabPolicy->>SQLite: COMMIT

  WriteAPI->>CollabPolicy: assertFileCollaborationWriteAllowed(baseRevisionId)
  CollabPolicy->>SQLite: BEGIN IMMEDIATE
  CollabPolicy->>SQLite: getLatestRevision, getActiveLock
  alt "baseRevisionId != latest revision id"
    CollabPolicy-->>WriteAPI: throw FILE_REVISION_ID_CONFLICT (409)
  else active lock held by different actor
    CollabPolicy-->>WriteAPI: throw FILE_LOCKED (423)
  else lockRequired and no active lock
    CollabPolicy-->>WriteAPI: throw FILE_LOCK_REQUIRED (423)
  end
  CollabPolicy->>SQLite: COMMIT

  WriteAPI->>SQLite: writeFile to disk
  WriteAPI->>CollabPolicy: "ensureFileRevisionForCurrentContent(afterRevision, actor=user)"
  CollabPolicy->>SQLite: BEGIN IMMEDIATE — INSERT post-write revision
  CollabPolicy->>SQLite: COMMIT

  WriteAPI->>CollabPolicy: getFileCollaborationState(ensureDocument:true)
  CollabPolicy->>SQLite: BEGIN IMMEDIATE — ensureCollaborationDocument if crdt_text
  CollabPolicy->>SQLite: COMMIT

  WriteAPI-->>Client: "{stats, revision, collaboration}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Client
  participant WriteAPI as /api/files/write
  participant RevGuard as revision-guard
  participant CollabPolicy as collaboration-policy
  participant SQLite

  Client->>WriteAPI: "POST {path, content, baseRevisionId}"
  WriteAPI->>RevGuard: assertWorkspaceFileRevisionAllowed(expectedSha256)
  RevGuard->>SQLite: read file stats from disk
  RevGuard-->>WriteAPI: beforeRevision (sha256, size)

  WriteAPI->>CollabPolicy: ensureFileRevisionForCurrentContent(beforeRevision)
  CollabPolicy->>SQLite: BEGIN IMMEDIATE
  CollabPolicy->>SQLite: SELECT latest revision
  CollabPolicy->>SQLite: INSERT if content changed — storedBaseRevision
  CollabPolicy->>SQLite: COMMIT

  WriteAPI->>CollabPolicy: assertFileCollaborationWriteAllowed(baseRevisionId)
  CollabPolicy->>SQLite: BEGIN IMMEDIATE
  CollabPolicy->>SQLite: getLatestRevision, getActiveLock
  alt "baseRevisionId != latest revision id"
    CollabPolicy-->>WriteAPI: throw FILE_REVISION_ID_CONFLICT (409)
  else active lock held by different actor
    CollabPolicy-->>WriteAPI: throw FILE_LOCKED (423)
  else lockRequired and no active lock
    CollabPolicy-->>WriteAPI: throw FILE_LOCK_REQUIRED (423)
  end
  CollabPolicy->>SQLite: COMMIT

  WriteAPI->>SQLite: writeFile to disk
  WriteAPI->>CollabPolicy: "ensureFileRevisionForCurrentContent(afterRevision, actor=user)"
  CollabPolicy->>SQLite: BEGIN IMMEDIATE — INSERT post-write revision
  CollabPolicy->>SQLite: COMMIT

  WriteAPI->>CollabPolicy: getFileCollaborationState(ensureDocument:true)
  CollabPolicy->>SQLite: BEGIN IMMEDIATE — ensureCollaborationDocument if crdt_text
  CollabPolicy->>SQLite: COMMIT

  WriteAPI-->>Client: "{stats, revision, collaboration}"
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Ftask-44-collaboration-locks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ftask-44-collaboration-locks%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapp%2Fapi%2Ffiles%2Fread%2Froute.ts%3A77-90%0A**Write%20transaction%20opened%20on%20every%20file%20read**%0A%0A%60ensureFileRevisionForCurrentContent%60%20always%20calls%20%60withCollaborationDatabase%28true%2C%20...%29%60%2C%20which%20issues%20%60BEGIN%20IMMEDIATE%60%20before%20the%20SELECT%2Fconditional-INSERT.%20This%20makes%20every%20non-meta%20file%20read%20a%20SQLite%20write-lock%20operation%2C%20even%20for%20personal%20or%20sandbox%20workspaces%20where%20%60workspaceRequiresCollaborationPolicy%60%20returns%20false.%20In%20those%20workspaces%20the%20recorded%20revisions%20are%20never%20used%20for%20conflict%20detection%20or%20locking%2C%20yet%20the%20write-lock%20contention%20is%20still%20paid%20on%20every%20open.%0A%0AA%20%60workspaceRequiresCollaborationPolicy%28workspaceResult.workspace%29%60%20guard%20before%20lines%2077%E2%80%9390%20would%20scope%20both%20the%20revision%20write%20and%20the%20%60ensureDocument%3A%20true%60%20document%20creation%20to%20the%20workspaces%20that%20actually%20enforce%20collaboration.%20The%20%60getFileCollaborationState%60%20call%20%28line%2086%29%20for%20non-policy%20workspaces%20could%20use%20the%20cheaper%20read%20path%20without%20%60ensureDocument%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Flib%2Fdb%2Fmigrate.ts%3A1874-1877%0A**%60collaboration_events%60%20sequence%20constraint%20has%20no%20backing%20implementation**%0A%0AThe%20%60UNIQUE%20INDEX%20%28document_id%2C%20sequence%29%60%20strongly%20implies%20per-document%20ordered%20event%20sourcing%2C%20but%20no%20code%20in%20this%20PR%20inserts%20into%20%60collaboration_events%60%20or%20manages%20the%20per-document%20sequence%20counter.%20Any%20future%20code%20that%20tries%20to%20write%20to%20this%20table%20without%20implementing%20a%20max-sequence%20lookup%20%2B%20increment-then-insert%20pattern%20will%20immediately%20hit%20%60SQLITE_CONSTRAINT_UNIQUE%60.%20The%20table%20is%20effectively%20unusable%20until%20sequence%20generation%20logic%20is%20added.%20A%20comment%20on%20the%20%60CREATE%20TABLE%60%20%28or%20a%20matching%20placeholder%20in%20%60collaboration-policy.ts%60%29%20noting%20%22reserved%20for%20Yjs%20op-log%20%E2%80%94%20sequence%20management%20required%20before%20use%22%20would%20prevent%20a%20silent%20correctness%20failure%20for%20the%20next%20contributor.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Fapi%2Ffiles%2Flocks%2Froute.ts%3A88-98%0A**%60lockedBySessionId%60%20is%20hardcoded%20to%20%60null%60%20for%20all%20API-acquired%20locks**%0A%0A%60acquireFileLock%60%20is%20called%20with%20%60lockedBySessionId%3A%20null%60.%20Since%20%60isSameActor%60%20only%20checks%20the%20session-ID%20branch%20when%20both%20sides%20are%20non-null%2C%20the%20%60locked_by_session_id%60%20column%20is%20permanently%20unpopulated%20for%20user-originated%20locks.%20This%20means%20two%20browser%20tabs%20from%20the%20same%20user%20are%20indistinguishable%20%E2%80%94%20either%20tab%20can%20refresh%20or%20release%20the%20other's%20lock.%20Agent%20operations%20do%20populate%20%60lockedBySessionId%60%20%28from%20%60executionContext.sessionId%60%29%2C%20so%20the%20asymmetry%20is%20already%20there.%20If%20per-session%20isolation%20is%20ever%20needed%20for%20multi-tab%20conflict%20detection%2C%20the%20schema%20and%20%60isSameActor%60%20logic%20already%20support%20it%3B%20surfacing%20a%20client-provided%20%60sessionId%60%20header%20or%20cookie%20here%20would%20be%20the%20only%20change%20needed.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=44&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile collaboration policy fe..."](https://github.com/canvascoding/canvas-notebook/commit/fc89974d34a159644635024ed6799a53a03c59d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39124903)</sub>

<!-- /greptile_comment -->