### PR TITLE
[codex] Local team workspace and Postgres setup fixes

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -22,6 +22,9 @@ QMD_ENABLED=false
 # sqlite is the single-user default. Team, RAG, and collaboration installs require postgres.
 CANVAS_DEPLOYMENT_MODE=single_user
 CANVAS_DATABASE_PROVIDER=sqlite
+# npm run setup enables the postgres Compose profile automatically when postgres/team mode is configured.
+# For direct docker compose commands, set COMPOSE_PROFILES=postgres or run with --profile postgres.
+# COMPOSE_PROFILES=postgres
 # DATABASE_URL=postgresql://canvas:change-me@postgres:5432/canvas_notebook
 CANVAS_POSTGRES_VECTOR_ENABLED=false
 CANVAS_POSTGRES_IMAGE=pgvector/pgvector:0.8.3-pg18

--- a/app/[locale]/(routes)/page.tsx
+++ b/app/[locale]/(routes)/page.tsx
@@ -33,16 +33,16 @@ export default async function Home() {
         <div className="flex h-full min-h-0 flex-col">
           {!licenseStatus.licensed && <LicenseBanner status={licenseStatus} />}
           <header className="sticky top-0 z-20 shrink-0 border-b border-border bg-background/95 pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-background/85">
-            <div className="mx-auto flex min-h-14 max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-2 md:px-6">
-              <div className="min-w-0 flex items-center gap-3">
-                <Image src="/logo.jpg" alt={tHome('header.logoAlt')} width={28} height={28} className="border border-border" />
+            <div className="mx-auto flex min-h-14 max-w-7xl flex-nowrap items-center justify-between gap-2 px-4 py-2 md:px-6">
+              <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
+                <Image src="/logo.jpg" alt={tHome('header.logoAlt')} width={28} height={28} className="shrink-0 border border-border" />
                 <div className="min-w-0 flex flex-col">
-                  <span className="text-[10px] font-bold tracking-widest text-muted-foreground uppercase">{tHome('header.productName')}</span>
+                  <span className="hidden text-[10px] font-bold tracking-widest text-muted-foreground uppercase sm:block">{tHome('header.productName')}</span>
                   <span className="truncate text-sm font-semibold">{tHome('header.productLabel')}</span>
                 </div>
               </div>
 
-              <div className="ml-auto flex items-center gap-2 md:gap-3">
+              <div className="ml-auto flex shrink-0 items-center gap-1.5 md:gap-3">
                 <WorkspaceSwitcher source="home" variant="compact" />
                 <NotificationBell />
                 <AppLauncher />

--- a/app/[locale]/(routes)/page.tsx
+++ b/app/[locale]/(routes)/page.tsx
@@ -29,30 +29,30 @@ export default async function Home() {
 
   return (
     <HomeHintProvider enabled={onboardingEnabled}>
-    <div className="h-[100dvh] overflow-hidden bg-background text-foreground">
-      {!licenseStatus.licensed && <LicenseBanner status={licenseStatus} />}
-      <div className="flex h-full flex-col">
-        <header className="sticky top-0 z-20 border-b border-border bg-background/95 pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-background/85">
-          <div className="mx-auto flex min-h-14 max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-2 md:px-6">
-            <div className="min-w-0 flex items-center gap-3">
-              <Image src="/logo.jpg" alt={tHome('header.logoAlt')} width={28} height={28} className="border border-border" />
-              <div className="min-w-0 flex flex-col">
-                <span className="text-[10px] font-bold tracking-widest text-muted-foreground uppercase">{tHome('header.productName')}</span>
-                <span className="truncate text-sm font-semibold">{tHome('header.productLabel')}</span>
+      <div className="fixed inset-0 overflow-hidden bg-background text-foreground">
+        <div className="flex h-full min-h-0 flex-col">
+          {!licenseStatus.licensed && <LicenseBanner status={licenseStatus} />}
+          <header className="sticky top-0 z-20 shrink-0 border-b border-border bg-background/95 pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-background/85">
+            <div className="mx-auto flex min-h-14 max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-2 md:px-6">
+              <div className="min-w-0 flex items-center gap-3">
+                <Image src="/logo.jpg" alt={tHome('header.logoAlt')} width={28} height={28} className="border border-border" />
+                <div className="min-w-0 flex flex-col">
+                  <span className="text-[10px] font-bold tracking-widest text-muted-foreground uppercase">{tHome('header.productName')}</span>
+                  <span className="truncate text-sm font-semibold">{tHome('header.productLabel')}</span>
+                </div>
+              </div>
+
+              <div className="ml-auto flex items-center gap-2 md:gap-3">
+                <WorkspaceSwitcher source="home" variant="compact" />
+                <NotificationBell />
+                <AppLauncher />
+                <ThemeToggle />
+                <LogoutButton />
               </div>
             </div>
+          </header>
 
-            <div className="ml-auto flex items-center gap-2 md:gap-3">
-              <WorkspaceSwitcher source="home" variant="compact" />
-              <NotificationBell />
-              <AppLauncher />
-              <ThemeToggle />
-              <LogoutButton />
-            </div>
-          </div>
-        </header>
-
-        <main className="flex-1 overflow-y-auto px-4 pt-6 pb-10 md:px-6 md:pt-10">
+          <main className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pt-6 pb-10 md:px-6 md:pt-10">
             <div className="mx-auto max-w-2xl space-y-6">
               <div className="text-center">
                 <p className="text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground">{tHome('hero.eyebrow')}</p>
@@ -61,57 +61,57 @@ export default async function Home() {
 
               <HomeWorkspaceView licenseLocked={!licenseStatus.licensed} />
             </div>
-        </main>
+          </main>
 
-        <footer className="border-t border-border bg-background/95">
-          <div className="mx-auto flex max-w-7xl items-center justify-between gap-2 px-4 py-3 text-[10px] md:px-6 md:text-[11px]">
-            <a
-              href="https://agency.canvas.holdings"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex shrink-0 items-center gap-1 text-muted-foreground transition-colors hover:text-foreground sm:gap-1.5"
-            >
-              <span className="hidden sm:inline">{tHome('footer.madeWith')}</span>
-              <span className="sm:hidden">by</span>
-              <Heart className="h-3 w-3 fill-current text-red-500" />
-              <span className="hidden sm:inline">{tHome('footer.byCanvasCoding')}</span>
-              <span className="sm:hidden">Canvas Coding</span>
-            </a>
-            <div className="flex min-w-0 items-center justify-end gap-2 whitespace-nowrap">
+          <footer className="shrink-0 border-t border-border bg-background/95">
+            <div className="mx-auto flex max-w-7xl items-center justify-between gap-2 px-4 py-3 text-[10px] md:px-6 md:text-[11px]">
               <a
-                href={repositoryUrl}
+                href="https://agency.canvas.holdings"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex min-w-0 items-center gap-1 text-muted-foreground transition-colors hover:text-foreground sm:gap-1.5"
+                className="flex shrink-0 items-center gap-1 text-muted-foreground transition-colors hover:text-foreground sm:gap-1.5"
               >
-                <svg
-                  aria-hidden="true"
-                  viewBox="0 0 24 24"
-                  className="h-3.5 w-3.5 shrink-0 fill-current"
-                >
-                  <path d="M12 1.25a10.75 10.75 0 0 0-3.4 20.95c.54.1.74-.23.74-.52v-1.84c-3 .65-3.63-1.28-3.63-1.28-.49-1.24-1.2-1.57-1.2-1.57-.98-.67.08-.66.08-.66 1.08.08 1.65 1.1 1.65 1.1.96 1.64 2.52 1.16 3.13.89.1-.7.38-1.16.68-1.43-2.4-.27-4.92-1.2-4.92-5.33 0-1.18.42-2.15 1.1-2.9-.1-.27-.48-1.37.11-2.84 0 0 .9-.29 2.95 1.1a10.25 10.25 0 0 1 5.38 0c2.04-1.39 2.95-1.1 2.95-1.1.59 1.47.22 2.57.11 2.84.68.75 1.1 1.72 1.1 2.9 0 4.14-2.53 5.05-4.94 5.32.39.34.73 1 .73 2.02v2.99c0 .29.2.63.74.52A10.75 10.75 0 0 0 12 1.25Z" />
-                </svg>
-                <span className="hidden sm:inline">canvascoding/canvas-notebook</span>
+                <span className="hidden sm:inline">{tHome('footer.madeWith')}</span>
+                <span className="sm:hidden">by</span>
+                <Heart className="h-3 w-3 fill-current text-red-500" />
+                <span className="hidden sm:inline">{tHome('footer.byCanvasCoding')}</span>
+                <span className="sm:hidden">Canvas Coding</span>
               </a>
-              <div className="flex items-center gap-1">
+              <div className="flex min-w-0 items-center justify-end gap-2 whitespace-nowrap">
                 <a
-                  href={releaseTagUrl}
+                  href={repositoryUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+                  className="flex min-w-0 items-center gap-1 text-muted-foreground transition-colors hover:text-foreground sm:gap-1.5"
                 >
-                  {tHome('footer.version', { version: releaseVersion })}
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    className="h-3.5 w-3.5 shrink-0 fill-current"
+                  >
+                    <path d="M12 1.25a10.75 10.75 0 0 0-3.4 20.95c.54.1.74-.23.74-.52v-1.84c-3 .65-3.63-1.28-3.63-1.28-.49-1.24-1.2-1.57-1.2-1.57-.98-.67.08-.66.08-.66 1.08.08 1.65 1.1 1.65 1.1.96 1.64 2.52 1.16 3.13.89.1-.7.38-1.16.68-1.43-2.4-.27-4.92-1.2-4.92-5.33 0-1.18.42-2.15 1.1-2.9-.1-.27-.48-1.37.11-2.84 0 0 .9-.29 2.95 1.1a10.25 10.25 0 0 1 5.38 0c2.04-1.39 2.95-1.1 2.95-1.1.59 1.47.22 2.57.11 2.84.68.75 1.1 1.72 1.1 2.9 0 4.14-2.53 5.05-4.94 5.32.39.34.73 1 .73 2.02v2.99c0 .29.2.63.74.52A10.75 10.75 0 0 0 12 1.25Z" />
+                  </svg>
+                  <span className="hidden sm:inline">canvascoding/canvas-notebook</span>
                 </a>
-                <VersionUpdateIndicator
-                  currentVersion={releaseVersion}
-                  repositoryUrl={repositoryUrl}
-                />
+                <div className="flex items-center gap-1">
+                  <a
+                    href={releaseTagUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    {tHome('footer.version', { version: releaseVersion })}
+                  </a>
+                  <VersionUpdateIndicator
+                    currentVersion={releaseVersion}
+                    repositoryUrl={repositoryUrl}
+                  />
+                </div>
               </div>
             </div>
-          </div>
-        </footer>
-       </div>
-     </div>
+          </footer>
+        </div>
+      </div>
     </HomeHintProvider>
-   );
+  );
 }

--- a/app/api/sessions/messages/route.ts
+++ b/app/api/sessions/messages/route.ts
@@ -7,6 +7,7 @@ import { and, asc, desc, eq, lt, gt, or } from 'drizzle-orm';
 import { DEFAULT_AGENT_ID } from '@/app/lib/channels/constants';
 import { normalizeManagedAgentId } from '@/app/lib/agents/registry';
 import { parsePersistedPiMessage, type PiMessageProjectionMode } from '@/app/lib/pi/message-projection';
+import { resolveAgentSessionWorkspaceForUser } from '@/app/lib/pi/session-workspace-context';
 
 const DEFAULT_LIMIT = 50;
 
@@ -27,6 +28,14 @@ function normalizeSessionAgentId(value: string | null): string {
   }
 }
 
+function normalizeOptionalString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 export async function GET(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session) {
@@ -36,6 +45,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const sessionId = searchParams.get('sessionId');
   const agentId = normalizeSessionAgentId(searchParams.get('agentId'));
+  const workspaceIdFilter = normalizeOptionalString(searchParams.get('workspaceId'));
 
   if (!sessionId) {
     return NextResponse.json({ success: false, error: 'Session ID required' }, { status: 400 });
@@ -73,6 +83,19 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    let scopedWorkspace: Awaited<ReturnType<typeof resolveAgentSessionWorkspaceForUser>> | null = null;
+    if (workspaceIdFilter) {
+      try {
+        scopedWorkspace = await resolveAgentSessionWorkspaceForUser({
+          userId: session.user.id,
+          workspaceId: workspaceIdFilter,
+          permissions: ['canRead', 'canRunAgent'],
+        });
+      } catch {
+        return NextResponse.json({ success: false, error: 'Workspace not found or inaccessible' }, { status: 403 });
+      }
+    }
+
     // Try PI session first (ownership enforced)
     const dbPiSessions = await db
       .select()
@@ -81,6 +104,16 @@ export async function GET(request: NextRequest) {
       .limit(1);
 
     if (dbPiSessions.length > 0) {
+      const piSession = dbPiSessions[0];
+      if (scopedWorkspace) {
+        const sessionWorkspaceId = piSession.workspaceId;
+        const isLegacyPersonalSession = !sessionWorkspaceId && scopedWorkspace.workspaceType === 'personal';
+        const isMatchingWorkspaceSession = sessionWorkspaceId === scopedWorkspace.workspaceId;
+        if (!isLegacyPersonalSession && !isMatchingWorkspaceSession) {
+          return NextResponse.json({ success: false, error: 'Session is outside the active workspace' }, { status: 403 });
+        }
+      }
+
       const conditions = [eq(piMessages.piSessionDbId, dbPiSessions[0].id)];
       if (beforeSequence !== null) {
         conditions.push(
@@ -186,6 +219,10 @@ export async function GET(request: NextRequest) {
 
     if (!(await legacyAiTablesExist())) {
       return NextResponse.json({ success: true, messages: [], hasMoreBefore: false, hasMoreAfter: false, oldestTimestamp: null, newestTimestamp: null });
+    }
+
+    if (scopedWorkspace && scopedWorkspace.workspaceType !== 'personal') {
+      return NextResponse.json({ success: false, error: 'Legacy session is outside the active workspace' }, { status: 403 });
     }
 
     // Fallback to legacy (ownership enforced)

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -5,7 +5,7 @@ import { legacyAiTablesExist } from '@/app/lib/db/legacy-ai-tables';
 import { aiSessions, aiMessages, user, piSessions, sessionChannelLinks } from '@/app/lib/db/schema';
 import { auth } from '@/app/lib/auth';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
-import { and, desc, eq, inArray, lt, or, isNull, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, lt, or, isNull, sql, type SQL } from 'drizzle-orm';
 import { type AgentId, isAgentId } from '@/app/lib/agents/catalog';
 import { enforceAiSessionRetention } from '@/app/lib/agents/session-retention';
 import { readAgentRuntimeConfig, providerIdToAgentId, readPiRuntimeConfig, writePiRuntimeConfig } from '@/app/lib/agents/storage';
@@ -44,6 +44,7 @@ type CreateSessionPayload = {
 type RenameSessionPayload = {
   sessionId?: string;
   agentId?: string;
+  workspaceId?: string;
   title?: string;
   markAsRead?: boolean;
   markAsUnread?: boolean;
@@ -96,6 +97,13 @@ function normalizeSessionAgentId(value: unknown): string {
 
 function resolveCreateSessionWorkspaceId(payload: CreateSessionPayload): string | null {
   return normalizeOptionalString(payload.workspaceId) ?? normalizeOptionalString(payload.workspace?.workspaceId);
+}
+
+function buildPiSessionWorkspaceCondition(workspace: Awaited<ReturnType<typeof resolveAgentSessionWorkspaceForUser>>): SQL {
+  if (workspace.workspaceType === 'personal') {
+    return or(eq(piSessions.workspaceId, workspace.workspaceId), isNull(piSessions.workspaceId))!;
+  }
+  return eq(piSessions.workspaceId, workspace.workspaceId);
 }
 
 function normalizeThinkingLevel(value: unknown): PiThinkingLevel | null {
@@ -177,6 +185,7 @@ export async function GET(request: NextRequest) {
   const countOnly = searchParams.get('countOnly') === 'true';
   const olderThanDays = searchParams.get('olderThanDays');
   const rawAgentIdFilter = searchParams.get('agentId');
+  const workspaceIdFilter = normalizeOptionalString(searchParams.get('workspaceId'));
   const includeAllAgentSessions = rawAgentIdFilter === 'all';
   let agentIdFilter: string | null;
 
@@ -189,22 +198,40 @@ export async function GET(request: NextRequest) {
   try {
     const legacyTablesAvailable = await legacyAiTablesExist();
     const cutoff = olderThanDays ? new Date(Date.now() - parseInt(olderThanDays, 10) * 24 * 60 * 60 * 1000) : null;
+    let scopedWorkspace: Awaited<ReturnType<typeof resolveAgentSessionWorkspaceForUser>> | null = null;
+    if (workspaceIdFilter) {
+      try {
+        scopedWorkspace = await resolveAgentSessionWorkspaceForUser({
+          userId: session.user.id,
+          workspaceId: workspaceIdFilter,
+          permissions: ['canRead', 'canRunAgent'],
+        });
+      } catch {
+        return NextResponse.json({ success: false, error: 'Workspace not found or inaccessible' }, { status: 403 });
+      }
+    }
+    const piWorkspaceCondition = scopedWorkspace ? buildPiSessionWorkspaceCondition(scopedWorkspace) : null;
 
     if (countOnly && cutoff) {
       const piCutoffCondition = cutoff
         ? or(lt(piSessions.lastMessageAt, cutoff), and(isNull(piSessions.lastMessageAt), lt(piSessions.createdAt, cutoff)))
         : undefined;
+      const piCountConditions: SQL[] = [eq(piSessions.userId, session.user.id), piCutoffCondition!];
+      if (!includeAllAgentSessions) {
+        piCountConditions.push(eq(piSessions.agentId, agentIdFilter!));
+      }
+      if (piWorkspaceCondition) {
+        piCountConditions.push(piWorkspaceCondition);
+      }
 
       const piOlderCount = await db
         .select({ count: sql<number>`count(*)` })
         .from(piSessions)
-        .where(
-          includeAllAgentSessions
-            ? and(eq(piSessions.userId, session.user.id), piCutoffCondition!)
-            : and(eq(piSessions.userId, session.user.id), eq(piSessions.agentId, agentIdFilter!), piCutoffCondition!)
-        );
+        .where(and(...piCountConditions));
 
-      const includeLegacyCount = legacyTablesAvailable && (includeAllAgentSessions || agentIdFilter === DEFAULT_AGENT_ID);
+      const includeLegacyCount = legacyTablesAvailable &&
+        (includeAllAgentSessions || agentIdFilter === DEFAULT_AGENT_ID) &&
+        (!scopedWorkspace || scopedWorkspace.workspaceType === 'personal');
       const legacyCutoffCondition = includeLegacyCount && cutoff
         ? and(eq(aiSessions.userId, session.user.id), lt(aiSessions.createdAt, cutoff))
         : undefined;
@@ -222,9 +249,11 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    const whereClause = legacyModelFilter
-      ? and(eq(aiSessions.model, legacyModelFilter), eq(aiSessions.userId, session.user.id))
-      : eq(aiSessions.userId, session.user.id);
+    const legacyConditions: SQL[] = [eq(aiSessions.userId, session.user.id)];
+    if (legacyModelFilter) {
+      legacyConditions.push(eq(aiSessions.model, legacyModelFilter));
+    }
+    const whereClause = and(...legacyConditions);
     const normalizedChannelFilter = channelIdFilter ? normalizeStoredChannelId(channelIdFilter) : null;
     const filteredPiSessionIds = normalizedChannelFilter
       ? await db
@@ -236,10 +265,18 @@ export async function GET(request: NextRequest) {
           ))
       : null;
     const filteredPiSessionIdValues = filteredPiSessionIds?.map((row) => row.sessionId) ?? null;
-    const includeLegacySessions = legacyTablesAvailable && (includeAllAgentSessions || agentIdFilter === DEFAULT_AGENT_ID) && (!normalizedChannelFilter || normalizedChannelFilter === WEB_CHANNEL_ID);
-    const piBaseWhere = includeAllAgentSessions
-      ? eq(piSessions.userId, session.user.id)
-      : and(eq(piSessions.userId, session.user.id), eq(piSessions.agentId, agentIdFilter!));
+    const includeLegacySessions = legacyTablesAvailable &&
+      (includeAllAgentSessions || agentIdFilter === DEFAULT_AGENT_ID) &&
+      (!normalizedChannelFilter || normalizedChannelFilter === WEB_CHANNEL_ID) &&
+      (!scopedWorkspace || scopedWorkspace.workspaceType === 'personal');
+    const piBaseConditions: SQL[] = [eq(piSessions.userId, session.user.id)];
+    if (!includeAllAgentSessions) {
+      piBaseConditions.push(eq(piSessions.agentId, agentIdFilter!));
+    }
+    if (piWorkspaceCondition) {
+      piBaseConditions.push(piWorkspaceCondition);
+    }
+    const piBaseWhere = and(...piBaseConditions);
 
     const [legacySessions, newPiSessions] = await Promise.all([
       includeLegacySessions ? db
@@ -528,6 +565,7 @@ export async function PATCH(request: NextRequest) {
     const markAsRead = typeof payload.markAsRead === 'boolean' ? payload.markAsRead : false;
     const markAsUnread = typeof payload.markAsUnread === 'boolean' ? payload.markAsUnread : false;
     const markAllAsRead = typeof payload.markAllAsRead === 'boolean' ? payload.markAllAsRead : false;
+    const workspaceIdFilter = normalizeOptionalString(payload.workspaceId);
     const requestedModel = normalizeOptionalString(payload.model);
     const requestedThinkingLevel = normalizeThinkingLevel(payload.thinkingLevel);
     let requestedAgentId: string;
@@ -545,10 +583,26 @@ export async function PATCH(request: NextRequest) {
     // Handle mark all as read
     if (markAllAsRead && !sessionId) {
       const now = new Date();
+      let scopedWorkspace: Awaited<ReturnType<typeof resolveAgentSessionWorkspaceForUser>> | null = null;
+      if (workspaceIdFilter) {
+        try {
+          scopedWorkspace = await resolveAgentSessionWorkspaceForUser({
+            userId: session.user.id,
+            workspaceId: workspaceIdFilter,
+            permissions: ['canRead', 'canRunAgent'],
+          });
+        } catch {
+          return NextResponse.json({ success: false, error: 'Workspace not found or inaccessible' }, { status: 403 });
+        }
+      }
+      const conditions: SQL[] = [eq(piSessions.userId, session.user.id), eq(piSessions.agentId, requestedAgentId)];
+      if (scopedWorkspace) {
+        conditions.push(buildPiSessionWorkspaceCondition(scopedWorkspace));
+      }
       await db
         .update(piSessions)
         .set({ lastViewedAt: now, updatedAt: now })
-        .where(and(eq(piSessions.userId, session.user.id), eq(piSessions.agentId, requestedAgentId)));
+        .where(and(...conditions));
 
       return NextResponse.json({
         success: true,

--- a/app/api/studio/edits/markup/route.ts
+++ b/app/api/studio/edits/markup/route.ts
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const source = await loadMediaReference(sourcePath, { allowedTypes: ['image'] });
+    const source = await loadMediaReference(sourcePath, { userId: session.user.id, allowedTypes: ['image'] });
     const mask = parseDataUrl(body.maskDataUrl);
     if (!mask.mimeType.startsWith('image/')) {
       return NextResponse.json({ success: false, error: 'maskDataUrl must be an image' }, { status: 400 });

--- a/app/apps/automations/components/AutomationsClient.tsx
+++ b/app/apps/automations/components/AutomationsClient.tsx
@@ -2132,7 +2132,7 @@ export function AutomationsClient({ initialJobId = null, initialTimeZone }: Auto
         )
       ) : (
         <div className="space-y-4">
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 lg:grid-cols-5">
             {[
               { label: t('overview.total'), value: overviewStats.total, icon: CalendarClock },
               { label: t('jobStatus.active'), value: overviewStats.active, icon: CheckCircle2 },
@@ -2143,12 +2143,12 @@ export function AutomationsClient({ initialJobId = null, initialTimeZone }: Auto
               const StatIcon = stat.icon;
               return (
                 <Card key={stat.label} className="min-w-0">
-                  <CardContent className="flex items-center justify-between gap-3 p-4">
+                  <CardContent className="flex min-h-16 items-start justify-between gap-2 p-2.5 sm:min-h-20 sm:items-center sm:gap-3 sm:p-4">
                     <div className="min-w-0">
                       <p className="truncate text-xs text-muted-foreground">{stat.label}</p>
-                      <p className="mt-1 text-2xl font-semibold">{stat.value}</p>
+                      <p className="text-xl font-semibold leading-tight sm:mt-1 sm:text-2xl">{stat.value}</p>
                     </div>
-                    <StatIcon className="h-5 w-5 shrink-0 text-muted-foreground" />
+                    <StatIcon className="h-4 w-4 shrink-0 text-muted-foreground sm:h-5 sm:w-5" />
                   </CardContent>
                 </Card>
               );

--- a/app/apps/email/components/EmailAttachmentPanel.tsx
+++ b/app/apps/email/components/EmailAttachmentPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useRef, useState, type DragEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from 'react';
 import { CheckSquare2, Loader2, Paperclip, RefreshCw, Search, Square, Upload, X } from 'lucide-react';
 
 import type { FilePickerFile } from '@/app/components/canvas-agent-chat/ChatComposer';
@@ -195,6 +195,9 @@ function AttachmentRow({
 export function EmailAttachmentPanel({ attachments, disabled = false, labels, onChange }: EmailAttachmentPanelProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const requestIdRef = useRef(0);
+  const attachmentsRef = useRef(attachments);
+  const isUploadingRef = useRef(false);
+  const selectedRef = useRef<EmailAttachmentDraft[]>([]);
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<'workspace' | 'upload'>('workspace');
   const [search, setSearch] = useState('');
@@ -204,6 +207,18 @@ export function EmailAttachmentPanel({ attachments, disabled = false, labels, on
   const [isDragOver, setIsDragOver] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<EmailAttachmentDraft[]>([]);
+
+  useEffect(() => {
+    attachmentsRef.current = attachments;
+  }, [attachments]);
+
+  useEffect(() => {
+    isUploadingRef.current = isUploading;
+  }, [isUploading]);
+
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
 
   const usage = emailAttachmentLimitUsageBytes(attachments);
   const selectedPreview = useMemo(() => mergeAttachments(attachments, selected), [attachments, selected]);
@@ -259,6 +274,8 @@ export function EmailAttachmentPanel({ attachments, disabled = false, labels, on
 
   const uploadFiles = useCallback(async (files: File[]) => {
     if (files.length === 0) return;
+    if (isUploadingRef.current) return;
+    isUploadingRef.current = true;
     setIsUploading(true);
     setError(null);
     try {
@@ -269,7 +286,7 @@ export function EmailAttachmentPanel({ attachments, disabled = false, labels, on
         mimeType: inferEmailAttachmentMimeType(file.name, file.type),
         size: file.size,
       }));
-      if (emailAttachmentLimitUsageBytes(mergeAttachments(attachments, [...selected, ...optimistic])) > EMAIL_ATTACHMENT_TOTAL_LIMIT_BYTES) {
+      if (emailAttachmentLimitUsageBytes(mergeAttachments(attachmentsRef.current, [...selectedRef.current, ...optimistic])) > EMAIL_ATTACHMENT_TOTAL_LIMIT_BYTES) {
         throw new Error(labels.attachmentsLimitExceeded);
       }
 
@@ -284,13 +301,13 @@ export function EmailAttachmentPanel({ attachments, disabled = false, labels, on
       if (!response.ok || !payload.success) throw new Error(payload.error || 'Upload failed');
       const uploaded = Array.isArray(payload.files) ? payload.files : [];
       setSelected((current) => mergeAttachments(current, uploaded));
-      setTab('workspace');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Upload failed');
     } finally {
+      isUploadingRef.current = false;
       setIsUploading(false);
     }
-  }, [attachments, labels.attachmentsLimitExceeded, selected]);
+  }, [labels.attachmentsLimitExceeded]);
 
   const handleDrop = useCallback((event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -471,9 +488,11 @@ export function EmailAttachmentPanel({ attachments, disabled = false, labels, on
                   multiple
                   className="hidden"
                   onChange={(event) => {
+                    const input = event.currentTarget;
                     const files = Array.from(event.target.files || []);
-                    void uploadFiles(files);
-                    event.target.value = '';
+                    void uploadFiles(files).finally(() => {
+                      input.value = '';
+                    });
                   }}
                 />
               </div>

--- a/app/apps/email/components/EmailClient.tsx
+++ b/app/apps/email/components/EmailClient.tsx
@@ -39,6 +39,7 @@ import { useLocale, useTranslations } from 'next-intl';
 
 import { EmailAttachmentPanel } from '@/app/apps/email/components/EmailAttachmentPanel';
 import { useSetEmailChatContext } from '@/app/apps/email/context/email-chat-context';
+import { buildEmailPageChatContext } from '@/app/apps/email/context/email-route-chat-context';
 import {
   ComposerReferencePicker,
   type ComposerReferencePickerItem,
@@ -1930,35 +1931,21 @@ export function EmailClient() {
   useEffect(() => () => stopMessageSummaryStream(), [stopMessageSummaryStream]);
 
   useEffect(() => {
-    setEmailChatContext({
-      currentPage: '/emails',
-      emailContext: {
-        accountEmail: activeAccount?.emailAddress,
-        accountId: activeAccount?.id,
-        filter: messageFilter,
-        folder: activeFolder,
-        folderName: activeFolderName,
-        query: submittedQuery || undefined,
-        selectedMessageDate: selectedMessage?.date || null,
-        selectedMessageFolder: selectedMessage?.folder || activeFolder,
-        selectedMessageFrom: selectedMessage?.from || null,
-        selectedMessageId: selectedMessage?.id || selectedMessageId || undefined,
-        selectedMessageIsRead: selectedMessage?.isRead ?? null,
-        selectedMessageSubject: selectedMessage?.subject || null,
-      },
-    });
+    setEmailChatContext(buildEmailPageChatContext({
+      account: activeAccount,
+      activeFolder,
+      activeFolderName,
+      filter: messageFilter,
+      selectedMessage,
+      selectedMessageId,
+      submittedQuery,
+    }));
   }, [
-    activeAccount?.emailAddress,
-    activeAccount?.id,
+    activeAccount,
     activeFolder,
     activeFolderName,
     messageFilter,
-    selectedMessage?.date,
-    selectedMessage?.folder,
-    selectedMessage?.from,
-    selectedMessage?.id,
-    selectedMessage?.isRead,
-    selectedMessage?.subject,
+    selectedMessage,
     selectedMessageId,
     setEmailChatContext,
     submittedQuery,

--- a/app/apps/email/components/EmailClient.tsx
+++ b/app/apps/email/components/EmailClient.tsx
@@ -1115,8 +1115,8 @@ function EmailMessageViewer({
   }
 
   return (
-    <article className={cn('h-full min-h-0 overflow-y-auto', className)}>
-      <header className="border-b border-border px-3 py-2.5 pr-10 sm:px-4">
+    <article className={cn('flex h-full min-h-0 flex-col overflow-hidden', className)}>
+      <header className="shrink-0 border-b border-border px-3 py-2.5 pr-10 sm:px-4">
         <h3 className="text-base font-semibold leading-6 sm:text-lg sm:leading-7">{message.subject || labels.noSubject}</h3>
         <div className="mt-1.5 flex flex-col gap-0.5 text-xs text-muted-foreground sm:text-sm">
           <p><span className="font-medium text-foreground">{labels.from}:</span> {message.from}</p>
@@ -1165,7 +1165,7 @@ function EmailMessageViewer({
           </div>
         )}
       </header>
-      <div className="px-4 py-4">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
         <EmailMessageBody
           allowRemoteResourcesByDefault={allowRemoteResourcesByDefault}
           allowedRemoteResourceSenders={allowedRemoteResourceSenders}

--- a/app/apps/email/context/email-route-chat-context.ts
+++ b/app/apps/email/context/email-route-chat-context.ts
@@ -1,0 +1,54 @@
+import type { ChatRequestContext } from '@/app/lib/chat/types';
+
+export type EmailChatContextMessage = {
+  id?: string;
+  folder?: string;
+  from?: string | null;
+  subject?: string | null;
+  date?: string | null;
+  isRead?: boolean | null;
+};
+
+export type EmailChatContextAccount = {
+  id?: string;
+  emailAddress?: string | null;
+};
+
+export function buildEmailPageChatContext(params: {
+  account?: EmailChatContextAccount | null;
+  activeFolder: string;
+  activeFolderName: string;
+  filter: 'all' | 'unread';
+  pathname?: string | null;
+  selectedMessage?: EmailChatContextMessage | null;
+  selectedMessageId?: string | null;
+  submittedQuery?: string | null;
+}): ChatRequestContext {
+  const selectedMessage = params.selectedMessage;
+
+  return {
+    currentPage: params.pathname || '/emails',
+    emailContext: {
+      accountEmail: params.account?.emailAddress || undefined,
+      accountId: params.account?.id || undefined,
+      filter: params.filter,
+      folder: params.activeFolder,
+      folderName: params.activeFolderName,
+      query: params.submittedQuery || undefined,
+      selectedMessageDate: selectedMessage?.date || null,
+      selectedMessageFolder: selectedMessage?.folder || params.activeFolder,
+      selectedMessageFrom: selectedMessage?.from || null,
+      selectedMessageId: selectedMessage?.id || params.selectedMessageId || undefined,
+      selectedMessageIsRead: selectedMessage?.isRead ?? null,
+      selectedMessageSubject: selectedMessage?.subject || null,
+    },
+  };
+}
+
+export function resolveEmailShellRequestContext(
+  chatContext: ChatRequestContext | null | undefined,
+  pathname: string | null | undefined,
+): ChatRequestContext {
+  const currentPage = pathname || '/emails';
+  return chatContext?.currentPage === currentPage ? chatContext : { currentPage };
+}

--- a/app/apps/studio/components/create/ReferenceHoverCard.tsx
+++ b/app/apps/studio/components/create/ReferenceHoverCard.tsx
@@ -22,6 +22,7 @@ interface ReferenceHoverCardProps {
   name: string;
   type: ReferenceType;
   thumbnailPath?: string;
+  thumbnailUrl?: string;
   previewImagePaths?: string[];
   fallbackIcon: React.ReactNode;
   bgColor: string;
@@ -122,6 +123,7 @@ function PreviewContent({
   name,
   type,
   thumbnailPath,
+  thumbnailUrl,
   previewImagePaths,
   fallbackIcon,
   onRemove,
@@ -130,6 +132,7 @@ function PreviewContent({
   name: string;
   type: ReferenceType;
   thumbnailPath?: string;
+  thumbnailUrl?: string;
   previewImagePaths?: string[];
   fallbackIcon: React.ReactNode;
   onRemove: () => void;
@@ -143,7 +146,11 @@ function PreviewContent({
   const [imageIndex, setImageIndex] = useState(0);
   const safeImageIndex = imagePaths.length > 0 ? imageIndex % imagePaths.length : 0;
   const currentImagePath = imagePaths[safeImageIndex];
-  const previewUrl = currentImagePath ? toPreviewUrl(currentImagePath, 320, { preset: 'mini' }) : undefined;
+  const previewUrl = !canShowMultipleImages && thumbnailUrl
+    ? thumbnailUrl
+    : currentImagePath
+      ? toPreviewUrl(currentImagePath, 320, { preset: 'mini' })
+      : undefined;
   const hasMultipleImages = canShowMultipleImages && imagePaths.length > 1;
   const nextPreviewPath = hasMultipleImages ? imagePaths[(safeImageIndex + 1) % imagePaths.length] : undefined;
 
@@ -253,6 +260,7 @@ export function ReferenceHoverCard({
   name,
   type,
   thumbnailPath,
+  thumbnailUrl,
   previewImagePaths,
   fallbackIcon,
   bgColor,
@@ -288,6 +296,7 @@ export function ReferenceHoverCard({
               name={name}
               type={type}
               thumbnailPath={thumbnailPath}
+              thumbnailUrl={thumbnailUrl}
               previewImagePaths={previewImagePaths}
               fallbackIcon={scaledFallbackIcon}
               onRemove={onRemove}
@@ -321,6 +330,7 @@ export function ReferenceHoverCard({
               name={name}
               type={type}
               thumbnailPath={thumbnailPath}
+              thumbnailUrl={thumbnailUrl}
               previewImagePaths={previewImagePaths}
               fallbackIcon={scaledFallbackIcon}
               onRemove={handleRemove}

--- a/app/apps/studio/components/create/ReferencePickerDialog.tsx
+++ b/app/apps/studio/components/create/ReferencePickerDialog.tsx
@@ -13,10 +13,11 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Loader2, Upload, RefreshCw, ChevronRight, ChevronsDownUp, Folder, Image as ImageIcon, CheckCircle2, CheckSquare2, FileVideo, Music } from 'lucide-react';
+import { Loader2, Upload, RefreshCw, ChevronRight, ChevronsDownUp, ChevronsUpDown, Folder, Image as ImageIcon, CheckCircle2, CheckSquare2, FileVideo, Music } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { toPreviewUrl, toMediaUrl } from '@/app/lib/utils/media-url';
+import { toPreviewUrl, toMediaUrl, toWorkspaceMediaUrl } from '@/app/lib/utils/media-url';
 import type { FileNode } from '@/app/lib/filesystem/workspace-files';
+import { loadWorkspaceTree as loadWorkspaceTreeForWorkspace } from '@/app/lib/files/client';
 import { ImagePreprocessDialog } from '@/app/components/shared/ImagePreprocessDialog';
 import type {
   ConvertParams,
@@ -28,6 +29,14 @@ import { isHeicUploadFile, shouldPreprocessImageFile } from '@/app/lib/images/cl
 import { prepareImageFilesForUpload, serializeUploadConvertParams } from '@/app/lib/images/client-upload-conversion';
 import { ReferenceHoverCard } from './ReferenceHoverCard';
 import { StudioMediaThumbnail } from '../StudioMediaThumbnail';
+import {
+  getWorkspaceKindLabel,
+  type WorkspaceKindLabels,
+} from '@/app/components/workspaces/workspace-utils';
+import {
+  selectActiveWorkspace,
+  useWorkspaceStore,
+} from '@/app/store/workspace-store';
 
 type Source = 'workspace' | 'studio' | 'upload' | 'urls';
 type MediaKind = 'image' | 'video' | 'audio';
@@ -37,6 +46,7 @@ interface ImageAsset {
   name: string;
   mediaUrl: string;
   previewUrl: string;
+  workspaceId?: string | null;
   modified?: number;
   size?: number;
   kind?: MediaKind;
@@ -126,6 +136,14 @@ function filterTreeBySearch(nodes: FileNode[], query: string, kind: MediaKind): 
     });
 }
 
+function buildWorkspaceReferencePath(filePath: string, workspaceId?: string | null) {
+  return toWorkspaceMediaUrl(filePath, { workspaceId });
+}
+
+function isWorkspaceReferencePath(filePath: string) {
+  return filePath.startsWith('/api/media/');
+}
+
 function StudioAssetGridSkeleton() {
   return (
     <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4" aria-hidden="true">
@@ -204,6 +222,7 @@ function SelectionChip({
       name={asset.name}
       type="file"
       thumbnailPath={asset.path}
+      thumbnailUrl={asset.previewUrl}
       fallbackIcon={mediaIcon(mediaKind, 'h-4 w-4 text-rose-600')}
       bgColor="bg-rose-50"
       onRemove={onRemove}
@@ -211,7 +230,7 @@ function SelectionChip({
       <div className="h-9 w-9 rounded-md border-2 border-rose-400 bg-rose-50 flex items-center justify-center overflow-hidden">
         {mediaKind === 'image' || mediaKind === 'video' ? (
           <StudioMediaThumbnail
-            src={toPreviewUrl(asset.path, 64, { preset: 'mini' })}
+            src={asset.previewUrl}
             alt=""
             fallback={mediaIcon(mediaKind, 'h-4 w-4 text-rose-600')}
             skeletonIcon={mediaIcon(mediaKind, 'h-4 w-4 text-rose-600')}
@@ -239,6 +258,7 @@ function TreeNode({
   onToggleSelect,
   multiple,
   mediaKind,
+  sourceWorkspaceId,
 }: {
   node: FileNode;
   depth?: number;
@@ -248,10 +268,12 @@ function TreeNode({
   onToggleSelect: (path: string) => void;
   multiple: boolean;
   mediaKind: MediaKind;
+  sourceWorkspaceId?: string | null;
 }) {
   if (node.type === 'file') {
     if (!isMedia(node.name, mediaKind)) return null;
-    const isSelected = selectedPaths.has(node.path);
+    const selectionPath = buildWorkspaceReferencePath(node.path, sourceWorkspaceId);
+    const isSelected = selectedPaths.has(selectionPath);
     return (
       <button
         key={node.path}
@@ -261,7 +283,7 @@ function TreeNode({
           isSelected ? 'bg-primary/10 text-primary' : 'hover:bg-muted text-foreground'
         )}
         style={{ paddingLeft: `${20 + depth * 16}px` }}
-        onClick={() => onToggleSelect(node.path)}
+        onClick={() => onToggleSelect(selectionPath)}
       >
         {isSelected ? (
           multiple ? (
@@ -275,6 +297,7 @@ function TreeNode({
         <ImageThumbnailIcon
           path={node.path}
           name={node.name}
+          workspaceId={sourceWorkspaceId}
           className="h-5 w-5 rounded-sm"
           fallbackIcon={mediaIcon(mediaKind)}
         />
@@ -307,6 +330,7 @@ function TreeNode({
             onToggleSelect={onToggleSelect}
             multiple={multiple}
             mediaKind={mediaKind}
+            sourceWorkspaceId={sourceWorkspaceId}
           />
         ))}
     </div>
@@ -315,10 +339,15 @@ function TreeNode({
 
 export function ReferencePickerDialog({ open, onOpenChange, onConfirm, multiple = true, maxSelection = 10, mediaKind = 'image', studioOnly = false, veoGeneratedOnly = false }: ReferencePickerDialogProps) {
   const t = useTranslations('studio.referencePicker');
+  const workspaceT = useTranslations('workspaces');
+  const workspaces = useWorkspaceStore((state) => state.workspaces);
+  const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
+  const hydrateWorkspaces = useWorkspaceStore((state) => state.hydrateWorkspaces);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [tab, setTab] = useState<Source>('studio');
   const [search, setSearch] = useState('');
   const [urlInput, setUrlInput] = useState('');
+  const [referenceWorkspaceId, setReferenceWorkspaceId] = useState<string | null>(null);
 
   const [assets, setAssets] = useState<ImageAsset[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -341,6 +370,27 @@ export function ReferencePickerDialog({ open, onOpenChange, onConfirm, multiple 
   const [imagePreprocessProgressItems, setImagePreprocessProgressItems] = useState<ImagePreprocessProgressItem[]>([]);
 
   const [isDragOver, setIsDragOver] = useState(false);
+
+  const readableWorkspaces = useMemo(
+    () => workspaces.filter((workspace) => workspace.status === 'active' && workspace.permissions.canRead),
+    [workspaces]
+  );
+
+  const effectiveReferenceWorkspaceId = useMemo(() => {
+    if (referenceWorkspaceId && readableWorkspaces.some((workspace) => workspace.id === referenceWorkspaceId)) {
+      return referenceWorkspaceId;
+    }
+    if (activeWorkspace?.status === 'active' && activeWorkspace.permissions.canRead) {
+      return activeWorkspace.id;
+    }
+    return readableWorkspaces[0]?.id ?? null;
+  }, [activeWorkspace, readableWorkspaces, referenceWorkspaceId]);
+
+  const workspaceKindLabels = useMemo(() => ({
+    personal: workspaceT('types.personal'),
+    team: workspaceT('types.team'),
+    project: workspaceT('types.project'),
+  } satisfies WorkspaceKindLabels), [workspaceT]);
 
   const displayTree = useMemo(() => {
     let result = pruneEmptyMediaDirs(tree, mediaKind);
@@ -368,14 +418,18 @@ export function ReferencePickerDialog({ open, onOpenChange, onConfirm, multiple 
     }
   }, [search, mediaKind, veoGeneratedOnly]);
 
-  const loadWorkspaceTree = async () => {
+  const loadWorkspaceTree = useCallback(async () => {
+    if (!effectiveReferenceWorkspaceId) {
+      setTree([]);
+      setExpandedDirs(new Set());
+      setTreeError(workspaceT('noWorkspaceAvailable'));
+      return;
+    }
+
     setIsTreeLoading(true);
     setTreeError(null);
     try {
-      const res = await fetch('/api/files/tree?path=.&depth=8', { credentials: 'include', cache: 'no-store' });
-      const payload = await res.json();
-      if (!res.ok || !payload.success) throw new Error(payload.error || 'Failed loading files');
-      const root = payload.data || [];
+      const root = await loadWorkspaceTreeForWorkspace('.', 8, true, 'Failed loading files', effectiveReferenceWorkspaceId);
       setTree(root);
       const initial = new Set<string>();
       const queue: FileNode[] = [...root];
@@ -399,9 +453,14 @@ export function ReferencePickerDialog({ open, onOpenChange, onConfirm, multiple 
     } finally {
       setIsTreeLoading(false);
     }
-  };
+  }, [effectiveReferenceWorkspaceId, workspaceT]);
 
   const collapseAll = () => setExpandedDirs(new Set());
+
+  useEffect(() => {
+    if (!open) return;
+    void hydrateWorkspaces();
+  }, [hydrateWorkspaces, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -409,6 +468,7 @@ export function ReferencePickerDialog({ open, onOpenChange, onConfirm, multiple 
     setSelectedPaths(new Set());
     setSearch('');
     setUrlInput('');
+    setReferenceWorkspaceId(activeWorkspace?.permissions.canRead ? activeWorkspace.id : null);
     /* eslint-enable react-hooks/set-state-in-effect */
     void loadStudioAssets();
     void loadWorkspaceTree();
@@ -427,8 +487,7 @@ export function ReferencePickerDialog({ open, onOpenChange, onConfirm, multiple 
     } else if (tab === 'workspace') {
       startTransition(() => { void loadWorkspaceTree(); });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab, open, search, studioOnly]);
+  }, [loadStudioAssets, loadWorkspaceTree, open, search, studioOnly, tab]);
 
   const toggleExpanded = (path: string) => {
     setExpandedDirs((prev) => {
@@ -451,20 +510,29 @@ export function ReferencePickerDialog({ open, onOpenChange, onConfirm, multiple 
     });
   };
 
+  const handleReferenceWorkspaceChange = (workspaceId: string) => {
+    if (!workspaceId || workspaceId === referenceWorkspaceId) return;
+    setReferenceWorkspaceId(workspaceId);
+    setTree([]);
+    setExpandedDirs(new Set());
+    setSelectedPaths((prev) => new Set(Array.from(prev).filter((path) => !isWorkspaceReferencePath(path))));
+  };
+
   const currentSelectionDisplay = useMemo(() => {
     const allAssets: ImageAsset[] = [];
     allAssets.push(...assets);
     allAssets.push(...walkMedia(tree, mediaKind).map((n) => ({
-      path: n.path,
+      path: buildWorkspaceReferencePath(n.path, effectiveReferenceWorkspaceId),
       name: n.name,
-      mediaUrl: toMediaUrl(n.path),
-      previewUrl: toPreviewUrl(n.path, 200),
+      mediaUrl: buildWorkspaceReferencePath(n.path, effectiveReferenceWorkspaceId),
+      previewUrl: toPreviewUrl(n.path, 200, { workspaceId: effectiveReferenceWorkspaceId }),
+      workspaceId: effectiveReferenceWorkspaceId,
       kind: mediaKind,
     })));
     return Array.from(selectedPaths)
       .map((p) => allAssets.find((a) => a.path === p))
       .filter(Boolean) as ImageAsset[];
-  }, [assets, mediaKind, selectedPaths, tree]);
+  }, [assets, effectiveReferenceWorkspaceId, mediaKind, selectedPaths, tree]);
 
   const addUploadedPathsToSelection = useCallback((newPaths: string[]) => {
     setSelectedPaths((prev) => {
@@ -776,9 +844,26 @@ export function ReferencePickerDialog({ open, onOpenChange, onConfirm, multiple 
 
             {/* Workspace tab */}
             <TabsContent value="workspace" className="flex flex-col flex-1 min-h-0 mt-0 data-[state=active]:flex overflow-hidden">
-              <div className="flex gap-2 py-3 shrink-0">
+              <div className="grid gap-2 py-3 shrink-0 sm:grid-cols-[minmax(180px,260px)_1fr_auto_auto]">
+                <label className="relative block min-w-0">
+                  <span className="sr-only">{workspaceT('sourceWorkspace')}</span>
+                  <select
+                    value={effectiveReferenceWorkspaceId ?? ''}
+                    onChange={(event) => handleReferenceWorkspaceChange(event.target.value)}
+                    disabled={readableWorkspaces.length === 0}
+                    className="h-9 w-full appearance-none rounded-md border border-input bg-background px-2 pr-8 text-left text-sm font-normal shadow-xs outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {!effectiveReferenceWorkspaceId ? <option value="">{workspaceT('sourceWorkspace')}</option> : null}
+                    {readableWorkspaces.map((workspace) => (
+                      <option key={workspace.id} value={workspace.id}>
+                        {workspace.name} - {getWorkspaceKindLabel(workspace, workspaceKindLabels)}
+                      </option>
+                    ))}
+                  </select>
+                  <ChevronsUpDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                </label>
                 <Input placeholder={t('searchWorkspacePlaceholder')} value={search} onChange={(e) => setSearch(e.target.value)} />
-                <Button variant="outline" size="sm" className="gap-1 shrink-0" onClick={() => { void loadWorkspaceTree(); }} disabled={isTreeLoading}>
+                <Button variant="outline" size="sm" className="gap-1 shrink-0" onClick={() => { void loadWorkspaceTree(); }} disabled={isTreeLoading || !effectiveReferenceWorkspaceId}>
                   <RefreshCw className={cn('h-4 w-4', isTreeLoading && 'animate-spin')} />
                   {t('refresh')}
                 </Button>
@@ -798,7 +883,7 @@ export function ReferencePickerDialog({ open, onOpenChange, onConfirm, multiple 
                 ) : (
                   <div className="space-y-0.5">
                     {displayTree.map((node) => (
-	                      <TreeNode key={node.path} node={node} selectedPaths={selectedPaths} expandedDirs={expandedDirs} onToggleDir={toggleExpanded} onToggleSelect={toggleSelect} multiple={multiple} mediaKind={mediaKind} />
+	                      <TreeNode key={node.path} node={node} selectedPaths={selectedPaths} expandedDirs={expandedDirs} onToggleDir={toggleExpanded} onToggleSelect={toggleSelect} multiple={multiple} mediaKind={mediaKind} sourceWorkspaceId={effectiveReferenceWorkspaceId} />
                     ))}
                   </div>
                 )}

--- a/app/components/DashboardShell.tsx
+++ b/app/components/DashboardShell.tsx
@@ -877,13 +877,19 @@ export function DashboardShell({ hintEnabled = true }: { hintEnabled?: boolean }
 
           {/* Right side: help, theme, logout */}
           <div className="relative z-50 flex items-center gap-1.5 md:gap-4">
-            <WorkspaceSwitcher source="notebook" variant="compact" />
+            <WorkspaceSwitcher source="notebook" variant="compact" className="hidden md:inline-flex" />
             <NotificationBell />
             <AppLauncher />
             <ThemeToggle />
           </div>
         </div>
       </header>
+
+      {isMobileViewport ? (
+        <div className="z-30 shrink-0 border-b border-border bg-background/95 px-3 py-2 md:hidden">
+          <WorkspaceSwitcher source="notebook" variant="mobile-sheet" />
+        </div>
+      ) : null}
 
       {viewportMode === null ? (
         <main className="flex min-h-0 flex-1 overflow-hidden bg-background" />

--- a/app/components/DashboardShell.tsx
+++ b/app/components/DashboardShell.tsx
@@ -45,6 +45,8 @@ import { NotificationBell } from '@/app/components/notifications/NotificationBel
 import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 
 import { useFileStore } from '@/app/store/file-store';
+import { useEditorStore } from '@/app/store/editor-store';
+import { WORKSPACE_CHANGED_EVENT } from '@/app/store/workspace-store';
 import { FileWatcherProvider } from '@/app/hooks/FileWatcherContext';
 import { CANVAS_CHAT_INITIAL_PROMPT_STORAGE_KEY } from '@/app/lib/chat/constants';
 import { WORKSPACE_FILE_OPENED_EVENT } from '@/app/lib/files/workspace-file-events';
@@ -405,6 +407,21 @@ export function DashboardShell({ hintEnabled = true }: { hintEnabled?: boolean }
 
     return unsubscribe;
   }, []);
+
+  useEffect(() => {
+    const handleWorkspaceChange = () => {
+      openedPathRef.current = normalizeNotebookFilePath(searchParams.get('path'));
+      previousCurrentFilePathRef.current = null;
+      suppressNextMobileFileOpenCloseRef.current = 0;
+      clearStoredNotebookOpenFilePath();
+      useFileStore.getState().clearCurrentFile();
+      useEditorStore.getState().clear();
+      setMobileSurface('editor');
+    };
+
+    window.addEventListener(WORKSPACE_CHANGED_EVENT, handleWorkspaceChange);
+    return () => window.removeEventListener(WORKSPACE_CHANGED_EVENT, handleWorkspaceChange);
+  }, [searchParams]);
 
   const applySidebarPanelWidth = useCallback((nextWidth: number) => {
     sidebarWidthRef.current = nextWidth;

--- a/app/components/EmailShell.tsx
+++ b/app/components/EmailShell.tsx
@@ -4,6 +4,7 @@ import { useMemo, type ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { useEmailChatContext } from '@/app/apps/email/context/email-chat-context';
+import { resolveEmailShellRequestContext } from '@/app/apps/email/context/email-route-chat-context';
 import { ChatDockShell } from '@/app/components/layout/ChatDockShell';
 import type { ChatRequestContext } from '@/app/lib/chat/types';
 import { usePathname } from '@/i18n/navigation';
@@ -14,7 +15,7 @@ export function EmailShell({ children, hintEnabled = true }: { children: ReactNo
   const pathname = usePathname();
   const { chatContext } = useEmailChatContext();
   const requestContext = useMemo<ChatRequestContext>(
-    () => (chatContext?.currentPage === pathname ? chatContext : { currentPage: pathname ?? '/emails' }),
+    () => resolveEmailShellRequestContext(chatContext, pathname),
     [chatContext, pathname],
   );
 

--- a/app/components/SuitePageLayout.tsx
+++ b/app/components/SuitePageLayout.tsx
@@ -66,9 +66,9 @@ export function SuitePageLayout({
   const backLabel = isStudioSubroute ? t('studio') : t('suite');
 
   const content = (
-    <div className="h-[100dvh] overflow-hidden bg-background text-foreground">
-      <div className="flex h-full flex-col">
-        <header className="sticky top-0 z-20 border-b border-border bg-background/95 pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-background/85">
+    <div className="fixed inset-0 overflow-hidden bg-background text-foreground">
+      <div className="flex h-full min-h-0 flex-col">
+        <header className="sticky top-0 z-20 shrink-0 border-b border-border bg-background/95 pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-background/85">
           <div className="mx-auto flex min-h-16 max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-3 md:px-6">
             <div className="min-w-0 flex items-center gap-2 sm:gap-3">
               <Button asChild variant="outline" size="sm" className="gap-2 px-2 sm:px-3">
@@ -92,7 +92,7 @@ export function SuitePageLayout({
           </div>
         </header>
 
-        <main className={cn('min-h-0 flex-1 overflow-y-auto', mainClassName)}>{children}</main>
+        <main className={cn('min-h-0 flex-1 overflow-y-auto overscroll-contain', mainClassName)}>{children}</main>
       </div>
     </div>
   );

--- a/app/components/canvas-agent-chat/CanvasAgentChat.tsx
+++ b/app/components/canvas-agent-chat/CanvasAgentChat.tsx
@@ -42,7 +42,10 @@ import {
 } from '@/app/store/workspace-store';
 import { getToolDisplayInfo } from '@/app/lib/pi/tool-display';
 
-import { CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY } from '@/app/lib/chat/constants';
+import {
+  clearCanvasChatActiveSessionStorage,
+  getCanvasChatActiveSessionStorageKey,
+} from '@/app/lib/chat/constants';
 import { removeComposerDraft } from '@/app/lib/chat/draft-storage';
 import { getAgentDisplayName } from '@/app/lib/chat/agent-display';
 import {
@@ -134,6 +137,11 @@ export default function CanvasAgentChat({
   const { planningMode, togglePlanningMode } = usePlanModeStore();
   const toolVerbosity = useToolVerbosityStore((s) => s.toolVerbosity);
   const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
+  const activeWorkspaceId = activeWorkspace?.id ?? null;
+  const activeSessionStorageKey = useMemo(
+    () => getCanvasChatActiveSessionStorageKey(activeWorkspaceId),
+    [activeWorkspaceId],
+  );
 
   // Container width detection for history layout
   const containerRef = useRef<HTMLDivElement>(null);
@@ -221,7 +229,7 @@ export default function CanvasAgentChat({
     const hasStoredInitialPrompt = Boolean(
       initialPromptStorageKey && window.sessionStorage.getItem(initialPromptStorageKey),
     );
-    const hasStoredSession = Boolean(window.sessionStorage.getItem(CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY));
+    const hasStoredSession = Boolean(window.sessionStorage.getItem(activeSessionStorageKey));
     return hasStoredInitialPrompt || hasStoredSession;
   });
   const [expandedRunKeys, setExpandedRunKeys] = useState<Set<string>>(() => new Set());
@@ -319,6 +327,7 @@ export default function CanvasAgentChat({
     startHistoryResizing,
     totalUnreadCount,
   } = useChatSessionHistory({
+    activeWorkspaceId,
     availableAgents,
     optimisticSessionTitlesRef,
     requestSavedMessageRefreshRef,
@@ -486,9 +495,9 @@ export default function CanvasAgentChat({
     // If we cleared on null, a fresh mount (sessionId=null) would erase the stored value
     // before the restore effect has a chance to read it.
     if (typeof window !== 'undefined' && sessionId) {
-      window.sessionStorage.setItem(CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY, sessionId);
+      window.sessionStorage.setItem(activeSessionStorageKey, sessionId);
     }
-  }, [resetInputHistoryNavigation, sessionId]);
+  }, [activeSessionStorageKey, resetInputHistoryNavigation, sessionId]);
 
   useEffect(() => {
     surfaceVisibleRef.current = isSurfaceVisible;
@@ -547,6 +556,7 @@ export default function CanvasAgentChat({
     activeModel,
     activeProvider,
     activeThinkingLevel,
+    activeWorkspaceId,
     addSessionToHistory,
     agentConfig,
     appendCompactionBreak,
@@ -605,7 +615,10 @@ export default function CanvasAgentChat({
   });
 
   useEffect(() => {
-    const handleWorkspaceChange = () => {
+    const handleWorkspaceChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ previousWorkspaceId?: string | null; activeWorkspaceId?: string | null }>).detail;
+      clearCanvasChatActiveSessionStorage(detail?.previousWorkspaceId ?? null);
+      clearCanvasChatActiveSessionStorage(detail?.activeWorkspaceId ?? null);
       startNewChat();
     };
 
@@ -617,6 +630,7 @@ export default function CanvasAgentChat({
     activeModel,
     activeProvider,
     activeThinkingLevel,
+    activeWorkspaceId,
     agentConfig,
     deferredSavedMessageRefreshSessionRef,
     ensureSessionSubscribed,
@@ -787,6 +801,8 @@ export default function CanvasAgentChat({
     fetchHistory,
     forcedSessionId,
     handleControlAction,
+    activeSessionStorageKey,
+    activeWorkspaceId,
     hasLoadedSessionListRef,
     historyLength: history.length,
     initialPrompt,

--- a/app/components/canvas-agent-chat/CanvasAgentChat.tsx
+++ b/app/components/canvas-agent-chat/CanvasAgentChat.tsx
@@ -617,9 +617,10 @@ export default function CanvasAgentChat({
   useEffect(() => {
     const handleWorkspaceChange = (event: Event) => {
       const detail = (event as CustomEvent<{ previousWorkspaceId?: string | null; activeWorkspaceId?: string | null }>).detail;
-      clearCanvasChatActiveSessionStorage(detail?.previousWorkspaceId ?? null);
-      clearCanvasChatActiveSessionStorage(detail?.activeWorkspaceId ?? null);
-      startNewChat();
+      if (detail?.previousWorkspaceId) {
+        clearCanvasChatActiveSessionStorage(detail.previousWorkspaceId);
+      }
+      startNewChat(undefined, { clearActiveSessionStorage: false });
     };
 
     window.addEventListener(WORKSPACE_CHANGED_EVENT, handleWorkspaceChange);

--- a/app/components/canvas-agent-chat/ChatHeader.tsx
+++ b/app/components/canvas-agent-chat/ChatHeader.tsx
@@ -17,7 +17,6 @@ import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { ChatAgentSelector } from '@/app/components/canvas-agent-chat/ChatAgentSelector';
 import { ChatRuntimeActivityBadge } from '@/app/components/canvas-agent-chat/ChatRuntimeActivityBadge';
-import { WorkspaceBadge } from '@/app/components/workspaces/WorkspaceBadge';
 import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 import type { RuntimeStatus } from '@/app/lib/chat/runtime-status';
 import type { AgentProfile } from '@/app/lib/chat/types';
@@ -161,7 +160,6 @@ export function ChatHeader({
                     agents={chatAgentOptions}
                     onSelectAgent={onSelectAgent}
                   />
-                  <WorkspaceBadge compact className="hidden lg:inline-flex" />
                 </div>
               )}
             </div>
@@ -319,7 +317,6 @@ export function ChatHeader({
                     {t('summary')}
                   </span>
                 )}
-                <WorkspaceBadge compact />
                 {runtimeStatus?.activeTool && toolVerbosity !== 'minimal' && (
                   <span className="inline-flex items-center gap-1 border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-600">
                     <Wrench size={9} />

--- a/app/components/canvas-agent-chat/useChatControlActions.ts
+++ b/app/components/canvas-agent-chat/useChatControlActions.ts
@@ -10,7 +10,7 @@ import {
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import { useTranslations } from 'next-intl';
 import { deriveUploadAttachmentPreview } from '@/app/lib/chat/attachment-preview';
-import { CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY } from '@/app/lib/chat/constants';
+import { clearCanvasChatActiveSessionStorage } from '@/app/lib/chat/constants';
 import { loadComposerDraft, removeComposerDraft, saveComposerDraft } from '@/app/lib/chat/draft-storage';
 import { saveLastActiveAgentId } from '@/app/lib/chat/agent-preferences';
 import type { RuntimeStatus } from '@/app/lib/chat/runtime-status';
@@ -62,6 +62,7 @@ type UseChatControlActionsParams = {
   activeModel: string;
   activeProvider: string;
   activeThinkingLevel: PiThinkingLevel;
+  activeWorkspaceId?: string | null;
   addSessionToHistory: (session: AISession) => void;
   agentConfig: AgentConfig | null;
   appendCompactionBreak: (kind: 'manual' | 'automatic', timestamp: string, omittedMessageCount: number) => void;
@@ -200,6 +201,7 @@ export function useChatControlActions({
   activeModel,
   activeProvider,
   activeThinkingLevel,
+  activeWorkspaceId,
   addSessionToHistory,
   agentConfig,
   appendCompactionBreak,
@@ -558,9 +560,7 @@ export function useChatControlActions({
     sessionAgentIdRef.current = nextAgentId;
     resetRuntimeMessageRefs();
     userStartedNewChatRef.current = true;
-    if (typeof window !== 'undefined') {
-      window.sessionStorage.removeItem(CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY);
-    }
+    clearCanvasChatActiveSessionStorage(activeWorkspaceId);
     setMessages([]);
     setHasMoreBefore(false);
     setOldestTimestamp(null);
@@ -580,7 +580,7 @@ export function useChatControlActions({
     setActiveProvider(providerState.provider);
     setActiveModel(providerState.model);
     setActiveThinkingLevel(providerState.thinkingLevel);
-  }, [agentConfig, input, isMobile, resetInputHistoryNavigation, resetRuntimeMessageRefs, resetStreamConnection, selectedAgentId, sessionAgentIdRef, sessionIdRef, setActiveModel, setActiveProvider, setActiveThinkingLevel, setAttachments, setExpandedRunKeys, setHasMoreBefore, setInput, setIsLoadingOlder, setMessages, setOldestSequence, setOldestTimestamp, setRuntimeStatus, setSessionId, setSessionTitle, setShowHistory, setShowMobileDetails, shouldShowHistoryAsOverlay, userStartedNewChatRef]);
+  }, [activeWorkspaceId, agentConfig, input, isMobile, resetInputHistoryNavigation, resetRuntimeMessageRefs, resetStreamConnection, selectedAgentId, sessionAgentIdRef, sessionIdRef, setActiveModel, setActiveProvider, setActiveThinkingLevel, setAttachments, setExpandedRunKeys, setHasMoreBefore, setInput, setIsLoadingOlder, setMessages, setOldestSequence, setOldestTimestamp, setRuntimeStatus, setSessionId, setSessionTitle, setShowHistory, setShowMobileDetails, shouldShowHistoryAsOverlay, userStartedNewChatRef]);
 
   const selectChatAgent = useCallback((agentId: string) => {
     if (agentId === selectedAgentId && !sessionIdRef.current) {

--- a/app/components/canvas-agent-chat/useChatControlActions.ts
+++ b/app/components/canvas-agent-chat/useChatControlActions.ts
@@ -58,6 +58,10 @@ type ChatRuntimeControlAction =
   | 'replace'
   | 'compact';
 
+type StartNewChatOptions = {
+  clearActiveSessionStorage?: boolean;
+};
+
 type UseChatControlActionsParams = {
   activeModel: string;
   activeProvider: string;
@@ -542,7 +546,7 @@ export function useChatControlActions({
     }
   }, [appendCompactionBreak, appendSystemMessage, postControl, sessionIdRef, t]);
 
-  const startNewChat = useCallback((agentIdOverride?: string) => {
+  const startNewChat = useCallback((agentIdOverride?: string, options?: StartNewChatOptions) => {
     const nextAgentId = agentIdOverride || selectedAgentId;
     resetStreamConnection();
     setRuntimeStatus(null);
@@ -560,7 +564,9 @@ export function useChatControlActions({
     sessionAgentIdRef.current = nextAgentId;
     resetRuntimeMessageRefs();
     userStartedNewChatRef.current = true;
-    clearCanvasChatActiveSessionStorage(activeWorkspaceId);
+    if (options?.clearActiveSessionStorage !== false) {
+      clearCanvasChatActiveSessionStorage(activeWorkspaceId);
+    }
     setMessages([]);
     setHasMoreBefore(false);
     setOldestTimestamp(null);

--- a/app/components/canvas-agent-chat/useChatSessionBootstrap.ts
+++ b/app/components/canvas-agent-chat/useChatSessionBootstrap.ts
@@ -8,7 +8,6 @@ import {
 } from 'react';
 import { useTranslations } from 'next-intl';
 import { deriveUploadAttachmentPreview } from '@/app/lib/chat/attachment-preview';
-import { CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY } from '@/app/lib/chat/constants';
 import { saveLastActiveAgentId } from '@/app/lib/chat/agent-preferences';
 import { isRecord } from '@/app/lib/chat/message-content';
 import { readLatestCachedChatSession } from '@/app/lib/chat/session-cache';
@@ -39,6 +38,8 @@ type UseChatSessionBootstrapParams = {
     action: 'send' | 'steer' | 'follow_up' | 'replace',
     override?: { text: string; attachments: Attachment[] },
   ) => Promise<void>;
+  activeSessionStorageKey: string;
+  activeWorkspaceId?: string | null;
   hasLoadedSessionListRef: MutableRefObject<boolean>;
   historyLength: number;
   initialPrompt?: string | null;
@@ -131,6 +132,13 @@ function parseInitialPromptPayload(storedData: string): InitialPromptPayload | n
   }
 }
 
+function sessionMatchesActiveWorkspace(session: AISession, activeWorkspaceId?: string | null): boolean {
+  if (!activeWorkspaceId) {
+    return true;
+  }
+  return session.workspace?.workspaceId === activeWorkspaceId;
+}
+
 export function useChatSessionBootstrap({
   addSessionToHistory,
   agentConfig,
@@ -139,6 +147,8 @@ export function useChatSessionBootstrap({
   fetchHistory,
   forcedSessionId,
   handleControlAction,
+  activeSessionStorageKey,
+  activeWorkspaceId,
   hasLoadedSessionListRef,
   historyLength,
   initialPrompt,
@@ -236,7 +246,7 @@ export function useChatSessionBootstrap({
     const loadRequestedSession = async () => {
       try {
         const cachedEntry = readLatestCachedChatSession(resolvedRequestedSessionId);
-        if (cachedEntry) {
+        if (cachedEntry && sessionMatchesActiveWorkspace(cachedEntry.session, activeWorkspaceId)) {
           addSessionToHistory(cachedEntry.session);
           await loadSession(cachedEntry.session);
           if (!forcedSessionId) {
@@ -273,7 +283,7 @@ export function useChatSessionBootstrap({
     };
 
     void loadRequestedSession();
-  }, [addSessionToHistory, clearSessionParamFromUrl, forcedSessionId, initialPrompt, initialPromptStorageKey, loadSession, loadSessionList, requestedSessionCleanupRef, resolvedRequestedSessionId, setHistoryAndLatest, setIsResolvingInitialChatState, userStartedNewChatRef]);
+  }, [activeWorkspaceId, addSessionToHistory, clearSessionParamFromUrl, forcedSessionId, initialPrompt, initialPromptStorageKey, loadSession, loadSessionList, requestedSessionCleanupRef, resolvedRequestedSessionId, setHistoryAndLatest, setIsResolvingInitialChatState, userStartedNewChatRef]);
 
   useEffect(() => {
     if (initialPrompt?.trim()) return;
@@ -286,7 +296,7 @@ export function useChatSessionBootstrap({
     if (sessionId) return;
 
     const storedSessionId = typeof window !== 'undefined'
-      ? window.sessionStorage.getItem(CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY)
+      ? window.sessionStorage.getItem(activeSessionStorageKey)
       : null;
     if (!storedSessionId) {
       setIsResolvingInitialChatState(false);
@@ -297,7 +307,7 @@ export function useChatSessionBootstrap({
     const restoreSession = async () => {
       try {
         const cachedEntry = readLatestCachedChatSession(storedSessionId);
-        if (cachedEntry) {
+        if (cachedEntry && sessionMatchesActiveWorkspace(cachedEntry.session, activeWorkspaceId)) {
           addSessionToHistory(cachedEntry.session);
           await loadSession(cachedEntry.session);
           void loadSessionList()
@@ -327,8 +337,22 @@ export function useChatSessionBootstrap({
     };
 
     void restoreSession();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [
+    activeSessionStorageKey,
+    activeWorkspaceId,
+    addSessionToHistory,
+    initialPrompt,
+    initialPromptConsumedRef,
+    initialPromptStorageKey,
+    loadSession,
+    loadSessionList,
+    resolvedRequestedSessionId,
+    sessionId,
+    sessionIdRef,
+    setHistoryAndLatest,
+    setIsResolvingInitialChatState,
+    userStartedNewChatRef,
+  ]);
 
   useEffect(() => {
     if (requestedSessionCleanupRef.current && !resolvedRequestedSessionId) {

--- a/app/components/canvas-agent-chat/useChatSessionHistory.ts
+++ b/app/components/canvas-agent-chat/useChatSessionHistory.ts
@@ -29,6 +29,7 @@ import type {
 type ChatTranslator = ReturnType<typeof useTranslations<'chat'>>;
 
 type UseChatSessionHistoryParams = {
+  activeWorkspaceId?: string | null;
   availableAgents: AgentProfile[];
   optimisticSessionTitlesRef: MutableRefObject<Record<string, string>>;
   requestSavedMessageRefreshRef: MutableRefObject<((sessionId: string) => void) | null>;
@@ -66,6 +67,7 @@ function getSessionTimeGroup(dateString: string): ChatHistoryGroup {
 }
 
 export function useChatSessionHistory({
+  activeWorkspaceId,
   availableAgents,
   optimisticSessionTitlesRef,
   requestSavedMessageRefreshRef,
@@ -92,6 +94,7 @@ export function useChatSessionHistory({
   const isHistoryResizing = useRef(false);
   const sessionListRequestRef = useRef<Promise<AISession[]> | null>(null);
   const hasLoadedSessionListRef = useRef(false);
+  const activeWorkspaceIdRef = useRef(activeWorkspaceId ?? null);
 
   useEffect(() => {
     historyRef.current = history;
@@ -134,7 +137,7 @@ export function useChatSessionHistory({
     }
 
     const request = (async () => {
-      const sessions = applyResolvedTitles(await fetchChatSessions('all'));
+      const sessions = applyResolvedTitles(await fetchChatSessions('all', { workspaceId: activeWorkspaceId }));
       hasLoadedSessionListRef.current = true;
       return sessions;
     })();
@@ -148,7 +151,7 @@ export function useChatSessionHistory({
         sessionListRequestRef.current = null;
       }
     }
-  }, [applyResolvedTitles]);
+  }, [activeWorkspaceId, applyResolvedTitles]);
 
   const setHistoryAndLatest = useCallback((sessions: AISession[]) => {
     setHistory(sessions);
@@ -172,6 +175,15 @@ export function useChatSessionHistory({
     setLatestSession(null);
     setTotalUnreadCount(0);
   }, []);
+
+  useEffect(() => {
+    const normalizedWorkspaceId = activeWorkspaceId ?? null;
+    if (activeWorkspaceIdRef.current === normalizedWorkspaceId) {
+      return;
+    }
+    activeWorkspaceIdRef.current = normalizedWorkspaceId;
+    resetHistoryState();
+  }, [activeWorkspaceId, resetHistoryState]);
 
   const fetchHistory = useCallback(async () => {
     setIsLoadingHistory(true);
@@ -234,7 +246,7 @@ export function useChatSessionHistory({
 
   const markAllAsRead = useCallback(async () => {
     try {
-      const data = await patchChatSessions({ agentId: selectedAgentId, markAllAsRead: true });
+      const data = await patchChatSessions({ agentId: selectedAgentId, markAllAsRead: true, workspaceId: activeWorkspaceId });
       if (data?.success) {
         const now = data.lastViewedAt;
         setHistory((prev) => prev.map((item) => (
@@ -245,7 +257,7 @@ export function useChatSessionHistory({
     } catch (err) {
       console.error('Failed to mark all as read', err);
     }
-  }, [selectedAgentId]);
+  }, [activeWorkspaceId, selectedAgentId]);
 
   useEffect(() => {
     const handleSessionUpdated = (event: CustomEvent<{ sessionId: string; lastMessageAt: string; title?: string }>) => {

--- a/app/components/canvas-agent-chat/useChatSessionMessages.ts
+++ b/app/components/canvas-agent-chat/useChatSessionMessages.ts
@@ -47,6 +47,7 @@ type UseChatSessionMessagesParams = {
   activeModel: string;
   activeProvider: string;
   activeThinkingLevel: PiThinkingLevel | null;
+  activeWorkspaceId?: string | null;
   agentConfig: AgentConfig | null;
   deferredSavedMessageRefreshSessionRef: MutableRefObject<string | null>;
   ensureSessionSubscribed: (targetSessionId: string) => Promise<void>;
@@ -107,6 +108,7 @@ export function useChatSessionMessages({
   activeModel,
   activeProvider,
   activeThinkingLevel,
+  activeWorkspaceId,
   agentConfig,
   deferredSavedMessageRefreshSessionRef,
   ensureSessionSubscribed,
@@ -202,6 +204,7 @@ export function useChatSessionMessages({
       lastMessageAt: historySession?.lastMessageAt ?? new Date().toISOString(),
       lastViewedAt: historySession?.lastViewedAt ?? null,
       hasUnread: false,
+      workspace: historySession?.workspace ?? null,
       creator: historySession?.creator,
     };
 
@@ -254,6 +257,7 @@ export function useChatSessionMessages({
           agentId: requestAgentId,
           sessionId: targetSessionId,
           limit: 50,
+          workspaceId: activeWorkspaceId,
           cache: 'no-store',
           credentials: 'include',
         });
@@ -282,7 +286,7 @@ export function useChatSessionMessages({
         console.error('Failed to refresh messages after saved chat response', error);
       }
     })();
-  }, [hydrateRuntimeMessageRefs, isAtBottomRef, mapRawMessages, messagesRef, scrollToBottom, selectedAgentId, sessionAgentIdRef, sessionIdRef, setHasMoreBefore, setMessages, setOldestMessageId, setOldestSequence, setOldestTimestamp]);
+  }, [activeWorkspaceId, hydrateRuntimeMessageRefs, isAtBottomRef, mapRawMessages, messagesRef, scrollToBottom, selectedAgentId, sessionAgentIdRef, sessionIdRef, setHasMoreBefore, setMessages, setOldestMessageId, setOldestSequence, setOldestTimestamp]);
 
   useEffect(() => {
     refreshSavedMessagesRef.current = refreshSavedMessages;
@@ -389,6 +393,7 @@ export function useChatSessionMessages({
         agentId: sessionAgentId,
         sessionId: session.sessionId,
         limit: 50,
+        workspaceId: activeWorkspaceId,
         signal: abortController.signal,
       });
 
@@ -482,7 +487,7 @@ export function useChatSessionMessages({
         loadSessionAbortRef.current = null;
       }
     }
-  }, [agentConfig, ensureSessionSubscribed, hydrateRuntimeMessageRefs, isMobile, mapRawMessages, resetRuntimeMessageRefs, resetStreamConnection, resolveSessionTitle, scrollToBottom, sessionAgentIdRef, sessionIdRef, setActiveModel, setActiveProvider, setActiveThinkingLevel, setExpandedRunKeys, setHasMoreBefore, setHasUnreadInCurrentSession, setHistory, setInput, setIsLoadingOlder, setLastCompactionMarker, setMessages, setOldestMessageId, setOldestSequence, setOldestTimestamp, setRuntimeStatus, setRuntimeStatusWithReconciliation, setSelectedAgentId, setSessionId, setSessionTitle, setShowHistory, setShowMobileDetails, setShowUnreadBanner, setTotalUnreadCount, shouldShowHistoryAsOverlay, t, userStartedNewChatRef, wsRequest]);
+  }, [activeWorkspaceId, agentConfig, ensureSessionSubscribed, hydrateRuntimeMessageRefs, isMobile, mapRawMessages, resetRuntimeMessageRefs, resetStreamConnection, resolveSessionTitle, scrollToBottom, sessionAgentIdRef, sessionIdRef, setActiveModel, setActiveProvider, setActiveThinkingLevel, setExpandedRunKeys, setHasMoreBefore, setHasUnreadInCurrentSession, setHistory, setInput, setIsLoadingOlder, setLastCompactionMarker, setMessages, setOldestMessageId, setOldestSequence, setOldestTimestamp, setRuntimeStatus, setRuntimeStatusWithReconciliation, setSelectedAgentId, setSessionId, setSessionTitle, setShowHistory, setShowMobileDetails, setShowUnreadBanner, setTotalUnreadCount, shouldShowHistoryAsOverlay, t, userStartedNewChatRef, wsRequest]);
 
   const loadOlderMessages = useCallback(async () => {
     const currentSessionId = sessionIdRef.current;
@@ -499,6 +504,7 @@ export function useChatSessionMessages({
         agentId,
         sessionId: currentSessionId,
         limit: 50,
+        workspaceId: activeWorkspaceId,
         beforeSequence: oldestSequence,
         before: oldestSequence === null ? oldestTimestamp : null,
         beforeId: oldestMessageId,
@@ -536,7 +542,7 @@ export function useChatSessionMessages({
     } finally {
       setIsLoadingOlder(false);
     }
-  }, [hasMoreBefore, isLoadingOlder, mapRawMessages, oldestMessageId, oldestSequence, oldestTimestamp, scrollContainerRef, selectedAgentId, sessionAgentIdRef, sessionIdRef, setHasMoreBefore, setIsLoadingOlder, setMessages, setOldestMessageId, setOldestSequence, setOldestTimestamp]);
+  }, [activeWorkspaceId, hasMoreBefore, isLoadingOlder, mapRawMessages, oldestMessageId, oldestSequence, oldestTimestamp, scrollContainerRef, selectedAgentId, sessionAgentIdRef, sessionIdRef, setHasMoreBefore, setIsLoadingOlder, setMessages, setOldestMessageId, setOldestSequence, setOldestTimestamp]);
 
   return {
     loadOlderMessages,

--- a/app/components/editor/MarkdownEditor.tsx
+++ b/app/components/editor/MarkdownEditor.tsx
@@ -87,10 +87,12 @@ import {
 import {
   createCurrentBlockCommandTarget,
   createInsertedBlockCommandTarget,
-  getBlockDropInsertPosition,
+  getBlockDropIndicatorTop,
+  getBlockDropTarget,
   getBlockInsertButtonPosition,
   moveReorderableBlock,
   type BlockControlPosition,
+  type BlockDropTarget,
   type BlockInsertPlacement,
   type ReorderableBlockRange,
 } from '@/app/lib/editor/reorderable-blocks';
@@ -962,7 +964,28 @@ function MarkdownBlockControls({
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const [position, setPosition] = useState<BlockControlPosition | null>(null);
+  const [dropIndicatorTop, setDropIndicatorTop] = useState<number | null>(null);
   const dragStateRef = useRef<ReorderableBlockRange | null>(null);
+
+  const clearDragState = useCallback(() => {
+    dragStateRef.current = null;
+    setDropIndicatorTop(null);
+  }, []);
+
+  const updateDropTarget = useCallback((event: DragEvent): BlockDropTarget | null => {
+    const container = scrollContainerRef.current;
+    const source = dragStateRef.current;
+    if (!editor || !container || !source) {
+      setDropIndicatorTop(null);
+      return null;
+    }
+
+    const dropTarget = getBlockDropTarget(editor, event, source);
+    const nextTop = dropTarget ? getBlockDropIndicatorTop(editor, container, dropTarget) : null;
+    setDropIndicatorTop(nextTop);
+
+    return dropTarget;
+  }, [editor, scrollContainerRef]);
 
   const updatePosition = useCallback(() => {
     const container = scrollContainerRef.current;
@@ -1012,109 +1035,131 @@ function MarkdownBlockControls({
       if (!dragStateRef.current) return;
 
       event.preventDefault();
+      const dropTarget = updateDropTarget(event);
       if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = 'move';
+        event.dataTransfer.dropEffect = dropTarget ? 'move' : 'none';
       }
     };
 
     const handleDrop = (event: DragEvent) => {
       const source = dragStateRef.current;
-      dragStateRef.current = null;
 
       if (!source) return;
 
       event.preventDefault();
       event.stopPropagation();
 
-      const insertPosition = getBlockDropInsertPosition(editor, event, source);
-      if (insertPosition === null) return;
+      const dropTarget = updateDropTarget(event);
+      clearDragState();
+      if (!dropTarget) return;
 
-      moveReorderableBlock(editor, source, insertPosition);
+      moveReorderableBlock(editor, source, dropTarget.insertPosition);
+    };
+
+    const handleDragLeave = (event: DragEvent) => {
+      const nextTarget = event.relatedTarget;
+      if (nextTarget instanceof Node && editorElement.contains(nextTarget)) return;
+      setDropIndicatorTop(null);
+    };
+
+    const handleGlobalDragEnd = () => {
+      clearDragState();
     };
 
     editorElement.addEventListener('dragover', handleDragOver);
+    editorElement.addEventListener('dragleave', handleDragLeave);
     editorElement.addEventListener('drop', handleDrop);
+    window.addEventListener('dragend', handleGlobalDragEnd);
+    window.addEventListener('drop', handleGlobalDragEnd);
 
     return () => {
       editorElement.removeEventListener('dragover', handleDragOver);
+      editorElement.removeEventListener('dragleave', handleDragLeave);
       editorElement.removeEventListener('drop', handleDrop);
+      window.removeEventListener('dragend', handleGlobalDragEnd);
+      window.removeEventListener('drop', handleGlobalDragEnd);
     };
-  }, [editor]);
+  }, [clearDragState, editor, updateDropTarget]);
 
-  if (!editor?.isEditable || !position) return null;
+  if (!editor?.isEditable || (!position && dropIndicatorTop === null)) return null;
 
   return (
-    <div
-      className="tiptap-block-controls absolute z-10 flex items-center gap-1 opacity-70 hover:opacity-100 focus-within:opacity-100"
-      style={{ top: position.top }}
-    >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label={labels.addBlock}
-            className="tiptap-block-control-button"
-            onMouseDown={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-            }}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              onAddBlock(editor, event.altKey ? 'above' : 'below', position.blockRange);
-            }}
-          >
-            <Plus />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="flex flex-col gap-1 text-left">
-          <span>{labels.addBlockBelowHint}</span>
-          <span>{labels.addBlockAboveHint}</span>
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label={labels.openBlockMenuHint}
-            className="tiptap-block-control-button tiptap-block-drag-handle"
-            draggable
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              onOpenCommandMenu(editor, position.menuRange);
-            }}
-            onDragEnd={() => {
-              dragStateRef.current = null;
-            }}
-            onDragStart={(event) => {
-              const source = position.blockRange;
-              if (!source || !event.dataTransfer) {
-                event.preventDefault();
-                return;
-              }
+    <>
+      {dropIndicatorTop !== null ? (
+        <div className="tiptap-block-drop-indicator absolute z-10" style={{ top: dropIndicatorTop }} />
+      ) : null}
+      {position ? (
+        <div
+          className="tiptap-block-controls absolute z-10 flex items-center gap-1 opacity-70 hover:opacity-100 focus-within:opacity-100"
+          style={{ top: position.top }}
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={labels.addBlock}
+                className="tiptap-block-control-button"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onAddBlock(editor, event.altKey ? 'above' : 'below', position.blockRange);
+                }}
+              >
+                <Plus />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="flex flex-col gap-1 text-left">
+              <span>{labels.addBlockBelowHint}</span>
+              <span>{labels.addBlockAboveHint}</span>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={labels.openBlockMenuHint}
+                className="tiptap-block-control-button tiptap-block-drag-handle"
+                draggable
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onOpenCommandMenu(editor, position.menuRange);
+                }}
+                onDragEnd={clearDragState}
+                onDragStart={(event) => {
+                  const source = position.blockRange;
+                  if (!source || !event.dataTransfer) {
+                    event.preventDefault();
+                    return;
+                  }
 
-              dragStateRef.current = source;
-              event.dataTransfer.effectAllowed = 'move';
-              event.dataTransfer.setData('text/plain', 'canvas-editor-block');
-            }}
-            onMouseDown={(event) => {
-              event.stopPropagation();
-            }}
-          >
-            <GripVertical />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="flex flex-col gap-1 text-left">
-          <span>{labels.dragBlockHint}</span>
-          <span>{labels.openBlockMenuHint}</span>
-        </TooltipContent>
-      </Tooltip>
-    </div>
+                  dragStateRef.current = source;
+                  event.dataTransfer.effectAllowed = 'move';
+                  event.dataTransfer.setData('text/plain', 'canvas-editor-block');
+                }}
+                onMouseDown={(event) => {
+                  event.stopPropagation();
+                }}
+              >
+                <GripVertical />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="flex flex-col gap-1 text-left">
+              <span>{labels.dragBlockHint}</span>
+              <span>{labels.openBlockMenuHint}</span>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      ) : null}
+    </>
   );
 }
 

--- a/app/components/editor/MarkdownEditor.tsx
+++ b/app/components/editor/MarkdownEditor.tsx
@@ -90,10 +90,12 @@ import {
   getBlockDropIndicatorTop,
   getBlockDropTarget,
   getBlockInsertButtonPosition,
+  getBlockOverlayRect,
   moveReorderableBlock,
   type BlockControlPosition,
   type BlockDropTarget,
   type BlockInsertPlacement,
+  type BlockOverlayRect,
   type ReorderableBlockRange,
 } from '@/app/lib/editor/reorderable-blocks';
 import { createInlineColorRegex, isColorCode } from '@/app/lib/markdown/color-code';
@@ -965,27 +967,46 @@ function MarkdownBlockControls({
 }) {
   const [position, setPosition] = useState<BlockControlPosition | null>(null);
   const [dropIndicatorTop, setDropIndicatorTop] = useState<number | null>(null);
+  const [dragSourceOverlay, setDragSourceOverlay] = useState<BlockOverlayRect | null>(null);
+  const [dropTargetOverlay, setDropTargetOverlay] = useState<BlockOverlayRect | null>(null);
   const dragStateRef = useRef<ReorderableBlockRange | null>(null);
 
   const clearDragState = useCallback(() => {
     dragStateRef.current = null;
+    setDragSourceOverlay(null);
     setDropIndicatorTop(null);
+    setDropTargetOverlay(null);
   }, []);
+
+  const updateDragSourceOverlay = useCallback(() => {
+    const container = scrollContainerRef.current;
+    const source = dragStateRef.current;
+    if (!editor || !container || !source) {
+      setDragSourceOverlay(null);
+      return;
+    }
+
+    setDragSourceOverlay(getBlockOverlayRect(editor, container, source));
+  }, [editor, scrollContainerRef]);
 
   const updateDropTarget = useCallback((event: DragEvent): BlockDropTarget | null => {
     const container = scrollContainerRef.current;
     const source = dragStateRef.current;
     if (!editor || !container || !source) {
       setDropIndicatorTop(null);
+      setDropTargetOverlay(null);
       return null;
     }
 
     const dropTarget = getBlockDropTarget(editor, event, source);
     const nextTop = dropTarget ? getBlockDropIndicatorTop(editor, container, dropTarget) : null;
+    const nextTargetOverlay = dropTarget ? getBlockOverlayRect(editor, container, dropTarget.target) : null;
     setDropIndicatorTop(nextTop);
+    setDropTargetOverlay(nextTargetOverlay);
+    updateDragSourceOverlay();
 
     return dropTarget;
-  }, [editor, scrollContainerRef]);
+  }, [editor, scrollContainerRef, updateDragSourceOverlay]);
 
   const updatePosition = useCallback(() => {
     const container = scrollContainerRef.current;
@@ -1017,14 +1038,19 @@ function MarkdownBlockControls({
     const container = scrollContainerRef.current;
     if (!container) return;
 
-    container.addEventListener('scroll', updatePosition, { passive: true });
+    const handleScroll = () => {
+      updatePosition();
+      updateDragSourceOverlay();
+    };
+
+    container.addEventListener('scroll', handleScroll, { passive: true });
     window.addEventListener('resize', updatePosition);
 
     return () => {
-      container.removeEventListener('scroll', updatePosition);
+      container.removeEventListener('scroll', handleScroll);
       window.removeEventListener('resize', updatePosition);
     };
-  }, [scrollContainerRef, updatePosition]);
+  }, [scrollContainerRef, updateDragSourceOverlay, updatePosition]);
 
   useEffect(() => {
     if (!editor) return;
@@ -1060,6 +1086,7 @@ function MarkdownBlockControls({
       const nextTarget = event.relatedTarget;
       if (nextTarget instanceof Node && editorElement.contains(nextTarget)) return;
       setDropIndicatorTop(null);
+      setDropTargetOverlay(null);
     };
 
     const handleGlobalDragEnd = () => {
@@ -1081,10 +1108,22 @@ function MarkdownBlockControls({
     };
   }, [clearDragState, editor, updateDropTarget]);
 
-  if (!editor?.isEditable || (!position && dropIndicatorTop === null)) return null;
+  if (!editor?.isEditable || (!position && !dragSourceOverlay && !dropTargetOverlay && dropIndicatorTop === null)) return null;
 
   return (
     <>
+      {dragSourceOverlay ? (
+        <div
+          className="tiptap-block-drag-overlay tiptap-block-drag-overlay-source absolute z-10"
+          style={{ height: dragSourceOverlay.height, top: dragSourceOverlay.top }}
+        />
+      ) : null}
+      {dropTargetOverlay ? (
+        <div
+          className="tiptap-block-drag-overlay tiptap-block-drag-overlay-target absolute z-10"
+          style={{ height: dropTargetOverlay.height, top: dropTargetOverlay.top }}
+        />
+      ) : null}
       {dropIndicatorTop !== null ? (
         <div className="tiptap-block-drop-indicator absolute z-10" style={{ top: dropIndicatorTop }} />
       ) : null}
@@ -1142,6 +1181,10 @@ function MarkdownBlockControls({
                   }
 
                   dragStateRef.current = source;
+                  const container = scrollContainerRef.current;
+                  if (container) {
+                    setDragSourceOverlay(getBlockOverlayRect(editor, container, source));
+                  }
                   event.dataTransfer.effectAllowed = 'move';
                   event.dataTransfer.setData('text/plain', 'canvas-editor-block');
                 }}

--- a/app/components/editor/MarkdownEditor.tsx
+++ b/app/components/editor/MarkdownEditor.tsx
@@ -23,7 +23,6 @@ import { TaskItem } from '@tiptap/extension-task-item';
 import { TableKit } from '@tiptap/extension-table';
 import { CodeBlock } from '@tiptap/extension-code-block';
 import { Suggestion, type SuggestionProps } from '@tiptap/suggestion';
-import { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import {
@@ -81,8 +80,20 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { SafeMarkdownImage } from '@/app/components/shared/SafeMarkdownImage';
 import {
   clampEditorRangeToDoc,
+  getSlashCommandDeletionRange,
+  isEditorRangeInsideDoc,
   isEditorPositionInsideDoc,
 } from '@/app/lib/editor/prosemirror-ranges';
+import {
+  createCurrentBlockCommandTarget,
+  createInsertedBlockCommandTarget,
+  getBlockDropInsertPosition,
+  getBlockInsertButtonPosition,
+  moveReorderableBlock,
+  type BlockControlPosition,
+  type BlockInsertPlacement,
+  type ReorderableBlockRange,
+} from '@/app/lib/editor/reorderable-blocks';
 import { createInlineColorRegex, isColorCode } from '@/app/lib/markdown/color-code';
 import { makeLinkPreviewImageAlt, parseLinkPreviewImageAlt } from '@/app/lib/markdown/link-preview-markdown';
 import {
@@ -204,26 +215,6 @@ type BlockCommandMenuState = {
     top: number;
     width: number;
   };
-};
-
-type BlockInsertPlacement = 'above' | 'below';
-
-type ReorderableBlockKind = 'topLevel' | 'listItem';
-
-type ReorderableBlockRange = {
-  depth: number;
-  from: number;
-  kind: ReorderableBlockKind;
-  node: ProseMirrorNode;
-  parentFrom: number;
-  parentTo: number;
-  to: number;
-};
-
-type BlockControlPosition = {
-  blockRange: ReorderableBlockRange;
-  menuRange: Range;
-  top: number;
 };
 
 type ImageDialogSeed = {
@@ -435,13 +426,33 @@ const ColorSwatchDecorations = Extension.create({
 
 function runAfterSlashDelete({ editor, range }: SlashCommandContext) {
   const chain = editor.chain().focus();
-  const safeRange = clampEditorRangeToDoc(editor, range);
-
-  if (!safeRange || safeRange.from === safeRange.to) {
+  if (!isEditorRangeInsideDoc(editor, range)) {
     return chain;
   }
 
-  return chain.deleteRange(safeRange);
+  if (range.from === range.to) {
+    return chain.setTextSelection(range.from);
+  }
+
+  const slashRange = getSlashCommandDeletionRange(editor, range);
+  return slashRange ? chain.deleteRange(slashRange) : chain.setTextSelection(range.from);
+}
+
+function prepareCommandDialogInsertionRange(editor: Editor, range: Range): Range | null {
+  if (!isEditorRangeInsideDoc(editor, range)) {
+    return null;
+  }
+
+  const slashRange = getSlashCommandDeletionRange(editor, range);
+  const chain = editor.chain().focus();
+
+  if (slashRange) {
+    chain.deleteRange(slashRange).run();
+  } else {
+    chain.setTextSelection(range.from).run();
+  }
+
+  return { from: range.from, to: range.from };
 }
 
 const SLASH_COMMAND_DEFINITIONS: SlashCommandDefinition[] = [
@@ -524,12 +535,12 @@ const SLASH_COMMAND_DEFINITIONS: SlashCommandDefinition[] = [
 
       const src = window.prompt(labels.imageSrcPrompt);
       if (!src?.trim()) {
-        editor.chain().focus().deleteRange(range).run();
+        runAfterSlashDelete({ actions, editor, labels, range }).run();
         return;
       }
 
       const alt = window.prompt(labels.imageAltPrompt) || '';
-      editor.chain().focus().deleteRange(range).setImage({ src: src.trim(), alt: alt.trim() }).run();
+      runAfterSlashDelete({ actions, editor, labels, range }).setImage({ src: src.trim(), alt: alt.trim() }).run();
     },
   },
   {
@@ -922,162 +933,9 @@ function createSlashCommandLabels(t: (key: string) => string): SlashCommandLabel
   };
 }
 
-function findActiveTextblockDepth(editor: Editor): number | null {
-  const { $from } = editor.state.selection;
-
-  for (let depth = $from.depth; depth > 0; depth -= 1) {
-    if ($from.node(depth).isTextblock) return depth;
-  }
-
-  return null;
-}
-
-function getTopLevelBlockRangeAt(editor: Editor, position: number): ReorderableBlockRange | null {
-  const docEnd = editor.state.doc.content.size;
-  const safePosition = Math.max(0, Math.min(position, docEnd));
-  let range: ReorderableBlockRange | null = null;
-
-  editor.state.doc.forEach((node, offset) => {
-    if (range) return;
-
-    const from = offset;
-    const to = offset + node.nodeSize;
-    const isInsideNode = safePosition >= from && safePosition < to;
-    const isAtDocumentEnd = safePosition === docEnd && safePosition === to;
-
-    if (isInsideNode || isAtDocumentEnd) {
-      range = {
-        depth: 1,
-        from,
-        kind: 'topLevel',
-        node,
-        parentFrom: 0,
-        parentTo: docEnd,
-        to,
-      };
-    }
-  });
-
-  return range;
-}
-
-function getListItemBlockRangeAt(
-  editor: Editor,
-  position: number,
-  requiredParent?: Pick<ReorderableBlockRange, 'parentFrom' | 'parentTo'>,
-): ReorderableBlockRange | null {
-  const doc = editor.state.doc;
-  const docEnd = doc.content.size;
-  if (docEnd <= 0) return null;
-
-  const safePosition = Math.max(0, Math.min(position, docEnd));
-  const resolvePosition = Math.max(0, Math.min(safePosition, docEnd - 1));
-  const $position = doc.resolve(resolvePosition);
-
-  for (let depth = $position.depth; depth > 0; depth -= 1) {
-    const node = $position.node(depth);
-    if (node.type.name !== 'listItem') continue;
-
-    const parentDepth = depth - 1;
-    const parentNode = $position.node(parentDepth);
-    if (parentNode.type.name !== 'bulletList' && parentNode.type.name !== 'orderedList' && parentNode.type.name !== 'taskList') {
-      continue;
-    }
-
-    const parentFrom = $position.start(parentDepth);
-    const parentTo = $position.end(parentDepth);
-    if (requiredParent && (parentFrom !== requiredParent.parentFrom || parentTo !== requiredParent.parentTo)) {
-      continue;
-    }
-
-    return {
-      depth,
-      from: $position.before(depth),
-      kind: 'listItem',
-      node,
-      parentFrom,
-      parentTo,
-      to: $position.after(depth),
-    };
-  }
-
-  return null;
-}
-
-function getReorderableBlockRangeAt(
-  editor: Editor,
-  position: number,
-  source?: ReorderableBlockRange,
-): ReorderableBlockRange | null {
-  if (source?.kind === 'listItem') {
-    return getListItemBlockRangeAt(editor, position, source);
-  }
-
-  if (source?.kind === 'topLevel') {
-    return getTopLevelBlockRangeAt(editor, position);
-  }
-
-  return getListItemBlockRangeAt(editor, position) ?? getTopLevelBlockRangeAt(editor, position);
-}
-
-function createEmptyListItemNode(editor: Editor, source: ReorderableBlockRange) {
-  const paragraph = editor.schema.nodes.paragraph.create();
-  return source.node.type.createAndFill(null, paragraph) ?? source.node.type.create(null, paragraph);
-}
-
-function createInsertedBlockCommandTarget(
-  editor: Editor,
-  placement: BlockInsertPlacement,
-  blockRange?: ReorderableBlockRange,
-): Range | null {
-  if (!editor.isEditable || editor.isActive('codeBlock')) return null;
-
-  if (blockRange) {
-    const insertPosition = placement === 'above' ? blockRange.from : blockRange.to;
-    const isListItem = blockRange.kind === 'listItem';
-    const cursorPosition = insertPosition + (isListItem ? 2 : 1);
-    const content = isListItem ? createEmptyListItemNode(editor, blockRange) : { type: 'paragraph' };
-
-    editor.chain().focus().insertContentAt(insertPosition, content).setTextSelection(cursorPosition).run();
-
-    return { from: cursorPosition, to: cursorPosition };
-  }
-
-  const { $from } = editor.state.selection;
-  const textblockDepth = findActiveTextblockDepth(editor);
-  if (!textblockDepth) return null;
-
-  const topLevelDepth = $from.depth >= 1 ? 1 : textblockDepth;
-  const insertPosition = placement === 'above' ? $from.before(topLevelDepth) : $from.after(topLevelDepth);
-  const cursorPosition = insertPosition + 1;
-  editor
-    .chain()
-    .focus()
-    .insertContentAt(insertPosition, { type: 'paragraph' })
-    .setTextSelection(cursorPosition)
-    .run();
-
-  return { from: cursorPosition, to: cursorPosition };
-}
-
-function createCurrentBlockCommandTarget(editor: Editor, menuRange?: Range): Range | null {
-  if (!editor.isEditable || editor.isActive('codeBlock')) return null;
-
-  if (menuRange) {
-    editor.chain().focus().setTextSelection(menuRange.from).run();
-    return menuRange;
-  }
-
-  const { $from } = editor.state.selection;
-  const textblockDepth = findActiveTextblockDepth(editor);
-  if (!textblockDepth) return null;
-
-  const position = $from.start(textblockDepth);
-  editor.chain().focus().setTextSelection(position).run();
-  return { from: position, to: position };
-}
-
 function createBlockCommandMenuState(editor: Editor, range: Range): BlockCommandMenuState | null {
+  if (!isEditorRangeInsideDoc(editor, range)) return null;
+
   try {
     const coords = editor.view.coordsAtPos(range.from);
     return {
@@ -1087,96 +945,6 @@ function createBlockCommandMenuState(editor: Editor, range: Range): BlockCommand
     };
   } catch {
     return null;
-  }
-}
-
-function getBlockInsertButtonPosition(editor: Editor, container: HTMLDivElement): BlockControlPosition | null {
-  if (!editor.isEditable || editor.isActive('codeBlock')) return null;
-
-  const { $from } = editor.state.selection;
-  const textblockDepth = findActiveTextblockDepth(editor);
-  if (!textblockDepth) return null;
-
-  const blockRange = getReorderableBlockRangeAt(editor, editor.state.selection.from);
-  if (!blockRange) return null;
-
-  const blockDom = editor.view.nodeDOM(blockRange.from);
-  const containerRect = container.getBoundingClientRect();
-  const menuPosition = $from.start(textblockDepth);
-  const menuRange = { from: menuPosition, to: menuPosition };
-
-  if (blockDom instanceof HTMLElement) {
-    const blockRect = blockDom.getBoundingClientRect();
-    return {
-      blockRange,
-      menuRange,
-      top: Math.max(6, blockRect.top - containerRect.top + container.scrollTop + (blockRect.height / 2) - 12),
-    };
-  }
-
-  const positionForCoords = Math.min(blockRange.from + 1, editor.state.doc.content.size);
-  const coords = editor.view.coordsAtPos(positionForCoords);
-
-  return {
-    blockRange,
-    menuRange,
-    top: Math.max(6, coords.top - containerRect.top + container.scrollTop),
-  };
-}
-
-function getBlockDropInsertPosition(
-  editor: Editor,
-  event: DragEvent,
-  source: ReorderableBlockRange,
-): number | null {
-  const positionAtCoords = editor.view.posAtCoords({
-    left: event.clientX,
-    top: event.clientY,
-  });
-
-  if (!positionAtCoords) {
-    return source.kind === 'topLevel' ? editor.state.doc.content.size : null;
-  }
-
-  const target = getReorderableBlockRangeAt(editor, positionAtCoords.pos, source);
-  if (!target) {
-    return null;
-  }
-
-  const targetDom = editor.view.nodeDOM(target.from);
-  const targetRect = targetDom instanceof HTMLElement ? targetDom.getBoundingClientRect() : null;
-  const insertPosition = targetRect
-    ? event.clientY < targetRect.top + targetRect.height / 2
-      ? target.from
-      : target.to
-    : positionAtCoords.pos <= target.from
-      ? target.from
-      : target.to;
-
-  if (insertPosition >= source.from && insertPosition <= source.to) {
-    return null;
-  }
-
-  return insertPosition;
-}
-
-function moveReorderableBlock(editor: Editor, source: ReorderableBlockRange, insertPosition: number) {
-  const sourceSize = source.to - source.from;
-  const adjustedInsertPosition = insertPosition > source.from ? insertPosition - sourceSize : insertPosition;
-
-  if (adjustedInsertPosition === source.from) return;
-
-  try {
-    const transaction = editor.state.tr
-      .delete(source.from, source.to)
-      .insert(adjustedInsertPosition, source.node)
-      .scrollIntoView();
-
-    editor.view.dispatch(transaction);
-    editor.commands.focus();
-  } catch {
-    // Ignore invalid drops, for example when the browser reports coordinates
-    // outside the reorderable parent list.
   }
 }
 
@@ -2730,6 +2498,7 @@ function RichMarkdownEditor({
   const latestValueRef = useRef(value);
   const acceptedExternalValueRef = useRef(value);
   const applyingExternalValueRef = useRef(false);
+  const pendingBlockCommandMenuFrameRef = useRef<number | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [tableDialogOpen, setTableDialogOpen] = useState(false);
   const [imageDialogOpen, setImageDialogOpen] = useState(false);
@@ -2743,14 +2512,8 @@ function RichMarkdownEditor({
     setImageDialogOpen(open);
   }, []);
   const openImageDialogFromSlash = useCallback((slashEditor: Editor, range: Range) => {
-    const safeRange = clampEditorRangeToDoc(slashEditor, range);
-    const insertPosition = safeRange?.from ?? slashEditor.state.selection.from;
-
-    if (safeRange && safeRange.from !== safeRange.to) {
-      slashEditor.chain().focus().deleteRange(safeRange).run();
-    } else {
-      slashEditor.chain().focus().setTextSelection(insertPosition).run();
-    }
+    const insertionRange = prepareCommandDialogInsertionRange(slashEditor, range);
+    const insertPosition = insertionRange?.from ?? slashEditor.state.selection.from;
 
     setImageDialogSeed((current) => ({
       id: current.id + 1,
@@ -2759,13 +2522,7 @@ function RichMarkdownEditor({
     setImageDialogOpen(true);
   }, []);
   const openTableDialogFromSlash = useCallback((slashEditor: Editor, range: Range) => {
-    const safeRange = clampEditorRangeToDoc(slashEditor, range);
-
-    if (safeRange && safeRange.from !== safeRange.to) {
-      slashEditor.chain().focus().deleteRange(safeRange).run();
-    } else if (safeRange) {
-      slashEditor.chain().focus().setTextSelection(safeRange.from).run();
-    }
+    prepareCommandDialogInsertionRange(slashEditor, range);
 
     setTableDialogOpen(true);
   }, []);
@@ -2807,18 +2564,33 @@ function RichMarkdownEditor({
     setTableDialogOpen(false);
   }, [editor]);
 
-  const closeBlockCommandMenu = useCallback(() => {
-    setBlockCommandMenu(null);
+  const cancelPendingBlockCommandMenu = useCallback(() => {
+    if (pendingBlockCommandMenuFrameRef.current === null) return;
+    window.cancelAnimationFrame(pendingBlockCommandMenuFrameRef.current);
+    pendingBlockCommandMenuFrameRef.current = null;
   }, []);
 
+  const closeBlockCommandMenu = useCallback(() => {
+    cancelPendingBlockCommandMenu();
+    setBlockCommandMenu(null);
+  }, [cancelPendingBlockCommandMenu]);
+
   const openBlockCommandMenuAtRange = useCallback((blockEditor: Editor, range: Range) => {
-    window.requestAnimationFrame(() => {
+    cancelPendingBlockCommandMenu();
+    setBlockCommandMenu(null);
+
+    if (!isEditorRangeInsideDoc(blockEditor, range)) return;
+
+    pendingBlockCommandMenuFrameRef.current = window.requestAnimationFrame(() => {
+      pendingBlockCommandMenuFrameRef.current = null;
+      if (!blockEditor.isEditable || !isEditorRangeInsideDoc(blockEditor, range)) return;
+
       const menuState = createBlockCommandMenuState(blockEditor, range);
       if (menuState) {
         setBlockCommandMenu(menuState);
       }
     });
-  }, []);
+  }, [cancelPendingBlockCommandMenu]);
 
   const openInsertedBlockCommandMenu = useCallback((
     blockEditor: Editor,
@@ -2837,6 +2609,10 @@ function RichMarkdownEditor({
 
     openBlockCommandMenuAtRange(blockEditor, range);
   }, [openBlockCommandMenuAtRange]);
+
+  useEffect(() => () => {
+    cancelPendingBlockCommandMenu();
+  }, [cancelPendingBlockCommandMenu]);
 
   useEffect(() => {
     if (!markdownEditor) return;
@@ -2891,11 +2667,11 @@ function RichMarkdownEditor({
     if (!readOnly) return undefined;
 
     const frame = window.requestAnimationFrame(() => {
-      setBlockCommandMenu(null);
+      closeBlockCommandMenu();
     });
 
     return () => window.cancelAnimationFrame(frame);
-  }, [readOnly]);
+  }, [closeBlockCommandMenu, readOnly]);
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">

--- a/app/components/file-browser/ShareMarkdownDialog.tsx
+++ b/app/components/file-browser/ShareMarkdownDialog.tsx
@@ -14,6 +14,8 @@ import {
 import { toast } from 'sonner';
 import { toHtmlPreviewUrl } from '@/app/lib/utils/media-url';
 import { HtmlPreviewBlocked, HtmlPreviewConsent } from '@/app/components/editor/HtmlPreviewConsent';
+import { WORKSPACE_ID_HEADER } from '@/app/lib/workspaces/constants';
+import { useWorkspaceStore } from '@/app/store/workspace-store';
 
 interface ShareMarkdownDialogProps {
   open: boolean;
@@ -50,6 +52,7 @@ export function ShareMarkdownDialog({
   markdownPdfUrl,
 }: ShareMarkdownDialogProps) {
   const t = useTranslations('notebook');
+  const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
   const [loading, setLoading] = useState(false);
   const [pdfLoading, setPdfLoading] = useState(false);
   const [htmlContent, setHtmlContent] = useState<string>('');
@@ -57,6 +60,20 @@ export function ShareMarkdownDialog({
   const [htmlPreviewAllowed, setHtmlPreviewAllowed] = useState(false);
   const [htmlPreviewDeclined, setHtmlPreviewDeclined] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const internalHeaders = useCallback((contentType?: string): HeadersInit | undefined => {
+    if (!activeWorkspaceId && !contentType) return undefined;
+    return {
+      ...(contentType ? { 'Content-Type': contentType } : {}),
+      ...(activeWorkspaceId ? { [WORKSPACE_ID_HEADER]: activeWorkspaceId } : {}),
+    };
+  }, [activeWorkspaceId]);
+
+  const internalUrl = useCallback((url: string) => {
+    if (!activeWorkspaceId) return url;
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}workspaceId=${encodeURIComponent(activeWorkspaceId)}`;
+  }, [activeWorkspaceId]);
 
   const loadHtmlExport = useCallback(async () => {
     if (kind === 'html') {
@@ -70,8 +87,16 @@ export function ShareMarkdownDialog({
     setError('');
 
     try {
+      const isPublicMarkdownExport = Boolean(markdownExportUrl);
+      const exportUrl = markdownExportUrl || internalUrl(
+        `/api/files/markdown-export?path=${encodeURIComponent(filePath)}`
+      );
       const response = await fetch(
-        markdownExportUrl || `/api/files/markdown-export?path=${encodeURIComponent(filePath)}`
+        exportUrl,
+        {
+          credentials: isPublicMarkdownExport ? 'same-origin' : 'include',
+          headers: isPublicMarkdownExport ? undefined : internalHeaders(),
+        }
       );
 
       if (!response.ok) {
@@ -90,7 +115,7 @@ export function ShareMarkdownDialog({
     } finally {
       setLoading(false);
     }
-  }, [filePath, kind, markdownExportUrl, t]);
+  }, [filePath, internalHeaders, internalUrl, kind, markdownExportUrl, t]);
 
   useEffect(() => {
     if (open && filePath) {
@@ -110,9 +135,13 @@ export function ShareMarkdownDialog({
     setPdfLoading(true);
     try {
       const publicMarkdownPdf = kind === 'markdown' && markdownPdfUrl;
-      const response = await fetch(kind === 'html' ? '/api/files/html-pdf' : markdownPdfUrl || '/api/files/markdown-pdf', {
+      const pdfUrl = kind === 'html'
+        ? internalUrl('/api/files/html-pdf')
+        : markdownPdfUrl || internalUrl('/api/files/markdown-pdf');
+      const response = await fetch(pdfUrl, {
         method: 'POST',
-        headers: publicMarkdownPdf ? undefined : { 'Content-Type': 'application/json' },
+        credentials: publicMarkdownPdf ? 'same-origin' : 'include',
+        headers: publicMarkdownPdf ? undefined : internalHeaders('application/json'),
         body: publicMarkdownPdf ? undefined : JSON.stringify({ path: filePath }),
       });
 
@@ -182,7 +211,7 @@ export function ShareMarkdownDialog({
                 htmlPreviewAllowed ? (
                   <iframe
                     ref={iframeRef}
-                    src={toHtmlPreviewUrl(filePath)}
+                    src={internalUrl(toHtmlPreviewUrl(filePath))}
                     className="w-full h-full"
                     sandbox="allow-scripts allow-same-origin"
                     title={t('previewTitle', { fileName })}

--- a/app/components/home/HomeChatPrompt.tsx
+++ b/app/components/home/HomeChatPrompt.tsx
@@ -6,7 +6,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { MessageSquare, Send, Paperclip, Megaphone, WandSparkles, Clapperboard, BriefcaseBusiness, FileText, FolderTree, Loader2 } from 'lucide-react';
 import { getFileIconComponent } from '@/app/lib/files/file-icons';
 
-import { CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY, CANVAS_CHAT_INITIAL_PROMPT_STORAGE_KEY } from '@/app/lib/chat/constants';
+import { clearCanvasChatActiveSessionStorage, CANVAS_CHAT_INITIAL_PROMPT_STORAGE_KEY } from '@/app/lib/chat/constants';
 import { DEFAULT_AGENT_ID } from '@/app/lib/channels/constants';
 import { BUSINESS_STARTER_PROMPTS, type StarterPromptDefinition, type StarterPromptIcon } from '@/app/lib/chat/starter-prompts';
 import { getSessionDisplayTitle } from '@/app/lib/pi/session-titles';
@@ -462,7 +462,7 @@ export function HomeChatPrompt() {
     setIsSubmitting(true);
 
     try {
-      window.sessionStorage.removeItem(CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY);
+      clearCanvasChatActiveSessionStorage();
       // Store prompt and attachments in sessionStorage
       const data = {
         prompt: normalizedPrompt,

--- a/app/components/home/PromptHero.tsx
+++ b/app/components/home/PromptHero.tsx
@@ -5,7 +5,7 @@ import { getPathname } from '@/i18n/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 import { Send, Paperclip, Loader2 } from 'lucide-react';
 import { getFileIconComponent } from '@/app/lib/files/file-icons';
-import { CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY, CANVAS_CHAT_INITIAL_PROMPT_STORAGE_KEY } from '@/app/lib/chat/constants';
+import { clearCanvasChatActiveSessionStorage, CANVAS_CHAT_INITIAL_PROMPT_STORAGE_KEY } from '@/app/lib/chat/constants';
 import { DEFAULT_AGENT_ID } from '@/app/lib/channels/constants';
 import { ChatAgentSelector } from '@/app/components/canvas-agent-chat/ChatAgentSelector';
 import { AttachmentPreviewDialog } from '@/app/components/canvas-agent-chat/AttachmentPreviewDialog';
@@ -413,7 +413,7 @@ export function PromptHero({ licenseLocked = false }: { licenseLocked?: boolean 
     setIsSubmitting(true);
 
     try {
-      window.sessionStorage.removeItem(CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY);
+      clearCanvasChatActiveSessionStorage();
       const data = {
         prompt: normalizedPrompt,
         attachments: attachments,

--- a/app/components/shared/ImageThumbnailIcon.tsx
+++ b/app/components/shared/ImageThumbnailIcon.tsx
@@ -8,6 +8,7 @@ import { toPreviewUrl } from '@/app/lib/utils/media-url';
 interface ImageThumbnailIconProps {
   path: string;
   name: string;
+  workspaceId?: string | null;
   className?: string;
   imageClassName?: string;
   fallbackIcon?: ReactNode;
@@ -16,6 +17,7 @@ interface ImageThumbnailIconProps {
 export function ImageThumbnailIcon({
   path,
   name,
+  workspaceId,
   className,
   imageClassName,
   fallbackIcon,
@@ -34,7 +36,7 @@ export function ImageThumbnailIcon({
     <span className={cn('block h-5 w-5 shrink-0 overflow-hidden rounded border border-border/70 bg-muted/40', className)}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        src={toPreviewUrl(path, 64, { preset: 'mini' })}
+        src={toPreviewUrl(path, 64, { preset: 'mini', workspaceId })}
         alt={name}
         className={cn('h-full w-full object-cover', imageClassName)}
         loading="lazy"

--- a/app/components/workspaces/WorkspaceDestinationPicker.tsx
+++ b/app/components/workspaces/WorkspaceDestinationPicker.tsx
@@ -1,26 +1,13 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
+import { ChevronsUpDown, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { DirectoryBrowser } from '@/app/components/file-browser/DirectoryBrowser';
 import type { FileNode } from '@/app/lib/files/types';
 import { loadWorkspaceTree } from '@/app/lib/files/client';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
 import {
   getWorkspaceKindLabel,
   type WorkspaceKindLabels,
@@ -67,7 +54,6 @@ export function WorkspaceDestinationPicker({
   const [loadingDirs, setLoadingDirs] = useState(new Set<string>());
   const [isLoadingTree, setIsLoadingTree] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
   const latestWorkspaceIdRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -139,9 +125,9 @@ export function WorkspaceDestinationPicker({
   }, [effectiveWorkspaceId, t]);
 
   const handleWorkspaceSelect = (workspaceId: string) => {
+    if (!workspaceId) return;
     onWorkspaceChange(workspaceId);
     onDirChange('.');
-    setWorkspaceMenuOpen(false);
   };
 
   const handleToggleDir = (dirPath: string) => {
@@ -185,55 +171,25 @@ export function WorkspaceDestinationPicker({
     );
   }
 
-  const selectedWorkspace = writableWorkspaces.find((workspace) => workspace.id === effectiveWorkspaceId);
-
   return (
     <div className={cn('min-w-0 space-y-3', className)}>
       <label className="flex min-w-0 flex-col gap-1 text-sm">
         <span className="text-xs font-medium text-muted-foreground">{t('targetWorkspace')}</span>
-        <Popover open={workspaceMenuOpen} onOpenChange={setWorkspaceMenuOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              type="button"
-              variant="outline"
-              role="combobox"
-              aria-expanded={workspaceMenuOpen}
-              className="h-9 min-w-0 justify-between px-2 text-left font-normal"
-            >
-              <span className="min-w-0 truncate">
-                {selectedWorkspace
-                  ? `${selectedWorkspace.name} - ${getWorkspaceKindLabel(selectedWorkspace, kindLabels)}`
-                  : t('targetWorkspace')}
-              </span>
-              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-1">
-            <Command>
-              <CommandList>
-                <CommandEmpty>{t('noWritableWorkspace')}</CommandEmpty>
-                <CommandGroup>
-                  {writableWorkspaces.map((workspace) => {
-                    const selected = workspace.id === effectiveWorkspaceId;
-                    return (
-                      <CommandItem
-                        key={workspace.id}
-                        value={`${workspace.name} ${workspace.id}`}
-                        onSelect={() => handleWorkspaceSelect(workspace.id)}
-                      >
-                        <Check className={cn('h-4 w-4', selected ? 'opacity-100' : 'opacity-0')} />
-                        <span className="min-w-0 flex-1 truncate">{workspace.name}</span>
-                        <span className="shrink-0 text-xs text-muted-foreground">
-                          {getWorkspaceKindLabel(workspace, kindLabels)}
-                        </span>
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
+        <span className="relative block">
+          <select
+            value={effectiveWorkspaceId ?? ''}
+            onChange={(event) => handleWorkspaceSelect(event.target.value)}
+            className="h-9 w-full appearance-none rounded-md border border-input bg-background px-2 pr-8 text-left text-sm font-normal shadow-xs outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {!effectiveWorkspaceId ? <option value="">{t('targetWorkspace')}</option> : null}
+            {writableWorkspaces.map((workspace) => (
+              <option key={workspace.id} value={workspace.id}>
+                {workspace.name} - {getWorkspaceKindLabel(workspace, kindLabels)}
+              </option>
+            ))}
+          </select>
+          <ChevronsUpDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        </span>
       </label>
 
       <div className="min-w-0 overflow-hidden rounded-md border border-border bg-muted/40 px-3 py-2">

--- a/app/components/workspaces/WorkspaceSwitcher.tsx
+++ b/app/components/workspaces/WorkspaceSwitcher.tsx
@@ -1,10 +1,19 @@
 'use client';
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Check, ChevronsUpDown, Loader2, Lock, RefreshCw } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,7 +35,7 @@ import {
   type WorkspaceSwitchSource,
 } from '@/app/store/workspace-store';
 
-type WorkspaceSwitcherVariant = 'default' | 'compact' | 'toolbar';
+type WorkspaceSwitcherVariant = 'default' | 'compact' | 'toolbar' | 'mobile-sheet';
 
 type WorkspaceSwitcherProps = {
   source: WorkspaceSwitchSource;
@@ -48,6 +57,7 @@ function getAccessLabel(workspace: ClientWorkspaceSummary, labels: WorkspaceAcce
 
 export function WorkspaceSwitcher({ source, variant = 'default', className }: WorkspaceSwitcherProps) {
   const t = useTranslations('workspaces');
+  const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
   const workspaces = useWorkspaceStore((state) => state.workspaces);
   const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
   const isLoading = useWorkspaceStore((state) => state.isLoading);
@@ -70,6 +80,7 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
 
   const isCompact = variant === 'compact';
   const isToolbar = variant === 'toolbar';
+  const isMobileSheet = variant === 'mobile-sheet';
   const kindLabels = {
     personal: t('types.personal'),
     team: t('types.team'),
@@ -82,6 +93,108 @@ export function WorkspaceSwitcher({ source, variant = 'default', className }: Wo
   } satisfies WorkspaceAccessLabels;
   const activeLabel = activeWorkspace?.name || (isLoading && !initialized ? t('loadingWorkspace') : t('label'));
   const canSwitch = workspaces.length > 1;
+
+  if (isMobileSheet) {
+    const buttonTitle = activeWorkspace ? `${activeWorkspace.name} · ${getAccessLabel(activeWorkspace, accessLabels)}` : activeLabel;
+
+    return (
+      <Sheet open={mobileSheetOpen} onOpenChange={setMobileSheetOpen}>
+        <SheetTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isLoading && !initialized}
+            data-testid="workspace-switcher"
+            data-active-workspace-id={activeWorkspace?.id ?? ''}
+            data-active-workspace-type={activeWorkspace?.type ?? ''}
+            className={cn('h-10 w-full justify-between gap-2 px-3 text-left', className)}
+            title={buttonTitle}
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              {isLoading && !initialized ? (
+                <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+              ) : (
+                renderWorkspaceIcon(activeWorkspace, 'h-4 w-4 shrink-0')
+              )}
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-semibold">{activeLabel}</span>
+                {activeWorkspace ? (
+                  <span className="block truncate text-[11px] font-normal text-muted-foreground">
+                    {getWorkspaceKindLabel(activeWorkspace, kindLabels)} · {getAccessLabel(activeWorkspace, accessLabels)}
+                  </span>
+                ) : null}
+              </span>
+            </span>
+            <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </Button>
+        </SheetTrigger>
+        <SheetContent side="bottom" className="max-h-[75dvh] gap-0 overflow-hidden rounded-t-xl p-0">
+          <SheetHeader className="border-b border-border px-4 py-3 text-left">
+            <SheetTitle>{t('label')}</SheetTitle>
+            <SheetDescription>
+              {activeWorkspace ? `${activeWorkspace.name} · ${getAccessLabel(activeWorkspace, accessLabels)}` : activeLabel}
+            </SheetDescription>
+          </SheetHeader>
+          <div className="max-h-[calc(75dvh-5rem)] overflow-y-auto p-2">
+            <button
+              type="button"
+              className="mb-1 flex h-9 w-full items-center justify-center gap-2 rounded-md text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              onClick={() => void refreshWorkspaces()}
+            >
+              <RefreshCw className={cn('h-3.5 w-3.5', isLoading && 'animate-spin')} />
+              {t('refresh')}
+            </button>
+            {error ? (
+              <div className="rounded-md px-2 py-1.5 text-xs text-destructive">{error}</div>
+            ) : null}
+            {workspaces.length === 0 && !error ? (
+              <div className="px-2 py-3 text-sm text-muted-foreground">
+                {isLoading ? t('loadingWorkspaces') : t('noWorkspaceAvailable')}
+              </div>
+            ) : null}
+            {workspaces.map((workspace) => {
+              const isActive = workspace.id === activeWorkspace?.id;
+              const disabled = workspace.status !== 'active' || !workspace.permissions.canRead;
+              const item = (
+                <button
+                  type="button"
+                  disabled={disabled}
+                  data-testid={`workspace-option-${workspace.id}`}
+                  className={cn(
+                    'flex w-full items-start gap-3 rounded-md px-3 py-3 text-left transition-colors',
+                    disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-accent hover:text-accent-foreground',
+                    isActive && 'bg-accent/70'
+                  )}
+                  onClick={() => {
+                    if (disabled) return;
+                    handleSelect(workspace);
+                    setMobileSheetOpen(false);
+                  }}
+                >
+                  {renderWorkspaceIcon(workspace, 'mt-0.5 h-4 w-4 shrink-0')}
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">{workspace.name}</span>
+                    <span className="block truncate text-[11px] text-muted-foreground">
+                      {getWorkspaceKindLabel(workspace, kindLabels)} · {getAccessLabel(workspace, accessLabels)}
+                    </span>
+                  </span>
+                  {isActive ? <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" /> : null}
+                </button>
+              );
+
+              return disabled ? (
+                <div key={workspace.id}>{item}</div>
+              ) : (
+                <SheetClose key={workspace.id} asChild>
+                  {item}
+                </SheetClose>
+              );
+            })}
+          </div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
 
   if (!canSwitch && activeWorkspace && isCompact) {
     return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -594,6 +594,22 @@ li.task-list-item > p {
   cursor: grabbing;
 }
 
+.tiptap-block-drag-overlay {
+  border-radius: 0.375rem;
+  left: 4.5rem;
+  pointer-events: none;
+  right: 1.25rem;
+}
+
+.tiptap-block-drag-overlay-source {
+  background: color-mix(in oklab, var(--primary) 9%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--primary) 20%, transparent);
+}
+
+.tiptap-block-drag-overlay-target {
+  background: color-mix(in oklab, var(--primary) 5%, transparent);
+}
+
 .tiptap-block-drop-indicator {
   background: var(--primary);
   border-radius: 999px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -594,6 +594,16 @@ li.task-list-item > p {
   cursor: grabbing;
 }
 
+.tiptap-block-drop-indicator {
+  background: var(--primary);
+  border-radius: 999px;
+  height: 2px;
+  left: 4.75rem;
+  pointer-events: none;
+  right: 1.5rem;
+  transform: translateY(-1px);
+}
+
 .tiptap-color-swatch-widget-root {
   display: inline-flex;
   vertical-align: -0.125rem;

--- a/app/lib/chat/constants.ts
+++ b/app/lib/chat/constants.ts
@@ -1,2 +1,31 @@
 export const CANVAS_CHAT_INITIAL_PROMPT_STORAGE_KEY = 'canvas.chat.initialPrompt';
 export const CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY = 'canvas.chat.activeSessionId';
+
+export function getCanvasChatActiveSessionStorageKey(workspaceId?: string | null): string {
+  const normalizedWorkspaceId = workspaceId?.trim();
+  return normalizedWorkspaceId
+    ? `${CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY}:${normalizedWorkspaceId}`
+    : CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY;
+}
+
+export function clearCanvasChatActiveSessionStorage(workspaceId?: string | null): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    if (workspaceId?.trim()) {
+      window.sessionStorage.removeItem(getCanvasChatActiveSessionStorageKey(workspaceId));
+      return;
+    }
+
+    window.sessionStorage.removeItem(CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY);
+    const scopedKeyPrefix = `${CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY}:`;
+    for (let index = window.sessionStorage.length - 1; index >= 0; index -= 1) {
+      const key = window.sessionStorage.key(index);
+      if (key?.startsWith(scopedKeyPrefix)) {
+        window.sessionStorage.removeItem(key);
+      }
+    }
+  } catch {
+    // Session restore is a convenience only; ignore storage failures.
+  }
+}

--- a/app/lib/chat/constants.ts
+++ b/app/lib/chat/constants.ts
@@ -18,13 +18,6 @@ export function clearCanvasChatActiveSessionStorage(workspaceId?: string | null)
     }
 
     window.sessionStorage.removeItem(CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY);
-    const scopedKeyPrefix = `${CANVAS_CHAT_ACTIVE_SESSION_STORAGE_KEY}:`;
-    for (let index = window.sessionStorage.length - 1; index >= 0; index -= 1) {
-      const key = window.sessionStorage.key(index);
-      if (key?.startsWith(scopedKeyPrefix)) {
-        window.sessionStorage.removeItem(key);
-      }
-    }
   } catch {
     // Session restore is a convenience only; ignore storage failures.
   }

--- a/app/lib/chat/session-api.ts
+++ b/app/lib/chat/session-api.ts
@@ -31,8 +31,11 @@ export type CreateChatSessionResponse = {
   };
 };
 
-export async function fetchChatSessions(agentId = 'all'): Promise<AISession[]> {
+export async function fetchChatSessions(agentId = 'all', options: { workspaceId?: string | null } = {}): Promise<AISession[]> {
   const params = new URLSearchParams({ agentId });
+  if (options.workspaceId) {
+    params.set('workspaceId', options.workspaceId);
+  }
   const res = await fetch(`/api/sessions?${params.toString()}`);
   const data = await safeFetchJson<{ success: boolean; sessions?: AISession[] }>(res);
   return data?.success ? data.sessions || [] : [];
@@ -77,6 +80,7 @@ export async function fetchChatSessionMessages(params: {
   before?: number | null;
   beforeId?: number | null;
   beforeSequence?: number | null;
+  workspaceId?: string | null;
   signal?: AbortSignal;
   cache?: RequestCache;
   credentials?: RequestCredentials;
@@ -94,6 +98,9 @@ export async function fetchChatSessionMessages(params: {
   }
   if (params.beforeId !== null && params.beforeId !== undefined) {
     searchParams.set('beforeId', String(params.beforeId));
+  }
+  if (params.workspaceId) {
+    searchParams.set('workspaceId', params.workspaceId);
   }
 
   const response = await fetch(`/api/sessions/messages?${searchParams.toString()}`, {

--- a/app/lib/chat/session-cache.ts
+++ b/app/lib/chat/session-cache.ts
@@ -56,6 +56,9 @@ function normalizeCachedSessionEntry(value: unknown): CachedChatSession | null {
     return null;
   }
 
+  const workspaceValue = isRecord(sessionValue.workspace) ? sessionValue.workspace : null;
+  const workspaceType = workspaceValue?.workspaceType;
+
   const session: AISession = {
     id: typeof sessionValue.id === 'number' ? sessionValue.id : cachedAt,
     sessionId,
@@ -71,6 +74,16 @@ function normalizeCachedSessionEntry(value: unknown): CachedChatSession | null {
     runtimePhase: normalizeSessionRuntimePhase(sessionValue.runtimePhase),
     runtimeActiveToolName: typeof sessionValue.runtimeActiveToolName === 'string' ? sessionValue.runtimeActiveToolName : null,
     hasUnread: typeof sessionValue.hasUnread === 'boolean' ? sessionValue.hasUnread : false,
+    workspace: workspaceValue && typeof workspaceValue.workspaceId === 'string'
+      ? {
+          workspaceId: workspaceValue.workspaceId,
+          workspaceType: workspaceType === 'team' || workspaceType === 'project' ? workspaceType : 'personal',
+          workspaceName: typeof workspaceValue.workspaceName === 'string' ? workspaceValue.workspaceName : 'Workspace',
+          organizationId: typeof workspaceValue.organizationId === 'string' ? workspaceValue.organizationId : null,
+          rootRelativePath: typeof workspaceValue.rootRelativePath === 'string' ? workspaceValue.rootRelativePath : null,
+          legacy: Boolean(workspaceValue.legacy),
+        }
+      : null,
     creator: isRecord(sessionValue.creator)
       ? {
           name: typeof sessionValue.creator.name === 'string' ? sessionValue.creator.name : null,

--- a/app/lib/editor/prosemirror-ranges.ts
+++ b/app/lib/editor/prosemirror-ranges.ts
@@ -25,3 +25,12 @@ export function clampEditorRangeToDoc(editor: Editor, range: Range): Range | nul
 
   return { from, to };
 }
+
+export function getSlashCommandDeletionRange(editor: Editor, range: Range): Range | null {
+  if (range.from === range.to || !isEditorRangeInsideDoc(editor, range)) {
+    return null;
+  }
+
+  const rangeText = editor.state.doc.textBetween(range.from, range.to, '\n', '\n');
+  return rangeText.startsWith('/') ? range : null;
+}

--- a/app/lib/editor/reorderable-blocks.ts
+++ b/app/lib/editor/reorderable-blocks.ts
@@ -1,5 +1,6 @@
 import type { Editor, Range } from '@tiptap/core';
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { Selection } from '@tiptap/pm/state';
 
 export type BlockInsertPlacement = 'above' | 'below';
 
@@ -19,6 +20,14 @@ export type BlockControlPosition = {
   blockRange: ReorderableBlockRange;
   menuRange: Range;
   top: number;
+};
+
+export type BlockDropPlacement = 'before' | 'after';
+
+export type BlockDropTarget = {
+  insertPosition: number;
+  placement: BlockDropPlacement;
+  target: ReorderableBlockRange;
 };
 
 export function findActiveTextblockDepth(editor: Editor): number | null {
@@ -103,7 +112,7 @@ function getListItemBlockRangeAt(
   return null;
 }
 
-function getReorderableBlockRangeAt(
+export function getReorderableBlockRangeAt(
   editor: Editor,
   position: number,
   source?: ReorderableBlockRange,
@@ -215,13 +224,33 @@ export function getBlockDropInsertPosition(
   event: DragEvent,
   source: ReorderableBlockRange,
 ): number | null {
+  return getBlockDropTarget(editor, event, source)?.insertPosition ?? null;
+}
+
+export function getBlockDropTarget(
+  editor: Editor,
+  event: DragEvent,
+  source: ReorderableBlockRange,
+): BlockDropTarget | null {
   const positionAtCoords = editor.view.posAtCoords({
     left: event.clientX,
     top: event.clientY,
   });
 
   if (!positionAtCoords) {
-    return source.kind === 'topLevel' ? editor.state.doc.content.size : null;
+    if (source.kind !== 'topLevel') return null;
+
+    const insertPosition = editor.state.doc.content.size;
+    if (insertPosition >= source.from && insertPosition <= source.to) return null;
+
+    const target = getTopLevelBlockRangeAt(editor, insertPosition);
+    if (!target) return null;
+
+    return {
+      insertPosition,
+      placement: 'after',
+      target,
+    };
   }
 
   const target = getReorderableBlockRangeAt(editor, positionAtCoords.pos, source);
@@ -231,37 +260,71 @@ export function getBlockDropInsertPosition(
 
   const targetDom = editor.view.nodeDOM(target.from);
   const targetRect = targetDom instanceof HTMLElement ? targetDom.getBoundingClientRect() : null;
-  const insertPosition = targetRect
+  const placement: BlockDropPlacement = targetRect
     ? event.clientY < targetRect.top + targetRect.height / 2
-      ? target.from
-      : target.to
+      ? 'before'
+      : 'after'
     : positionAtCoords.pos <= target.from
-      ? target.from
-      : target.to;
+      ? 'before'
+      : 'after';
+  const insertPosition = placement === 'before' ? target.from : target.to;
 
   if (insertPosition >= source.from && insertPosition <= source.to) {
     return null;
   }
 
-  return insertPosition;
+  return {
+    insertPosition,
+    placement,
+    target,
+  };
 }
 
-export function moveReorderableBlock(editor: Editor, source: ReorderableBlockRange, insertPosition: number) {
+export function getBlockDropIndicatorTop(
+  editor: Editor,
+  container: HTMLDivElement,
+  dropTarget: BlockDropTarget,
+): number | null {
+  const targetDom = editor.view.nodeDOM(dropTarget.target.from);
+  if (!(targetDom instanceof HTMLElement)) return null;
+
+  const containerRect = container.getBoundingClientRect();
+  const targetRect = targetDom.getBoundingClientRect();
+  const targetEdge = dropTarget.placement === 'before' ? targetRect.top : targetRect.bottom;
+
+  return Math.max(4, targetEdge - containerRect.top + container.scrollTop);
+}
+
+export function moveReorderableBlock(editor: Editor, source: ReorderableBlockRange, insertPosition: number): boolean {
   const sourceSize = source.to - source.from;
   const adjustedInsertPosition = insertPosition > source.from ? insertPosition - sourceSize : insertPosition;
 
-  if (adjustedInsertPosition === source.from) return;
+  if (adjustedInsertPosition === source.from) return false;
 
   try {
     const transaction = editor.state.tr
       .delete(source.from, source.to)
       .insert(adjustedInsertPosition, source.node)
       .scrollIntoView();
+    const selectionPosition = Math.min(adjustedInsertPosition + 1, transaction.doc.content.size);
+
+    if (selectionPosition >= 0) {
+      transaction.setSelection(Selection.near(transaction.doc.resolve(selectionPosition), 1));
+    }
 
     editor.view.dispatch(transaction);
-    editor.commands.focus();
   } catch {
     // Ignore invalid drops, for example when the browser reports coordinates
     // outside the reorderable parent list.
+    return false;
   }
+
+  try {
+    editor.commands.focus();
+  } catch {
+    // Focusing can fail in non-browser test environments after a successful
+    // transaction; the reorder itself is still complete.
+  }
+
+  return true;
 }

--- a/app/lib/editor/reorderable-blocks.ts
+++ b/app/lib/editor/reorderable-blocks.ts
@@ -1,0 +1,267 @@
+import type { Editor, Range } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+
+export type BlockInsertPlacement = 'above' | 'below';
+
+export type ReorderableBlockKind = 'topLevel' | 'listItem';
+
+export type ReorderableBlockRange = {
+  depth: number;
+  from: number;
+  kind: ReorderableBlockKind;
+  node: ProseMirrorNode;
+  parentFrom: number;
+  parentTo: number;
+  to: number;
+};
+
+export type BlockControlPosition = {
+  blockRange: ReorderableBlockRange;
+  menuRange: Range;
+  top: number;
+};
+
+export function findActiveTextblockDepth(editor: Editor): number | null {
+  const { $from } = editor.state.selection;
+
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    if ($from.node(depth).isTextblock) return depth;
+  }
+
+  return null;
+}
+
+function getTopLevelBlockRangeAt(editor: Editor, position: number): ReorderableBlockRange | null {
+  const docEnd = editor.state.doc.content.size;
+  const safePosition = Math.max(0, Math.min(position, docEnd));
+  let range: ReorderableBlockRange | null = null;
+
+  editor.state.doc.forEach((node, offset) => {
+    if (range) return;
+
+    const from = offset;
+    const to = offset + node.nodeSize;
+    const isInsideNode = safePosition >= from && safePosition < to;
+    const isAtDocumentEnd = safePosition === docEnd && safePosition === to;
+
+    if (isInsideNode || isAtDocumentEnd) {
+      range = {
+        depth: 1,
+        from,
+        kind: 'topLevel',
+        node,
+        parentFrom: 0,
+        parentTo: docEnd,
+        to,
+      };
+    }
+  });
+
+  return range;
+}
+
+function getListItemBlockRangeAt(
+  editor: Editor,
+  position: number,
+  requiredParent?: Pick<ReorderableBlockRange, 'parentFrom' | 'parentTo'>,
+): ReorderableBlockRange | null {
+  const doc = editor.state.doc;
+  const docEnd = doc.content.size;
+  if (docEnd <= 0) return null;
+
+  const safePosition = Math.max(0, Math.min(position, docEnd));
+  const resolvePosition = Math.max(0, Math.min(safePosition, docEnd - 1));
+  const $position = doc.resolve(resolvePosition);
+
+  for (let depth = $position.depth; depth > 0; depth -= 1) {
+    const node = $position.node(depth);
+    if (node.type.name !== 'listItem') continue;
+
+    const parentDepth = depth - 1;
+    const parentNode = $position.node(parentDepth);
+    if (parentNode.type.name !== 'bulletList' && parentNode.type.name !== 'orderedList' && parentNode.type.name !== 'taskList') {
+      continue;
+    }
+
+    const parentFrom = $position.start(parentDepth);
+    const parentTo = $position.end(parentDepth);
+    if (requiredParent && (parentFrom !== requiredParent.parentFrom || parentTo !== requiredParent.parentTo)) {
+      continue;
+    }
+
+    return {
+      depth,
+      from: $position.before(depth),
+      kind: 'listItem',
+      node,
+      parentFrom,
+      parentTo,
+      to: $position.after(depth),
+    };
+  }
+
+  return null;
+}
+
+function getReorderableBlockRangeAt(
+  editor: Editor,
+  position: number,
+  source?: ReorderableBlockRange,
+): ReorderableBlockRange | null {
+  if (source?.kind === 'listItem') {
+    return getListItemBlockRangeAt(editor, position, source);
+  }
+
+  if (source?.kind === 'topLevel') {
+    return getTopLevelBlockRangeAt(editor, position);
+  }
+
+  return getListItemBlockRangeAt(editor, position) ?? getTopLevelBlockRangeAt(editor, position);
+}
+
+function createEmptyListItemNode(editor: Editor, source: ReorderableBlockRange) {
+  const paragraph = editor.schema.nodes.paragraph.create();
+  return source.node.type.createAndFill(null, paragraph) ?? source.node.type.create(null, paragraph);
+}
+
+export function createInsertedBlockCommandTarget(
+  editor: Editor,
+  placement: BlockInsertPlacement,
+  blockRange?: ReorderableBlockRange,
+): Range | null {
+  if (!editor.isEditable || editor.isActive('codeBlock')) return null;
+
+  if (blockRange) {
+    const insertPosition = placement === 'above' ? blockRange.from : blockRange.to;
+    const isListItem = blockRange.kind === 'listItem';
+    const cursorPosition = insertPosition + (isListItem ? 2 : 1);
+    const content = isListItem ? createEmptyListItemNode(editor, blockRange) : { type: 'paragraph' };
+
+    editor.chain().focus().insertContentAt(insertPosition, content).setTextSelection(cursorPosition).run();
+
+    return { from: cursorPosition, to: cursorPosition };
+  }
+
+  const { $from } = editor.state.selection;
+  const textblockDepth = findActiveTextblockDepth(editor);
+  if (!textblockDepth) return null;
+
+  const topLevelDepth = $from.depth >= 1 ? 1 : textblockDepth;
+  const insertPosition = placement === 'above' ? $from.before(topLevelDepth) : $from.after(topLevelDepth);
+  const cursorPosition = insertPosition + 1;
+  editor
+    .chain()
+    .focus()
+    .insertContentAt(insertPosition, { type: 'paragraph' })
+    .setTextSelection(cursorPosition)
+    .run();
+
+  return { from: cursorPosition, to: cursorPosition };
+}
+
+export function createCurrentBlockCommandTarget(editor: Editor, menuRange?: Range): Range | null {
+  if (!editor.isEditable || editor.isActive('codeBlock')) return null;
+
+  if (menuRange) {
+    editor.chain().focus().setTextSelection(menuRange.from).run();
+    return menuRange;
+  }
+
+  const { $from } = editor.state.selection;
+  const textblockDepth = findActiveTextblockDepth(editor);
+  if (!textblockDepth) return null;
+
+  const position = $from.start(textblockDepth);
+  editor.chain().focus().setTextSelection(position).run();
+  return { from: position, to: position };
+}
+
+export function getBlockInsertButtonPosition(editor: Editor, container: HTMLDivElement): BlockControlPosition | null {
+  if (!editor.isEditable || editor.isActive('codeBlock')) return null;
+
+  const { $from } = editor.state.selection;
+  const textblockDepth = findActiveTextblockDepth(editor);
+  if (!textblockDepth) return null;
+
+  const blockRange = getReorderableBlockRangeAt(editor, editor.state.selection.from);
+  if (!blockRange) return null;
+
+  const blockDom = editor.view.nodeDOM(blockRange.from);
+  const containerRect = container.getBoundingClientRect();
+  const menuPosition = $from.start(textblockDepth);
+  const menuRange = { from: menuPosition, to: menuPosition };
+
+  if (blockDom instanceof HTMLElement) {
+    const blockRect = blockDom.getBoundingClientRect();
+    return {
+      blockRange,
+      menuRange,
+      top: Math.max(6, blockRect.top - containerRect.top + container.scrollTop + (blockRect.height / 2) - 12),
+    };
+  }
+
+  const positionForCoords = Math.min(blockRange.from + 1, editor.state.doc.content.size);
+  const coords = editor.view.coordsAtPos(positionForCoords);
+
+  return {
+    blockRange,
+    menuRange,
+    top: Math.max(6, coords.top - containerRect.top + container.scrollTop),
+  };
+}
+
+export function getBlockDropInsertPosition(
+  editor: Editor,
+  event: DragEvent,
+  source: ReorderableBlockRange,
+): number | null {
+  const positionAtCoords = editor.view.posAtCoords({
+    left: event.clientX,
+    top: event.clientY,
+  });
+
+  if (!positionAtCoords) {
+    return source.kind === 'topLevel' ? editor.state.doc.content.size : null;
+  }
+
+  const target = getReorderableBlockRangeAt(editor, positionAtCoords.pos, source);
+  if (!target) {
+    return null;
+  }
+
+  const targetDom = editor.view.nodeDOM(target.from);
+  const targetRect = targetDom instanceof HTMLElement ? targetDom.getBoundingClientRect() : null;
+  const insertPosition = targetRect
+    ? event.clientY < targetRect.top + targetRect.height / 2
+      ? target.from
+      : target.to
+    : positionAtCoords.pos <= target.from
+      ? target.from
+      : target.to;
+
+  if (insertPosition >= source.from && insertPosition <= source.to) {
+    return null;
+  }
+
+  return insertPosition;
+}
+
+export function moveReorderableBlock(editor: Editor, source: ReorderableBlockRange, insertPosition: number) {
+  const sourceSize = source.to - source.from;
+  const adjustedInsertPosition = insertPosition > source.from ? insertPosition - sourceSize : insertPosition;
+
+  if (adjustedInsertPosition === source.from) return;
+
+  try {
+    const transaction = editor.state.tr
+      .delete(source.from, source.to)
+      .insert(adjustedInsertPosition, source.node)
+      .scrollIntoView();
+
+    editor.view.dispatch(transaction);
+    editor.commands.focus();
+  } catch {
+    // Ignore invalid drops, for example when the browser reports coordinates
+    // outside the reorderable parent list.
+  }
+}

--- a/app/lib/editor/reorderable-blocks.ts
+++ b/app/lib/editor/reorderable-blocks.ts
@@ -30,6 +30,11 @@ export type BlockDropTarget = {
   target: ReorderableBlockRange;
 };
 
+export type BlockOverlayRect = {
+  height: number;
+  top: number;
+};
+
 export function findActiveTextblockDepth(editor: Editor): number | null {
   const { $from } = editor.state.selection;
 
@@ -293,6 +298,23 @@ export function getBlockDropIndicatorTop(
   const targetEdge = dropTarget.placement === 'before' ? targetRect.top : targetRect.bottom;
 
   return Math.max(4, targetEdge - containerRect.top + container.scrollTop);
+}
+
+export function getBlockOverlayRect(
+  editor: Editor,
+  container: HTMLDivElement,
+  blockRange: ReorderableBlockRange,
+): BlockOverlayRect | null {
+  const blockDom = editor.view.nodeDOM(blockRange.from);
+  if (!(blockDom instanceof HTMLElement)) return null;
+
+  const containerRect = container.getBoundingClientRect();
+  const blockRect = blockDom.getBoundingClientRect();
+
+  return {
+    height: Math.max(20, blockRect.height),
+    top: Math.max(4, blockRect.top - containerRect.top + container.scrollTop),
+  };
 }
 
 export function moveReorderableBlock(editor: Editor, source: ReorderableBlockRange, insertPosition: number): boolean {

--- a/app/lib/integrations/legacy-secret-migration.ts
+++ b/app/lib/integrations/legacy-secret-migration.ts
@@ -105,7 +105,12 @@ function parseEnvEntries(content: string): EnvEntry[] {
 function formatEnvValue(value: string): string {
   if (!value) return '';
   if (/^[A-Za-z0-9_./:-]+$/u.test(value)) return value;
-  return `"${value.replace(/\\/gu, '\\\\').replace(/"/gu, '\\"')}"`;
+  return `"${value
+    .replace(/\\/gu, '\\\\')
+    .replace(/"/gu, '\\"')
+    .replace(/\n/gu, '\\n')
+    .replace(/\r/gu, '\\r')
+    .replace(/\t/gu, '\\t')}"`;
 }
 
 function serializeEnvEntries(entries: EnvEntry[]): string {

--- a/app/lib/integrations/legacy-secret-migration.ts
+++ b/app/lib/integrations/legacy-secret-migration.ts
@@ -1,0 +1,224 @@
+import 'server-only';
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
+import {
+  createAtomicTempPath,
+  normalizeDataScopeId,
+  resolveDefaultAgentsEnvPath,
+  resolveDefaultIntegrationsEnvPath,
+  resolveScopedAgentsEnvPath,
+  resolveScopedIntegrationsEnvPath,
+  resolveSystemMigrationDir,
+} from '@/app/lib/runtime-data-paths';
+
+type EnvKind = 'integrations' | 'agents';
+
+type EnvEntry = {
+  key: string;
+  value: string;
+};
+
+export type LegacySecretMigrationResult = {
+  status: 'migrated' | 'skipped';
+  reason?: 'already_migrated' | 'source_missing' | 'source_empty';
+  markerPath: string;
+  userId: string;
+  migratedFiles: Array<{
+    kind: EnvKind;
+    sourcePath: string;
+    targetPath: string;
+    copiedKeys: string[];
+    preservedKeys: string[];
+  }>;
+};
+
+type LegacySecretMigrationManifest = {
+  schemaVersion: 1;
+  operation: 'legacy-secrets-to-user-scope';
+  userId: string;
+  importedAt: string;
+  migratedFiles: LegacySecretMigrationResult['migratedFiles'];
+};
+
+const LEGACY_ENV_FILES: Array<{
+  kind: EnvKind;
+  legacyPath: () => string;
+  scopedPath: (userId: string) => string;
+}> = [
+  {
+    kind: 'integrations',
+    legacyPath: resolveDefaultIntegrationsEnvPath,
+    scopedPath: (userId) => resolveScopedIntegrationsEnvPath({ userId }),
+  },
+  {
+    kind: 'agents',
+    legacyPath: resolveDefaultAgentsEnvPath,
+    scopedPath: (userId) => resolveScopedAgentsEnvPath({ userId }),
+  },
+];
+
+function markerPathFor(userId: string): string {
+  return path.join(
+    resolveSystemMigrationDir(),
+    'legacy-secret-imports',
+    `${normalizeDataScopeId(userId, 'userId')}.json`,
+  );
+}
+
+function parseEnvEntries(content: string): EnvEntry[] {
+  const entries: EnvEntry[] = [];
+
+  for (const rawLine of content.split(/\r?\n/u)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const normalized = trimmed.startsWith('export ') ? trimmed.slice(7).trim() : trimmed;
+    const equalsIndex = normalized.indexOf('=');
+    if (equalsIndex <= 0) continue;
+
+    const key = normalized.slice(0, equalsIndex).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key)) continue;
+
+    let value = normalized.slice(equalsIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    entries.push({ key, value });
+  }
+
+  return entries;
+}
+
+function formatEnvValue(value: string): string {
+  if (!value) return '';
+  if (/^[A-Za-z0-9_./:-]+$/u.test(value)) return value;
+  return `"${value.replace(/\\/gu, '\\\\').replace(/"/gu, '\\"')}"`;
+}
+
+function serializeEnvEntries(entries: EnvEntry[]): string {
+  if (entries.length === 0) return '';
+  const sorted = [...entries].sort((a, b) => a.key.localeCompare(b.key));
+  return `${sorted.map((entry) => `${entry.key}=${formatEnvValue(entry.value)}`).join('\n')}\n`;
+}
+
+function readEnvEntries(filePath: string): EnvEntry[] {
+  if (!isFile(filePath)) return [];
+  return parseEnvEntries(readFileSync(filePath, 'utf8'));
+}
+
+function isFile(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function writeEnvEntries(filePath: string, entries: EnvEntry[]): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = createAtomicTempPath(filePath);
+  writeFileSync(tempPath, serializeEnvEntries(entries), { encoding: 'utf8', mode: 0o600 });
+  renameSync(tempPath, filePath);
+}
+
+function writeManifest(markerPath: string, manifest: LegacySecretMigrationManifest): void {
+  mkdirSync(path.dirname(markerPath), { recursive: true });
+  const tempPath = createAtomicTempPath(markerPath);
+  writeFileSync(tempPath, `${JSON.stringify(manifest, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  renameSync(tempPath, markerPath);
+}
+
+export function migrateLegacySecretsToUserScope(userId: string): LegacySecretMigrationResult {
+  const markerPath = markerPathFor(userId);
+  if (existsSync(markerPath)) {
+    return {
+      status: 'skipped',
+      reason: 'already_migrated',
+      markerPath,
+      userId,
+      migratedFiles: [],
+    };
+  }
+
+  const migratedFiles: LegacySecretMigrationResult['migratedFiles'] = [];
+  let sawLegacyFile = false;
+  let sawLegacyEntries = false;
+
+  for (const file of LEGACY_ENV_FILES) {
+    const sourcePath = file.legacyPath();
+    if (!isFile(sourcePath)) continue;
+
+    sawLegacyFile = true;
+    const legacyEntries = readEnvEntries(sourcePath);
+    if (legacyEntries.length === 0) continue;
+
+    sawLegacyEntries = true;
+    const targetPath = file.scopedPath(userId);
+    const targetEntries = readEnvEntries(targetPath);
+    const byKey = new Map(targetEntries.map((entry) => [entry.key, entry]));
+    const copiedKeys: string[] = [];
+    const preservedKeys: string[] = [];
+
+    for (const legacyEntry of legacyEntries) {
+      if (byKey.has(legacyEntry.key)) {
+        preservedKeys.push(legacyEntry.key);
+        continue;
+      }
+
+      byKey.set(legacyEntry.key, legacyEntry);
+      copiedKeys.push(legacyEntry.key);
+    }
+
+    if (copiedKeys.length > 0) {
+      writeEnvEntries(targetPath, Array.from(byKey.values()));
+    } else {
+      mkdirSync(path.dirname(targetPath), { recursive: true });
+    }
+
+    migratedFiles.push({
+      kind: file.kind,
+      sourcePath,
+      targetPath,
+      copiedKeys,
+      preservedKeys,
+    });
+  }
+
+  if (!sawLegacyFile || !sawLegacyEntries) {
+    return {
+      status: 'skipped',
+      reason: sawLegacyFile ? 'source_empty' : 'source_missing',
+      markerPath,
+      userId,
+      migratedFiles: [],
+    };
+  }
+
+  writeManifest(markerPath, {
+    schemaVersion: 1,
+    operation: 'legacy-secrets-to-user-scope',
+    userId,
+    importedAt: new Date().toISOString(),
+    migratedFiles,
+  });
+
+  return {
+    status: 'migrated',
+    markerPath,
+    userId,
+    migratedFiles,
+  };
+}

--- a/app/lib/integrations/media-reference-resolver.ts
+++ b/app/lib/integrations/media-reference-resolver.ts
@@ -5,6 +5,10 @@ import path from 'node:path';
 
 import { resolveCanvasDataRoot } from '@/app/lib/runtime-data-paths';
 import { fetchExternalResourceSafely } from '@/app/lib/security/safe-external-fetch';
+import { resolveExistingWorkspacePath } from '@/app/lib/filesystem/workspace-files';
+import { openOrganizationBootstrapDatabase } from '@/app/lib/organization/bootstrap';
+import { resolveWorkspaceActor } from '@/app/lib/workspaces/context';
+import { resolveWorkspaceContextById } from '@/app/lib/workspaces/service';
 import {
   getWorkspaceRoot,
   resolveValidatedStudioAssetPath,
@@ -58,6 +62,7 @@ export interface ResolvedMediaReference {
   fileName: string;
   mimeType: string;
   mediaType: MediaReferenceType;
+  workspaceId?: string | null;
 }
 
 export interface LoadedMediaFile {
@@ -123,16 +128,34 @@ function decodePath(filePath: string): string {
     .join('/');
 }
 
-function getLocalReferencePath(rawValue: string): { pathOnly: string; isRemoteUrl: boolean } | null {
+function extractWorkspaceId(searchParams: URLSearchParams): string | null {
+  const workspaceId = searchParams.get('workspaceId')?.trim();
+  return workspaceId || null;
+}
+
+function parseLocalPath(rawValue: string): { pathOnly: string; workspaceId: string | null } | null {
+  const withoutHash = rawValue.split('#', 1)[0] || '';
+  const queryIndex = withoutHash.indexOf('?');
+  const pathOnly = (queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash).trim();
+  if (!pathOnly) return null;
+
+  const query = queryIndex >= 0 ? withoutHash.slice(queryIndex + 1) : '';
+  return {
+    pathOnly,
+    workspaceId: query ? extractWorkspaceId(new URLSearchParams(query)) : null,
+  };
+}
+
+function getLocalReferencePath(rawValue: string): { pathOnly: string; isRemoteUrl: boolean; workspaceId: string | null } | null {
   try {
     const parsed = new URL(rawValue);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
       return null;
     }
-    return { pathOnly: parsed.pathname, isRemoteUrl: true };
+    return { pathOnly: parsed.pathname, isRemoteUrl: true, workspaceId: extractWorkspaceId(parsed.searchParams) };
   } catch {
-    const pathOnly = rawValue.split(/[?#]/, 1)[0]?.trim();
-    return pathOnly ? { pathOnly, isRemoteUrl: false } : null;
+    const localPath = parseLocalPath(rawValue);
+    return localPath ? { ...localPath, isRemoteUrl: false } : null;
   }
 }
 
@@ -161,6 +184,7 @@ function makeResolvedReference(
   input: string,
   relativePath: string,
   absolutePath: string | null,
+  workspaceId?: string | null,
 ): ResolvedMediaReference | null {
   const normalizedRelativePath = relativePath.replace(/^\/+/, '');
   if (kind !== 'external_url' && !isSafeRelativePath(normalizedRelativePath)) {
@@ -179,6 +203,7 @@ function makeResolvedReference(
     ),
     mimeType,
     mediaType,
+    workspaceId: workspaceId || null,
   };
 }
 
@@ -231,7 +256,7 @@ export function classifyMediaReference(input: string, options: Pick<LoadMediaRef
     return null;
   }
 
-  const { pathOnly, isRemoteUrl } = localPath;
+  const { pathOnly, isRemoteUrl, workspaceId } = localPath;
   if (pathOnly.startsWith('/api/studio/references/')) {
     const referenceId = decodePath(pathOnly.slice('/api/studio/references/'.length));
     if (!referenceId || referenceId.includes('/') || referenceId.includes('\\') || referenceId.includes('..')) {
@@ -253,7 +278,13 @@ export function classifyMediaReference(input: string, options: Pick<LoadMediaRef
 
   if (pathOnly.startsWith('/api/media/')) {
     const relativePath = decodePath(pathOnly.slice('/api/media/'.length));
-    return makeResolvedReference('workspace_relative', rawValue, relativePath, resolveValidatedWorkspaceRelativePath(relativePath));
+    return makeResolvedReference(
+      'workspace_relative',
+      rawValue,
+      relativePath,
+      workspaceId ? null : resolveValidatedWorkspaceRelativePath(relativePath),
+      workspaceId,
+    );
   }
 
   const workspaceRoot = getWorkspaceRoot();
@@ -267,7 +298,14 @@ export function classifyMediaReference(input: string, options: Pick<LoadMediaRef
     return makeResolvedReference('external_url', rawValue, rawValue, null);
   }
 
-  return makeResolvedReference('workspace_relative', rawValue, decodePath(pathOnly.replace(/^\.?\//, '')), resolveValidatedWorkspaceRelativePath(decodePath(pathOnly.replace(/^\.?\//, ''))));
+  const relativePath = decodePath(pathOnly.replace(/^\.?\//, ''));
+  return makeResolvedReference(
+    'workspace_relative',
+    rawValue,
+    relativePath,
+    workspaceId ? null : resolveValidatedWorkspaceRelativePath(relativePath),
+    workspaceId,
+  );
 }
 
 function assertAllowedType(ref: ResolvedMediaReference, allowedTypes: MediaReferenceType[] | undefined): void {
@@ -284,10 +322,44 @@ function assertAllowedType(ref: ResolvedMediaReference, allowedTypes: MediaRefer
   }
 }
 
-async function readFilesystemReference(ref: ResolvedMediaReference, maxBytes: number): Promise<{ buffer: Buffer; absolutePath: string }> {
-  const candidates = [ref.absolutePath].filter(Boolean) as string[];
+async function resolveWorkspaceScopedReferencePath(
+  ref: ResolvedMediaReference,
+  options: LoadMediaReferenceOptions,
+): Promise<string | null> {
+  if (!ref.workspaceId || (ref.kind !== 'workspace_relative' && ref.kind !== 'workspace_absolute')) {
+    return null;
+  }
+
+  if (!options.userId) {
+    throw new Error(`Workspace-scoped reference requires user context: ${ref.sourceId}`);
+  }
+
+  const sqlite = openOrganizationBootstrapDatabase();
+  try {
+    const workspace = resolveWorkspaceContextById(sqlite, {
+      actor: resolveWorkspaceActor({ id: options.userId }),
+      workspaceId: ref.workspaceId,
+    });
+
+    if (!workspace || !workspace.permissions.canRead) {
+      throw new Error(`Workspace reference is not readable: ${ref.sourceId}`);
+    }
+
+    return await resolveExistingWorkspacePath(ref.relativePath, { workspace });
+  } finally {
+    sqlite.close();
+  }
+}
+
+async function readFilesystemReference(
+  ref: ResolvedMediaReference,
+  maxBytes: number,
+  options: LoadMediaReferenceOptions,
+): Promise<{ buffer: Buffer; absolutePath: string }> {
+  const workspaceScopedPath = await resolveWorkspaceScopedReferencePath(ref, options);
+  const candidates = [workspaceScopedPath, ref.absolutePath].filter(Boolean) as string[];
   if (ref.kind === 'workspace_relative' || ref.kind === 'workspace_absolute' || ref.kind === 'studio_asset' || ref.kind === 'studio_output') {
-    const dataFallback = resolveWithinRoot(resolveCanvasDataRoot(), ref.relativePath);
+    const dataFallback = ref.workspaceId ? null : resolveWithinRoot(resolveCanvasDataRoot(), ref.relativePath);
     if (dataFallback && !candidates.includes(dataFallback)) {
       candidates.push(dataFallback);
     }
@@ -340,7 +412,7 @@ export async function loadMediaReference(input: string, options: LoadMediaRefere
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
   const loaded = ref.kind === 'external_url'
     ? await fetchExternalReference(ref, maxBytes, options.timeoutMs ?? DEFAULT_EXTERNAL_TIMEOUT_MS)
-    : { buffer: (await readFilesystemReference(ref, maxBytes)).buffer, mimeType: ref.mimeType };
+    : { buffer: (await readFilesystemReference(ref, maxBytes, options)).buffer, mimeType: ref.mimeType };
   const buffer = loaded.buffer;
   const mimeType = loaded.mimeType === 'application/octet-stream' ? ref.mimeType : loaded.mimeType;
   if (options.allowedTypes?.length) {

--- a/app/lib/integrations/studio-aspect-ratio-service.ts
+++ b/app/lib/integrations/studio-aspect-ratio-service.ts
@@ -331,7 +331,7 @@ export async function createAspectRatioPreview(
   storageScope?: EnvStorageScope | null,
 ): Promise<AspectRatioPreviewResult> {
   const request = validatePreviewRequest(input);
-  const source = await loadMediaReference(request.sourcePath, { allowedTypes: ['image'] });
+  const source = await loadMediaReference(request.sourcePath, { userId: storageScope?.userId ?? undefined, allowedTypes: ['image'] });
   const sourceBytes = source.bytes;
   const metadata = await sharp(sourceBytes, { limitInputPixels: false }).metadata();
   const sourceWidth = metadata.width || source.width || 0;

--- a/app/lib/integrations/studio-generation-service.ts
+++ b/app/lib/integrations/studio-generation-service.ts
@@ -1061,6 +1061,7 @@ async function executeStudioGenerationProcessing(
           nsfwChecker: parsedMeta.videoNsfwChecker,
         },
         storageScope,
+        userId,
       );
     } else if (mode === 'sound') {
       outputs = await generateStudioSound(
@@ -1346,6 +1347,7 @@ async function generateStudioVideo(
     nsfwChecker?: boolean;
   },
   storageScope?: EnvStorageScope | null,
+  userId?: string | null,
 ): Promise<StudioGenerationOutput[]> {
   if (!prompt && !videoExtendSourcePath) {
     throw new StudioServiceError(
@@ -1380,6 +1382,7 @@ async function generateStudioVideo(
       referenceAudios,
       videoOptions,
       storageScope,
+      userId,
     );
   }
 
@@ -1425,7 +1428,7 @@ async function generateStudioVideo(
     requestBody.referenceImagePaths = tempPaths;
   }
 
-  const videoResult = await generateVideo(requestBody, 'studio-generation');
+  const videoResult = await generateVideo(requestBody, 'studio-generation', { userId });
 
   const outputId = randomUUID();
   const now = new Date();
@@ -1458,9 +1461,9 @@ async function generateStudioVideo(
   }];
 }
 
-async function loadSeedanceFrame(filePath: string): Promise<SeedanceReferenceMedia> {
+async function loadSeedanceFrame(filePath: string, userId?: string | null): Promise<SeedanceReferenceMedia> {
   try {
-    const file = await loadMediaReference(filePath, { allowedTypes: ['image'] });
+    const file = await loadMediaReference(filePath, { userId: userId ?? undefined, allowedTypes: ['image'] });
     return {
       imageBytes: file.imageBytes,
       mimeType: file.mimeType,
@@ -1504,11 +1507,12 @@ async function generateStudioSeedanceVideo(
     nsfwChecker?: boolean;
   },
   storageScope?: EnvStorageScope | null,
+  userId?: string | null,
 ): Promise<StudioGenerationOutput[]> {
   console.log(`[Studio Generation] Seedance video: refs=${referenceImages.length}, startFrame=${startFramePath ? 'yes' : 'no'}, endFrame=${endFramePath ? 'yes' : 'no'}, duration=${videoDuration || 6}s`);
-  const firstFrame = startFramePath ? await loadSeedanceFrame(startFramePath) : null;
+  const firstFrame = startFramePath ? await loadSeedanceFrame(startFramePath, userId) : null;
   const lastFramePath = isLooping ? startFramePath : endFramePath;
-  const lastFrame = lastFramePath ? await loadSeedanceFrame(lastFramePath) : null;
+  const lastFrame = lastFramePath ? await loadSeedanceFrame(lastFramePath, userId) : null;
   console.log(`[Studio Generation] Seedance frames loaded: first=${firstFrame ? `${firstFrame.mimeType} ${firstFrame.fileName}` : 'none'}, last=${lastFrame ? `${lastFrame.mimeType} ${lastFrame.fileName}` : 'none'}`);
 
   const hasFrameScenario = Boolean(firstFrame || lastFrame);

--- a/app/lib/integrations/veo-generation-service.ts
+++ b/app/lib/integrations/veo-generation-service.ts
@@ -54,6 +54,10 @@ export interface VideoGenerationResultData {
   metadata: Record<string, unknown>;
 }
 
+interface GenerateVideoOptions {
+  userId?: string | null;
+}
+
 function sanitizePrompt(prompt: string): string {
   return prompt.replace(/\s+/g, ' ').trim();
 }
@@ -67,9 +71,9 @@ function promptToSlug(prompt: string): string {
   return slug || 'video';
 }
 
-async function loadImageBytes(filePath: string): Promise<{ imageBytes: string; mimeType: string }> {
+async function loadImageBytes(filePath: string, options: GenerateVideoOptions = {}): Promise<{ imageBytes: string; mimeType: string }> {
   try {
-    const file = await loadMediaReference(filePath, { allowedTypes: ['image'] });
+    const file = await loadMediaReference(filePath, { userId: options.userId ?? undefined, allowedTypes: ['image'] });
     return {
       imageBytes: file.imageBytes,
       mimeType: file.mimeType,
@@ -79,9 +83,9 @@ async function loadImageBytes(filePath: string): Promise<{ imageBytes: string; m
   }
 }
 
-async function loadVideoBytes(filePath: string): Promise<{ videoBytes: string; mimeType: string }> {
+async function loadVideoBytes(filePath: string, options: GenerateVideoOptions = {}): Promise<{ videoBytes: string; mimeType: string }> {
   try {
-    const file = await loadMediaReference(filePath, { allowedTypes: ['video'] });
+    const file = await loadMediaReference(filePath, { userId: options.userId ?? undefined, allowedTypes: ['video'] });
     return {
       videoBytes: file.videoBytes,
       mimeType: file.mimeType,
@@ -143,6 +147,7 @@ async function fetchOperationVideo(
 export async function generateVideo(
   body: GenerateVideoRequestBody,
   callerEmail = 'system',
+  options: GenerateVideoOptions = {},
 ): Promise<VideoGenerationResultData> {
   const apiKey = await getGeminiApiKeyFromIntegrations(body.storageScope);
   const useManagedFallback = !apiKey && isManagedMediaFallbackAvailable();
@@ -208,23 +213,23 @@ export async function generateVideo(
       if (!body.startFramePath) {
         throw new IntegrationServiceError('Start frame is required.', 400);
       }
-      references.push({ ...(await loadImageBytes(body.startFramePath)), role: 'start_frame' });
+      references.push({ ...(await loadImageBytes(body.startFramePath, options)), role: 'start_frame' });
       const endFramePath = body.isLooping ? null : body.endFramePath;
-      if (endFramePath) references.push({ ...(await loadImageBytes(endFramePath)), role: 'end_frame' });
+      if (endFramePath) references.push({ ...(await loadImageBytes(endFramePath, options)), role: 'end_frame' });
       for (const sourcePath of (body.referenceImagePaths || []).slice(0, VEO_MAX_REFERENCE_IMAGES)) {
-        references.push({ ...(await loadImageBytes(sourcePath)), role: 'reference' });
+        references.push({ ...(await loadImageBytes(sourcePath, options)), role: 'reference' });
       }
     }
     if (mode === 'references_to_video') {
       for (const sourcePath of (body.referenceImagePaths || []).slice(0, VEO_MAX_REFERENCE_IMAGES)) {
-        references.push({ ...(await loadImageBytes(sourcePath)), role: 'reference' });
+        references.push({ ...(await loadImageBytes(sourcePath, options)), role: 'reference' });
       }
     }
     if (mode === 'extend_video') {
       if (!body.inputVideoPath) {
         throw new IntegrationServiceError('Input video is required for extend mode.', 400);
       }
-      const video = await loadVideoBytes(body.inputVideoPath);
+      const video = await loadVideoBytes(body.inputVideoPath, options);
       references.push({
         imageBytes: video.videoBytes,
         mimeType: video.mimeType,
@@ -335,12 +340,12 @@ export async function generateVideo(
       throw new IntegrationServiceError('Start frame is required.', 400);
     }
 
-    const startFrame = await loadImageBytes(body.startFramePath);
+    const startFrame = await loadImageBytes(body.startFramePath, options);
     payload.image = startFrame;
 
     const endFramePath = body.isLooping ? body.startFramePath : body.endFramePath;
     if (endFramePath) {
-      const endFrame = await loadImageBytes(endFramePath);
+      const endFrame = await loadImageBytes(endFramePath, options);
       config.lastFrame = endFrame;
     }
 
@@ -348,7 +353,7 @@ export async function generateVideo(
     if (sourcePaths.length > 0 && caps.references) {
       const referenceImages: VideoGenerationReferenceImage[] = [];
       for (const sourcePath of sourcePaths) {
-        const image = await loadImageBytes(sourcePath);
+        const image = await loadImageBytes(sourcePath, options);
         referenceImages.push({
           image,
           referenceType: VideoGenerationReferenceType.ASSET,
@@ -369,7 +374,7 @@ export async function generateVideo(
 
     const referenceImages: VideoGenerationReferenceImage[] = [];
     for (const sourcePath of sourcePaths) {
-      const image = await loadImageBytes(sourcePath);
+      const image = await loadImageBytes(sourcePath, options);
       referenceImages.push({
         image,
         referenceType: VideoGenerationReferenceType.ASSET,
@@ -383,7 +388,7 @@ export async function generateVideo(
     if (!body.inputVideoPath) {
       throw new IntegrationServiceError('Input video is required for extend mode.', 400);
     }
-    payload.video = await loadVideoBytes(body.inputVideoPath);
+    payload.video = await loadVideoBytes(body.inputVideoPath, options);
   }
 
   let operation = (await ai.models.generateVideos(payload as never)) as GenerateVideosOperation;

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 
 import { getBootstrapAdminEmail } from '@/app/lib/bootstrap-admin';
 import { runMigrations } from '@/app/lib/db/migrate';
+import { migrateLegacySecretsToUserScope } from '@/app/lib/integrations/legacy-secret-migration';
 import {
   type DatabaseProvider,
   getDatabaseProvider as resolveConfiguredDatabaseProvider,
@@ -458,6 +459,7 @@ export function ensureOrganizationBootstrapForUser(
     userId: ownerUser.id,
     personalWorkspace: ownerWorkspaceRecords.personal,
   });
+  migrateLegacySecretsToUserScope(ownerUser.id);
   if (targetUser.id !== ownerUser.id) {
     ensureScopedDirectories(organization.organization_id, targetUser.id, teamFeaturesEnabled);
     ensureDefaultWorkspaceRecords(sqlite, {

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -32,6 +32,7 @@ import {
   resolveUserSettingsDir,
   resolveUserSkillsDir,
 } from '@/app/lib/runtime-data-paths';
+import { migrateLegacyWorkspaceToPersonalWorkspace } from '@/app/lib/workspaces/legacy-migration';
 import { ensureDefaultWorkspaceRecords } from '@/app/lib/workspaces/service';
 import { resolveWorkspaceDataRoot } from '@/app/lib/workspaces/context';
 
@@ -447,10 +448,15 @@ export function ensureOrganizationBootstrapForUser(
   }
 
   ensureScopedDirectories(organization.organization_id, ownerUser.id, teamFeaturesEnabled);
-  ensureDefaultWorkspaceRecords(sqlite, {
+  const ownerWorkspaceRecords = ensureDefaultWorkspaceRecords(sqlite, {
     organizationId: organization.organization_id,
     userId: ownerUser.id,
     teamFeaturesEnabled,
+  });
+  migrateLegacyWorkspaceToPersonalWorkspace({
+    organizationId: organization.organization_id,
+    userId: ownerUser.id,
+    personalWorkspace: ownerWorkspaceRecords.personal,
   });
   if (targetUser.id !== ownerUser.id) {
     ensureScopedDirectories(organization.organization_id, targetUser.id, teamFeaturesEnabled);

--- a/app/lib/organization/bootstrap.ts
+++ b/app/lib/organization/bootstrap.ts
@@ -454,12 +454,20 @@ export function ensureOrganizationBootstrapForUser(
     userId: ownerUser.id,
     teamFeaturesEnabled,
   });
-  migrateLegacyWorkspaceToPersonalWorkspace({
-    organizationId: organization.organization_id,
-    userId: ownerUser.id,
-    personalWorkspace: ownerWorkspaceRecords.personal,
-  });
-  migrateLegacySecretsToUserScope(ownerUser.id);
+  try {
+    migrateLegacyWorkspaceToPersonalWorkspace({
+      organizationId: organization.organization_id,
+      userId: ownerUser.id,
+      personalWorkspace: ownerWorkspaceRecords.personal,
+    });
+  } catch (error) {
+    console.warn('[organization-bootstrap] Legacy workspace migration failed:', error);
+  }
+  try {
+    migrateLegacySecretsToUserScope(ownerUser.id);
+  } catch (error) {
+    console.warn('[organization-bootstrap] Legacy secret migration failed:', error);
+  }
   if (targetUser.id !== ownerUser.id) {
     ensureScopedDirectories(organization.organization_id, targetUser.id, teamFeaturesEnabled);
     ensureDefaultWorkspaceRecords(sqlite, {

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -1780,12 +1780,12 @@ function shellRedirectWritesManagedPath(command: string, cdsIntoManagedPath: boo
 }
 
 function shellUsesDirectFileMutationCommand(command: string): boolean {
-  const directMutationCommandPattern = /(?:^|[;&|]\s*|\b(?:then|do)\s+)(?:sudo\s+)?(?:rm|mv|cp|mkdir|rmdir|touch|chmod|chown|chgrp|ln|truncate|dd|rsync|install)\b/i;
+  const directMutationCommandPattern = /(?:^|[;&|]\s*|\$\(\s*|`\s*|\b(?:then|do)\s+)(?:sudo\s+)?(?:rm|mv|cp|mkdir|rmdir|touch|chmod|chown|chgrp|ln|truncate|dd|rsync|install)\b/i;
   return directMutationCommandPattern.test(command);
 }
 
 function shellUsesMutatingGitCommand(command: string): boolean {
-  const gitMutationPattern = /(?:^|[;&|]\s*|\b(?:then|do)\s+)(?:sudo\s+)?git\s+(?:clean|reset|checkout|restore|switch|merge|rebase|apply|am)\b/i;
+  const gitMutationPattern = /(?:^|[;&|]\s*|\$\(\s*|`\s*|\b(?:then|do)\s+)(?:sudo\s+)?git\s+(?:clean|reset|checkout|restore|switch|merge|rebase|apply|am)\b/i;
   return gitMutationPattern.test(command);
 }
 

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -1779,6 +1779,16 @@ function shellRedirectWritesManagedPath(command: string, cdsIntoManagedPath: boo
   });
 }
 
+function shellUsesDirectFileMutationCommand(command: string): boolean {
+  const directMutationCommandPattern = /(?:^|[;&|]\s*|\b(?:then|do)\s+)(?:sudo\s+)?(?:rm|mv|cp|mkdir|rmdir|touch|chmod|chown|chgrp|ln|truncate|dd|rsync|install)\b/i;
+  return directMutationCommandPattern.test(command);
+}
+
+function shellUsesMutatingGitCommand(command: string): boolean {
+  const gitMutationPattern = /(?:^|[;&|]\s*|\b(?:then|do)\s+)(?:sudo\s+)?git\s+(?:clean|reset|checkout|restore|switch|merge|rebase|apply|am)\b/i;
+  return gitMutationPattern.test(command);
+}
+
 export function detectUnsafeBashCommand(command: string): string | null {
   const secretPatterns = [
     /\b(?:env|printenv)\b/i,
@@ -1806,6 +1816,14 @@ export function detectUnsafeBashCommand(command: string): string | null {
   const mentionsManagedPath = /\/data\/(?:workspace|workspaces|agents)(?:\/|$)/.test(normalized) ||
     Boolean(executionContext?.workspaceRoot && normalized.includes(executionContext.workspaceRoot));
   const cdsIntoManagedPath = /\bcd\s+\/data\/(?:workspace|workspaces|agents)(?:\/|$|\s)/.test(normalized);
+
+  if (shellUsesDirectFileMutationCommand(normalized)) {
+    return 'Direct shell file mutations are blocked. Use write, edit_file, apply_patch, copy_path, move_path, or delete_path so workspace permissions, revisions, and audit logs are enforced.';
+  }
+
+  if (shellUsesMutatingGitCommand(normalized)) {
+    return 'Mutating git commands are blocked in bash. Use dedicated file tools or ask the user before changing repository state.';
+  }
 
   if (/\bsed\b(?=[^;&|]*\s-[A-Za-z]*i(?:\b|\.|['"]|$))/.test(normalized)) {
     return 'Unsafe in-place file edits with sed are blocked. Use edit_file or apply_patch instead.';

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -49,6 +49,13 @@ import {
   type RuntimeContinuationDecision,
 } from '@/app/lib/pi/run-continuation-guard';
 import { and, eq } from 'drizzle-orm';
+import {
+  applyPiRuntimePromptContext,
+  type PiRuntimePromptContext,
+  type RuntimePromptContextTarget,
+} from '@/app/lib/pi/runtime-prompt-context';
+
+export type { PiRuntimePromptContext } from '@/app/lib/pi/runtime-prompt-context';
 
 const IDLE_TTL_MS = 15 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 60 * 1000;
@@ -130,48 +137,6 @@ export type RuntimeErrorEvent = {
 };
 
 export type PiRuntimeStreamEvent = AgentEvent | RuntimeStatusEvent | ContextCompactedEvent | RuntimeErrorEvent;
-export type PiRuntimePromptContext = {
-  channelId?: string;
-  activeFilePath?: string | null;
-  userTimeZone?: string;
-  currentTime?: string;
-  workspace?: {
-    workspaceId: string;
-    workspaceType: 'personal' | 'team' | 'project';
-    workspaceName: string;
-    organizationId?: string | null;
-    canWrite: boolean;
-    canShare: boolean;
-  };
-  planningMode?: boolean;
-  currentPage?: string;
-  studioContext?: {
-    generationId?: string;
-    currentOutputId?: string;
-    generationPrompt?: string | null;
-    generationPresetId?: string | null;
-    generationProductIds?: string[];
-    generationPersonaIds?: string[];
-    outputFilePath?: string | null;
-    outputMediaUrl?: string | null;
-    activeImagePath?: string | null;
-  };
-  emailContext?: {
-    accountEmail?: string;
-    accountId?: string;
-    filter?: 'all' | 'unread';
-    folder?: string;
-    folderName?: string;
-    query?: string;
-    selectedMessageDate?: string | null;
-    selectedMessageFolder?: string;
-    selectedMessageFrom?: string | null;
-    selectedMessageId?: string;
-    selectedMessageIsRead?: boolean | null;
-    selectedMessageSubject?: string | null;
-  };
-};
-
 type RuntimeSubscriber = (event: PiRuntimeStreamEvent) => void;
 
 type RuntimeQueueEntry = {
@@ -351,36 +316,10 @@ function getRuntimeStatusSignature(status: PiRuntimeStatus): string {
   });
 }
 
-type PiRuntimePromptDispatchTarget = {
-  setChannelContext: (channelId: string | undefined) => void;
-  setTimeZoneContext: (timeZone: string, currentTime: string) => void;
-  setActiveFileContext: (path: string | null) => void;
-  setPlanningMode: (enabled: boolean) => void;
-  setPageContext: (page: string | undefined) => void;
-  setStudioContext: (context: PiRuntimePromptContext['studioContext']) => void;
-  setEmailContext: (context: PiRuntimePromptContext['emailContext']) => void;
-  setWorkspaceContext: (context: PiRuntimePromptContext['workspace']) => void;
+type PiRuntimePromptDispatchTarget = RuntimePromptContextTarget & {
   reloadTools: () => Promise<void>;
   startPrompt: (message: Extract<AgentMessage, { role: 'user' }>) => void;
 };
-
-function applyPiRuntimePromptContext(
-  runtime: PiRuntimePromptDispatchTarget,
-  context?: PiRuntimePromptContext,
-) {
-  runtime.setChannelContext(context?.channelId);
-
-  if (context?.userTimeZone && context.currentTime) {
-    runtime.setTimeZoneContext(context.userTimeZone, context.currentTime);
-  }
-
-  runtime.setActiveFileContext(context?.activeFilePath ?? null);
-  runtime.setPlanningMode(context?.planningMode ?? false);
-  runtime.setPageContext(context?.currentPage);
-  runtime.setStudioContext(context?.studioContext);
-  runtime.setEmailContext(context?.emailContext);
-  runtime.setWorkspaceContext(context?.workspace);
-}
 
 class LivePiRuntime {
   readonly sessionId: string;

--- a/app/lib/pi/runtime-prompt-context.ts
+++ b/app/lib/pi/runtime-prompt-context.ts
@@ -1,0 +1,32 @@
+import type { ChatRequestContext } from '@/app/lib/chat/types';
+
+export type PiRuntimePromptContext = ChatRequestContext;
+
+export type RuntimePromptContextTarget = {
+  setChannelContext: (channelId: string | undefined) => void;
+  setTimeZoneContext: (timeZone: string, currentTime: string) => void;
+  setActiveFileContext: (path: string | null) => void;
+  setPlanningMode: (enabled: boolean) => void;
+  setPageContext: (page: string | undefined) => void;
+  setStudioContext: (context: PiRuntimePromptContext['studioContext']) => void;
+  setEmailContext: (context: PiRuntimePromptContext['emailContext']) => void;
+  setWorkspaceContext: (context: PiRuntimePromptContext['workspace']) => void;
+};
+
+export function applyPiRuntimePromptContext(
+  runtime: RuntimePromptContextTarget,
+  context?: PiRuntimePromptContext,
+): void {
+  runtime.setChannelContext(context?.channelId);
+
+  if (context?.userTimeZone && context.currentTime) {
+    runtime.setTimeZoneContext(context.userTimeZone, context.currentTime);
+  }
+
+  runtime.setActiveFileContext(context?.activeFilePath ?? null);
+  runtime.setPlanningMode(context?.planningMode ?? false);
+  runtime.setPageContext(context?.currentPage);
+  runtime.setStudioContext(context?.studioContext);
+  runtime.setEmailContext(context?.emailContext);
+  runtime.setWorkspaceContext(context?.workspace);
+}

--- a/app/lib/pi/runtime-service.ts
+++ b/app/lib/pi/runtime-service.ts
@@ -13,6 +13,7 @@ import {
   invalidatePiRuntime,
   type PiRuntimeStatus,
 } from '@/app/lib/pi/live-runtime';
+import { applyPiRuntimePromptContext } from '@/app/lib/pi/runtime-prompt-context';
 import { getStudioOutputsRoot } from '@/app/lib/integrations/studio-workspace';
 import { normalizeTimeZone } from '@/app/lib/time-zones';
 import { getUserPreferredTimeZone } from '@/app/lib/user-preferences';
@@ -216,20 +217,6 @@ async function injectStudioImage(
   return message;
 }
 
-function applyPromptContext(runtimeInstance: RuntimeInstance, context: ChatRequestContext): void {
-  runtimeInstance.setChannelContext(context.channelId);
-
-  if (context.userTimeZone && context.currentTime) {
-    runtimeInstance.setTimeZoneContext(context.userTimeZone, context.currentTime);
-  }
-
-  runtimeInstance.setActiveFileContext(context.activeFilePath ?? null);
-  runtimeInstance.setPlanningMode(context.planningMode === true);
-  runtimeInstance.setPageContext(context.currentPage);
-  runtimeInstance.setStudioContext(context.studioContext);
-  runtimeInstance.setWorkspaceContext(context.workspace);
-}
-
 export async function prepareRuntimePrompt(
   sessionId: string,
   userId: string,
@@ -249,7 +236,7 @@ export async function prepareRuntimePrompt(
     throw new RuntimeServiceError('Prompt message required when no run is active.', 400);
   }
 
-  applyPromptContext(runtimeInstance, context);
+  applyPiRuntimePromptContext(runtimeInstance, context);
   if (!status.canAbort) {
     await runtimeInstance.reloadTools();
   }

--- a/app/lib/pi/tool-registry.ts
+++ b/app/lib/pi/tool-registry.ts
@@ -41,13 +41,6 @@ import {
   type MemoryTarget,
 } from '@/app/lib/agents/memory-store';
 import { assertUserOrganizationPermission } from '@/app/lib/organization/permissions';
-
-function assertBashCommandAllowed(command: string): void {
-  const blockedReason = detectUnsafeBashCommand(command);
-  if (blockedReason) {
-    throw new Error(blockedReason);
-  }
-}
 import { resolveAgentRuntimeSettings } from '../agents/effective-runtime-config';
 import { resolveEnabledToolNames, isLegacyEnabledToolsValue, getDefaultEnabledToolNames } from './enabled-tools';
 import { PLANNING_MODE_ALLOWED_TOOLS } from './planning-mode';
@@ -129,9 +122,24 @@ import {
 } from '@/app/lib/integrations/audio-transcription-service';
 import { getAgentExecutionContext, runWithAgentExecutionContext, type AgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
 import { resolveAgentExecutionContextForSession } from '@/app/lib/pi/session-workspace-context';
+import { hashAuditValue, recordAuditEvent, type AuditStatus } from '@/app/lib/audit/audit-service';
 
 
 const execAsync = promisify(exec);
+
+class BlockedBashCommandError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BlockedBashCommandError';
+  }
+}
+
+function assertBashCommandAllowed(command: string): void {
+  const blockedReason = detectUnsafeBashCommand(command);
+  if (blockedReason) {
+    throw new BlockedBashCommandError(blockedReason);
+  }
+}
 
 function wrapToolWithExecutionContext(tool: AgentTool, context: AgentExecutionContext): AgentTool {
   const execute = tool.execute;
@@ -142,6 +150,58 @@ function wrapToolWithExecutionContext(tool: AgentTool, context: AgentExecutionCo
       () => execute(toolCallId, params, signal),
     ),
   };
+}
+
+async function recordBashToolAudit(input: {
+  command: string;
+  status: AuditStatus;
+  durationMs: number;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+  exitCode?: string | number | null;
+}) {
+  const executionContext = getAgentExecutionContext();
+  if (!executionContext) return;
+
+  const commandHash = hashAuditValue({ command: input.command });
+  await recordAuditEvent({
+    organizationId: executionContext.organizationId,
+    customerId: executionContext.customerId,
+    projectId: executionContext.projectId,
+    workspaceId: executionContext.workspaceId,
+    userId: executionContext.userId,
+    sessionId: executionContext.sessionId,
+    agentId: executionContext.agentId,
+    source: 'agent_tool',
+    eventType: 'command',
+    entityType: 'workspace_shell',
+    entityId: executionContext.workspaceId,
+    action: 'agent_bash.execute',
+    status: input.status,
+    summary: `Agent bash command ${input.status}.`,
+    metadata: {
+      commandHash,
+      commandLength: input.command.length,
+      durationMs: input.durationMs,
+      exitCode: input.exitCode ?? null,
+      stdoutBytes: Buffer.byteLength(input.stdout ?? '', 'utf8'),
+      stderrBytes: Buffer.byteLength(input.stderr ?? '', 'utf8'),
+      error: input.error ? input.error.slice(0, 500) : null,
+      workspace: {
+        workspaceId: executionContext.workspaceId,
+        workspaceType: executionContext.workspaceType,
+        workspaceName: executionContext.workspaceName,
+        workspaceRootRelativePath: executionContext.workspaceRootRelativePath,
+      },
+    },
+    inputHash: commandHash,
+    outputHash: hashAuditValue({
+      stdout: input.stdout ?? '',
+      stderr: input.stderr ?? '',
+      error: input.error ?? '',
+    }),
+  });
 }
 
 const DEFAULT_READ_TEXT_LIMIT = 40_000;
@@ -2418,12 +2478,13 @@ export const piTools: AgentTool[] = [
   {
     name: 'bash',
     label: 'Executing command',
-    description: 'Executes a bash command from the workspace bound to the current chat session. Prefer file tools for writes.',
+    description: 'Executes an inspection-oriented bash command from the workspace bound to the current chat session. Do not use this for file mutations; use write, edit_file, apply_patch, copy_path, move_path, or delete_path so workspace permissions, revisions, and audit logs are enforced.',
     parameters: Type.Object({
       command: Type.String({ description: 'The command to execute.' }),
     }),
     execute: async (toolCallId, params, signal) => {
       const { command } = params as { command: string };
+      const startedAt = Date.now();
       try {
         throwIfAborted(signal);
         assertBashCommandAllowed(command);
@@ -2432,6 +2493,14 @@ export const piTools: AgentTool[] = [
           env: filterSafeEnv(process.env) as NodeJS.ProcessEnv,
           signal,
         });
+        await recordBashToolAudit({
+          command,
+          status: 'success',
+          durationMs: Date.now() - startedAt,
+          stdout,
+          stderr,
+          exitCode: 0,
+        });
         const output = [stdout, stderr].filter(Boolean).join('\n');
         return {
           content: [{ type: 'text', text: output || '(no output)' }],
@@ -2439,6 +2508,12 @@ export const piTools: AgentTool[] = [
         };
       } catch (error: unknown) {
         if (isAbortError(error, signal)) {
+          await recordBashToolAudit({
+            command,
+            status: 'error',
+            durationMs: Date.now() - startedAt,
+            error: 'Tool execution aborted.',
+          });
           return {
             content: [{ type: 'text', text: 'Error: Tool execution aborted.' }],
             details: { error: 'Tool execution aborted.' },
@@ -2446,6 +2521,15 @@ export const piTools: AgentTool[] = [
         }
         const execError = asCommandExecutionError(error);
         const output = [execError.stdout, execError.stderr, execError.message].filter(Boolean).join('\n');
+        await recordBashToolAudit({
+          command,
+          status: error instanceof BlockedBashCommandError ? 'blocked' : 'failure',
+          durationMs: Date.now() - startedAt,
+          stdout: execError.stdout,
+          stderr: execError.stderr,
+          error: execError.message,
+          exitCode: execError.code ?? null,
+        });
         return {
           content: [{ type: 'text', text: output }],
           details: { error: execError.message, stdout: execError.stdout, stderr: execError.stderr },

--- a/app/lib/public-sharing/public-file-response.ts
+++ b/app/lib/public-sharing/public-file-response.ts
@@ -107,7 +107,7 @@ async function resolveResponseFile(
 
   const fullPath = workspacePath === resolved.workspacePath
     ? resolved.fullPath
-    : await resolveExistingWorkspacePath(workspacePath);
+    : await resolveExistingWorkspacePath(workspacePath, { workspace: resolved.workspace });
   const rootDir = path.dirname(resolved.fullPath);
   const realPath = await fs.realpath(fullPath);
   if (!isWithinDirectory(realPath, rootDir)) return null;

--- a/app/lib/public-sharing/public-file-shares.ts
+++ b/app/lib/public-sharing/public-file-shares.ts
@@ -81,6 +81,7 @@ export type PublicShareResolution = {
   ok: true;
   share: PublicShareDto;
   row: PublicShareRow;
+  workspace: WorkspaceContext;
   workspacePath: string;
   fullPath: string;
   sizeBytes: number;
@@ -935,7 +936,8 @@ async function resolvePublicShareRow(row: PublicShareRow, options: ResolvePublic
   }
 
   const withShortCode = await ensureShortCode(reconciled);
-  const details = await getWorkspaceFileDetails(withShortCode.workspacePath, workspaceForRow(withShortCode));
+  const workspace = workspaceForRow(withShortCode);
+  const details = await getWorkspaceFileDetails(withShortCode.workspacePath, workspace);
 
   const updated = options.recordAccess === false
     ? withShortCode
@@ -953,6 +955,7 @@ async function resolvePublicShareRow(row: PublicShareRow, options: ResolvePublic
     ok: true,
     share: toDto(updated, null),
     row: updated,
+    workspace,
     workspacePath: details.workspacePath,
     fullPath: details.fullPath,
     sizeBytes: details.sizeBytes,

--- a/app/lib/public-sharing/public-markdown-export.ts
+++ b/app/lib/public-sharing/public-markdown-export.ts
@@ -60,7 +60,7 @@ export async function getPublicMarkdownExport(token: string): Promise<PublicMark
     };
   }
 
-  const html = await getCachedMarkdownHtmlDocument(resolved.workspacePath);
+  const html = await getCachedMarkdownHtmlDocument(resolved.workspacePath, { workspace: resolved.workspace });
   return {
     ok: true,
     fileName: resolved.share.fileName,

--- a/app/lib/utils/media-url.ts
+++ b/app/lib/utils/media-url.ts
@@ -5,8 +5,22 @@ function encodePathSegments(filePath: string) {
     .join('/');
 }
 
-export function toWorkspaceMediaUrl(filePath: string) {
-  return `/api/media/${encodePathSegments(filePath.replace(/^\/+/, ''))}`;
+interface MediaUrlOptions {
+  workspaceId?: string | null;
+}
+
+interface PreviewUrlOptions extends MediaUrlOptions {
+  preset?: 'default' | 'mini';
+}
+
+function withWorkspaceId(url: string, options: MediaUrlOptions = {}) {
+  const workspaceId = options.workspaceId?.trim();
+  if (!workspaceId) return url;
+  return `${url}${url.includes('?') ? '&' : '?'}workspaceId=${encodeURIComponent(workspaceId)}`;
+}
+
+export function toWorkspaceMediaUrl(filePath: string, options: MediaUrlOptions = {}) {
+  return withWorkspaceId(`/api/media/${encodePathSegments(filePath.replace(/^\/+/, ''))}`, options);
 }
 
 export function toUploadMediaUrl(fileId: string) {
@@ -25,7 +39,7 @@ export function toUploadPreviewUrl(fileId: string, width: number, options: Previ
   return `/api/files/${encodeURIComponent(fileId)}/preview?${params.toString()}`;
 }
 
-export function toMediaUrl(filePath: string) {
+export function toMediaUrl(filePath: string, options: MediaUrlOptions = {}) {
   const encodedPath = encodePathSegments(filePath);
   
   if (filePath.startsWith('studio/')) {
@@ -51,7 +65,7 @@ export function toMediaUrl(filePath: string) {
   }
   
   // Use API route for media serving (works with Next.js standalone)
-  return `/api/media/${encodedPath}`;
+  return withWorkspaceId(`/api/media/${encodedPath}`, options);
 }
 
 export function toHtmlPreviewUrl(filePath: string) {
@@ -82,10 +96,6 @@ export function toHtmlPreviewUrl(filePath: string) {
   return `/api/media/preview/${encodedPath}`;
 }
 
-interface PreviewUrlOptions {
-  preset?: 'default' | 'mini';
-}
-
 export function toPreviewUrl(filePath: string, width: number, options: PreviewUrlOptions = {}) {
   const params = new URLSearchParams({
     path: filePath,
@@ -94,6 +104,10 @@ export function toPreviewUrl(filePath: string, width: number, options: PreviewUr
 
   if (options.preset && options.preset !== 'default') {
     params.set('preset', options.preset);
+  }
+
+  if (options.workspaceId?.trim()) {
+    params.set('workspaceId', options.workspaceId.trim());
   }
 
   // Use relative URLs so they work in both dev and production

--- a/app/lib/workspaces/legacy-migration.ts
+++ b/app/lib/workspaces/legacy-migration.ts
@@ -1,0 +1,222 @@
+import 'server-only';
+
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
+import { normalizeDataScopeId, resolveSystemMigrationDir } from '@/app/lib/runtime-data-paths';
+import { resolveLegacyWorkspaceRoot } from './context';
+import { workspaceAbsoluteRoot, type WorkspaceRecord } from './service';
+
+const LEGACY_WORKSPACE_IMPORT_NAME = '_legacy-workspace-import';
+const MARKER_VERSION = 1;
+const HIDDEN_LEGACY_METADATA_FILES = new Set(['.gitkeep', '.keep']);
+
+export type LegacyWorkspaceMigrationResult = {
+  status: 'migrated' | 'skipped';
+  reason?: 'already_migrated' | 'source_missing' | 'source_empty' | 'invalid_target';
+  markerPath: string;
+  sourceRoot: string;
+  targetRoot: string;
+  copiedEntries: string[];
+  conflictedEntries: string[];
+  conflictRootRelativePath: string | null;
+};
+
+type LegacyWorkspaceMigrationManifest = {
+  schemaVersion: number;
+  operation: 'legacy-workspace-to-personal-workspace';
+  organizationId: string;
+  userId: string;
+  sourceRoot: string;
+  targetRoot: string;
+  targetRootRelativePath: string;
+  importedAt: string;
+  copiedEntries: string[];
+  conflictedEntries: string[];
+  conflictRootRelativePath: string | null;
+};
+
+function safeMarkerName(organizationId: string, userId: string): string {
+  return `${normalizeDataScopeId(organizationId, 'organizationId')}--${normalizeDataScopeId(userId, 'userId')}.json`;
+}
+
+function markerPathFor(organizationId: string, userId: string): string {
+  return path.join(resolveSystemMigrationDir(), 'legacy-workspace-imports', safeMarkerName(organizationId, userId));
+}
+
+function isDirectory(targetPath: string): boolean {
+  try {
+    return statSync(targetPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function meaningfulLegacyEntries(sourceRoot: string): string[] {
+  return readdirSync(sourceRoot, { withFileTypes: true })
+    .filter((entry) => !HIDDEN_LEGACY_METADATA_FILES.has(entry.name))
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function importTimestamp(): string {
+  return new Date().toISOString().replace(/[:.]/gu, '-');
+}
+
+function workspaceRelativePath(...segments: string[]): string {
+  return segments.join('/').replace(/\/+/gu, '/');
+}
+
+function writeManifest(markerPath: string, manifest: LegacyWorkspaceMigrationManifest): void {
+  mkdirSync(path.dirname(markerPath), { recursive: true });
+  const tempPath = `${markerPath}.tmp-${Date.now()}-${process.pid}`;
+  writeFileSync(tempPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  renameSync(tempPath, markerPath);
+}
+
+function readExistingManifest(markerPath: string): Pick<LegacyWorkspaceMigrationResult, 'copiedEntries' | 'conflictedEntries' | 'conflictRootRelativePath'> {
+  try {
+    const manifest = JSON.parse(readFileSync(markerPath, 'utf8')) as Partial<LegacyWorkspaceMigrationManifest>;
+    return {
+      copiedEntries: Array.isArray(manifest.copiedEntries) ? manifest.copiedEntries.filter((entry) => typeof entry === 'string') : [],
+      conflictedEntries: Array.isArray(manifest.conflictedEntries) ? manifest.conflictedEntries.filter((entry) => typeof entry === 'string') : [],
+      conflictRootRelativePath: typeof manifest.conflictRootRelativePath === 'string' ? manifest.conflictRootRelativePath : null,
+    };
+  } catch {
+    return { copiedEntries: [], conflictedEntries: [], conflictRootRelativePath: null };
+  }
+}
+
+export function migrateLegacyWorkspaceToPersonalWorkspace(params: {
+  organizationId: string;
+  userId: string;
+  personalWorkspace: WorkspaceRecord;
+}): LegacyWorkspaceMigrationResult {
+  const sourceRoot = resolveLegacyWorkspaceRoot();
+  const targetRoot = workspaceAbsoluteRoot(params.personalWorkspace.rootRelativePath);
+  const markerPath = markerPathFor(params.organizationId, params.userId);
+
+  if (existsSync(markerPath)) {
+    const existing = readExistingManifest(markerPath);
+    return {
+      status: 'skipped',
+      reason: 'already_migrated',
+      markerPath,
+      sourceRoot,
+      targetRoot,
+      ...existing,
+    };
+  }
+
+  if (!isDirectory(sourceRoot)) {
+    return {
+      status: 'skipped',
+      reason: 'source_missing',
+      markerPath,
+      sourceRoot,
+      targetRoot,
+      copiedEntries: [],
+      conflictedEntries: [],
+      conflictRootRelativePath: null,
+    };
+  }
+
+  const sourceReal = path.resolve(sourceRoot);
+  const targetReal = path.resolve(targetRoot);
+  if (sourceReal === targetReal || targetReal.startsWith(`${sourceReal}${path.sep}`)) {
+    return {
+      status: 'skipped',
+      reason: 'invalid_target',
+      markerPath,
+      sourceRoot,
+      targetRoot,
+      copiedEntries: [],
+      conflictedEntries: [],
+      conflictRootRelativePath: null,
+    };
+  }
+
+  const entries = meaningfulLegacyEntries(sourceRoot);
+  if (entries.length === 0) {
+    return {
+      status: 'skipped',
+      reason: 'source_empty',
+      markerPath,
+      sourceRoot,
+      targetRoot,
+      copiedEntries: [],
+      conflictedEntries: [],
+      conflictRootRelativePath: null,
+    };
+  }
+
+  mkdirSync(targetRoot, { recursive: true });
+  const copiedEntries: string[] = [];
+  const conflictedEntries: string[] = [];
+  const conflictImportDirName = importTimestamp();
+  const conflictRootRelativePath = workspaceRelativePath(LEGACY_WORKSPACE_IMPORT_NAME, conflictImportDirName);
+  let conflictRootCreated = false;
+
+  for (const entry of entries) {
+    const sourcePath = path.join(sourceRoot, entry);
+    const directTargetPath = path.join(targetRoot, entry);
+
+    if (!existsSync(directTargetPath)) {
+      cpSync(sourcePath, directTargetPath, {
+        recursive: true,
+        preserveTimestamps: true,
+        errorOnExist: true,
+        force: false,
+      });
+      copiedEntries.push(entry);
+      continue;
+    }
+
+    if (!conflictRootCreated) {
+      mkdirSync(path.join(targetRoot, conflictRootRelativePath), { recursive: true });
+      conflictRootCreated = true;
+    }
+
+    cpSync(sourcePath, path.join(targetRoot, conflictRootRelativePath, entry), {
+      recursive: true,
+      preserveTimestamps: true,
+      errorOnExist: true,
+      force: false,
+    });
+    conflictedEntries.push(entry);
+  }
+
+  const manifest: LegacyWorkspaceMigrationManifest = {
+    schemaVersion: MARKER_VERSION,
+    operation: 'legacy-workspace-to-personal-workspace',
+    organizationId: params.organizationId,
+    userId: params.userId,
+    sourceRoot,
+    targetRoot,
+    targetRootRelativePath: params.personalWorkspace.rootRelativePath,
+    importedAt: new Date().toISOString(),
+    copiedEntries,
+    conflictedEntries,
+    conflictRootRelativePath: conflictedEntries.length > 0 ? conflictRootRelativePath : null,
+  };
+  writeManifest(markerPath, manifest);
+
+  return {
+    status: 'migrated',
+    markerPath,
+    sourceRoot,
+    targetRoot,
+    copiedEntries,
+    conflictedEntries,
+    conflictRootRelativePath: manifest.conflictRootRelativePath,
+  };
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,10 @@ services:
       - "3456:3000"
     env_file:
       - .env.docker.local
+    depends_on:
+      postgres:
+        condition: service_healthy
+        required: false
     environment:
       # Do not change
       HOSTNAME: 0.0.0.0
@@ -17,3 +21,24 @@ services:
     volumes:
       - ./data:/data
     restart: unless-stopped
+
+  postgres:
+    profiles:
+      - postgres
+    image: ${CANVAS_POSTGRES_IMAGE:-pgvector/pgvector:0.8.3-pg18}
+    environment:
+      POSTGRES_DB: ${CANVAS_POSTGRES_DB:-canvas_notebook}
+      POSTGRES_USER: ${CANVAS_POSTGRES_USER:-canvas}
+      POSTGRES_PASSWORD: ${CANVAS_POSTGRES_PASSWORD:-unused-sqlite-profile-disabled}
+    volumes:
+      - canvas-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  canvas-postgres-data:
+    name: ${CANVAS_POSTGRES_DATA_VOLUME:-canvas-postgres-data}

--- a/messages/de.json
+++ b/messages/de.json
@@ -54,6 +54,7 @@
     "loadingContext": "Workspace-Kontext wird geladen",
     "noWorkspaceAvailable": "Kein Workspace verfügbar",
     "refresh": "Workspaces aktualisieren",
+    "sourceWorkspace": "Quell-Workspace",
     "targetWorkspace": "Ziel-Workspace",
     "targetFolder": "Zielordner",
     "folderLoadFailed": "Workspace-Ordner konnten nicht geladen werden",

--- a/messages/en.json
+++ b/messages/en.json
@@ -54,6 +54,7 @@
     "loadingContext": "Workspace context is loading",
     "noWorkspaceAvailable": "No workspace available",
     "refresh": "Refresh workspaces",
+    "sourceWorkspace": "Source workspace",
     "targetWorkspace": "Target workspace",
     "targetFolder": "Target folder",
     "folderLoadFailed": "Could not load workspace folders",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:email:mime": "tsx scripts/email-mime-header-test.ts",
     "test:email:attachments": "tsx scripts/email-attachments-test.ts",
     "test:email:accounts": "tsx scripts/email-accounts-service-test.ts",
+    "test:email:chat-context": "tsx scripts/email-chat-context-test.ts",
     "test:composio:user-scope": "tsx scripts/composio-user-scope-test.ts",
     "test:auth:setup": "tsx --conditions react-server scripts/auth-setup-test.ts",
     "test:organization:permissions": "tsx --conditions react-server scripts/organization-permission-guards-test.ts",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:pi:summary": "tsx scripts/pi-session-summary-test.ts",
     "test:pi:usage": "tsx scripts/pi-usage-test.ts",
     "test:pi:tools": "tsx scripts/pi-tool-registry-test.ts",
+    "test:pi:runtime-context": "tsx scripts/runtime-prompt-context-test.ts",
     "test:brave-search": "tsx scripts/brave-search-service-test.ts",
     "test:pi:session-search": "tsx scripts/pi-session-search-tool-test.ts",
     "test:pi:delegate-task": "tsx scripts/pi-delegate-task-tool-test.ts",

--- a/scripts/auth-setup-test.ts
+++ b/scripts/auth-setup-test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
@@ -8,6 +8,11 @@ import { verifyPassword } from 'better-auth/crypto';
 
 const dataDir = mkdtempSync(path.join(tmpdir(), 'canvas-auth-setup-'));
 process.env.DATA = dataDir;
+
+function envValue(content: string, key: string): string | null {
+  const line = content.split(/\r?\n/).find((candidate) => candidate.startsWith(`${key}=`));
+  return line ? line.slice(key.length + 1).replace(/^"|"$/g, '') : null;
+}
 
 function assertOrganizationBootstrapState(
   sqlite: Database.Database,
@@ -110,6 +115,18 @@ async function main() {
 
   assert.equal(hasAnyAuthUser(), false);
 
+  mkdirSync(path.join(dataDir, 'secrets'), { recursive: true });
+  writeFileSync(
+    path.join(dataDir, 'secrets', 'Canvas-Integrations.env'),
+    'OPENAI_API_KEY=legacy-openai\nGEMINI_API_KEY=legacy-gemini\n',
+    'utf8',
+  );
+  writeFileSync(
+    path.join(dataDir, 'secrets', 'Canvas-Agents.env'),
+    'ANTHROPIC_API_KEY=legacy-anthropic\n',
+    'utf8',
+  );
+
   const owner = await createInitialOwner({
     name: ' Setup Admin ',
     email: 'SETUP@example.test ',
@@ -151,6 +168,23 @@ async function main() {
   assert.ok(accounts[0].password);
   assert.equal(await verifyPassword({ hash: accounts[0].password!, password: 'SetupPassword123!' }), true);
   assertOrganizationBootstrapState(sqlite, owner.id, 'setup@example.test');
+
+  const userSecretsDir = path.join(dataDir, 'users', owner.id, 'secrets');
+  const migratedIntegrations = readFileSync(path.join(userSecretsDir, 'Canvas-Integrations.env'), 'utf8');
+  const migratedAgents = readFileSync(path.join(userSecretsDir, 'Canvas-Agents.env'), 'utf8');
+  assert.equal(envValue(migratedIntegrations, 'OPENAI_API_KEY'), 'legacy-openai');
+  assert.equal(envValue(migratedIntegrations, 'GEMINI_API_KEY'), 'legacy-gemini');
+  assert.equal(envValue(migratedAgents, 'ANTHROPIC_API_KEY'), 'legacy-anthropic');
+  assert.equal(existsSync(path.join(dataDir, 'system', 'migration', 'legacy-secret-imports', `${owner.id}.json`)), true);
+
+  writeFileSync(
+    path.join(userSecretsDir, 'Canvas-Integrations.env'),
+    'OPENAI_API_KEY=user-openai\n',
+    'utf8',
+  );
+  ensureOrganizationBootstrapForUser(sqlite, owner.id);
+  const preservedIntegrations = readFileSync(path.join(userSecretsDir, 'Canvas-Integrations.env'), 'utf8');
+  assert.equal(envValue(preservedIntegrations, 'OPENAI_API_KEY'), 'user-openai');
 
   sqlite.prepare(`
     UPDATE organization_user_permissions

--- a/scripts/bootstrap-admin.js
+++ b/scripts/bootstrap-admin.js
@@ -1,6 +1,15 @@
 const path = require('node:path');
 const { randomUUID } = require('node:crypto');
-const { mkdirSync } = require('node:fs');
+const {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} = require('node:fs');
 const Database = require('better-sqlite3');
 const { hashPassword } = require('better-auth/crypto');
 const { loadAppEnv } = require('../server/load-app-env.js');
@@ -444,6 +453,126 @@ function ensureWorkspaceDirectory(rootRelativePath) {
   mkdirSync(workspaceAbsoluteRoot(rootRelativePath), { recursive: true });
 }
 
+function normalizeDataScopeId(id, label) {
+  const normalized = String(id || '').trim();
+  if (!normalized || normalized === '.' || normalized === '..' || normalized.includes('/') || normalized.includes('\\') || normalized.includes('\0')) {
+    throw new Error(`Invalid ${label}.`);
+  }
+  return normalized;
+}
+
+function legacyWorkspaceMigrationMarkerPath(organizationId, userId) {
+  const fileName = `${normalizeDataScopeId(organizationId, 'organizationId')}--${normalizeDataScopeId(userId, 'userId')}.json`;
+  return path.join(getDataRoot(), 'system', 'migration', 'legacy-workspace-imports', fileName);
+}
+
+function directoryExists(targetPath) {
+  try {
+    return statSync(targetPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function meaningfulLegacyWorkspaceEntries(sourceRoot) {
+  return readdirSync(sourceRoot, { withFileTypes: true })
+    .filter((entry) => entry.name !== '.gitkeep' && entry.name !== '.keep')
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function safeImportTimestamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function writeLegacyWorkspaceMigrationManifest(markerPath, manifest) {
+  mkdirSync(path.dirname(markerPath), { recursive: true });
+  const tempPath = `${markerPath}.tmp-${Date.now()}-${process.pid}`;
+  writeFileSync(tempPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  renameSync(tempPath, markerPath);
+}
+
+function readExistingLegacyWorkspaceMigrationMarker(markerPath) {
+  try {
+    const manifest = JSON.parse(readFileSync(markerPath, 'utf8'));
+    return {
+      copiedEntries: Array.isArray(manifest.copiedEntries) ? manifest.copiedEntries : [],
+      conflictedEntries: Array.isArray(manifest.conflictedEntries) ? manifest.conflictedEntries : [],
+      conflictRootRelativePath: typeof manifest.conflictRootRelativePath === 'string' ? manifest.conflictRootRelativePath : null,
+    };
+  } catch {
+    return { copiedEntries: [], conflictedEntries: [], conflictRootRelativePath: null };
+  }
+}
+
+function migrateLegacyWorkspaceToPersonalWorkspace(organizationId, userId, personalWorkspace) {
+  const sourceRoot = path.join(getDataRoot(), 'workspace');
+  const targetRoot = workspaceAbsoluteRoot(personalWorkspace.root_relative_path);
+  const markerPath = legacyWorkspaceMigrationMarkerPath(organizationId, userId);
+
+  if (existsSync(markerPath)) {
+    return {
+      status: 'skipped',
+      reason: 'already_migrated',
+      ...readExistingLegacyWorkspaceMigrationMarker(markerPath),
+    };
+  }
+
+  if (!directoryExists(sourceRoot)) {
+    return { status: 'skipped', reason: 'source_missing', copiedEntries: [], conflictedEntries: [], conflictRootRelativePath: null };
+  }
+
+  const sourceReal = path.resolve(sourceRoot);
+  const targetReal = path.resolve(targetRoot);
+  if (sourceReal === targetReal || targetReal.startsWith(`${sourceReal}${path.sep}`)) {
+    return { status: 'skipped', reason: 'invalid_target', copiedEntries: [], conflictedEntries: [], conflictRootRelativePath: null };
+  }
+
+  const entries = meaningfulLegacyWorkspaceEntries(sourceRoot);
+  if (entries.length === 0) {
+    return { status: 'skipped', reason: 'source_empty', copiedEntries: [], conflictedEntries: [], conflictRootRelativePath: null };
+  }
+
+  mkdirSync(targetRoot, { recursive: true });
+  const copiedEntries = [];
+  const conflictedEntries = [];
+  const conflictRootRelativePath = `_legacy-workspace-import/${safeImportTimestamp()}`;
+  let conflictRootCreated = false;
+
+  for (const entry of entries) {
+    const sourcePath = path.join(sourceRoot, entry);
+    const directTargetPath = path.join(targetRoot, entry);
+    if (!existsSync(directTargetPath)) {
+      cpSync(sourcePath, directTargetPath, { recursive: true, preserveTimestamps: true, errorOnExist: true, force: false });
+      copiedEntries.push(entry);
+      continue;
+    }
+
+    if (!conflictRootCreated) {
+      mkdirSync(path.join(targetRoot, conflictRootRelativePath), { recursive: true });
+      conflictRootCreated = true;
+    }
+    cpSync(sourcePath, path.join(targetRoot, conflictRootRelativePath, entry), { recursive: true, preserveTimestamps: true, errorOnExist: true, force: false });
+    conflictedEntries.push(entry);
+  }
+
+  const manifest = {
+    schemaVersion: 1,
+    operation: 'legacy-workspace-to-personal-workspace',
+    organizationId,
+    userId,
+    sourceRoot,
+    targetRoot,
+    targetRootRelativePath: personalWorkspace.root_relative_path,
+    importedAt: new Date().toISOString(),
+    copiedEntries,
+    conflictedEntries,
+    conflictRootRelativePath: conflictedEntries.length > 0 ? conflictRootRelativePath : null,
+  };
+  writeLegacyWorkspaceMigrationManifest(markerPath, manifest);
+  return { status: 'migrated', copiedEntries, conflictedEntries, conflictRootRelativePath: manifest.conflictRootRelativePath };
+}
+
 function ensureWorkspaceRecord(db, input) {
   const now = Date.now();
   const existing = input.type === 'personal'
@@ -467,15 +596,20 @@ function ensureWorkspaceRecord(db, input) {
       WHERE id = ?
     `).run(input.rootRelativePath, input.displayName, now, existing.id);
     ensureWorkspaceDirectory(input.rootRelativePath);
-    return;
+    return {
+      ...existing,
+      root_relative_path: input.rootRelativePath,
+      display_name: input.displayName,
+    };
   }
 
+  const id = `ws_${randomUUID()}`;
   db.prepare(`
     INSERT INTO canvas_workspaces (
       id, organization_id, type, owner_user_id, root_relative_path, display_name, status, created_at, updated_at
     ) VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?)
   `).run(
-    `ws_${randomUUID()}`,
+    id,
     input.organizationId,
     input.type,
     input.ownerUserId,
@@ -485,10 +619,16 @@ function ensureWorkspaceRecord(db, input) {
     now,
   );
   ensureWorkspaceDirectory(input.rootRelativePath);
+  return {
+    id,
+    root_relative_path: input.rootRelativePath,
+    display_name: input.displayName,
+    status: 'active',
+  };
 }
 
 function ensureDefaultWorkspaceRecords(db, organizationId, userId, includeTeamWorkspace) {
-  ensureWorkspaceRecord(db, {
+  const personal = ensureWorkspaceRecord(db, {
     organizationId,
     type: 'personal',
     ownerUserId: userId,
@@ -496,8 +636,9 @@ function ensureDefaultWorkspaceRecords(db, organizationId, userId, includeTeamWo
     displayName: 'Personal Workspace',
   });
 
+  let team = null;
   if (includeTeamWorkspace) {
-    ensureWorkspaceRecord(db, {
+    team = ensureWorkspaceRecord(db, {
       organizationId,
       type: 'team',
       ownerUserId: null,
@@ -505,6 +646,8 @@ function ensureDefaultWorkspaceRecords(db, organizationId, userId, includeTeamWo
       displayName: 'Team Workspace',
     });
   }
+
+  return { personal, team };
 }
 
 function ensureOrganizationBootstrap(db, userId) {
@@ -546,7 +689,8 @@ function ensureOrganizationBootstrap(db, userId) {
     ensurePermissionRow(db, organization.organization_id, targetUser.id, 'admin');
   }
   ensureScopedDirectories(organization.organization_id, ownerUser.id, includeTeamWorkspace);
-  ensureDefaultWorkspaceRecords(db, organization.organization_id, ownerUser.id, includeTeamWorkspace);
+  const ownerWorkspaceRecords = ensureDefaultWorkspaceRecords(db, organization.organization_id, ownerUser.id, includeTeamWorkspace);
+  migrateLegacyWorkspaceToPersonalWorkspace(organization.organization_id, ownerUser.id, ownerWorkspaceRecords.personal);
   if (targetUser.id !== ownerUser.id) {
     ensureScopedDirectories(organization.organization_id, targetUser.id, includeTeamWorkspace);
     ensureDefaultWorkspaceRecords(db, organization.organization_id, targetUser.id, includeTeamWorkspace);

--- a/scripts/bootstrap-admin.js
+++ b/scripts/bootstrap-admin.js
@@ -505,6 +505,151 @@ function readExistingLegacyWorkspaceMigrationMarker(markerPath) {
   }
 }
 
+function legacySecretMigrationMarkerPath(userId) {
+  return path.join(getDataRoot(), 'system', 'migration', 'legacy-secret-imports', `${normalizeDataScopeId(userId, 'userId')}.json`);
+}
+
+function parseEnvEntries(content) {
+  const entries = [];
+  for (const rawLine of content.split(/\r?\n/g)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const normalized = trimmed.startsWith('export ') ? trimmed.slice(7).trim() : trimmed;
+    const equalsIndex = normalized.indexOf('=');
+    if (equalsIndex <= 0) continue;
+
+    const key = normalized.slice(0, equalsIndex).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+
+    let value = normalized.slice(equalsIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    entries.push({ key, value });
+  }
+  return entries;
+}
+
+function formatEnvValue(value) {
+  if (!value) return '';
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) return value;
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function serializeEnvEntries(entries) {
+  if (entries.length === 0) return '';
+  const sorted = [...entries].sort((a, b) => a.key.localeCompare(b.key));
+  return `${sorted.map((entry) => `${entry.key}=${formatEnvValue(entry.value)}`).join('\n')}\n`;
+}
+
+function readEnvEntries(filePath) {
+  if (!fileExists(filePath)) return [];
+  return parseEnvEntries(readFileSync(filePath, 'utf8'));
+}
+
+function fileExists(filePath) {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function writeAtomicFile(filePath, content) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp-${Date.now()}-${process.pid}`;
+  writeFileSync(tempPath, content, { encoding: 'utf8', mode: 0o600 });
+  renameSync(tempPath, filePath);
+}
+
+function writeEnvEntries(filePath, entries) {
+  writeAtomicFile(filePath, serializeEnvEntries(entries));
+}
+
+function migrateLegacySecretsToUserScope(userId) {
+  const markerPath = legacySecretMigrationMarkerPath(userId);
+  if (existsSync(markerPath)) {
+    return { status: 'skipped', reason: 'already_migrated', migratedFiles: [] };
+  }
+
+  const legacyFiles = [
+    {
+      kind: 'integrations',
+      sourcePath: path.join(getDataRoot(), 'secrets', 'Canvas-Integrations.env'),
+      targetPath: path.join(getDataRoot(), 'users', userId, 'secrets', 'Canvas-Integrations.env'),
+    },
+    {
+      kind: 'agents',
+      sourcePath: path.join(getDataRoot(), 'secrets', 'Canvas-Agents.env'),
+      targetPath: path.join(getDataRoot(), 'users', userId, 'secrets', 'Canvas-Agents.env'),
+    },
+  ];
+
+  const migratedFiles = [];
+  let sawLegacyFile = false;
+  let sawLegacyEntries = false;
+
+  for (const file of legacyFiles) {
+    if (!fileExists(file.sourcePath)) continue;
+
+    sawLegacyFile = true;
+    const legacyEntries = readEnvEntries(file.sourcePath);
+    if (legacyEntries.length === 0) continue;
+
+    sawLegacyEntries = true;
+    const targetEntries = readEnvEntries(file.targetPath);
+    const byKey = new Map(targetEntries.map((entry) => [entry.key, entry]));
+    const copiedKeys = [];
+    const preservedKeys = [];
+
+    for (const legacyEntry of legacyEntries) {
+      if (byKey.has(legacyEntry.key)) {
+        preservedKeys.push(legacyEntry.key);
+        continue;
+      }
+      byKey.set(legacyEntry.key, legacyEntry);
+      copiedKeys.push(legacyEntry.key);
+    }
+
+    if (copiedKeys.length > 0) {
+      writeEnvEntries(file.targetPath, Array.from(byKey.values()));
+    } else {
+      mkdirSync(path.dirname(file.targetPath), { recursive: true });
+    }
+
+    migratedFiles.push({
+      kind: file.kind,
+      sourcePath: file.sourcePath,
+      targetPath: file.targetPath,
+      copiedKeys,
+      preservedKeys,
+    });
+  }
+
+  if (!sawLegacyFile || !sawLegacyEntries) {
+    return {
+      status: 'skipped',
+      reason: sawLegacyFile ? 'source_empty' : 'source_missing',
+      migratedFiles: [],
+    };
+  }
+
+  writeAtomicFile(markerPath, `${JSON.stringify({
+    schemaVersion: 1,
+    operation: 'legacy-secrets-to-user-scope',
+    userId,
+    importedAt: new Date().toISOString(),
+    migratedFiles,
+  }, null, 2)}\n`);
+
+  return { status: 'migrated', migratedFiles };
+}
+
 function migrateLegacyWorkspaceToPersonalWorkspace(organizationId, userId, personalWorkspace) {
   const sourceRoot = path.join(getDataRoot(), 'workspace');
   const targetRoot = workspaceAbsoluteRoot(personalWorkspace.root_relative_path);
@@ -691,6 +836,7 @@ function ensureOrganizationBootstrap(db, userId) {
   ensureScopedDirectories(organization.organization_id, ownerUser.id, includeTeamWorkspace);
   const ownerWorkspaceRecords = ensureDefaultWorkspaceRecords(db, organization.organization_id, ownerUser.id, includeTeamWorkspace);
   migrateLegacyWorkspaceToPersonalWorkspace(organization.organization_id, ownerUser.id, ownerWorkspaceRecords.personal);
+  migrateLegacySecretsToUserScope(ownerUser.id);
   if (targetUser.id !== ownerUser.id) {
     ensureScopedDirectories(organization.organization_id, targetUser.id, includeTeamWorkspace);
     ensureDefaultWorkspaceRecords(db, organization.organization_id, targetUser.id, includeTeamWorkspace);

--- a/scripts/email-chat-context-test.ts
+++ b/scripts/email-chat-context-test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+
+import {
+  buildEmailPageChatContext,
+  resolveEmailShellRequestContext,
+} from '../app/apps/email/context/email-route-chat-context';
+import { EMAIL_SYSTEM_PROMPT_BLOCK } from '../app/lib/agents/email-prompt-block';
+
+const noSelectedMessageContext = buildEmailPageChatContext({
+  account: null,
+  activeFolder: 'INBOX',
+  activeFolderName: 'Inbox',
+  filter: 'all',
+});
+
+assert.equal(noSelectedMessageContext.currentPage, '/emails');
+assert.deepEqual(noSelectedMessageContext.emailContext, {
+  accountEmail: undefined,
+  accountId: undefined,
+  filter: 'all',
+  folder: 'INBOX',
+  folderName: 'Inbox',
+  query: undefined,
+  selectedMessageDate: null,
+  selectedMessageFolder: 'INBOX',
+  selectedMessageFrom: null,
+  selectedMessageId: undefined,
+  selectedMessageIsRead: null,
+  selectedMessageSubject: null,
+});
+
+const loadingSelectedMessageContext = buildEmailPageChatContext({
+  account: { id: 'account-2', emailAddress: 'second@example.test' },
+  activeFolder: 'Archive',
+  activeFolderName: 'Archive',
+  filter: 'unread',
+  selectedMessageId: 'loading-message',
+  submittedQuery: 'renewal',
+});
+
+assert.deepEqual(loadingSelectedMessageContext.emailContext, {
+  accountEmail: 'second@example.test',
+  accountId: 'account-2',
+  filter: 'unread',
+  folder: 'Archive',
+  folderName: 'Archive',
+  query: 'renewal',
+  selectedMessageDate: null,
+  selectedMessageFolder: 'Archive',
+  selectedMessageFrom: null,
+  selectedMessageId: 'loading-message',
+  selectedMessageIsRead: null,
+  selectedMessageSubject: null,
+});
+
+const selectedMessageWithBody = {
+  id: 'message-with-body',
+  folder: 'Sent',
+  from: 'client@example.test',
+  subject: 'Contract',
+  date: '2026-06-26T11:00:00.000Z',
+  isRead: true,
+  body: 'This body must not be injected into chat context.',
+  bodyHtml: '<p>This body must not be injected into chat context.</p>',
+};
+const selectedMessageContext = buildEmailPageChatContext({
+  account: { id: 'account-3', emailAddress: 'third@example.test' },
+  activeFolder: 'INBOX',
+  activeFolderName: 'Inbox',
+  filter: 'all',
+  selectedMessage: selectedMessageWithBody,
+});
+
+assert.deepEqual(selectedMessageContext.emailContext, {
+  accountEmail: 'third@example.test',
+  accountId: 'account-3',
+  filter: 'all',
+  folder: 'INBOX',
+  folderName: 'Inbox',
+  query: undefined,
+  selectedMessageDate: '2026-06-26T11:00:00.000Z',
+  selectedMessageFolder: 'Sent',
+  selectedMessageFrom: 'client@example.test',
+  selectedMessageId: 'message-with-body',
+  selectedMessageIsRead: true,
+  selectedMessageSubject: 'Contract',
+});
+assert.doesNotMatch(JSON.stringify(selectedMessageContext), /This body must not be injected/);
+
+const accountSwitchContext = buildEmailPageChatContext({
+  account: { id: 'account-4', emailAddress: 'fourth@example.test' },
+  activeFolder: 'Projects',
+  activeFolderName: 'Projects',
+  filter: 'unread',
+  selectedMessageId: null,
+  submittedQuery: '',
+});
+assert.equal(accountSwitchContext.emailContext?.accountId, 'account-4');
+assert.equal(accountSwitchContext.emailContext?.selectedMessageId, undefined);
+assert.equal(accountSwitchContext.emailContext?.query, undefined);
+assert.equal(accountSwitchContext.emailContext?.selectedMessageFolder, 'Projects');
+
+const staleContext = buildEmailPageChatContext({
+  account: { id: 'old-account', emailAddress: 'old@example.test' },
+  activeFolder: 'INBOX',
+  activeFolderName: 'Inbox',
+  filter: 'all',
+  pathname: '/emails',
+  selectedMessageId: 'old-message',
+});
+assert.deepEqual(resolveEmailShellRequestContext(staleContext, '/settings'), { currentPage: '/settings' });
+assert.equal(resolveEmailShellRequestContext(staleContext, '/emails'), staleContext);
+assert.deepEqual(resolveEmailShellRequestContext(null, null), { currentPage: '/emails' });
+assert.match(EMAIL_SYSTEM_PROMPT_BLOCK, /Do not assume the visible message body is available in context/);
+assert.match(EMAIL_SYSTEM_PROMPT_BLOCK, /Use email_read when the user asks you to reason about the actual email body/);
+
+console.log('Email chat context test passed');

--- a/scripts/legacy-secret-migration-test.ts
+++ b/scripts/legacy-secret-migration-test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function envValue(content: string, key: string): string | null {
+  const line = content.split(/\r?\n/u).find((candidate) => candidate.startsWith(`${key}=`));
+  return line ? line.slice(key.length + 1).replace(/^"|"$/gu, '') : null;
+}
+
+async function main() {
+  const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-legacy-secret-migration-'));
+  const previousData = process.env.DATA;
+  const previousCanvasDataRoot = process.env.CANVAS_DATA_ROOT;
+  const previousIntegrationsPath = process.env.INTEGRATIONS_ENV_PATH;
+  const previousAgentsPath = process.env.AGENTS_ENV_PATH;
+
+  try {
+    process.env.DATA = dataRoot;
+    delete process.env.CANVAS_DATA_ROOT;
+    delete process.env.INTEGRATIONS_ENV_PATH;
+    delete process.env.AGENTS_ENV_PATH;
+
+    await fs.mkdir(path.join(dataRoot, 'secrets'), { recursive: true });
+    await fs.mkdir(path.join(dataRoot, 'users', 'owner-user', 'secrets'), { recursive: true });
+    await fs.writeFile(
+      path.join(dataRoot, 'secrets', 'Canvas-Integrations.env'),
+      'OPENAI_API_KEY=legacy-openai\nGEMINI_API_KEY=legacy-gemini\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(dataRoot, 'secrets', 'Canvas-Agents.env'),
+      'ANTHROPIC_API_KEY=legacy-anthropic\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(dataRoot, 'users', 'owner-user', 'secrets', 'Canvas-Integrations.env'),
+      'OPENAI_API_KEY=user-openai\n',
+      'utf8',
+    );
+
+    const { migrateLegacySecretsToUserScope } = await import('../app/lib/integrations/legacy-secret-migration');
+    const result = migrateLegacySecretsToUserScope('owner-user');
+    assert.equal(result.status, 'migrated');
+    assert.equal(result.migratedFiles.length, 2);
+
+    const migratedIntegrations = await fs.readFile(
+      path.join(dataRoot, 'users', 'owner-user', 'secrets', 'Canvas-Integrations.env'),
+      'utf8',
+    );
+    const migratedAgents = await fs.readFile(
+      path.join(dataRoot, 'users', 'owner-user', 'secrets', 'Canvas-Agents.env'),
+      'utf8',
+    );
+
+    assert.equal(envValue(migratedIntegrations, 'OPENAI_API_KEY'), 'user-openai');
+    assert.equal(envValue(migratedIntegrations, 'GEMINI_API_KEY'), 'legacy-gemini');
+    assert.equal(envValue(migratedAgents, 'ANTHROPIC_API_KEY'), 'legacy-anthropic');
+
+    const secondRun = migrateLegacySecretsToUserScope('owner-user');
+    assert.equal(secondRun.status, 'skipped');
+    assert.equal(secondRun.reason, 'already_migrated');
+
+    console.log('legacy-secret-migration-test: ok');
+  } finally {
+    if (previousData === undefined) {
+      delete process.env.DATA;
+    } else {
+      process.env.DATA = previousData;
+    }
+    if (previousCanvasDataRoot === undefined) {
+      delete process.env.CANVAS_DATA_ROOT;
+    } else {
+      process.env.CANVAS_DATA_ROOT = previousCanvasDataRoot;
+    }
+    if (previousIntegrationsPath === undefined) {
+      delete process.env.INTEGRATIONS_ENV_PATH;
+    } else {
+      process.env.INTEGRATIONS_ENV_PATH = previousIntegrationsPath;
+    }
+    if (previousAgentsPath === undefined) {
+      delete process.env.AGENTS_ENV_PATH;
+    } else {
+      process.env.AGENTS_ENV_PATH = previousAgentsPath;
+    }
+    await fs.rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/legacy-secret-migration-test.ts
+++ b/scripts/legacy-secret-migration-test.ts
@@ -25,7 +25,7 @@ async function main() {
     await fs.mkdir(path.join(dataRoot, 'users', 'owner-user', 'secrets'), { recursive: true });
     await fs.writeFile(
       path.join(dataRoot, 'secrets', 'Canvas-Integrations.env'),
-      'OPENAI_API_KEY=legacy-openai\nGEMINI_API_KEY=legacy-gemini\n',
+      'OPENAI_API_KEY=legacy-openai\nGEMINI_API_KEY=legacy-gemini\nMULTILINE_KEY="line1\tline2"\n',
       'utf8',
     );
     await fs.writeFile(
@@ -55,6 +55,7 @@ async function main() {
 
     assert.equal(envValue(migratedIntegrations, 'OPENAI_API_KEY'), 'user-openai');
     assert.equal(envValue(migratedIntegrations, 'GEMINI_API_KEY'), 'legacy-gemini');
+    assert.equal(envValue(migratedIntegrations, 'MULTILINE_KEY'), 'line1\\tline2');
     assert.equal(envValue(migratedAgents, 'ANTHROPIC_API_KEY'), 'legacy-anthropic');
 
     const secondRun = migrateLegacySecretsToUserScope('owner-user');

--- a/scripts/pi-tool-registry-test.ts
+++ b/scripts/pi-tool-registry-test.ts
@@ -221,7 +221,7 @@ async function main() {
     path: 'hausarbeit/00_Projektplan_Team6_v2.md',
     maxChars: 12,
   });
-  assert.match(getText(truncatedReadResult), /^# Projektpla/);
+  assert.match(getText(truncatedReadResult), /# Projektpla/);
   assert.match(getText(truncatedReadResult), /content truncated after 12 characters/);
   assert.equal((truncatedReadResult.details as { type: string; truncated: boolean }).type, 'text');
   assert.equal((truncatedReadResult.details as { type: string; truncated: boolean }).truncated, true);
@@ -499,9 +499,12 @@ async function main() {
   await assert.rejects(fs.stat(path.join(workspaceDir, 'multi-moved', 'one.txt')));
   await assert.rejects(fs.stat(path.join(workspaceDir, 'multi-copy', 'dir-one')));
 
-  assert.equal(detectUnsafeBashCommand('cp -r /data/workspace/a /data/workspace/b'), null);
-  assert.equal(detectUnsafeBashCommand('mv /data/workspace/a /data/workspace/b'), null);
-  assert.equal(detectUnsafeBashCommand('rm -rf /data/workspace/a'), null);
+  assert.match(detectUnsafeBashCommand('cp -r /data/workspace/a /data/workspace/b') || '', /file mutations/i);
+  assert.match(detectUnsafeBashCommand('mv /data/workspace/a /data/workspace/b') || '', /file mutations/i);
+  assert.match(detectUnsafeBashCommand('rm -rf /data/workspace/a') || '', /file mutations/i);
+  assert.match(detectUnsafeBashCommand('echo $(rm ./workspace-file)') || '', /file mutations/i);
+  assert.match(detectUnsafeBashCommand('result=`git reset HEAD~1`') || '', /git/i);
+  assert.equal(detectUnsafeBashCommand('npm install'), null);
   assert.match(detectUnsafeBashCommand("sed -i 's/a/b/' /data/workspace/file.md") || '', /sed/i);
   assert.match(detectUnsafeBashCommand('echo broken > /data/workspace/file.md') || '', /redirects/i);
   assert.match(detectUnsafeBashCommand('cd /data/workspace && echo broken > file.md') || '', /redirects/i);

--- a/scripts/public-share-workspace-scope-test.ts
+++ b/scripts/public-share-workspace-scope-test.ts
@@ -176,6 +176,7 @@ async function main() {
       syncPublicSharesAfterMove,
       syncPublicSharesAfterWrite,
     } = await import('../app/lib/public-sharing/public-file-shares');
+    const { getPublicMarkdownExport } = await import('../app/lib/public-sharing/public-markdown-export');
 
     const personalCreate = await createPublicFileShares({
       paths: ['docs/report.txt'],
@@ -204,6 +205,40 @@ async function main() {
     assert.equal(teamCreate.shares[0].workspaceName, ownerTeam.displayName);
     assert.equal(personalCreate.shares[0].targetRevisionPolicy, 'latest');
     assert.equal(personalCreate.shares[0].passwordEnabled, false);
+
+    await writeFile(path.join(ownerPersonal.rootPath, 'docs', 'shared.md'), '# Personal markdown\n\npersonal scoped content\n');
+    await writeFile(path.join(ownerTeam.rootPath, 'docs', 'shared.md'), '# Team markdown\n\nteam scoped content\n');
+    const personalMarkdownCreate = await createPublicFileShares({
+      paths: ['docs/shared.md'],
+      createdByUserId: 'user-owner',
+      workspace: ownerPersonal,
+      source: 'ui',
+      confirmPublicExposure: true,
+      baseUrl: 'https://notebook.example.test',
+    });
+    const teamMarkdownCreate = await createPublicFileShares({
+      paths: ['docs/shared.md'],
+      createdByUserId: 'user-owner',
+      workspace: ownerTeam,
+      source: 'ui',
+      confirmPublicExposure: true,
+      baseUrl: 'https://notebook.example.test',
+    });
+    assert.equal(personalMarkdownCreate.shares.length, 1);
+    assert.equal(teamMarkdownCreate.shares.length, 1);
+
+    const personalMarkdownExport = await getPublicMarkdownExport(tokenFromPublicUrl(personalMarkdownCreate.shares[0].publicUrl));
+    const teamMarkdownExport = await getPublicMarkdownExport(tokenFromPublicUrl(teamMarkdownCreate.shares[0].publicUrl));
+    assert.equal(personalMarkdownExport.ok, true);
+    assert.equal(teamMarkdownExport.ok, true);
+    if (personalMarkdownExport.ok && teamMarkdownExport.ok) {
+      assert.match(personalMarkdownExport.html, /Personal markdown/);
+      assert.match(personalMarkdownExport.html, /personal scoped content/);
+      assert.doesNotMatch(personalMarkdownExport.html, /team scoped content/);
+      assert.match(teamMarkdownExport.html, /Team markdown/);
+      assert.match(teamMarkdownExport.html, /team scoped content/);
+      assert.doesNotMatch(teamMarkdownExport.html, /personal scoped content/);
+    }
 
     await writeFile(path.join(ownerTeam.rootPath, 'docs', 'agent-root.txt'), 'team agent root\n');
     const ownerTeamWithoutRelativePath: WorkspaceContext = {

--- a/scripts/runtime-prompt-context-test.ts
+++ b/scripts/runtime-prompt-context-test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+
+import {
+  applyPiRuntimePromptContext,
+  type RuntimePromptContextTarget,
+} from '../app/lib/pi/runtime-prompt-context';
+
+function createTarget() {
+  const calls: Record<string, unknown> = {};
+  const target: RuntimePromptContextTarget = {
+    setChannelContext: (value) => { calls.channelId = value; },
+    setTimeZoneContext: (timeZone, currentTime) => {
+      calls.timeZone = timeZone;
+      calls.currentTime = currentTime;
+    },
+    setActiveFileContext: (value) => { calls.activeFilePath = value; },
+    setPlanningMode: (value) => { calls.planningMode = value; },
+    setPageContext: (value) => { calls.currentPage = value; },
+    setStudioContext: (value) => { calls.studioContext = value; },
+    setEmailContext: (value) => { calls.emailContext = value; },
+    setWorkspaceContext: (value) => { calls.workspace = value; },
+  };
+
+  return { calls, target };
+}
+
+const emailContext = {
+  accountEmail: 'agent@example.test',
+  accountId: 'account-1',
+  filter: 'unread' as const,
+  folder: 'INBOX',
+  folderName: 'Inbox',
+  query: 'invoice',
+  selectedMessageDate: '2026-06-26T10:00:00.000Z',
+  selectedMessageFolder: 'INBOX',
+  selectedMessageFrom: 'sender@example.test',
+  selectedMessageId: 'message-1',
+  selectedMessageIsRead: false,
+  selectedMessageSubject: 'Invoice follow-up',
+};
+
+const { calls, target } = createTarget();
+applyPiRuntimePromptContext(target, {
+  channelId: 'web',
+  userTimeZone: 'Europe/Berlin',
+  currentTime: '2026-06-26T12:00:00.000Z',
+  activeFilePath: '/data/workspaces/demo/file.md',
+  planningMode: true,
+  currentPage: '/emails',
+  emailContext,
+  studioContext: {
+    generationId: 'studio-gen-1',
+    outputFilePath: 'studio/outputs/image.png',
+  },
+  workspace: {
+    workspaceId: 'workspace-1',
+    workspaceType: 'personal',
+    workspaceName: 'Personal',
+    canWrite: true,
+    canShare: false,
+  },
+});
+
+assert.equal(calls.channelId, 'web');
+assert.equal(calls.timeZone, 'Europe/Berlin');
+assert.equal(calls.currentTime, '2026-06-26T12:00:00.000Z');
+assert.equal(calls.activeFilePath, '/data/workspaces/demo/file.md');
+assert.equal(calls.planningMode, true);
+assert.equal(calls.currentPage, '/emails');
+assert.deepEqual(calls.emailContext, emailContext);
+assert.deepEqual(calls.studioContext, {
+  generationId: 'studio-gen-1',
+  outputFilePath: 'studio/outputs/image.png',
+});
+assert.deepEqual(calls.workspace, {
+  workspaceId: 'workspace-1',
+  workspaceType: 'personal',
+  workspaceName: 'Personal',
+  canWrite: true,
+  canShare: false,
+});
+
+const { calls: emptyCalls, target: emptyTarget } = createTarget();
+applyPiRuntimePromptContext(emptyTarget);
+
+assert.equal(emptyCalls.channelId, undefined);
+assert.equal(emptyCalls.activeFilePath, null);
+assert.equal(emptyCalls.planningMode, false);
+assert.equal(emptyCalls.currentPage, undefined);
+assert.equal(emptyCalls.emailContext, undefined);
+assert.equal(emptyCalls.studioContext, undefined);
+assert.equal(emptyCalls.workspace, undefined);
+assert.equal(emptyCalls.timeZone, undefined);
+
+console.log('Runtime prompt context test passed');

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -54,6 +54,114 @@ function exec(command, options = {}) {
   }
 }
 
+function parseEnvValue(rawValue) {
+  let value = rawValue.trim();
+  if (!value) return '';
+
+  const quote = value[0];
+  if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
+    value = value.slice(1, -1);
+  } else {
+    value = value.replace(/\s+#.*$/u, '').trim();
+  }
+
+  return value;
+}
+
+function loadEnvFile(envFile) {
+  const values = {};
+  const content = readFileSync(envFile, 'utf-8');
+  for (const rawLine of content.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const separatorIndex = line.indexOf('=');
+    if (separatorIndex <= 0) continue;
+    const key = line.slice(0, separatorIndex).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key)) continue;
+    values[key] = parseEnvValue(line.slice(separatorIndex + 1));
+  }
+  return values;
+}
+
+function normalizeEnvValue(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function isTruthyEnv(value) {
+  const normalized = normalizeEnvValue(value);
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
+}
+
+function isSingleUserDeploymentMode(deploymentMode) {
+  const normalized = normalizeEnvValue(deploymentMode).replace(/_/gu, '-');
+  return normalized === 'community'
+    || normalized === 'single-user'
+    || normalized === 'singleuser'
+    || normalized === 'managed-single'
+    || normalized === 'local'
+    || normalized === 'development'
+    || normalized === 'dev';
+}
+
+function deploymentRequiresPostgres(deploymentMode, teamFeaturesEnabled) {
+  const normalized = normalizeEnvValue(deploymentMode).replace(/_/gu, '-');
+  if (!normalized || isSingleUserDeploymentMode(normalized)) {
+    return false;
+  }
+  return normalized.includes('team')
+    || normalized.includes('enterprise')
+    || normalized.includes('advanced')
+    || teamFeaturesEnabled;
+}
+
+function parseComposeProfiles(value) {
+  return new Set(
+    String(value ?? '')
+      .split(/[,\s]+/u)
+      .map((profile) => profile.trim())
+      .filter(Boolean),
+  );
+}
+
+function resolveDockerComposeEnvironment(envFile) {
+  const fileEnv = loadEnvFile(envFile);
+  const provider = normalizeEnvValue(fileEnv.CANVAS_DATABASE_PROVIDER || process.env.CANVAS_DATABASE_PROVIDER || 'sqlite');
+  const deploymentMode = fileEnv.CANVAS_DEPLOYMENT_MODE || process.env.CANVAS_DEPLOYMENT_MODE || 'single_user';
+  const teamFeaturesEnabled = isTruthyEnv(fileEnv.CANVAS_TEAM_FEATURES_ENABLED || process.env.CANVAS_TEAM_FEATURES_ENABLED);
+  const needsPostgres = deploymentRequiresPostgres(deploymentMode, teamFeaturesEnabled);
+  const profiles = parseComposeProfiles(fileEnv.COMPOSE_PROFILES || process.env.COMPOSE_PROFILES);
+  const explicitPostgres = provider === 'postgres'
+    || profiles.has('postgres')
+    || isTruthyEnv(fileEnv.CANVAS_LOCAL_POSTGRES_ENABLED || process.env.CANVAS_LOCAL_POSTGRES_ENABLED);
+
+  if (explicitPostgres || needsPostgres) {
+    profiles.add('postgres');
+  }
+
+  if (needsPostgres && provider !== 'postgres') {
+    warn(`Team/advanced deployment mode "${deploymentMode}" expects CANVAS_DATABASE_PROVIDER=postgres.`);
+    warn('The local setup will still start the Postgres container profile, but the app env should be updated before a full team-mode run.');
+  }
+
+  const env = {
+    ...process.env,
+    ...fileEnv,
+  };
+
+  if (profiles.size > 0) {
+    env.COMPOSE_PROFILES = [...profiles].join(',');
+  } else {
+    delete env.COMPOSE_PROFILES;
+  }
+
+  return {
+    env,
+    provider,
+    deploymentMode,
+    postgresProfileEnabled: profiles.has('postgres'),
+  };
+}
+
 function removeLingeringComposeContainers() {
   try {
     const output = execFileSync(
@@ -185,7 +293,7 @@ function createSpinner(getMessage) {
 
 // ─── Docker build with progress ───────────────────────────────────────────────
 
-function buildWithProgress() {
+function buildWithProgress(composeEnv) {
   return new Promise((resolve, reject) => {
     const start = Date.now();
     let frame = 0;
@@ -220,7 +328,7 @@ function buildWithProgress() {
 
     const proc = spawn('docker', ['compose', 'build', '--no-cache', '--progress=plain'], {
       cwd: rootDir,
-      env: process.env,
+      env: composeEnv,
     });
 
     let stdoutBuffer = '';
@@ -429,7 +537,13 @@ async function main() {
     process.exit(1);
   }
 
+  const composeConfig = resolveDockerComposeEnvironment(envFile);
   ok('.env.docker.local is configured');
+  info(`Deployment mode: ${composeConfig.deploymentMode}`);
+  info(`Database provider: ${composeConfig.provider}`);
+  if (composeConfig.postgresProfileEnabled) {
+    info('Docker Compose profile enabled: postgres');
+  }
 
   // ── Step 3: Data directories ───────────────────────────────────────────────
   step(3, 'Preparing data directories...');
@@ -438,7 +552,7 @@ async function main() {
 
   // ── Step 4: Stop existing container ───────────────────────────────────────
   step(4, 'Stopping existing container (if any)...');
-  exec('docker compose down --remove-orphans', { ignoreError: true });
+  exec('docker compose down --remove-orphans', { ignoreError: true, env: composeConfig.env });
   removeLingeringComposeContainers();
   ok('Done');
 
@@ -447,7 +561,7 @@ async function main() {
   info('This may take a few minutes on the first run.');
   console.log();
   try {
-    await buildWithProgress();
+    await buildWithProgress(composeConfig.env);
   } catch {
     process.exit(1);
   }
@@ -455,15 +569,15 @@ async function main() {
   // ── Step 6: Start container ────────────────────────────────────────────────
   step(6, 'Starting container...');
   try {
-    exec('docker compose up -d --force-recreate');
+    exec('docker compose up -d --force-recreate', { env: composeConfig.env });
     ok('Container started');
   } catch {
     warn('Container start hit a conflict. Retrying once after explicit cleanup...');
-    exec('docker compose down --remove-orphans', { ignoreError: true });
+    exec('docker compose down --remove-orphans', { ignoreError: true, env: composeConfig.env });
     removeLingeringComposeContainers();
 
     try {
-      exec('docker compose up -d --force-recreate');
+      exec('docker compose up -d --force-recreate', { env: composeConfig.env });
       ok('Container started');
     } catch {
       fail('Failed to start container. Check the output above for errors.');
@@ -479,7 +593,7 @@ async function main() {
 
   // ── Step 8: Summary ────────────────────────────────────────────────────────
   try {
-    const status = execSync('docker compose ps', { encoding: 'utf-8', cwd: rootDir });
+    const status = execSync('docker compose ps', { encoding: 'utf-8', cwd: rootDir, env: composeConfig.env });
     log('Container status:', 'blue');
     console.log(status.toString().trimEnd());
     console.log();

--- a/scripts/tiptap-markdown-roundtrip-test.ts
+++ b/scripts/tiptap-markdown-roundtrip-test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 
 import { JSDOM } from 'jsdom';
 
-import { clampEditorRangeToDoc, isEditorRangeInsideDoc } from '../app/lib/editor/prosemirror-ranges';
+import {
+  clampEditorRangeToDoc,
+  getSlashCommandDeletionRange,
+  isEditorRangeInsideDoc,
+} from '../app/lib/editor/prosemirror-ranges';
 
 const dom = new JSDOM('<!doctype html><html><body></body></html>');
 
@@ -141,7 +145,23 @@ async function main() {
     { from: smallEditor.state.doc.content.size, to: smallEditor.state.doc.content.size },
     'stale insertion ranges should clamp to a valid document position',
   );
+  assert.equal(
+    getSlashCommandDeletionRange(smallEditor, { from: 1, to: 2 }),
+    null,
+    'slash command cleanup should not delete non-slash text from an otherwise valid stale range',
+  );
 
+  const slashEditor = new Editor({
+    content: '/heading',
+    extensions: [StarterKit],
+  });
+  assert.deepEqual(
+    getSlashCommandDeletionRange(slashEditor, { from: 1, to: 9 }),
+    { from: 1, to: 9 },
+    'slash command cleanup should delete the active slash query range',
+  );
+
+  slashEditor.destroy();
   smallEditor.destroy();
   editor.destroy();
 

--- a/scripts/tiptap-markdown-roundtrip-test.ts
+++ b/scripts/tiptap-markdown-roundtrip-test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 
+import type { Editor as TiptapEditor } from '@tiptap/core';
 import { JSDOM } from 'jsdom';
 
 import {
@@ -7,6 +8,10 @@ import {
   getSlashCommandDeletionRange,
   isEditorRangeInsideDoc,
 } from '../app/lib/editor/prosemirror-ranges';
+import {
+  getReorderableBlockRangeAt,
+  moveReorderableBlock,
+} from '../app/lib/editor/reorderable-blocks';
 
 const dom = new JSDOM('<!doctype html><html><body></body></html>');
 
@@ -19,6 +24,7 @@ for (const key of ['window', 'document', 'DOMParser', 'navigator', 'Node', 'HTML
 
 type JsonNode = {
   type?: string;
+  text?: string;
   attrs?: Record<string, unknown>;
   content?: JsonNode[];
 };
@@ -35,6 +41,22 @@ function collectTableAlignments(node: JsonNode): string[] {
     ...(typeof node.attrs?.align === 'string' ? [node.attrs.align] : []),
     ...(node.content ?? []).flatMap(collectTableAlignments),
   ];
+}
+
+function findDocTextPosition(editor: TiptapEditor, text: string): number | null {
+  let found: number | null = null;
+
+  editor.state.doc.descendants((node, position) => {
+    if (found !== null) return false;
+    if (node.isText && node.text?.includes(text)) {
+      found = position;
+      return false;
+    }
+
+    return true;
+  });
+
+  return found;
 }
 
 const sampleMarkdown = `# Title
@@ -161,6 +183,53 @@ async function main() {
     'slash command cleanup should delete the active slash query range',
   );
 
+  const blockEditor = new Editor({
+    content: 'One\n\nTwo\n\nThree',
+    contentType: 'markdown',
+    extensions: [StarterKit, Markdown],
+  });
+  const firstBlockPosition = findDocTextPosition(blockEditor, 'One');
+  assert.notEqual(firstBlockPosition, null, 'top-level block text should be discoverable');
+  const firstBlock = getReorderableBlockRangeAt(blockEditor, firstBlockPosition ?? 0);
+  assert.equal(firstBlock?.kind, 'topLevel', 'paragraphs should move as top-level blocks');
+  assert.equal(
+    firstBlock ? moveReorderableBlock(blockEditor, firstBlock, blockEditor.state.doc.content.size) : false,
+    true,
+    'top-level block reorder should move the block',
+  );
+  const reorderedBlocks = blockEditor.getMarkdown();
+  assert.ok(
+    reorderedBlocks.indexOf('Two') < reorderedBlocks.indexOf('Three') &&
+      reorderedBlocks.indexOf('Three') < reorderedBlocks.indexOf('One'),
+    'top-level block reorder should preserve content and order',
+  );
+
+  const listEditor = new Editor({
+    content: '- A\n- B\n- C',
+    contentType: 'markdown',
+    extensions: [StarterKit, Markdown],
+  });
+  const firstListItemPosition = findDocTextPosition(listEditor, 'A');
+  const secondListItemPosition = findDocTextPosition(listEditor, 'B');
+  assert.notEqual(firstListItemPosition, null, 'first list item text should be discoverable');
+  assert.notEqual(secondListItemPosition, null, 'second list item text should be discoverable');
+  const firstListItem = getReorderableBlockRangeAt(listEditor, firstListItemPosition ?? 0);
+  const secondListItem = getReorderableBlockRangeAt(listEditor, secondListItemPosition ?? 0);
+  assert.equal(secondListItem?.kind, 'listItem', 'list items should move as list item blocks');
+  assert.equal(
+    firstListItem && secondListItem ? moveReorderableBlock(listEditor, secondListItem, firstListItem.from) : false,
+    true,
+    'list item reorder should move the item inside the list',
+  );
+  const reorderedList = listEditor.getMarkdown();
+  assert.ok(
+    reorderedList.indexOf('- B') < reorderedList.indexOf('- A') &&
+      reorderedList.indexOf('- A') < reorderedList.indexOf('- C'),
+    'list item reorder should preserve list markdown order',
+  );
+
+  listEditor.destroy();
+  blockEditor.destroy();
   slashEditor.destroy();
   smallEditor.destroy();
   editor.destroy();

--- a/scripts/tiptap-markdown-roundtrip-test.ts
+++ b/scripts/tiptap-markdown-roundtrip-test.ts
@@ -59,6 +59,22 @@ function findDocTextPosition(editor: TiptapEditor, text: string): number | null 
   return found;
 }
 
+function findDocNodePosition(editor: TiptapEditor, typeName: string): number | null {
+  let found: number | null = null;
+
+  editor.state.doc.descendants((node, position) => {
+    if (found !== null) return false;
+    if (node.type.name === typeName) {
+      found = position;
+      return false;
+    }
+
+    return true;
+  });
+
+  return found;
+}
+
 const sampleMarkdown = `# Title
 
 Paragraph with **bold**, *italic*, ~~strike~~, \`code\`, emoji 😄, and [link](https://example.com). ![Link preview: example.com](https://cdn.example.com/og.png)
@@ -152,6 +168,21 @@ async function main() {
   assert.ok(tableAlignments.includes('right'), 'GFM table alignment should preserve right cells');
   assert.ok(nodeTypes.includes('image'), 'Markdown images should parse as image nodes');
   assert.ok(nodeTypes.includes('codeBlock'), 'Mermaid fences should remain code blocks');
+
+  const imagePosition = findDocNodePosition(editor, 'image');
+  const tablePosition = findDocNodePosition(editor, 'table');
+  assert.notEqual(imagePosition, null, 'image node should be discoverable for block controls');
+  assert.notEqual(tablePosition, null, 'table node should be discoverable for block controls');
+  assert.equal(
+    getReorderableBlockRangeAt(editor, imagePosition ?? 0)?.kind,
+    'topLevel',
+    'image nodes should drag as top-level blocks',
+  );
+  assert.equal(
+    getReorderableBlockRangeAt(editor, tablePosition ?? 0)?.kind,
+    'topLevel',
+    'tables should drag as top-level blocks',
+  );
 
   const smallEditor = new Editor({
     content: 'x',

--- a/scripts/workspace-model-service-test.ts
+++ b/scripts/workspace-model-service-test.ts
@@ -24,6 +24,14 @@ async function main() {
   process.env.CANVAS_DATABASE_PROVIDER = 'postgres';
 
   await fs.mkdir(dataRoot, { recursive: true });
+  const legacyRoot = path.join(dataRoot, 'workspace');
+  const plannedOwnerPersonalRoot = path.join(dataRoot, 'workspaces', 'personal', 'user-owner', 'files');
+  await fs.mkdir(path.join(legacyRoot, 'docs'), { recursive: true });
+  await fs.mkdir(plannedOwnerPersonalRoot, { recursive: true });
+  await fs.writeFile(path.join(legacyRoot, 'legacy.md'), '# Legacy\n');
+  await fs.writeFile(path.join(legacyRoot, 'conflict.md'), '# Legacy conflict\n');
+  await fs.writeFile(path.join(legacyRoot, 'docs', 'nested.md'), '# Nested legacy\n');
+  await fs.writeFile(path.join(plannedOwnerPersonalRoot, 'conflict.md'), '# Existing personal file\n');
   const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
   try {
     runMigrations(sqlite);
@@ -71,6 +79,54 @@ async function main() {
     );
     await fs.access(ownerWorkspaces[0].rootPath);
     await fs.access(ownerWorkspaces[1].rootPath);
+    assert.equal(
+      await fs.readFile(path.join(ownerWorkspaces[0].rootPath, 'legacy.md'), 'utf8'),
+      '# Legacy\n'
+    );
+    assert.equal(
+      await fs.readFile(path.join(ownerWorkspaces[0].rootPath, 'docs', 'nested.md'), 'utf8'),
+      '# Nested legacy\n'
+    );
+    assert.equal(
+      await fs.readFile(path.join(ownerWorkspaces[0].rootPath, 'conflict.md'), 'utf8'),
+      '# Existing personal file\n'
+    );
+    assert.equal(
+      await fs.readFile(path.join(legacyRoot, 'legacy.md'), 'utf8'),
+      '# Legacy\n'
+    );
+
+    const legacyImportRoot = path.join(ownerWorkspaces[0].rootPath, '_legacy-workspace-import');
+    const legacyImportDirs = await fs.readdir(legacyImportRoot);
+    assert.equal(legacyImportDirs.length, 1);
+    assert.equal(
+      await fs.readFile(path.join(legacyImportRoot, legacyImportDirs[0], 'conflict.md'), 'utf8'),
+      '# Legacy conflict\n'
+    );
+
+    const markerDir = path.join(dataRoot, 'system', 'migration', 'legacy-workspace-imports');
+    const markers = await fs.readdir(markerDir);
+    assert.equal(markers.length, 1);
+    const marker = JSON.parse(await fs.readFile(path.join(markerDir, markers[0]), 'utf8')) as {
+      operation?: string;
+      copiedEntries?: string[];
+      conflictedEntries?: string[];
+      conflictRootRelativePath?: string | null;
+    };
+    assert.equal(marker.operation, 'legacy-workspace-to-personal-workspace');
+    assert.deepEqual(marker.copiedEntries?.sort(), ['docs', 'legacy.md']);
+    assert.deepEqual(marker.conflictedEntries, ['conflict.md']);
+    assert.equal(marker.conflictRootRelativePath?.startsWith('_legacy-workspace-import/'), true);
+
+    await fs.writeFile(path.join(legacyRoot, 'after-marker.md'), '# After marker\n');
+    sqlite.exec('BEGIN IMMEDIATE');
+    ensureOrganizationBootstrapForUser(sqlite, 'user-owner');
+    sqlite.exec('COMMIT');
+    assert.deepEqual(await fs.readdir(legacyImportRoot), legacyImportDirs);
+    await assert.rejects(
+      () => fs.readFile(path.join(ownerWorkspaces[0].rootPath, 'after-marker.md'), 'utf8'),
+      (error: unknown) => Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')
+    );
 
     const defaultWorkspace = resolveDefaultWorkspaceContext(sqlite, { actor: ownerActor, organizationId });
     assert.equal(defaultWorkspace?.workspaceId, ownerWorkspaces[0].workspaceId);


### PR DESCRIPTION
## Summary
- add local Postgres compose/setup support for team-mode testing
- migrate legacy workspace and single-user secrets into the new scoped workspace model
- fix workspace-aware markdown sharing, studio copy/reference pickers, chat history, and mobile workspace UI behavior
- harden agent bash execution so file mutations go through audited workspace tools

## Validation
- npm run build
- npx eslint app/lib/pi/agent-file-operations.ts app/lib/pi/tool-registry.ts

## Notes
- Greptile should run its automatic first review for this PR. I have not manually triggered greploop/Greptile.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds local Postgres/pgvector support via a Docker Compose profile, migrates legacy single-user workspace and secret data into the new scoped workspace model, and extends workspace awareness to chat history, session APIs, markdown sharing, studio reference pickers, and mobile workspace UI.

- **Postgres + setup**: `compose.yaml` adds an optional `postgres` profile with health-check and named volume; `scripts/setup.mjs` auto-detects team/enterprise deployment mode and enables the profile automatically.
- **Legacy migrations**: two new idempotent migration functions run at bootstrap with outer try/catch guards; both use atomic temp-file renames for crash-safety.
- **Agent hardening**: `agent-file-operations.ts` gains direct-mutation and mutating-git-command detectors matching `$()` and backtick forms; `tool-registry.ts` adds a named `BlockedBashCommandError` class and full audit-log records for every bash tool outcome.
- **Workspace-scoped sessions & sharing**: session list/messages APIs, chat history hooks, `ShareMarkdownDialog`, and studio `ReferencePickerDialog` all forward the active workspace ID so cross-workspace data leakage is prevented.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the ReferencePickerDialog workspace picker reset is fixed — that UI feature is currently non-functional on workspace change.

The studio reference picker workspace dropdown resets to the active workspace on every selection because `setReferenceWorkspaceId(activeWorkspace.id)` is co-located in the same `useEffect` that lists `loadWorkspaceTree` as a dependency; changing the picker updates `effectiveReferenceWorkspaceId`, which regenerates `loadWorkspaceTree`, which re-triggers the effect and overwrites the user's choice. All other changes — migrations, session scoping, bash hardening, and Compose setup — look correct and well-guarded.

app/apps/studio/components/create/ReferencePickerDialog.tsx — the workspace-picker reset bug lives in the useEffect dependency wiring around line 466.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/apps/studio/components/create/ReferencePickerDialog.tsx | Adds workspace picker to studio reference browser — but adding `loadWorkspaceTree` to a shared useEffect dep array causes the picker to reset to the active workspace immediately after every user selection. |
| app/lib/integrations/legacy-secret-migration.ts | New file: migrates legacy flat env secrets into per-user scoped files atomically. No marker written for source_missing/source_empty, causing repeated I/O checks on every login for users without legacy secrets. |
| app/lib/workspaces/legacy-migration.ts | New file: copies legacy workspace root into the personal workspace directory, with conflict handling and manifest writing. Same missing-marker pattern as secret migration for empty/missing source. |
| app/lib/organization/bootstrap.ts | Integrates both legacy migrations into bootstrap with outer try/catch guards so I/O failures degrade gracefully rather than aborting server startup. |
| app/lib/pi/tool-registry.ts | Promotes BlockedBashCommandError to a named class and adds audit logging for every bash tool execution (success, abort, blocked, failure). |
| app/lib/pi/agent-file-operations.ts | Adds shellUsesDirectFileMutationCommand and shellUsesMutatingGitCommand guards that now also match commands inside $() and backtick substitutions. |
| app/api/sessions/route.ts | Adds workspace-scoped filtering to session list, count-only, and mark-all-as-read endpoints. Non-null assertion on or() is a minor code smell. |
| app/api/sessions/messages/route.ts | Adds workspace ownership check before returning session messages; correctly allows legacy personal sessions when the active workspace is personal. |
| app/lib/integrations/media-reference-resolver.ts | Parses workspaceId query param from media URLs and resolves the correct workspace root via permission check; throws explicitly when workspaceId is present but userId is missing. |
| app/components/workspaces/WorkspaceSwitcher.tsx | Adds a new mobile-sheet variant rendering the workspace list in a bottom Sheet instead of a dropdown. |
| app/components/canvas-agent-chat/CanvasAgentChat.tsx | Replaces the single global active-session storage key with a per-workspace key; fixes the workspace-change handler to clear only the departing workspace's session. |
| compose.yaml | Adds an optional postgres service under the postgres Docker Compose profile with pgvector, health-check, and named volume; required:false keeps SQLite setups unaffected. |
| scripts/setup.mjs | Adds resolveDockerComposeEnvironment to auto-enable the postgres Compose profile when team/enterprise deployment mode is detected; passes the resolved env to all docker compose invocations. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant BootstrapTS as bootstrap.ts
    participant WsLegacy as legacy-migration.ts
    participant SecLegacy as legacy-secret-migration.ts
    participant SessionAPI as /api/sessions
    participant MsgAPI as /api/sessions/messages
    participant MediaResolver as media-reference-resolver.ts

    Browser->>BootstrapTS: user login
    BootstrapTS->>WsLegacy: migrateLegacyWorkspaceToPersonalWorkspace()
    WsLegacy-->>BootstrapTS: "status (migrated | skipped)"
    BootstrapTS->>SecLegacy: migrateLegacySecretsToUserScope(userId)
    SecLegacy-->>BootstrapTS: "status (migrated | skipped)"

    Browser->>SessionAPI: "GET /api/sessions?workspaceId=X"
    SessionAPI->>SessionAPI: resolveAgentSessionWorkspaceForUser(userId, X)
    SessionAPI->>SessionAPI: buildPiSessionWorkspaceCondition(workspace)
    SessionAPI-->>Browser: sessions filtered to workspace X

    Browser->>MsgAPI: "GET /api/sessions/messages?workspaceId=X"
    MsgAPI->>MsgAPI: check sessionWorkspaceId matches X
    MsgAPI-->>Browser: messages or 403

    Browser->>MediaResolver: "loadMediaReference("/api/media/f.png?workspaceId=X")"
    MediaResolver->>MediaResolver: "resolveWorkspaceScopedReferencePath(ref, {userId})"
    MediaResolver-->>Browser: file buffer
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant BootstrapTS as bootstrap.ts
    participant WsLegacy as legacy-migration.ts
    participant SecLegacy as legacy-secret-migration.ts
    participant SessionAPI as /api/sessions
    participant MsgAPI as /api/sessions/messages
    participant MediaResolver as media-reference-resolver.ts

    Browser->>BootstrapTS: user login
    BootstrapTS->>WsLegacy: migrateLegacyWorkspaceToPersonalWorkspace()
    WsLegacy-->>BootstrapTS: "status (migrated | skipped)"
    BootstrapTS->>SecLegacy: migrateLegacySecretsToUserScope(userId)
    SecLegacy-->>BootstrapTS: "status (migrated | skipped)"

    Browser->>SessionAPI: "GET /api/sessions?workspaceId=X"
    SessionAPI->>SessionAPI: resolveAgentSessionWorkspaceForUser(userId, X)
    SessionAPI->>SessionAPI: buildPiSessionWorkspaceCondition(workspace)
    SessionAPI-->>Browser: sessions filtered to workspace X

    Browser->>MsgAPI: "GET /api/sessions/messages?workspaceId=X"
    MsgAPI->>MsgAPI: check sessionWorkspaceId matches X
    MsgAPI-->>Browser: messages or 403

    Browser->>MediaResolver: "loadMediaReference("/api/media/f.png?workspaceId=X")"
    MediaResolver->>MediaResolver: "resolveWorkspaceScopedReferencePath(ref, {userId})"
    MediaResolver-->>Browser: file buffer
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review feedback"](https://github.com/canvascoding/canvas-notebook/commit/62290f7a6cfd358dfbb82418d06e2344cdbcaf0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40097697)</sub>

<!-- /greptile_comment -->