### PR TITLE
Expose automations in mobile bootstrap

### DIFF
--- a/app/lib/mobile/bootstrap.ts
+++ b/app/lib/mobile/bootstrap.ts
@@ -120,6 +120,12 @@ export function createMobileBootstrap(input: {
     'studio.bulk',
     'studio.aspect_ratio',
     'studio.aspect_ratio.positioned_crop',
+    'automations.jobs',
+    'automations.run_control',
+    'automations.run_history',
+    'automations.heartbeat',
+    'automations.webhooks',
+    'automations.composio_triggers',
   ];
   if (input.listing.canCreateSharedWorkspaces) capabilities.push('workspace.create');
 

--- a/scripts/mobile-bootstrap-test.ts
+++ b/scripts/mobile-bootstrap-test.ts
@@ -99,6 +99,12 @@ assert.deepEqual(bootstrap.mobileApi.capabilities, [
   'studio.bulk',
   'studio.aspect_ratio',
   'studio.aspect_ratio.positioned_crop',
+  'automations.jobs',
+  'automations.run_control',
+  'automations.run_history',
+  'automations.heartbeat',
+  'automations.webhooks',
+  'automations.composio_triggers',
   'workspace.create',
 ]);
 assert.equal(bootstrap.user.role, 'admin');


### PR DESCRIPTION
## Summary
- advertise all six Automation capabilities in the authenticated mobile bootstrap
- extend the bootstrap contract regression test

## Verification
- `npm run test:mobile:bootstrap`
- `npm run test:mobile:automations`
- `npm run build`
- authenticated iOS simulator test reproduced the disabled Automation action before this fix

No UI screenshots required; this is a server contract correction.