### PR TITLE
Add positioned mobile Studio crops

### DIFF
--- a/app/api/mobile/v1/studio/generations/[generationId]/outputs/[outputId]/reframe/route.ts
+++ b/app/api/mobile/v1/studio/generations/[generationId]/outputs/[outputId]/reframe/route.ts
@@ -5,10 +5,10 @@ import {
   createAspectRatioPreview,
   getAspectRatioModelOptions,
   saveAspectRatioEdit,
-  type AspectRatioFrame,
   type AspectRatioMode,
   type AspectRatioProvider,
 } from '@/app/lib/integrations/studio-aspect-ratio-service';
+import { resolveMobileStudioReframeFrame } from '@/app/lib/mobile/studio-reframe';
 import { requireStudioRequestScope } from '@/app/lib/integrations/studio-request-scope';
 import { MobileStudioError, resolveMobileStudioOutput } from '@/app/lib/mobile/studio';
 import { mobileStudioErrorResponse, mobileStudioResponseHeaders } from '@/app/lib/mobile/studio-route';
@@ -19,24 +19,6 @@ function ratioValue(value: unknown): { label: typeof RATIOS[number]; value: numb
   if (typeof value !== 'string' || !RATIOS.includes(value as typeof RATIOS[number])) throw new MobileStudioError('Aspect ratio is not supported.', 400, 'INVALID_ASPECT_RATIO');
   const [width, height] = value.split(':').map(Number);
   return { label: value as typeof RATIOS[number], value: width / height };
-}
-
-function frameFor(width: number, height: number, targetRatio: number, mode: AspectRatioMode): AspectRatioFrame {
-  const sourceRatio = width / height;
-  if (mode === 'crop') {
-    if (sourceRatio > targetRatio) {
-      const frameWidth = height * targetRatio;
-      return { x: (width - frameWidth) / 2, y: 0, width: frameWidth, height };
-    }
-    const frameHeight = width / targetRatio;
-    return { x: 0, y: (height - frameHeight) / 2, width, height: frameHeight };
-  }
-  if (sourceRatio > targetRatio) {
-    const frameHeight = width / targetRatio;
-    return { x: 0, y: (height - frameHeight) / 2, width, height: frameHeight };
-  }
-  const frameWidth = height * targetRatio;
-  return { x: (width - frameWidth) / 2, y: 0, width: frameWidth, height };
 }
 
 function targetSize(targetRatio: number) {
@@ -63,7 +45,13 @@ export async function POST(request: NextRequest, context: { params: Promise<{ ge
     if (mode === 'ai_extend' && !model) throw new MobileStudioError('Image extension provider is unavailable.', 409, 'PROVIDER_UNAVAILABLE');
     const preview = await createAspectRatioPreview({
       sourcePath: output.filePath,
-      frame: frameFor(output.width, output.height, ratio.value, mode),
+      frame: resolveMobileStudioReframeFrame({
+        frame: body?.frame,
+        mode,
+        sourceWidth: output.width,
+        sourceHeight: output.height,
+        targetRatio: ratio.value,
+      }),
       mode,
       aspectRatio: ratio.label,
       ...targetSize(ratio.value),

--- a/app/lib/mobile/studio-reframe.ts
+++ b/app/lib/mobile/studio-reframe.ts
@@ -1,0 +1,112 @@
+import 'server-only';
+
+import type {
+  AspectRatioFrame,
+  AspectRatioMode,
+} from '@/app/lib/integrations/studio-aspect-ratio-service';
+
+import { MobileStudioError } from './studio';
+
+const MINIMUM_FRAME_EDGE = 24;
+const RATIO_TOLERANCE = 0.01;
+
+type MobileStudioReframeFrameInput = {
+  frame: unknown;
+  mode: AspectRatioMode;
+  sourceWidth: number;
+  sourceHeight: number;
+  targetRatio: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function invalidFrame(): never {
+  throw new MobileStudioError(
+    'The crop frame is invalid.',
+    400,
+    'INVALID_CROP_FRAME',
+  );
+}
+
+function finiteCoordinate(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) invalidFrame();
+  return value;
+}
+
+export function centeredMobileStudioReframeFrame(
+  sourceWidth: number,
+  sourceHeight: number,
+  targetRatio: number,
+  mode: AspectRatioMode,
+): AspectRatioFrame {
+  const sourceRatio = sourceWidth / sourceHeight;
+  if (mode === 'crop') {
+    if (sourceRatio > targetRatio) {
+      const width = sourceHeight * targetRatio;
+      return { x: (sourceWidth - width) / 2, y: 0, width, height: sourceHeight };
+    }
+    const height = sourceWidth / targetRatio;
+    return { x: 0, y: (sourceHeight - height) / 2, width: sourceWidth, height };
+  }
+  if (sourceRatio > targetRatio) {
+    const height = sourceWidth / targetRatio;
+    return { x: 0, y: (sourceHeight - height) / 2, width: sourceWidth, height };
+  }
+  const width = sourceHeight * targetRatio;
+  return { x: (sourceWidth - width) / 2, y: 0, width, height: sourceHeight };
+}
+
+export function resolveMobileStudioReframeFrame({
+  frame,
+  mode,
+  sourceWidth,
+  sourceHeight,
+  targetRatio,
+}: MobileStudioReframeFrameInput): AspectRatioFrame {
+  const centered = centeredMobileStudioReframeFrame(
+    sourceWidth,
+    sourceHeight,
+    targetRatio,
+    mode,
+  );
+  if (mode !== 'crop' || frame === undefined || frame === null) return centered;
+  if (!isRecord(frame)) invalidFrame();
+
+  const requested = {
+    x: finiteCoordinate(frame.x),
+    y: finiteCoordinate(frame.y),
+    width: finiteCoordinate(frame.width),
+    height: finiteCoordinate(frame.height),
+  };
+  if (
+    requested.x < 0 ||
+    requested.y < 0 ||
+    requested.width < MINIMUM_FRAME_EDGE ||
+    requested.height < MINIMUM_FRAME_EDGE ||
+    requested.x + requested.width > sourceWidth ||
+    requested.y + requested.height > sourceHeight
+  ) invalidFrame();
+
+  const ratioError = Math.abs(requested.width / requested.height - targetRatio) / targetRatio;
+  if (ratioError > RATIO_TOLERANCE) invalidFrame();
+
+  const left = Math.round(requested.x);
+  const top = Math.round(requested.y);
+  const right = Math.round(requested.x + requested.width);
+  const bottom = Math.round(requested.y + requested.height);
+  const normalized = {
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+  };
+  if (
+    normalized.width < MINIMUM_FRAME_EDGE ||
+    normalized.height < MINIMUM_FRAME_EDGE ||
+    normalized.x + normalized.width > sourceWidth ||
+    normalized.y + normalized.height > sourceHeight
+  ) invalidFrame();
+  return normalized;
+}

--- a/scripts/mobile-studio-test.ts
+++ b/scripts/mobile-studio-test.ts
@@ -89,6 +89,10 @@ async function main() {
       listMobileStudioGenerations,
       parseMobileStudioGenerationRequest,
     } = await import('../app/lib/mobile/studio');
+    const {
+      centeredMobileStudioReframeFrame,
+      resolveMobileStudioReframeFrame,
+    } = await import('../app/lib/mobile/studio-reframe');
     const { createPersistedStudioScope } = await import('../app/lib/integrations/studio-scope');
     const { parseMobileStudioLibraryKind } = await import('../app/lib/mobile/studio-management');
     const { parseMobileStudioPresetInput } = await import('../app/lib/mobile/studio-presets');
@@ -104,6 +108,31 @@ async function main() {
       name: 'Mobile campaign', category: 'product', blocks: [{ type: 'lighting', label: 'Soft', promptFragment: 'soft light' }],
     }).blocks.map((block) => block.type), ['lighting']);
     assert.throws(() => parseMobileStudioPresetInput({ name: 'Empty', category: 'product', blocks: [] }), /at least one block/u);
+    assert.deepEqual(
+      centeredMobileStudioReframeFrame(1_600, 1_200, 4 / 5, 'crop'),
+      { x: 320, y: 0, width: 960, height: 1_200 },
+    );
+    assert.deepEqual(resolveMobileStudioReframeFrame({
+      frame: { x: 120, y: 100, width: 800, height: 1_000 },
+      mode: 'crop',
+      sourceWidth: 1_600,
+      sourceHeight: 1_200,
+      targetRatio: 4 / 5,
+    }), { x: 120, y: 100, width: 800, height: 1_000 });
+    assert.throws(() => resolveMobileStudioReframeFrame({
+      frame: { x: -1, y: 0, width: 800, height: 1_000 },
+      mode: 'crop',
+      sourceWidth: 1_600,
+      sourceHeight: 1_200,
+      targetRatio: 4 / 5,
+    }), /crop frame is invalid/u);
+    assert.throws(() => resolveMobileStudioReframeFrame({
+      frame: { x: 120, y: 100, width: 900, height: 1_000 },
+      mode: 'crop',
+      sourceWidth: 1_600,
+      sourceHeight: 1_200,
+      targetRatio: 4 / 5,
+    }), /crop frame is invalid/u);
 
     const catalog = await getMobileStudioCatalog({ scope, userId: 'studio-user', canWrite: true, canDeleteAssets: true });
     const nullablePreset = catalog.presets.find((preset) => preset.id === 'preset-nullable');


### PR DESCRIPTION
## Summary

- allow the authenticated Mobile-v1 Studio reframe endpoint to accept an optional positioned crop frame
- keep centered crop behavior for existing clients that do not send a frame
- validate finite coordinates, minimum size, source-image bounds, and target aspect ratio before image processing
- cover centered, positioned, out-of-bounds, and wrong-ratio frames in the Mobile Studio contract test

## Why

The private Expo app now offers a native drag/pinch crop editor. The server must receive the selected source-pixel frame without trusting client geometry or exposing internal Studio paths.

## Verification

- `npm run test:mobile:studio`
- `npm run build`

The production build completed successfully, including TypeScript and the third-party license gate.
