### PR TITLE
Notify unread automation responses

### DIFF
--- a/app/lib/automations/runner.ts
+++ b/app/lib/automations/runner.ts
@@ -36,6 +36,7 @@ import {
   workspaceToPiSessionFields,
 } from '@/app/lib/pi/session-workspace-context';
 import { findOwnedPiSessionForRuntime, isPiSessionInWorkspace } from '@/app/lib/pi/session-runtime-access';
+import { sendAgentResponseReadyPush } from '@/app/lib/mobile/push-devices';
 import {
   PiSessionBusyError,
   withExclusivePiSessionExecution,
@@ -118,6 +119,25 @@ async function sendAutomationFailurePush(input: {
     const message = error instanceof Error ? error.message : 'Failed to send automation push notification.';
     console.warn('[Automationen] Push notification failed:', message);
   }
+}
+
+function queueAutomationResponsePush(input: {
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  job: AutomationJobRecord;
+  resolution: AutomationDeliveryResolution;
+}): void {
+  if (input.job.deliveryMode === 'silent' || input.resolution.channelId !== 'web') return;
+  void sendAgentResponseReadyPush({
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+    sessionId: input.sessionId,
+  })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : 'Failed to send automation response push notification.';
+      console.warn('[Automationen] Response push notification failed:', message);
+    });
 }
 
 function assertAutomationExecutionActive(signal: AbortSignal): void {
@@ -688,6 +708,13 @@ export async function executeAutomationRun(runId: string): Promise<void> {
           console.warn(`[Automationen] Run ${runId} completed but its terminal transition lost the run CAS`);
           return;
         }
+        queueAutomationResponsePush({
+          userId: automationUserId,
+          workspaceId: automationWorkspace.workspaceId,
+          sessionId: piSessionId,
+          job,
+          resolution: deliveryResolution,
+        });
         const duration = Date.now() - runStartTime;
         console.log(`[Automationen] Run ${runId} completed successfully (duration=${duration}ms)`);
       } catch (error) {

--- a/scripts/automation-runner-tool-context-test.ts
+++ b/scripts/automation-runner-tool-context-test.ts
@@ -38,6 +38,7 @@ const runtimeResolutionCalls: Array<{
 }> = [];
 const quarantinedSettlements: Promise<unknown>[] = [];
 let releaseDetachedTimeoutOperation: (() => void) | null = null;
+const agentResponsePushCalls: Array<{ userId: string; workspaceId: string; sessionId: string }> = [];
 
 const testModel = {
   id: 'test-model',
@@ -83,6 +84,16 @@ class TestAutomationLoopShutdownError extends Error {
 moduleInternals._load = (request, parent, isMain) => {
   if (request === 'server-only') {
     return {};
+  }
+
+  if (request === '@/app/lib/mobile/push-devices' || request.endsWith('/mobile/push-devices')) {
+    return {
+      sendAgentResponseReadyPush: async (input: { userId: string; workspaceId: string; sessionId: string }) => {
+        agentResponsePushCalls.push(input);
+        return { attempted: 1, accepted: 1 };
+      },
+      sendFailureAttentionPush: async () => ({ attempted: 1, accepted: 1 }),
+    };
   }
 
   if (request === '@earendil-works/pi-ai' || request === '@earendil-works/pi-ai/compat' || request === '@earendil-works/pi-ai/oauth') {
@@ -401,6 +412,7 @@ async function main() {
   assert.ok(run);
 
   await executeAutomationRun(run.id);
+  await new Promise<void>((resolve) => setImmediate(resolve));
 
   assert.deepEqual(toolCalls, [{ userId, agentId, sessionId: `auto-${run.id.replace(/^run-/, '')}` }]);
   assert.deepEqual(agentLoopToolNames, ['studio_generate_image']);
@@ -421,6 +433,7 @@ async function main() {
   const finishedRun = await getAutomationRun(run.id);
   assert.equal(finishedRun?.status, 'success');
   assert.equal(finishedRun?.errorMessage, null);
+  assert.deepEqual(agentResponsePushCalls, [{ userId, workspaceId: job.workspaceId, sessionId: `auto-${run.id.replace(/^run-/, '')}` }]);
   assert.deepEqual(finishedRun?.metadataJson?.runtime, {
     providerInstallationId: testSelection.selection.providerInstallationId,
     providerId: testSelection.selection.providerId,
@@ -435,9 +448,11 @@ async function main() {
   const completedLoopCount = agentLoopStreamFns.length;
   const completedRuntimeResolutionCount = runtimeResolutionCalls.length;
   await executeAutomationRun(run.id);
+  await new Promise<void>((resolve) => setImmediate(resolve));
   assert.equal((await getAutomationRun(run.id))?.status, 'success');
   assert.equal(agentLoopStreamFns.length, completedLoopCount);
   assert.equal(runtimeResolutionCalls.length, completedRuntimeResolutionCount);
+  assert.equal(agentResponsePushCalls.length, 1, 'a terminal run must not emit a duplicate response push');
 
   const staleRetry = await markAutomationRunRetryScheduled(
     run.id,
@@ -650,6 +665,7 @@ async function main() {
   const runtimeCallsBeforeRetry = runtimeResolutionCalls.length;
   agentLoopMode = 'success';
   await executeAutomationRun(failingRun.id);
+  await new Promise<void>((resolve) => setImmediate(resolve));
   const completedRetry = await getAutomationRun(failingRun.id);
   assert.equal(completedRetry?.status, 'success');
   assert.deepEqual(
@@ -661,6 +677,7 @@ async function main() {
   });
   assert.equal(retrySessions.length, 1);
   assert.equal(agentLoopStreamFns.at(-1), testStreamFn);
+  assert.equal(agentResponsePushCalls.length, 2, 'a successful retry must emit one unread-aware response push');
 
   const organization = await db.query.canvasOrganizationSettings.findFirst();
   assert.ok(organization);


### PR DESCRIPTION
## Summary
- route successful automation results delivered to the web channel through the existing unread-aware agent response push path
- suppress duplicate, silent, externally delivered, already-read, and superseded response notifications
- cover initial success, terminal replay, and successful retry behavior

## Verification
- `npm run test:automation:runner`
- `npm run test:mobile:push`
- `npm run test:mobile:automations`
- `npm run build`