### PR TITLE
Fix agent runtime queue races

### DIFF
--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -59,6 +59,11 @@ import {
   getAgentRuntimeTempPromptBlock,
   resolveAgentRuntimeTempDir,
 } from '@/app/lib/pi/agent-runtime-temp';
+import {
+  RuntimeMessageQueues,
+  type RuntimeQueueEntry,
+  type RuntimeQueuePreview,
+} from '@/app/lib/pi/runtime-queue';
 
 export type { PiRuntimePromptContext } from '@/app/lib/pi/runtime-prompt-context';
 
@@ -121,21 +126,13 @@ async function getEmitter() {
 
 type RuntimePhase = 'idle' | 'streaming' | 'running_tool' | 'aborting';
 
-type QueueEntryPreview = {
-  id: string;
-  text: string;
-  attachmentCount: number;
-  messageTimestamp?: number;
-  signature?: string;
-};
-
 export type PiRuntimeStatus = {
   sessionId: string;
   phase: RuntimePhase;
   activeTool: { toolCallId: string; name: string } | null;
   pendingToolCalls: number;
-  followUpQueue: QueueEntryPreview[];
-  steeringQueue: QueueEntryPreview[];
+  followUpQueue: RuntimeQueuePreview[];
+  steeringQueue: RuntimeQueuePreview[];
   canAbort: boolean;
   contextWindow: number;
   estimatedHistoryTokens: number;
@@ -169,13 +166,6 @@ export type RuntimeErrorEvent = {
 
 export type PiRuntimeStreamEvent = AgentEvent | RuntimeStatusEvent | ContextCompactedEvent | RuntimeErrorEvent;
 type RuntimeSubscriber = (event: PiRuntimeStreamEvent) => void;
-
-type RuntimeQueueEntry = {
-  id: string;
-  preview: QueueEntryPreview;
-  message: Extract<AgentMessage, { role: 'user' }>;
-  signature: string;
-};
 
 type RuntimeTurnEndEvent = Extract<AgentEvent, { type: 'turn_end' }>;
 
@@ -276,7 +266,7 @@ function countMessageAttachments(message: Extract<AgentMessage, { role: 'user' }
   return message.content.filter((part) => part && typeof part === 'object' && 'type' in part && part.type === 'image').length;
 }
 
-function buildQueuePreview(message: Extract<AgentMessage, { role: 'user' }>): QueueEntryPreview {
+function buildQueuePreview(message: Extract<AgentMessage, { role: 'user' }>): RuntimeQueuePreview {
   return {
     id: `queue-${message.timestamp}-${Math.random().toString(36).slice(2, 8)}`,
     text: extractUserMessageText(message),
@@ -363,8 +353,7 @@ class LivePiRuntime {
   readonly agent: Agent;
 
   private readonly subscribers = new Set<RuntimeSubscriber>();
-  private followUpQueue: RuntimeQueueEntry[] = [];
-  private steeringQueue: RuntimeQueueEntry[] = [];
+  private readonly messageQueues = new RuntimeMessageQueues();
   private pendingReplace: RuntimeQueueEntry | null = null;
   private activeTool: { toolCallId: string; name: string } | null = null;
   private abortRequested = false;
@@ -438,6 +427,14 @@ class LivePiRuntime {
     return this.pendingReplace !== null;
   }
 
+  private get followUpQueue() {
+    return this.messageQueues.followUps;
+  }
+
+  private get steeringQueue() {
+    return this.messageQueues.steering;
+  }
+
   subscribe(subscriber: RuntimeSubscriber) {
     this.subscribers.add(subscriber);
     return () => {
@@ -492,9 +489,8 @@ class LivePiRuntime {
 
     const sanitized = sanitizeUserMessage(message);
     const entry = this.createQueueEntry(sanitized);
-    this.followUpQueue.push(entry);
+    this.messageQueues.enqueueFollowUp(entry, this.agent);
     this.touch();
-    this.agent.followUp(entry.message);
     this.publishStatus();
     return this.getStatus();
   }
@@ -506,27 +502,16 @@ class LivePiRuntime {
 
     const sanitized = sanitizeUserMessage(message);
     const entry = this.createQueueEntry(sanitized);
-    this.steeringQueue.push(entry);
+    this.messageQueues.enqueueSteering(entry, this.agent);
     this.touch();
-    this.agent.steer(entry.message);
     this.publishStatus();
     return this.getStatus();
   }
 
   async promoteQueuedMessageToSteering(queueItemId: string) {
-    const followUpIndex = this.followUpQueue.findIndex((entry) => entry.preview.id === queueItemId || entry.id === queueItemId);
-    if (followUpIndex === -1) {
-      return this.getStatus();
-    }
-
-    const [entry] = this.followUpQueue.splice(followUpIndex, 1);
+    const entry = this.messageQueues.promoteFollowUp(queueItemId, this.agent);
     if (!entry) {
       return this.getStatus();
-    }
-
-    this.agent.clearFollowUpQueue();
-    for (const queuedEntry of this.followUpQueue) {
-      this.agent.followUp(queuedEntry.message);
     }
 
     if (!this.isRunning && !this.agent.state.isStreaming) {
@@ -534,33 +519,15 @@ class LivePiRuntime {
       return this.getStatus();
     }
 
-    this.steeringQueue.push(entry);
+    this.messageQueues.enqueueSteering(entry, this.agent);
     this.touch();
-    this.agent.steer(entry.message);
     this.publishStatus();
     return this.getStatus();
   }
 
   async removeQueuedMessage(queueItemId: string) {
-    const followUpIndex = this.followUpQueue.findIndex((entry) => entry.preview.id === queueItemId || entry.id === queueItemId);
-    if (followUpIndex !== -1) {
-      this.followUpQueue.splice(followUpIndex, 1);
-      this.agent.clearFollowUpQueue();
-      for (const entry of this.followUpQueue) {
-        this.agent.followUp(entry.message);
-      }
-      this.touch();
-      this.publishStatus();
-      return this.getStatus();
-    }
-
-    const steeringIndex = this.steeringQueue.findIndex((entry) => entry.preview.id === queueItemId || entry.id === queueItemId);
-    if (steeringIndex !== -1) {
-      this.steeringQueue.splice(steeringIndex, 1);
-      this.agent.clearSteeringQueue();
-      for (const entry of this.steeringQueue) {
-        this.agent.steer(entry.message);
-      }
+    const removedKind = this.messageQueues.remove(queueItemId, this.agent);
+    if (removedKind) {
       this.touch();
       this.publishStatus();
     }
@@ -576,9 +543,7 @@ class LivePiRuntime {
       return this.getStatus();
     }
 
-    this.agent.clearAllQueues();
-    this.followUpQueue = [];
-    this.steeringQueue = [];
+    this.messageQueues.clear(this.agent);
     this.pendingReplace = this.createQueueEntry(sanitized);
     this.abortRequested = true;
     this.touch();
@@ -1223,17 +1188,7 @@ class LivePiRuntime {
   }
 
   private consumeQueuedMessage(message: Extract<AgentMessage, { role: 'user' }>) {
-    const signature = getMessageSignature(message);
-    const steeringIndex = this.steeringQueue.findIndex((entry) => entry.signature === signature);
-    if (steeringIndex !== -1) {
-      this.steeringQueue.splice(steeringIndex, 1);
-      return;
-    }
-
-    const followUpIndex = this.followUpQueue.findIndex((entry) => entry.signature === signature);
-    if (followUpIndex !== -1) {
-      this.followUpQueue.splice(followUpIndex, 1);
-    }
+    this.messageQueues.consume(getMessageSignature(message), this.agent);
   }
 
   private async handleTurnEnd(event: RuntimeTurnEndEvent) {

--- a/app/lib/pi/runtime-queue.ts
+++ b/app/lib/pi/runtime-queue.ts
@@ -1,0 +1,132 @@
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+
+export type RuntimeQueuePreview = {
+  id: string;
+  text: string;
+  attachmentCount: number;
+  messageTimestamp?: number;
+  signature?: string;
+};
+
+export type RuntimeQueueEntry = {
+  id: string;
+  preview: RuntimeQueuePreview;
+  message: Extract<AgentMessage, { role: 'user' }>;
+  signature: string;
+};
+
+type RuntimeQueueAgent = {
+  followUp: (message: AgentMessage) => void;
+  steer: (message: AgentMessage) => void;
+  clearFollowUpQueue: () => void;
+  clearSteeringQueue: () => void;
+  clearAllQueues: () => void;
+};
+
+export class RuntimeMessageQueues {
+  readonly followUps: RuntimeQueueEntry[] = [];
+  readonly steering: RuntimeQueueEntry[] = [];
+  private followUpsSuspended = false;
+  private attachedFollowUpId: string | null = null;
+
+  enqueueFollowUp(entry: RuntimeQueueEntry, agent: RuntimeQueueAgent): void {
+    this.followUps.push(entry);
+    this.attachNextFollowUp(agent);
+  }
+
+  enqueueSteering(entry: RuntimeQueueEntry, agent: RuntimeQueueAgent): void {
+    this.steering.push(entry);
+    agent.steer(entry.message);
+  }
+
+  promoteFollowUp(queueItemId: string, agent: RuntimeQueueAgent): RuntimeQueueEntry | null {
+    const followUpIndex = this.followUps.findIndex((entry) => entry.preview.id === queueItemId || entry.id === queueItemId);
+    if (followUpIndex === -1) {
+      return null;
+    }
+
+    const [entry] = this.followUps.splice(followUpIndex, 1);
+    if (!entry) {
+      return null;
+    }
+
+    // Agent-core continues draining every follow-up after a steering turn. Keep
+    // the remaining entries runtime-owned so Steer injects only this entry.
+    agent.clearFollowUpQueue();
+    this.attachedFollowUpId = null;
+    this.followUpsSuspended = this.followUps.length > 0;
+    return entry;
+  }
+
+  remove(queueItemId: string, agent: RuntimeQueueAgent): 'follow_up' | 'steer' | null {
+    const followUpIndex = this.followUps.findIndex((entry) => entry.preview.id === queueItemId || entry.id === queueItemId);
+    if (followUpIndex !== -1) {
+      const [removed] = this.followUps.splice(followUpIndex, 1);
+      if (this.followUpsSuspended) {
+        if (this.followUps.length === 0) {
+          this.followUpsSuspended = false;
+        }
+      } else if (removed?.id === this.attachedFollowUpId) {
+        agent.clearFollowUpQueue();
+        this.attachedFollowUpId = null;
+        this.attachNextFollowUp(agent);
+      }
+      return 'follow_up';
+    }
+
+    const steeringIndex = this.steering.findIndex((entry) => entry.preview.id === queueItemId || entry.id === queueItemId);
+    if (steeringIndex === -1) {
+      return null;
+    }
+
+    this.steering.splice(steeringIndex, 1);
+    agent.clearSteeringQueue();
+    for (const entry of this.steering) {
+      agent.steer(entry.message);
+    }
+    return 'steer';
+  }
+
+  consume(signature: string, agent: RuntimeQueueAgent): void {
+    const steeringIndex = this.steering.findIndex((entry) => entry.signature === signature);
+    if (steeringIndex !== -1) {
+      this.steering.splice(steeringIndex, 1);
+      return;
+    }
+
+    const followUpIndex = this.followUps.findIndex((entry) => entry.signature === signature);
+    if (followUpIndex !== -1) {
+      const [consumed] = this.followUps.splice(followUpIndex, 1);
+      if (consumed?.id === this.attachedFollowUpId) {
+        this.attachedFollowUpId = null;
+      }
+      if (this.followUps.length === 0) {
+        this.followUpsSuspended = false;
+      }
+      this.attachNextFollowUp(agent);
+    }
+  }
+
+  clear(agent: RuntimeQueueAgent): void {
+    agent.clearAllQueues();
+    this.followUps.length = 0;
+    this.steering.length = 0;
+    this.followUpsSuspended = false;
+    this.attachedFollowUpId = null;
+  }
+
+  private attachNextFollowUp(agent: RuntimeQueueAgent): void {
+    if (this.followUpsSuspended || this.attachedFollowUpId) {
+      return;
+    }
+
+    const nextEntry = this.followUps[0];
+    if (!nextEntry) {
+      return;
+    }
+
+    this.attachedFollowUpId = nextEntry.id;
+    agent.followUp(nextEntry.message);
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:pi:session-search": "tsx scripts/pi-session-search-tool-test.ts",
     "test:pi:delegate-task": "tsx scripts/pi-delegate-task-tool-test.ts",
     "test:pi:continuation": "tsx scripts/pi-run-continuation-guard-test.ts",
+    "test:pi:queue": "tsx scripts/pi-runtime-queue-test.ts",
     "test:pi:oauth-scope": "tsx scripts/pi-oauth-user-scope-test.ts",
     "test:agent:memory": "tsx scripts/agent-memory-store-test.ts",
     "test:agent:runtime-temp": "tsx --conditions react-server scripts/agent-runtime-temp-test.ts",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "test:all": "node scripts/test-all.mjs",
     "test:websocket:connection": "node scripts/test-websocket-connection.js",
     "test:websocket:multitab": "node scripts/test-websocket-multitab.js",
+    "test:websocket:session-queue": "tsx scripts/websocket-session-queue-test.ts",
     "test:websocket:read-unread": "node scripts/test-websocket-read-unread.js",
     "test:websocket:toast": "node scripts/test-websocket-toast.js",
     "test:websocket:load": "node scripts/test-websocket-load.js",

--- a/scripts/pi-runtime-queue-test.ts
+++ b/scripts/pi-runtime-queue-test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+
+import {
+  RuntimeMessageQueues,
+  type RuntimeQueueEntry,
+} from '../app/lib/pi/runtime-queue';
+
+type QueueAgentSpy = {
+  followUps: AgentMessage[];
+  steering: AgentMessage[];
+  clearFollowUps: number;
+  clearSteering: number;
+  followUp: (message: AgentMessage) => void;
+  steer: (message: AgentMessage) => void;
+  clearFollowUpQueue: () => void;
+  clearSteeringQueue: () => void;
+  clearAllQueues: () => void;
+};
+
+function createAgentSpy(): QueueAgentSpy {
+  const spy: QueueAgentSpy = {
+    followUps: [],
+    steering: [],
+    clearFollowUps: 0,
+    clearSteering: 0,
+    followUp: (message) => { spy.followUps.push(message); },
+    steer: (message) => { spy.steering.push(message); },
+    clearFollowUpQueue: () => {
+      spy.clearFollowUps += 1;
+      spy.followUps = [];
+    },
+    clearSteeringQueue: () => {
+      spy.clearSteering += 1;
+      spy.steering = [];
+    },
+    clearAllQueues: () => {
+      spy.clearFollowUpQueue();
+      spy.clearSteeringQueue();
+    },
+  };
+  return spy;
+}
+
+function entry(id: string, text: string, timestamp: number): RuntimeQueueEntry {
+  const message: Extract<AgentMessage, { role: 'user' }> = {
+    role: 'user',
+    content: text,
+    timestamp,
+  };
+  return {
+    id,
+    preview: {
+      id,
+      text,
+      attachmentCount: 0,
+      messageTimestamp: timestamp,
+      signature: `${timestamp}:${text}:0`,
+    },
+    message,
+    signature: `${timestamp}:${text}:0`,
+  };
+}
+
+const agent = createAgentSpy();
+const queues = new RuntimeMessageQueues();
+const keepQueued = entry('keep', 'keep queued', 1);
+const selected = entry('selected', 'steer only this', 2);
+
+queues.enqueueFollowUp(keepQueued, agent);
+queues.enqueueFollowUp(selected, agent);
+assert.deepEqual(agent.followUps.map((message) => message.content), ['keep queued']);
+
+const promoted = queues.promoteFollowUp(selected.id, agent);
+assert.equal(promoted, selected);
+assert.deepEqual(queues.followUps, [keepQueued]);
+assert.deepEqual(agent.followUps, []);
+
+queues.enqueueSteering(promoted!, agent);
+assert.deepEqual(agent.steering.map((message) => message.content), ['steer only this']);
+
+const laterFollowUp = entry('later', 'also keep queued', 3);
+queues.enqueueFollowUp(laterFollowUp, agent);
+assert.deepEqual(queues.followUps, [keepQueued, laterFollowUp]);
+assert.deepEqual(agent.followUps, []);
+
+agent.steering.shift();
+queues.consume(selected.signature, agent);
+assert.deepEqual(queues.followUps, [keepQueued, laterFollowUp]);
+assert.deepEqual(agent.followUps, []);
+
+assert.equal(queues.remove(keepQueued.id, agent), 'follow_up');
+assert.equal(queues.remove(laterFollowUp.id, agent), 'follow_up');
+
+const resumedFollowUp = entry('resumed', 'queue normally again', 4);
+queues.enqueueFollowUp(resumedFollowUp, agent);
+assert.deepEqual(agent.followUps.map((message) => message.content), ['queue normally again']);
+
+const automaticAgent = createAgentSpy();
+const automaticQueues = new RuntimeMessageQueues();
+const firstAutomatic = entry('first-auto', 'first automatic', 5);
+const secondAutomatic = entry('second-auto', 'second automatic', 6);
+automaticQueues.enqueueFollowUp(firstAutomatic, automaticAgent);
+automaticQueues.enqueueFollowUp(secondAutomatic, automaticAgent);
+assert.deepEqual(automaticAgent.followUps.map((message) => message.content), ['first automatic']);
+
+// Agent-core removes the active entry before emitting message_start. The queue
+// controller then releases exactly one following entry.
+automaticAgent.followUps.shift();
+automaticQueues.consume(firstAutomatic.signature, automaticAgent);
+assert.deepEqual(automaticAgent.followUps.map((message) => message.content), ['second automatic']);
+
+console.log('pi-runtime-queue-test: ok');

--- a/scripts/websocket-session-queue-test.ts
+++ b/scripts/websocket-session-queue-test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+
+import { runWebSocketSessionAction } from '../server/websocket-session-queue';
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+async function main() {
+  const firstStarted = createDeferred();
+  const allowFirstToFinish = createDeferred();
+  const order: string[] = [];
+
+  const first = runWebSocketSessionAction('user-1', 'session-1', async () => {
+    order.push('first:start');
+    firstStarted.resolve();
+    await allowFirstToFinish.promise;
+    order.push('first:end');
+  });
+
+  await firstStarted.promise;
+
+  const second = runWebSocketSessionAction('user-1', 'session-1', async () => {
+    order.push('second:start');
+    order.push('second:end');
+  });
+
+  await Promise.resolve();
+  assert.deepEqual(order, ['first:start']);
+
+  allowFirstToFinish.resolve();
+  await Promise.all([first, second]);
+  assert.deepEqual(order, ['first:start', 'first:end', 'second:start', 'second:end']);
+
+  const parallelStarted = createDeferred();
+  const parallelFinished = createDeferred();
+  let otherSessionRan = false;
+
+  const blockedSession = runWebSocketSessionAction('user-1', 'session-1', async () => {
+    parallelStarted.resolve();
+    await parallelFinished.promise;
+  });
+
+  await parallelStarted.promise;
+  await runWebSocketSessionAction('user-1', 'session-2', async () => {
+    otherSessionRan = true;
+  });
+  assert.equal(otherSessionRan, true);
+
+  parallelFinished.resolve();
+  await blockedSession;
+
+  let recoveredAfterFailure = false;
+  await assert.rejects(
+    runWebSocketSessionAction('user-1', 'session-3', async () => {
+      throw new Error('expected failure');
+    }),
+    /expected failure/,
+  );
+  await runWebSocketSessionAction('user-1', 'session-3', async () => {
+    recoveredAfterFailure = true;
+  });
+  assert.equal(recoveredAfterFailure, true);
+
+  console.log('websocket-session-queue-test: ok');
+}
+
+void main();

--- a/server/websocket-server.ts
+++ b/server/websocket-server.ts
@@ -23,6 +23,7 @@ import {
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import { initializeWebSocketBridge } from './chat-event-bridge';
 import { checkWsRateLimit } from './websocket-rate-limit';
+import { runWebSocketSessionAction } from './websocket-session-queue';
 import type { ChatRequestContext } from '@/app/lib/chat/types';
 import { db } from '@/app/lib/db';
 import { piSessions } from '@/app/lib/db/schema';
@@ -108,6 +109,16 @@ type ServerMessage =
       timestamp: number;
     }
   | { type: 'error'; error: string; code: string };
+
+function shouldSerializeSessionAction(message: ClientMessage): message is Extract<ClientMessage, {
+  type: 'send_message' | 'control' | 'change_model' | 'get_status';
+}> {
+  return (
+    (message.type === 'send_message' || message.type === 'control' || message.type === 'change_model' || message.type === 'get_status') &&
+    typeof message.sessionId === 'string' &&
+    message.sessionId.length > 0
+  );
+}
 
 const QUIET_SERVER_MESSAGE_TYPES = new Set(['agent_event']);
 
@@ -362,7 +373,10 @@ async function handleConnection(ws: WebSocket, request: IncomingMessage): Promis
         userId: connection.userId,
         ...summarizeClientMessage(message),
       });
-      void handleMessage(connection, message).catch((error) => {
+      const messageHandler = shouldSerializeSessionAction(message)
+        ? runWebSocketSessionAction(connection.userId, message.sessionId, () => handleMessage(connection, message))
+        : handleMessage(connection, message);
+      void messageHandler.catch((error) => {
         console.error('[WebSocket] handleMessage failed', {
           connectionId,
           userId: connection?.userId,

--- a/server/websocket-session-queue.ts
+++ b/server/websocket-session-queue.ts
@@ -1,0 +1,42 @@
+/**
+ * Serializes state-changing chat WebSocket actions for one user/session pair.
+ *
+ * WebSocket frames are received in order, but their asynchronous handlers are
+ * otherwise allowed to overlap. Runtime startup and queue controls must keep
+ * that arrival order so a follow-up cannot overtake the prompt that starts it.
+ */
+
+const sessionActionTails = new Map<string, Promise<void>>();
+
+function getSessionActionKey(userId: string, sessionId: string): string {
+  return JSON.stringify([userId, sessionId]);
+}
+
+export async function runWebSocketSessionAction<T>(
+  userId: string,
+  sessionId: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  const key = getSessionActionKey(userId, sessionId);
+  const previousTail = sessionActionTails.get(key) ?? Promise.resolve();
+
+  let releaseCurrent!: () => void;
+  const currentAction = new Promise<void>((resolve) => {
+    releaseCurrent = resolve;
+  });
+  const currentTail = previousTail
+    .catch(() => undefined)
+    .then(() => currentAction);
+
+  sessionActionTails.set(key, currentTail);
+  await previousTail.catch(() => undefined);
+
+  try {
+    return await action();
+  } finally {
+    releaseCurrent();
+    if (sessionActionTails.get(key) === currentTail) {
+      sessionActionTails.delete(key);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Serialize state-changing chat WebSocket actions per user/session so follow-ups cannot overtake runtime startup.
- Keep follow-up queue ownership in the runtime and attach only one item to agent-core at a time.
- Make Steer suspend all remaining follow-ups, so only the selected message enters the active runtime.
- Add regression tests for WebSocket session ordering and runtime queue consumption.

## Verification
- npm run lint
- npm run build
- npm run test:websocket:session-queue
- npm run test:pi:queue

## Notes
- No UI change; no Playwright run was started under the repository explicit-approval rule.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how Pi runtime and WebSocket queues preserve chat action order. The main changes are:

- Runtime-owned follow-up and steering queues in `RuntimeMessageQueues`.
- One-at-a-time follow-up attachment to agent-core.
- Per-user/session WebSocket action serialization.
- Regression scripts for runtime queue and WebSocket ordering behavior.

<h3>Confidence Score: 4/5</h3>

The runtime queue promotion path can leave remaining follow-ups stuck.

- Promoting one queued follow-up clears agent-core's follow-up queue.
- Remaining runtime-owned follow-ups stay suspended after the steering message is consumed.
- WebSocket session serialization and import changes look contained.

app/lib/pi/runtime-queue.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/lib/pi/runtime-queue.ts | Adds runtime-owned queue management, with a stuck suspended-follow-up path after steering promotion. |
| app/lib/pi/live-runtime.ts | Delegates follow-up, steering, remove, replace, and consume behavior to the new queue controller. |
| server/websocket-session-queue.ts | Adds a per-user/session promise queue for ordered WebSocket action handling. |
| server/websocket-server.ts | Wraps session-scoped chat actions in the new WebSocket session queue. |
| scripts/pi-runtime-queue-test.ts | Adds coverage for one-at-a-time runtime queue attachment and steering promotion behavior. |
| scripts/websocket-session-queue-test.ts | Adds coverage for FIFO session actions, cross-session parallelism, and recovery after failures. |
| package.json | Adds npm scripts for the new queue tests. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Multiple follow-ups queued] --> B[One follow-up attached to agent-core]
  A --> C[User promotes a queued follow-up]
  C --> D[Agent follow-up queue is cleared]
  D --> E[Remaining follow-ups stay runtime-owned]
  E --> F[followUpsSuspended remains true]
  C --> G[Promoted message enters steering]
  G --> H[Steering message is consumed]
  H --> I[Remaining follow-ups are not re-attached]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Multiple follow-ups queued] --> B[One follow-up attached to agent-core]
  A --> C[User promotes a queued follow-up]
  C --> D[Agent follow-up queue is cleared]
  D --> E[Remaining follow-ups stay runtime-owned]
  E --> F[followUpsSuspended remains true]
  C --> G[Promoted message enters steering]
  G --> H[Steering message is consumed]
  H --> I[Remaining follow-ups are not re-attached]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22canvascoding%2Fcanvas-notebook%22%20on%20the%20existing%20branch%20%22codex%2Ffix-agent-runtime-queue-pr%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-agent-runtime-queue-pr%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Flib%2Fpi%2Fruntime-queue.ts%3A57%0A**Suspended%20Follow-Ups%20Stay%20Stuck**%0A%0AWhen%20one%20follow-up%20is%20promoted%20while%20others%20remain%20queued%2C%20this%20clears%20agent-core's%20follow-up%20queue%20and%20leaves%20%60followUpsSuspended%60%20set%20to%20%60true%60.%20The%20promoted%20steering%20message%20is%20consumed%20from%20the%20steering%20queue%2C%20so%20the%20remaining%20follow-ups%20are%20never%20re-attached%20to%20agent-core%3B%20they%20stay%20visible%20in%20status%20but%20do%20not%20run%20unless%20the%20user%20manually%20removes%20or%20clears%20them.%0A%0A&repo=canvascoding%2Fcanvas-notebook&pr=52&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Prevent Steer from draining queued follo..."](https://github.com/canvascoding/canvas-notebook/commit/68a9c27435e8861c00bc0975b593fc86be2054b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43263669)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/frankalexanderweber/github/canvascoding/canvas-notebook/-/custom-context?memory=b35881f6-33ef-4271-aa8c-df3699308035))
- Context used - AGENTS.md ([source](https://app.greptile.com/frankalexanderweber/github/canvascoding/canvas-notebook/-/custom-context?memory=860bb516-1d67-4762-a09d-53ca2be05b40))
- Context used - seed_sys_prompts/AGENTS.md ([source](https://app.greptile.com/frankalexanderweber/github/canvascoding/canvas-notebook/-/custom-context?memory=22280b08-f012-4954-8123-d51dd80dd274))
</details>

<!-- /greptile_comment -->