### PR TITLE
Fix legacy migration index ordering

### DIFF
--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -1377,11 +1377,8 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_pi_usage_events_model_assistant_timestamp ON pi_usage_events (model, assistant_timestamp);
     CREATE INDEX IF NOT EXISTS idx_automation_jobs_next_run_at ON automation_jobs (next_run_at);
     CREATE INDEX IF NOT EXISTS idx_automation_jobs_status ON automation_jobs (status);
-    CREATE INDEX IF NOT EXISTS idx_automation_jobs_owner_scope ON automation_jobs (owner_user_id, scope);
-    CREATE INDEX IF NOT EXISTS idx_automation_jobs_org_workspace ON automation_jobs (organization_id, workspace_id);
     CREATE INDEX IF NOT EXISTS idx_automation_runs_job_id_created_at ON automation_runs (job_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_automation_runs_status ON automation_runs (status);
-    CREATE INDEX IF NOT EXISTS idx_automation_runs_workspace_created ON automation_runs (workspace_id, created_at);
     CREATE TABLE IF NOT EXISTS composio_webhook_subscriptions (
       id TEXT PRIMARY KEY NOT NULL,
       subscription_id TEXT NOT NULL UNIQUE,
@@ -1500,19 +1497,16 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_public_file_shares_expires_at ON public_file_shares (expires_at);
     CREATE INDEX IF NOT EXISTS idx_knowledge_sources_store_status ON knowledge_sources (knowledge_store, status);
     CREATE INDEX IF NOT EXISTS idx_knowledge_sources_org_workspace ON knowledge_sources (organization_id, workspace_id, knowledge_store, status);
-    CREATE INDEX IF NOT EXISTS idx_knowledge_sources_project_store ON knowledge_sources (project_id, knowledge_store, status);
     CREATE INDEX IF NOT EXISTS idx_knowledge_sources_user_store ON knowledge_sources (user_id, knowledge_store, status);
     CREATE INDEX IF NOT EXISTS idx_knowledge_sources_workspace_path ON knowledge_sources (workspace_id, source_path);
     CREATE INDEX IF NOT EXISTS idx_knowledge_sources_content_hash ON knowledge_sources (content_hash);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_knowledge_chunks_source_chunk ON knowledge_chunks (source_id, chunk_index);
     CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_org_workspace ON knowledge_chunks (organization_id, workspace_id, knowledge_store, embedding_index_status);
-    CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_project_store ON knowledge_chunks (project_id, knowledge_store, embedding_index_status);
     CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_user_store ON knowledge_chunks (user_id, knowledge_store, embedding_index_status);
     CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_policy ON knowledge_chunks (policy_decision, scan_status, embedding_index_status);
     CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_content_hash ON knowledge_chunks (content_hash);
     CREATE INDEX IF NOT EXISTS idx_audit_events_created ON audit_events (created_at);
     CREATE INDEX IF NOT EXISTS idx_audit_events_org_created ON audit_events (organization_id, created_at);
-    CREATE INDEX IF NOT EXISTS idx_audit_events_project_created ON audit_events (project_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_audit_events_workspace_created ON audit_events (workspace_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_audit_events_user_created ON audit_events (user_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_audit_events_entity_created ON audit_events (entity_type, entity_id, created_at);
@@ -1867,8 +1861,14 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_pi_usage_events_project ON pi_usage_events (project_id, assistant_timestamp);
     CREATE INDEX IF NOT EXISTS idx_pi_usage_events_user_workspace ON pi_usage_events (user_id, workspace_id, assistant_timestamp);
     CREATE INDEX IF NOT EXISTS idx_pi_usage_events_agent ON pi_usage_events (agent_id, assistant_timestamp);
+    CREATE INDEX IF NOT EXISTS idx_knowledge_sources_project_store ON knowledge_sources (project_id, knowledge_store, status);
+    CREATE INDEX IF NOT EXISTS idx_knowledge_chunks_project_store ON knowledge_chunks (project_id, knowledge_store, embedding_index_status);
+    CREATE INDEX IF NOT EXISTS idx_audit_events_project_created ON audit_events (project_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_automation_jobs_owner_scope ON automation_jobs (owner_user_id, scope);
+    CREATE INDEX IF NOT EXISTS idx_automation_jobs_org_workspace ON automation_jobs (organization_id, workspace_id);
     CREATE INDEX IF NOT EXISTS idx_automation_jobs_project_status ON automation_jobs (project_id, status, next_run_at);
     CREATE INDEX IF NOT EXISTS idx_automation_jobs_job_scope_status ON automation_jobs (job_scope, status, next_run_at);
+    CREATE INDEX IF NOT EXISTS idx_automation_runs_workspace_created ON automation_runs (workspace_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_automation_runs_project_created ON automation_runs (project_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_automation_runs_job_scope_status ON automation_runs (job_scope, status, scheduled_for);
   `);

--- a/scripts/db-migration-legacy-test.ts
+++ b/scripts/db-migration-legacy-test.ts
@@ -150,6 +150,98 @@ try {
 
     INSERT INTO channel_active_sessions (user_id, channel_id, channel_session_key, channel_thread_key, session_id, updated_at)
     VALUES ('user-migration', 'web', 'web:user:user-migration', '', 'sess-migration', 1700000100);
+
+    CREATE TABLE automation_jobs (
+      id TEXT PRIMARY KEY NOT NULL,
+      name TEXT NOT NULL,
+      status TEXT NOT NULL,
+      prompt TEXT NOT NULL,
+      preferred_skill TEXT NOT NULL,
+      workspace_context_paths_json TEXT NOT NULL,
+      schedule_kind TEXT NOT NULL,
+      schedule_config_json TEXT NOT NULL,
+      time_zone TEXT NOT NULL,
+      next_run_at INTEGER,
+      last_run_at INTEGER,
+      last_run_status TEXT,
+      created_by_user_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE automation_runs (
+      id TEXT PRIMARY KEY NOT NULL,
+      job_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      trigger_type TEXT NOT NULL,
+      scheduled_for INTEGER,
+      started_at INTEGER,
+      finished_at INTEGER,
+      attempt_number INTEGER NOT NULL,
+      output_dir TEXT,
+      log_path TEXT,
+      result_path TEXT,
+      error_message TEXT,
+      pi_session_id TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE knowledge_sources (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      workspace_id TEXT,
+      user_id TEXT,
+      knowledge_store TEXT NOT NULL,
+      source_path TEXT NOT NULL,
+      content_hash TEXT,
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE knowledge_chunks (
+      id TEXT PRIMARY KEY NOT NULL,
+      source_id TEXT NOT NULL,
+      organization_id TEXT,
+      workspace_id TEXT,
+      user_id TEXT,
+      knowledge_store TEXT NOT NULL,
+      chunk_index INTEGER NOT NULL,
+      content_hash TEXT,
+      policy_decision TEXT,
+      scan_status TEXT,
+      embedding_index_status TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE audit_events (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      workspace_id TEXT,
+      user_id TEXT,
+      source TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      entity_type TEXT NOT NULL,
+      entity_id TEXT,
+      action TEXT NOT NULL,
+      status TEXT NOT NULL,
+      summary TEXT,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE public_file_shares (
+      id TEXT PRIMARY KEY NOT NULL,
+      token_hash TEXT NOT NULL,
+      token TEXT NOT NULL,
+      workspace_path TEXT NOT NULL,
+      created_by_user_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      expires_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
   `);
 
   runMigrations(sqlite);
@@ -226,6 +318,41 @@ try {
   assert.equal(migratedUsage.workspaceId, null);
   assert.equal(migratedUsage.workspaceType, null);
 
+  const automationJobColumns = getColumns(sqlite, 'automation_jobs');
+  assert.ok(automationJobColumns.has('owner_user_id'));
+  assert.ok(automationJobColumns.has('scope'));
+  assert.ok(automationJobColumns.has('organization_id'));
+  assert.ok(automationJobColumns.has('workspace_id'));
+  assert.ok(automationJobColumns.has('project_id'));
+  assert.ok(indexExists(sqlite, 'automation_jobs', 'idx_automation_jobs_owner_scope'));
+  assert.ok(indexExists(sqlite, 'automation_jobs', 'idx_automation_jobs_org_workspace'));
+  assert.ok(indexExists(sqlite, 'automation_jobs', 'idx_automation_jobs_project_status'));
+
+  const automationRunColumns = getColumns(sqlite, 'automation_runs');
+  assert.ok(automationRunColumns.has('workspace_id'));
+  assert.ok(automationRunColumns.has('project_id'));
+  assert.ok(automationRunColumns.has('job_scope'));
+  assert.ok(indexExists(sqlite, 'automation_runs', 'idx_automation_runs_workspace_created'));
+  assert.ok(indexExists(sqlite, 'automation_runs', 'idx_automation_runs_project_created'));
+
+  const knowledgeSourceColumns = getColumns(sqlite, 'knowledge_sources');
+  assert.ok(knowledgeSourceColumns.has('project_id'));
+  assert.ok(indexExists(sqlite, 'knowledge_sources', 'idx_knowledge_sources_project_store'));
+
+  const knowledgeChunkColumns = getColumns(sqlite, 'knowledge_chunks');
+  assert.ok(knowledgeChunkColumns.has('project_id'));
+  assert.ok(indexExists(sqlite, 'knowledge_chunks', 'idx_knowledge_chunks_project_store'));
+
+  const auditEventColumns = getColumns(sqlite, 'audit_events');
+  assert.ok(auditEventColumns.has('project_id'));
+  assert.ok(indexExists(sqlite, 'audit_events', 'idx_audit_events_project_created'));
+
+  const publicShareColumns = getColumns(sqlite, 'public_file_shares');
+  assert.ok(publicShareColumns.has('organization_id'));
+  assert.ok(publicShareColumns.has('project_id'));
+  assert.ok(publicShareColumns.has('short_code'));
+  assert.ok(indexExists(sqlite, 'public_file_shares', 'idx_public_file_shares_project_status'));
+
   sqlite.close();
   console.log('legacy db migration tests passed');
 } finally {
@@ -245,4 +372,9 @@ function tableExists(sqlite: Database.Database, table: string): boolean {
       .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1")
       .get(table),
   );
+}
+
+function indexExists(sqlite: Database.Database, table: string, indexName: string): boolean {
+  return sqlite.prepare(`PRAGMA index_list(${table})`).all()
+    .some((index) => (index as { name: string }).name === indexName);
 }


### PR DESCRIPTION
## Summary
- move indexes that depend on newly added migration columns into the deferred index block after `addColumns` runs
- cover automation owner/workspace indexes plus knowledge/audit project indexes that can break older SQLite volumes
- extend the legacy DB migration test with old automation, knowledge, audit, and public share table shapes

## Verification
- tsx --conditions react-server scripts/db-migration-legacy-test.ts
- tsx --conditions react-server scripts/migration-import-dry-run-test.ts
- npm run test:workspace:model
- npm run test:automation:workspace-scope
- npm run test:db:provider
- npm run lint
- npx tsc --noEmit --pretty false
- npm run build

## Notes
- Fixes startup failures like `SqliteError: no such column: owner_user_id` during agent runtime bootstrap on upgraded existing volumes.
- Greptile score: pending automatic initial review.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes startup crashes on existing SQLite volumes by relocating six indexes that reference newly-added columns (via `addColumns`) to a deferred index block that runs after those `addColumns` calls complete. Without this ordering fix, upgrading an older volume would fail with `SqliteError: no such column` when SQLite tried to build an index on a column not yet present in the table.

- Six indexes across `automation_jobs`, `automation_runs`, `knowledge_sources`, `knowledge_chunks`, and `audit_events` are moved from the early index-creation batch (~line 1378–1510) to the deferred block (~line 1864–1873) that executes after all relevant `addColumns` calls.
- `scripts/db-migration-legacy-test.ts` is extended with old-schema table shapes for automation, knowledge, audit, and public-share tables, asserting that every moved index and its dependency columns exist after migration.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure ordering fix with no schema alteration, idempotent index creation, and direct test coverage for the exact failure scenario it addresses.

Every moved index references columns that are provably present by the time the deferred block executes. New installs are unaffected because CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS are idempotent and the deferred block runs after all addColumns calls. The legacy test script exercises the full upgrade path from an old-schema DB, asserting both column and index existence after migration.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/db/migrate.ts | Moves 6 indexes from the early bulk-index block to the deferred block that runs after addColumns; all moved indexes reference columns confirmed to be added by the intervening addColumns calls at lines 1613–1689. |
| scripts/db-migration-legacy-test.ts | Adds old-schema table shapes for 6 tables and asserts that all newly-added columns and the moved indexes exist after runMigrations; new indexExists helper correctly uses PRAGMA index_list (PRAGMA does not support bound params, so string interpolation is the only option). |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runMigrations start] --> B[CREATE TABLE IF NOT EXISTS blocks\nnew installs get full schema]
    B --> C[Early index block\nindexes on original columns only\nlines ~1360–1510]
    C --> D[addColumns: knowledge_sources\nproject_id line 1613]
    D --> E[addColumns: knowledge_chunks\nproject_id line 1618]
    E --> F[addColumns: audit_events\nproject_id line 1623]
    F --> G[addColumns: public_file_shares\nshort_code organization_id project_id line 1597]
    G --> H[public_file_shares deferred indexes\nline 1628–1633]
    H --> I[addColumns: automation_jobs\nowner_user_id scope organization_id workspace_id project_id line 1660]
    I --> J[addColumns: automation_runs\nworkspace_id project_id job_scope line 1689]
    J --> K[UPDATE backfill statements\nlines 1702–1748]
    K --> L[Deferred index block\nlines 1840–1873]

    subgraph MOVED["Indexes moved to deferred block"]
        M1[idx_knowledge_sources_project_store]
        M2[idx_knowledge_chunks_project_store]
        M3[idx_audit_events_project_created]
        M4[idx_automation_jobs_owner_scope]
        M5[idx_automation_jobs_org_workspace]
        M6[idx_automation_runs_workspace_created]
    end

    L --> MOVED

    style MOVED fill:#d4edda,stroke:#28a745
    style C fill:#fff3cd,stroke:#ffc107
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runMigrations start] --> B[CREATE TABLE IF NOT EXISTS blocks\nnew installs get full schema]
    B --> C[Early index block\nindexes on original columns only\nlines ~1360–1510]
    C --> D[addColumns: knowledge_sources\nproject_id line 1613]
    D --> E[addColumns: knowledge_chunks\nproject_id line 1618]
    E --> F[addColumns: audit_events\nproject_id line 1623]
    F --> G[addColumns: public_file_shares\nshort_code organization_id project_id line 1597]
    G --> H[public_file_shares deferred indexes\nline 1628–1633]
    H --> I[addColumns: automation_jobs\nowner_user_id scope organization_id workspace_id project_id line 1660]
    I --> J[addColumns: automation_runs\nworkspace_id project_id job_scope line 1689]
    J --> K[UPDATE backfill statements\nlines 1702–1748]
    K --> L[Deferred index block\nlines 1840–1873]

    subgraph MOVED["Indexes moved to deferred block"]
        M1[idx_knowledge_sources_project_store]
        M2[idx_knowledge_chunks_project_store]
        M3[idx_audit_events_project_created]
        M4[idx_automation_jobs_owner_scope]
        M5[idx_automation_jobs_org_workspace]
        M6[idx_automation_runs_workspace_created]
    end

    L --> MOVED

    style MOVED fill:#d4edda,stroke:#28a745
    style C fill:#fff3cd,stroke:#ffc107
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix legacy migration index ordering"](https://github.com/canvascoding/canvas-notebook/commit/a5849b61c276017d3879af21b3322101532b89d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39147755)</sub>

<!-- /greptile_comment -->