### PR TITLE
Expose mobile compatibility handshake

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -9,7 +9,12 @@ const LICENSE_GATE_COOKIE = 'canvas_license_gate';
 
 // Public routes that don't require authentication
 const PUBLIC_PREFIX_ROUTES = ['/login', '/sign-in', '/sign-up', '/setup', '/api/auth', '/api/license', '/api/setup', '/api/automations/execute', '/api/automations/scheduler'];
-const PUBLIC_EXACT_ROUTES = ['/', '/api/health', '/manifest.webmanifest'];
+const PUBLIC_EXACT_ROUTES = [
+  '/',
+  '/api/health',
+  '/api/mobile/v1/compatibility',
+  '/manifest.webmanifest',
+];
 const PUBLIC_SHARE_PREFIX_ROUTES = [
   '/p/',
   '/public/files/',

--- a/scripts/mobile-compatibility-route-test.ts
+++ b/scripts/mobile-compatibility-route-test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 const keys = ['CANVAS_DEPLOYMENT_MODE', 'CANVAS_INSTANCE_ID', 'CANVAS_INSTANCE_NAME'] as const;
 const original = new Map<string, string | undefined>(keys.map((key) => [key, process.env[key]]));
@@ -24,6 +25,13 @@ async function main() {
     cookiePrefix: 'better-auth',
     expoPlugin: true,
   });
+
+  const proxySource = readFileSync(new URL('../proxy.ts', import.meta.url), 'utf8');
+  assert.match(
+    proxySource,
+    /PUBLIC_EXACT_ROUTES\s*=\s*\[[\s\S]*['"]\/api\/mobile\/v1\/compatibility['"][\s\S]*\]/u,
+    'The pre-authentication compatibility handshake must remain public in proxy.ts',
+  );
 }
 
 main()


### PR DESCRIPTION
## Summary

- make `/api/mobile/v1/compatibility` reachable before authentication
- add a regression assertion that keeps the pre-authentication route in the proxy allowlist

## Verification

- `npm run test:mobile:compatibility`
- `npx eslint proxy.ts scripts/mobile-compatibility-route-test.ts`
- `DATA=/tmp/canvas-mobile-live-server.ryZXV9/data npm run build`
- live local preflight: compatibility, Better Auth login/session restore, mobile bootstrap, one-time WebSocket authentication, and ticket replay rejection

No container was built.
