### PR TITLE
Advertise positioned mobile Studio crops

### DIFF
--- a/app/lib/mobile/bootstrap.ts
+++ b/app/lib/mobile/bootstrap.ts
@@ -119,6 +119,7 @@ export function createMobileBootstrap(input: {
     'studio.presets_manage',
     'studio.bulk',
     'studio.aspect_ratio',
+    'studio.aspect_ratio.positioned_crop',
   ];
   if (input.listing.canCreateSharedWorkspaces) capabilities.push('workspace.create');
 

--- a/app/lib/mobile/compatibility.ts
+++ b/app/lib/mobile/compatibility.ts
@@ -54,6 +54,7 @@ export type MobileCompatibility = {
       'studio.presets_manage',
       'studio.bulk',
       'studio.aspect_ratio',
+      'studio.aspect_ratio.positioned_crop',
     ];
   };
   auth: {
@@ -129,6 +130,7 @@ export function createMobileCompatibility(input: {
         'studio.presets_manage',
         'studio.bulk',
         'studio.aspect_ratio',
+        'studio.aspect_ratio.positioned_crop',
       ],
     },
     auth: {

--- a/scripts/mobile-bootstrap-test.ts
+++ b/scripts/mobile-bootstrap-test.ts
@@ -98,6 +98,7 @@ assert.deepEqual(bootstrap.mobileApi.capabilities, [
   'studio.presets_manage',
   'studio.bulk',
   'studio.aspect_ratio',
+  'studio.aspect_ratio.positioned_crop',
   'workspace.create',
 ]);
 assert.equal(bootstrap.user.role, 'admin');

--- a/scripts/mobile-compatibility-test.ts
+++ b/scripts/mobile-compatibility-test.ts
@@ -68,6 +68,7 @@ assert.deepEqual(compatibility, {
       'studio.presets_manage',
       'studio.bulk',
       'studio.aspect_ratio',
+      'studio.aspect_ratio.positioned_crop',
     ],
   },
   auth: {


### PR DESCRIPTION
## Summary

- advertise `studio.aspect_ratio.positioned_crop` through both public compatibility and authenticated bootstrap contracts
- cover the new capability in compatibility and bootstrap tests

## Why

The Expo app uses this capability to distinguish servers that validate positioned crop frames from older servers that only perform center crop. This prevents a manual mobile selection from being silently ignored.

## Verification

- `npm run test:mobile:compatibility`
- `npm run test:mobile:bootstrap`
- `npm run test:mobile:studio`
- `npm run build`
