### PR TITLE
Redesign settings navigation with sidebar

### DIFF
--- a/app/[locale]/(routes)/settings/page.tsx
+++ b/app/[locale]/(routes)/settings/page.tsx
@@ -8,10 +8,13 @@ import { isAdminUser } from '@/app/lib/admin-auth';
 import { readOrganizationPermissionForUser } from '@/app/lib/organization/permissions';
 import { getServerPreferredTimeZone } from '@/app/lib/server-settings';
 import { getUserOnboardingState } from '@/app/lib/user-preferences';
+import { SETTINGS_SIDEBAR_COLLAPSED_COOKIE } from '@/app/lib/settings-navigation';
+import { cookies } from 'next/headers';
 
 export default async function SettingsPage() {
   const session = await requirePageSession({ allowUnlicensed: true });
   const t = await getTranslations('settings');
+  const cookieStore = await cookies();
 
   const isAdmin = isAdminUser(session?.user);
   const currentUserId = session?.user?.id || '';
@@ -19,6 +22,7 @@ export default async function SettingsPage() {
   const userEmail = session?.user?.email || '';
   const isManagedControlPlane = isManagedControlPlaneAvailable();
   const initialTimeZone = await getServerPreferredTimeZone();
+  const initialSettingsSidebarCollapsed = cookieStore.get(SETTINGS_SIDEBAR_COLLAPSED_COOKIE)?.value === 'true';
   const userOnboarding = currentUserId ? await getUserOnboardingState(currentUserId) : null;
   let organizationPermission = null;
   if (currentUserId) {
@@ -38,6 +42,7 @@ export default async function SettingsPage() {
           userEmail={userEmail}
           isManagedControlPlane={isManagedControlPlane}
           initialTimeZone={initialTimeZone}
+          initialSettingsSidebarCollapsed={initialSettingsSidebarCollapsed}
           organizationPermission={organizationPermission}
         />
     </SuitePageLayout>

--- a/app/components/settings/IntegrationsSettingsClient.tsx
+++ b/app/components/settings/IntegrationsSettingsClient.tsx
@@ -38,6 +38,7 @@ import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useHintContext } from '@/app/components/onboarding/HintProvider';
 import type { OrganizationPermissionSnapshot } from '@/app/lib/organization/bootstrap';
+import { SETTINGS_SIDEBAR_COLLAPSED_COOKIE } from '@/app/lib/settings-navigation';
 import { cn } from '@/lib/utils';
 
 type EnvScope = 'integrations' | 'agents';
@@ -250,7 +251,6 @@ type ScopeCardConfig = {
 };
 
 const SETTINGS_TAB_STORAGE_KEY = 'canvas-settings-active-tab';
-const SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY = 'canvas-settings-sidebar-collapsed';
 const ENV_CARD_OPEN_STORAGE_KEY = 'canvas-settings-env-card-open-state';
 const INTEGRATIONS_SECTION_OPEN_STORAGE_KEY = 'canvas-settings-integrations-section-open-state';
 const SETTINGS_TAB_CONTENT_CLASS = 'space-y-4';
@@ -2219,6 +2219,7 @@ export function IntegrationsSettingsClient({
   userEmail = '',
   isManagedControlPlane = false,
   initialTimeZone,
+  initialSettingsSidebarCollapsed = false,
   organizationPermission = null,
 }: {
   isAdmin?: boolean;
@@ -2227,6 +2228,7 @@ export function IntegrationsSettingsClient({
   userEmail?: string;
   isManagedControlPlane?: boolean;
   initialTimeZone?: string;
+  initialSettingsSidebarCollapsed?: boolean;
   organizationPermission?: WorkspaceOrganizationPermission;
 }) {
   const t = useTranslations('settings');
@@ -2236,7 +2238,7 @@ export function IntegrationsSettingsClient({
   const initialTab = getInitialSettingsTab(requestedTab);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>(initialTab);
   const [loadedTabs, setLoadedTabs] = useState<Set<SettingsTab>>(() => new Set([initialTab]));
-  const [settingsSidebarCollapsed, setSettingsSidebarCollapsed] = useState(false);
+  const [settingsSidebarCollapsed, setSettingsSidebarCollapsed] = useState(initialSettingsSidebarCollapsed);
   const { activeTabOverride } = useHintContext();
   const integrationsInitialLoadStartedRef = useRef(false);
 
@@ -2549,11 +2551,6 @@ export function IntegrationsSettingsClient({
     startTransition(() => {
       setEnvCardOpenByScope(getStoredEnvCardOpenState());
       setIntegrationsSectionOpenById(getStoredIntegrationsSectionOpenState());
-      try {
-        setSettingsSidebarCollapsed(window.localStorage.getItem(SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY) === 'true');
-      } catch {
-        // The expanded settings navigation remains usable without browser storage.
-      }
     });
   }, []);
 
@@ -2942,7 +2939,8 @@ export function IntegrationsSettingsClient({
   const handleSettingsSidebarCollapsedChange = (collapsed: boolean) => {
     setSettingsSidebarCollapsed(collapsed);
     try {
-      window.localStorage.setItem(SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY, String(collapsed));
+      const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie = `${SETTINGS_SIDEBAR_COLLAPSED_COOKIE}=${String(collapsed)}; Path=/; Max-Age=31536000; SameSite=Lax${secure}`;
     } catch {
       // The settings navigation still collapses for the current session.
     }

--- a/app/components/settings/IntegrationsSettingsClient.tsx
+++ b/app/components/settings/IntegrationsSettingsClient.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, startTransition, typ
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { ChevronDown, Copy, ExternalLink, Eye, EyeOff, Loader2, Mail, Menu, Plus, RefreshCw, Save, Search, Settings, Star, Trash2 } from 'lucide-react';
+import { ChevronDown, Copy, ExternalLink, Eye, EyeOff, Loader2, Mail, Plus, RefreshCw, Save, Search, Settings, Star, Trash2 } from 'lucide-react';
 
 import { GeneralSettingsPanel } from '@/app/components/settings/GeneralSettingsPanel';
 import {
@@ -19,12 +19,18 @@ import {
   type McpServerDraft,
 } from '@/app/components/settings/McpServerDialog';
 import { SettingsAccordionCard } from '@/app/components/settings/SettingsAccordionCard';
+import {
+  SETTINGS_NAV_GROUPS,
+  SETTINGS_TAB_ITEMS,
+  SETTINGS_TABS,
+  SettingsNavigation,
+  type SettingsTab,
+} from '@/app/components/settings/SettingsNavigation';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -32,6 +38,7 @@ import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useHintContext } from '@/app/components/onboarding/HintProvider';
 import type { OrganizationPermissionSnapshot } from '@/app/lib/organization/bootstrap';
+import { cn } from '@/lib/utils';
 
 type EnvScope = 'integrations' | 'agents';
 
@@ -242,27 +249,12 @@ type ScopeCardConfig = {
   keyHint: string;
 };
 
-const SETTINGS_TAB_ITEMS = [
-  { value: 'general', labelKey: 'tabs.general' },
-  { value: 'integrations', labelKey: 'tabs.integrations' },
-  { value: 'agent-settings', labelKey: 'tabs.agentSettings' },
-  { value: 'browser', labelKey: 'tabs.browser' },
-  { value: 'workspace', labelKey: 'tabs.workspace' },
-  { value: 'knowledge', labelKey: 'tabs.knowledge' },
-  { value: 'user-management', labelKey: 'tabs.userManagement' },
-  { value: 'channels', labelKey: 'tabs.channels' },
-  { value: 'usage', labelKey: 'tabs.usage' },
-  { value: 'skills', labelKey: 'tabs.skills' },
-  { value: 'license', labelKey: 'tabs.license' },
-] as const;
-const SETTINGS_TABS = SETTINGS_TAB_ITEMS.map((tab) => tab.value);
 const SETTINGS_TAB_STORAGE_KEY = 'canvas-settings-active-tab';
+const SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY = 'canvas-settings-sidebar-collapsed';
 const ENV_CARD_OPEN_STORAGE_KEY = 'canvas-settings-env-card-open-state';
 const INTEGRATIONS_SECTION_OPEN_STORAGE_KEY = 'canvas-settings-integrations-section-open-state';
-const SETTINGS_TAB_TRIGGER_CLASS = 'min-h-9 min-w-0 border border-border px-2 data-[state=active]:bg-muted';
-const SETTINGS_TAB_CONTENT_CLASS = 'space-y-4 data-[state=inactive]:hidden';
+const SETTINGS_TAB_CONTENT_CLASS = 'space-y-4';
 
-type SettingsTab = (typeof SETTINGS_TAB_ITEMS)[number]['value'];
 type EnvCardOpenState = Record<EnvScope, boolean>;
 type IntegrationsSectionId = 'search' | 'connectedApps' | 'emailAccounts' | 'mcpConfig';
 type IntegrationsSectionOpenState = Record<IntegrationsSectionId, boolean>;
@@ -2244,6 +2236,7 @@ export function IntegrationsSettingsClient({
   const initialTab = getInitialSettingsTab(requestedTab);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>(initialTab);
   const [loadedTabs, setLoadedTabs] = useState<Set<SettingsTab>>(() => new Set([initialTab]));
+  const [settingsSidebarCollapsed, setSettingsSidebarCollapsed] = useState(false);
   const { activeTabOverride } = useHintContext();
   const integrationsInitialLoadStartedRef = useRef(false);
 
@@ -2272,14 +2265,14 @@ export function IntegrationsSettingsClient({
     const shouldRender = shouldRenderTab(tab);
 
     return (
-      <TabsContent
-        value={tab}
+      <section
         className={SETTINGS_TAB_CONTENT_CLASS}
         id={options.id}
-        forceMount={shouldRender ? true : undefined}
+        aria-labelledby={`settings-content-${tab}`}
+        hidden={visibleEffectiveTab !== tab}
       >
         {shouldRender ? children : null}
-      </TabsContent>
+      </section>
     );
   };
   const handleTabChange = (value: string) => {
@@ -2556,6 +2549,11 @@ export function IntegrationsSettingsClient({
     startTransition(() => {
       setEnvCardOpenByScope(getStoredEnvCardOpenState());
       setIntegrationsSectionOpenById(getStoredIntegrationsSectionOpenState());
+      try {
+        setSettingsSidebarCollapsed(window.localStorage.getItem(SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY) === 'true');
+      } catch {
+        // The expanded settings navigation remains usable without browser storage.
+      }
     });
   }, []);
 
@@ -2938,131 +2936,141 @@ export function IntegrationsSettingsClient({
   };
 
   const activeSettingsTab = visibleSettingsTabItems.find((tab) => tab.value === visibleEffectiveTab) ?? visibleSettingsTabItems[0] ?? SETTINGS_TAB_ITEMS[0];
+  const activeSettingsGroup = SETTINGS_NAV_GROUPS.find((group) => group.id === activeSettingsTab.group) ?? SETTINGS_NAV_GROUPS[0];
+  const ActiveSettingsIcon = activeSettingsTab.icon;
+
+  const handleSettingsSidebarCollapsedChange = (collapsed: boolean) => {
+    setSettingsSidebarCollapsed(collapsed);
+    try {
+      window.localStorage.setItem(SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY, String(collapsed));
+    } catch {
+      // The settings navigation still collapses for the current session.
+    }
+  };
 
   return (
-    <div className="mx-auto w-full max-w-6xl overflow-x-hidden px-3 py-4 sm:px-6 sm:py-6">
-      <Tabs
-        value={visibleEffectiveTab}
-        onValueChange={handleTabChange}
-        className="min-w-0 space-y-4"
+    <div className="mx-auto w-full max-w-7xl overflow-x-clip">
+      <div
+        className={cn(
+          'min-w-0 lg:grid lg:transition-[grid-template-columns] lg:duration-200 lg:ease-out',
+          settingsSidebarCollapsed
+            ? 'lg:grid-cols-[4rem_minmax(0,1fr)]'
+            : 'lg:grid-cols-[16rem_minmax(0,1fr)]',
+        )}
       >
-        <div className="lg:hidden">
-          <DropdownMenu modal={false}>
-            <DropdownMenuTrigger asChild>
-              <Button type="button" variant="outline" className="h-11 w-full justify-between px-3">
-                <span className="flex min-w-0 items-center gap-2">
-                  <Menu className="h-4 w-4" aria-hidden="true" />
-                  <span className="min-w-0 truncate">{t(activeSettingsTab.labelKey)}</span>
-                </span>
-                <ChevronDown className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" sideOffset={8} className="max-h-[min(26rem,calc(100dvh-8rem))] w-[calc(100vw-1.5rem)] max-w-sm overflow-y-auto">
-              <DropdownMenuRadioGroup value={visibleEffectiveTab} onValueChange={handleTabChange}>
-                {visibleSettingsTabItems.map((tab) => (
-                  <DropdownMenuRadioItem key={tab.value} value={tab.value} className="min-h-10">
-                    {t(tab.labelKey)}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+        <SettingsNavigation
+          activeTab={visibleEffectiveTab}
+          visibleTabs={visibleSettingsTabs}
+          collapsed={settingsSidebarCollapsed}
+          onCollapsedChange={handleSettingsSidebarCollapsedChange}
+          onTabChange={handleTabChange}
+        />
 
-        <TabsList className="hidden h-auto w-full grid-cols-[repeat(auto-fit,minmax(0,1fr))] gap-2 bg-transparent p-0 lg:grid">
-          {visibleSettingsTabItems.map((tab) => (
-            <TabsTrigger key={tab.value} value={tab.value} className={SETTINGS_TAB_TRIGGER_CLASS}>
-              <span className="min-w-0 truncate">{t(tab.labelKey)}</span>
-            </TabsTrigger>
-          ))}
-        </TabsList>
+        <div className="min-w-0 px-3 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-7">
+          <div className="mb-5 flex min-w-0 items-start gap-3 border-b border-border/70 pb-5 sm:gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border bg-muted/60 shadow-sm sm:h-11 sm:w-11">
+              <ActiveSettingsIcon className="h-5 w-5 text-primary" aria-hidden="true" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-[0.65rem] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+                {t(activeSettingsGroup.labelKey)}
+              </p>
+              <h2 className="mt-1 text-xl font-semibold tracking-tight sm:text-2xl" id={`settings-content-${activeSettingsTab.value}`}>
+                {t(activeSettingsTab.labelKey)}
+              </h2>
+              <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
+                {t(activeSettingsTab.descriptionKey)}
+              </p>
+            </div>
+          </div>
 
-        {renderLazyTabContent('general',
-          <GeneralSettingsPanel
-            userName={userName}
-            userEmail={userEmail}
-            isManagedControlPlane={isManagedControlPlane}
-            isAdmin={isAdmin}
-            initialTimeZone={initialTimeZone}
-          />,
-        )}
+          {renderLazyTabContent('general',
+            <GeneralSettingsPanel
+              userName={userName}
+              userEmail={userEmail}
+              isManagedControlPlane={isManagedControlPlane}
+              isAdmin={isAdmin}
+              initialTimeZone={initialTimeZone}
+            />,
+          )}
 
-        {renderLazyTabContent('integrations',
-          <>
-            <SearchIntegrationCard
-              isOpen={integrationsSectionOpenById.search}
-              onOpenChange={(isOpen) => setIntegrationsSectionOpen('search', isOpen)}
-              onEnvSaved={() => loadState('integrations')}
-            />
-            <ConnectedAppsPanel
-              isOpen={integrationsSectionOpenById.connectedApps}
-              onOpenChange={(isOpen) => setIntegrationsSectionOpen('connectedApps', isOpen)}
-            />
-            <EmailAccountsCard
-              isOpen={integrationsSectionOpenById.emailAccounts}
-              onOpenChange={(isOpen) => setIntegrationsSectionOpen('emailAccounts', isOpen)}
-            />
-            <McpConfigCard
-              isOpen={integrationsSectionOpenById.mcpConfig}
-              onOpenChange={(isOpen) => setIntegrationsSectionOpen('mcpConfig', isOpen)}
-              editor={mcpEditor}
-              onLoad={loadMcpConfig}
-              onLoadStatus={loadMcpStatus}
-              onServerAction={runMcpServerAction}
-              onSaveServer={saveMcpServer}
-              onDeleteServer={deleteMcpServer}
-              onRawChange={setMcpRawContent}
-              onSave={saveMcpConfig}
-            />
-            {SCOPE_CARDS.map((card) => (
-              <EnvEditorCard
-                key={card.scope}
-                card={card}
-                editor={editors[card.scope]}
-                isOpen={envCardOpenByScope[card.scope]}
-                onOpenChange={setEnvCardOpen}
-                onActiveTabChange={setActiveTab}
-                onLoad={loadState}
-                onAddEntry={addDraftEntry}
-                onRemoveEntry={removeDraftEntry}
-                onUpdateEntry={updateDraftEntry}
-                onToggleSecret={toggleSecretVisibility}
-                onRawChange={setRawContent}
-                onSaveKeyValue={saveKeyValue}
-                onSaveRaw={saveRaw}
+          {renderLazyTabContent('integrations',
+            <>
+              <SearchIntegrationCard
+                isOpen={integrationsSectionOpenById.search}
+                onOpenChange={(isOpen) => setIntegrationsSectionOpen('search', isOpen)}
+                onEnvSaved={() => loadState('integrations')}
               />
-            ))}
-          </>,
-          { id: 'onboarding-settings-integrations' },
-        )}
+              <ConnectedAppsPanel
+                isOpen={integrationsSectionOpenById.connectedApps}
+                onOpenChange={(isOpen) => setIntegrationsSectionOpen('connectedApps', isOpen)}
+              />
+              <EmailAccountsCard
+                isOpen={integrationsSectionOpenById.emailAccounts}
+                onOpenChange={(isOpen) => setIntegrationsSectionOpen('emailAccounts', isOpen)}
+              />
+              <McpConfigCard
+                isOpen={integrationsSectionOpenById.mcpConfig}
+                onOpenChange={(isOpen) => setIntegrationsSectionOpen('mcpConfig', isOpen)}
+                editor={mcpEditor}
+                onLoad={loadMcpConfig}
+                onLoadStatus={loadMcpStatus}
+                onServerAction={runMcpServerAction}
+                onSaveServer={saveMcpServer}
+                onDeleteServer={deleteMcpServer}
+                onRawChange={setMcpRawContent}
+                onSave={saveMcpConfig}
+              />
+              {SCOPE_CARDS.map((card) => (
+                <EnvEditorCard
+                  key={card.scope}
+                  card={card}
+                  editor={editors[card.scope]}
+                  isOpen={envCardOpenByScope[card.scope]}
+                  onOpenChange={setEnvCardOpen}
+                  onActiveTabChange={setActiveTab}
+                  onLoad={loadState}
+                  onAddEntry={addDraftEntry}
+                  onRemoveEntry={removeDraftEntry}
+                  onUpdateEntry={updateDraftEntry}
+                  onToggleSecret={toggleSecretVisibility}
+                  onRawChange={setRawContent}
+                  onSaveKeyValue={saveKeyValue}
+                  onSaveRaw={saveRaw}
+                />
+              ))}
+            </>,
+            { id: 'onboarding-settings-integrations' },
+          )}
 
-        {renderLazyTabContent('agent-settings', <AgentSettingsPanel />)}
+          {renderLazyTabContent('agent-settings', <AgentSettingsPanel />)}
 
-        {renderLazyTabContent('browser', <BrowserSettingsPanel isAdmin={isAdmin} />)}
+          {renderLazyTabContent('browser', <BrowserSettingsPanel isAdmin={isAdmin} />)}
 
-        {renderLazyTabContent('workspace', (
-          <WorkspaceSettingsPanel
-            isAdmin={isAdmin}
-            organizationPermission={organizationPermission}
-            workspaceManagementOpen={workspaceManagementOpen}
-            createWorkspaceOpen={createWorkspaceOpen}
-          />
-        ))}
+          {renderLazyTabContent('workspace', (
+            <WorkspaceSettingsPanel
+              isAdmin={isAdmin}
+              organizationPermission={organizationPermission}
+              workspaceManagementOpen={workspaceManagementOpen}
+              createWorkspaceOpen={createWorkspaceOpen}
+            />
+          ))}
 
-        {renderLazyTabContent('knowledge', <KnowledgeSettingsPanel />)}
+          {renderLazyTabContent('knowledge', <KnowledgeSettingsPanel />)}
 
-        {renderLazyTabContent('user-management',
-          <UserManagementPanel currentUserId={currentUserId} isAdmin={isAdmin} />,
-        )}
+          {renderLazyTabContent('user-management',
+            <UserManagementPanel currentUserId={currentUserId} isAdmin={isAdmin} />,
+          )}
 
-        {renderLazyTabContent('channels', <ChannelsPanel isAdmin={isAdmin} />)}
+          {renderLazyTabContent('channels', <ChannelsPanel isAdmin={isAdmin} />)}
 
-        {renderLazyTabContent('usage', <UsageAnalyticsClient isAdmin={isAdmin} />, { id: 'onboarding-settings-usage' })}
+          {renderLazyTabContent('usage', <UsageAnalyticsClient isAdmin={isAdmin} />, { id: 'onboarding-settings-usage' })}
 
-        {renderLazyTabContent('skills', <SkillsPanel />)}
+          {renderLazyTabContent('skills', <SkillsPanel />)}
 
-        {renderLazyTabContent('license', <LicenseActivationPanel defaultEmail={userEmail} />)}
-      </Tabs>
+          {renderLazyTabContent('license', <LicenseActivationPanel defaultEmail={userEmail} />)}
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/components/settings/SettingsNavigation.tsx
+++ b/app/components/settings/SettingsNavigation.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useMemo, useState, type ComponentType } from 'react';
+import {
+  BadgeCheck,
+  BarChart3,
+  Bot,
+  BrainCircuit,
+  FolderCog,
+  Globe,
+  Menu,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Plug,
+  Puzzle,
+  Radio,
+  Settings2,
+  UserRound,
+  Users,
+  type LucideProps,
+} from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+export type SettingsTab =
+  | 'general'
+  | 'integrations'
+  | 'agent-settings'
+  | 'browser'
+  | 'workspace'
+  | 'knowledge'
+  | 'user-management'
+  | 'channels'
+  | 'usage'
+  | 'skills'
+  | 'license';
+
+export type SettingsGroup = 'account' | 'workspace' | 'agents' | 'connections' | 'system';
+
+type SettingsIcon = ComponentType<LucideProps>;
+
+export type SettingsNavigationItem = {
+  value: SettingsTab;
+  labelKey: string;
+  descriptionKey: string;
+  group: SettingsGroup;
+  icon: SettingsIcon;
+};
+
+export const SETTINGS_NAV_GROUPS: ReadonlyArray<{ id: SettingsGroup; labelKey: string }> = [
+  { id: 'account', labelKey: 'navigation.groups.account' },
+  { id: 'workspace', labelKey: 'navigation.groups.workspace' },
+  { id: 'agents', labelKey: 'navigation.groups.agents' },
+  { id: 'connections', labelKey: 'navigation.groups.connections' },
+  { id: 'system', labelKey: 'navigation.groups.system' },
+];
+
+export const SETTINGS_TAB_ITEMS: ReadonlyArray<SettingsNavigationItem> = [
+  {
+    value: 'general',
+    labelKey: 'tabs.general',
+    descriptionKey: 'navigation.descriptions.general',
+    group: 'account',
+    icon: UserRound,
+  },
+  {
+    value: 'workspace',
+    labelKey: 'tabs.workspace',
+    descriptionKey: 'navigation.descriptions.workspace',
+    group: 'workspace',
+    icon: FolderCog,
+  },
+  {
+    value: 'knowledge',
+    labelKey: 'tabs.knowledge',
+    descriptionKey: 'navigation.descriptions.knowledge',
+    group: 'workspace',
+    icon: BrainCircuit,
+  },
+  {
+    value: 'agent-settings',
+    labelKey: 'tabs.agentSettings',
+    descriptionKey: 'navigation.descriptions.agentSettings',
+    group: 'agents',
+    icon: Bot,
+  },
+  {
+    value: 'browser',
+    labelKey: 'tabs.browser',
+    descriptionKey: 'navigation.descriptions.browser',
+    group: 'agents',
+    icon: Globe,
+  },
+  {
+    value: 'skills',
+    labelKey: 'tabs.skills',
+    descriptionKey: 'navigation.descriptions.skills',
+    group: 'agents',
+    icon: Puzzle,
+  },
+  {
+    value: 'integrations',
+    labelKey: 'tabs.integrations',
+    descriptionKey: 'navigation.descriptions.integrations',
+    group: 'connections',
+    icon: Plug,
+  },
+  {
+    value: 'channels',
+    labelKey: 'tabs.channels',
+    descriptionKey: 'navigation.descriptions.channels',
+    group: 'connections',
+    icon: Radio,
+  },
+  {
+    value: 'user-management',
+    labelKey: 'tabs.userManagement',
+    descriptionKey: 'navigation.descriptions.userManagement',
+    group: 'system',
+    icon: Users,
+  },
+  {
+    value: 'usage',
+    labelKey: 'tabs.usage',
+    descriptionKey: 'navigation.descriptions.usage',
+    group: 'system',
+    icon: BarChart3,
+  },
+  {
+    value: 'license',
+    labelKey: 'tabs.license',
+    descriptionKey: 'navigation.descriptions.license',
+    group: 'system',
+    icon: BadgeCheck,
+  },
+];
+
+export const SETTINGS_TABS = SETTINGS_TAB_ITEMS.map((item) => item.value);
+
+type SettingsNavigationProps = {
+  activeTab: SettingsTab;
+  visibleTabs: ReadonlySet<SettingsTab>;
+  collapsed: boolean;
+  onCollapsedChange: (collapsed: boolean) => void;
+  onTabChange: (tab: SettingsTab) => void;
+};
+
+function NavigationItems({
+  activeTab,
+  visibleTabs,
+  collapsed,
+  onTabChange,
+  onNavigate,
+}: Pick<SettingsNavigationProps, 'activeTab' | 'visibleTabs' | 'collapsed' | 'onTabChange'> & {
+  onNavigate?: () => void;
+}) {
+  const t = useTranslations('settings');
+  const visibleGroups = useMemo(
+    () => SETTINGS_NAV_GROUPS.map((group) => ({
+      ...group,
+      items: SETTINGS_TAB_ITEMS.filter((item) => item.group === group.id && visibleTabs.has(item.value)),
+    })).filter((group) => group.items.length > 0),
+    [visibleTabs],
+  );
+
+  return (
+    <nav aria-label={t('navigation.ariaLabel')} className="space-y-5">
+      {visibleGroups.map((group, groupIndex) => (
+        <div
+          key={group.id}
+          className={cn(collapsed && groupIndex > 0 && 'border-t border-border/70 pt-3')}
+        >
+          <p
+            className={cn(
+              'mb-1.5 px-2 text-[0.65rem] font-bold uppercase tracking-[0.18em] text-muted-foreground/80',
+              collapsed && 'sr-only',
+            )}
+          >
+            {t(group.labelKey)}
+          </p>
+          <div className="space-y-1">
+            {group.items.map((item) => {
+              const Icon = item.icon;
+              const isActive = item.value === activeTab;
+              const button = (
+                <button
+                  key={item.value}
+                  type="button"
+                  aria-current={isActive ? 'page' : undefined}
+                  aria-label={collapsed ? t(item.labelKey) : undefined}
+                  onClick={() => {
+                    onTabChange(item.value);
+                    onNavigate?.();
+                  }}
+                  className={cn(
+                    'group/item relative flex min-h-10 w-full items-center gap-3 rounded-md px-2.5 text-left text-sm font-medium text-muted-foreground outline-none transition-colors',
+                    'hover:bg-background/80 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-muted',
+                    'after:absolute after:inset-y-2 after:left-0 after:w-0.5 after:rounded-full after:bg-primary after:opacity-0 after:transition-opacity',
+                    isActive && 'bg-background text-foreground shadow-sm after:opacity-100',
+                    collapsed && 'justify-center px-0',
+                  )}
+                >
+                  <Icon
+                    className={cn(
+                      'h-4 w-4 shrink-0 transition-colors',
+                      isActive ? 'text-primary' : 'text-muted-foreground group-hover/item:text-foreground',
+                    )}
+                    aria-hidden="true"
+                  />
+                  <span className={cn('min-w-0 truncate', collapsed && 'sr-only')}>{t(item.labelKey)}</span>
+                </button>
+              );
+
+              if (!collapsed) return button;
+
+              return (
+                <Tooltip key={item.value}>
+                  <TooltipTrigger asChild>{button}</TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={10}>{t(item.labelKey)}</TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </nav>
+  );
+}
+
+export function SettingsNavigation({
+  activeTab,
+  visibleTabs,
+  collapsed,
+  onCollapsedChange,
+  onTabChange,
+}: SettingsNavigationProps) {
+  const t = useTranslations('settings');
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const activeItem = SETTINGS_TAB_ITEMS.find((item) => item.value === activeTab) ?? SETTINGS_TAB_ITEMS[0];
+  const ActiveIcon = activeItem.icon;
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div className="px-3 pt-4 sm:px-6 sm:pt-6 lg:hidden">
+        <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+          <SheetTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-12 w-full justify-between rounded-lg border-border/80 bg-card px-3 shadow-sm"
+            >
+              <span className="flex min-w-0 items-center gap-3">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted">
+                  <ActiveIcon className="h-4 w-4 text-primary" aria-hidden="true" />
+                </span>
+                <span className="min-w-0 text-left">
+                  <span className="block text-[0.65rem] font-bold uppercase tracking-[0.16em] text-muted-foreground">
+                    {t('navigation.areas')}
+                  </span>
+                  <span className="block truncate text-sm font-semibold">{t(activeItem.labelKey)}</span>
+                </span>
+              </span>
+              <Menu className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-[min(21rem,88vw)] gap-0 overflow-y-auto p-0">
+            <SheetHeader className="border-b border-border/70 px-5 py-5 text-left">
+              <div className="flex items-center gap-3">
+                <span className="flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-muted/70">
+                  <Settings2 className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <div>
+                  <SheetTitle>{t('title')}</SheetTitle>
+                  <SheetDescription>{t('navigation.mobileDescription')}</SheetDescription>
+                </div>
+              </div>
+            </SheetHeader>
+            <div className="px-3 py-5">
+              <NavigationItems
+                activeTab={activeTab}
+                visibleTabs={visibleTabs}
+                collapsed={false}
+                onTabChange={onTabChange}
+                onNavigate={() => setMobileOpen(false)}
+              />
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      <aside
+        className={cn(
+          'sticky top-0 hidden h-[calc(100dvh_-_4rem_-_env(safe-area-inset-top))] min-h-0 self-start border-r border-border/70 bg-gradient-to-b from-muted/65 via-muted/30 to-background transition-[width] duration-200 ease-out lg:flex lg:flex-col',
+          collapsed ? 'w-16' : 'w-64',
+        )}
+      >
+        <div className={cn('flex h-16 shrink-0 items-center border-b border-border/70 px-3', collapsed ? 'justify-center' : 'justify-between')}>
+          <div className={cn('flex min-w-0 items-center gap-3', collapsed && 'sr-only')}>
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border bg-background shadow-sm">
+              <Settings2 className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold">{t('navigation.areas')}</p>
+              <p className="truncate text-xs text-muted-foreground">{t('navigation.desktopDescription')}</p>
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => onCollapsedChange(!collapsed)}
+            aria-label={t(collapsed ? 'navigation.expand' : 'navigation.collapse')}
+            title={t(collapsed ? 'navigation.expand' : 'navigation.collapse')}
+            className="shrink-0"
+          >
+            {collapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
+          </Button>
+        </div>
+        <div className={cn('min-h-0 flex-1 overflow-y-auto py-5', collapsed ? 'px-2' : 'px-3')}>
+          <NavigationItems
+            activeTab={activeTab}
+            visibleTabs={visibleTabs}
+            collapsed={collapsed}
+            onTabChange={onTabChange}
+          />
+        </div>
+      </aside>
+    </TooltipProvider>
+  );
+}

--- a/app/lib/settings-navigation.ts
+++ b/app/lib/settings-navigation.ts
@@ -1,0 +1,2 @@
+export const SETTINGS_SIDEBAR_COLLAPSED_COOKIE = 'canvas-settings-sidebar-collapsed';
+

--- a/messages/de.json
+++ b/messages/de.json
@@ -1730,6 +1730,34 @@
       "skills": "Plugins",
       "license": "Lizenz"
     },
+    "navigation": {
+      "ariaLabel": "Einstellungsbereiche",
+      "areas": "Bereiche",
+      "desktopDescription": "Nach Aufgabe gruppiert",
+      "mobileDescription": "Wähle einen Einstellungsbereich",
+      "collapse": "Settings-Seitenleiste einklappen",
+      "expand": "Settings-Seitenleiste ausklappen",
+      "groups": {
+        "account": "Konto",
+        "workspace": "Workspace",
+        "agents": "Agents & Tools",
+        "connections": "Verbindungen",
+        "system": "System & Verwaltung"
+      },
+      "descriptions": {
+        "general": "Konto, Sprache und grundlegende Instanzoptionen verwalten.",
+        "workspace": "Workspace-Speicher, Organisation und Migration verwalten.",
+        "knowledge": "Knowledge-Verarbeitung, Ressourcen und Feature-Gates konfigurieren.",
+        "agentSettings": "Modelle, Fähigkeiten, Tools und Laufzeitverhalten der Agents steuern.",
+        "browser": "Browser-Laufzeit und Browser-Zugriff für Agents konfigurieren.",
+        "skills": "Plugins, Skills und deren Verbindungen verwalten.",
+        "integrations": "API-Schlüssel, verbundene Apps, E-Mail und MCP-Dienste einrichten.",
+        "channels": "Externe Kommunikationskanäle und Benutzerverknüpfungen verwalten.",
+        "userManagement": "Benutzerkonten, Rollen, Rechte und Zugriff verwalten.",
+        "usage": "Tokenverbrauch, Kosten und Laufzeitereignisse analysieren.",
+        "license": "Lizenzstatus und Aktivierung dieser Instanz verwalten."
+      }
+    },
     "sections": {
       "expand": "Aufklappen",
       "collapse": "Einklappen"

--- a/messages/en.json
+++ b/messages/en.json
@@ -1731,6 +1731,34 @@
       "skills": "Plugins",
       "license": "License"
     },
+    "navigation": {
+      "ariaLabel": "Settings areas",
+      "areas": "Areas",
+      "desktopDescription": "Grouped by task",
+      "mobileDescription": "Choose a settings area",
+      "collapse": "Collapse settings sidebar",
+      "expand": "Expand settings sidebar",
+      "groups": {
+        "account": "Account",
+        "workspace": "Workspace",
+        "agents": "Agents & Tools",
+        "connections": "Connections",
+        "system": "System & Administration"
+      },
+      "descriptions": {
+        "general": "Manage your account, language, and basic instance options.",
+        "workspace": "Manage workspace storage, organization, and migration.",
+        "knowledge": "Configure knowledge processing, resources, and feature gates.",
+        "agentSettings": "Control agent models, capabilities, tools, and runtime behavior.",
+        "browser": "Configure the browser runtime and browser access for agents.",
+        "skills": "Manage plugins, skills, and their connections.",
+        "integrations": "Set up API keys, connected apps, email, and MCP services.",
+        "channels": "Manage external communication channels and user bindings.",
+        "userManagement": "Manage user accounts, roles, permissions, and access.",
+        "usage": "Analyze token usage, cost, and runtime events.",
+        "license": "Manage the license status and activation of this instance."
+      }
+    },
     "sections": {
       "expand": "Expand",
       "collapse": "Collapse"


### PR DESCRIPTION
## Summary

- replaces the horizontal settings tab grid with a grouped left-hand navigation
- adds a collapsible desktop sidebar and a grouped mobile sheet
- adds contextual section headers and descriptions while preserving the existing settings panels
- keeps existing `?tab=` deep links, lazy mounting, onboarding overrides, and permission-based visibility
- adds German and English navigation copy

## Why

The settings page exposed eleven equally weighted tabs in a horizontal grid. This made the information architecture difficult to scan and hid all grouping on mobile. The new layout organizes settings by account, workspace, agents and tools, connections, and system administration without changing the underlying settings behavior.

## User impact

Settings are easier to discover and navigate on desktop and mobile. Desktop users can collapse the sidebar into an icon rail, and the preference is stored locally. Existing links into specific settings areas continue to work.

## Screenshots

Not included yet. Repository rules require separate approval before running Playwright for UI capture; the PR is opened as a draft.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- verified German and English navigation keys are complete

The production build succeeds with the existing Turbopack broad-pattern warning in `app/lib/pi/core-tools.ts`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR redesigns settings navigation around grouped sidebar and mobile-sheet controls.

- Replaces the desktop tab grid with a collapsible sidebar.
- Adds grouped mobile settings navigation.
- Preserves tab deep links, visibility rules, and lazy panel mounting.
- Adds English and German navigation copy.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The server and client now use the same cookie-derived initial sidebar state.
- The updated navigation keeps permission-filtered tabs and existing deep-link handling.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/[locale]/(routes)/settings/page.tsx | Reads the sidebar preference from the request cookie and supplies the initial client state. |
| app/components/settings/IntegrationsSettingsClient.tsx | Uses the server-provided sidebar state and retains tab visibility and lazy content behavior. |
| app/components/settings/SettingsNavigation.tsx | Adds responsive grouped navigation for desktop and mobile settings views. |
| app/lib/settings-navigation.ts | Defines the shared sidebar-preference cookie name. |
| messages/en.json | Adds English labels and descriptions for the grouped settings navigation. |
| messages/de.json | Adds matching German labels and descriptions for the grouped settings navigation. |

<sub>Reviews (2): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/canvascoding/canvas-notebook/commit/c655421b026c075313cd93b37c50ce90f2bca0ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43496674)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/frankalexanderweber/github/canvascoding/canvas-notebook/-/custom-context?memory=b35881f6-33ef-4271-aa8c-df3699308035))
- Context used - AGENTS.md ([source](https://app.greptile.com/frankalexanderweber/github/canvascoding/canvas-notebook/-/custom-context?memory=860bb516-1d67-4762-a09d-53ca2be05b40))
- Context used - seed_sys_prompts/AGENTS.md ([source](https://app.greptile.com/frankalexanderweber/github/canvascoding/canvas-notebook/-/custom-context?memory=22280b08-f012-4954-8123-d51dd80dd274))
</details>

<!-- /greptile_comment -->