### PR TITLE
Fix chat runtime status ordering

### DIFF
--- a/app/components/canvas-agent-chat/useChatRuntimeEvents.ts
+++ b/app/components/canvas-agent-chat/useChatRuntimeEvents.ts
@@ -35,7 +35,7 @@ import {
   getHistoryRuntimeActiveToolName,
   getHistoryRuntimePhase,
 } from '@/app/lib/chat/runtime-message-utils';
-import type { RuntimeStatus } from '@/app/lib/chat/runtime-status';
+import { isRuntimeStatusStale, type RuntimeStatus } from '@/app/lib/chat/runtime-status';
 import type {
   AISession,
   Attachment,
@@ -257,6 +257,10 @@ export function useChatRuntimeEvents({
   }, [historyRef, setHistory]);
 
   const setRuntimeStatusWithReconciliation = useCallback((status: RuntimeStatus) => {
+    if (isRuntimeStatusStale(runtimeStatusRef.current, status)) {
+      return;
+    }
+    runtimeStatusRef.current = status;
     setRuntimeStatus(status);
     applyRuntimeStatusToHistory(status);
     reconcileQueuedMessages(status);

--- a/app/lib/channels/message-normalization.ts
+++ b/app/lib/channels/message-normalization.ts
@@ -19,5 +19,8 @@ export function buildUserAgentMessageFromInbound(message: InboundMessage): UserA
     role: 'user',
     content,
     timestamp,
+    ...(typeof message.clientMessageId === 'string' && message.clientMessageId.trim()
+      ? { clientMessageId: message.clientMessageId.trim() }
+      : {}),
   } as Extract<AgentMessage, { role: 'user' }>;
 }

--- a/app/lib/channels/types.ts
+++ b/app/lib/channels/types.ts
@@ -35,6 +35,8 @@ export interface InboundMessage {
   channelThreadKey?: string;
   requestedSessionId?: string;
   agentId?: string;
+  /** Stable client-owned identity used to reconcile optimistic mobile rows. */
+  clientMessageId?: string;
   agentMessageTimestamp?: number;
   userId: string;
   text: string;

--- a/app/lib/chat/runtime-status.ts
+++ b/app/lib/chat/runtime-status.ts
@@ -10,6 +10,8 @@ export type RuntimeQueueItem = {
 
 export type RuntimeStatus = {
   sessionId: string;
+  /** Server-assigned monotonic revision used to reject stale transport paths. */
+  revision?: number;
   browser?: BrowserSessionSnapshot;
   phase: 'idle' | 'streaming' | 'running_tool' | 'aborting';
   activeTool: { toolCallId: string; name: string } | null;
@@ -28,3 +30,8 @@ export type RuntimeStatus = {
   lastCompactionKind: 'manual' | 'automatic' | null;
   lastCompactionOmittedCount: number;
 };
+
+export function isRuntimeStatusStale(current: RuntimeStatus | null, next: RuntimeStatus): boolean {
+  if (!current || current.sessionId !== next.sessionId) return false;
+  return (next.revision ?? 0) < (current.revision ?? 0);
+}

--- a/app/lib/mobile/chat.ts
+++ b/app/lib/mobile/chat.ts
@@ -81,6 +81,7 @@ export type MobileChatMessage = {
   role: 'user' | 'assistant' | 'system' | 'tool';
   kind: 'message' | 'tool' | 'error';
   text: string;
+  clientMessageId?: string;
   toolName: string | null;
   toolInput: string | null;
   attachments: MobileChatAttachment[];
@@ -250,12 +251,17 @@ export function serializeMobileChatMessage(input: {
   const visibleText = extractPiMessageText(piMessage, { hideAttachmentMetadata: true })
     || stripAttachmentBlocks(contentToString(parsed.content));
   const toolCallId = messageToolCallId(parsed);
+  const clientMessageId = typeof parsed.clientMessageId === 'string'
+    && parsed.clientMessageId.trim().length <= 256
+    ? parsed.clientMessageId.trim()
+    : undefined;
   return {
     id: String(input.id),
     sequence: input.sequence,
     role,
     kind: isError ? 'error' : role === 'tool' ? 'tool' : 'message',
     text: visibleText,
+    ...(clientMessageId ? { clientMessageId } : {}),
     toolName: messageToolName(parsed),
     toolInput: toolCallId ? toolInputsById.get(toolCallId) || null : null,
     attachments: attachments.map(serializeMessageAttachment),

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -469,6 +469,7 @@ class LivePiRuntime {
   constructor(init: RuntimeInit, agent: Agent, private readonly options: RuntimeOptions = {}) {
     this.sessionId = init.sessionId;
     this.userId = init.userId;
+    this.statusRevision = currentRuntimeStatusRevision(init.sessionId, init.userId);
     this.agentId = init.agentId;
     this.provider = init.provider;
     this.model = init.model;
@@ -1622,7 +1623,7 @@ class LivePiRuntime {
     if (signature === this.lastBroadcastStatusSignature) {
       return;
     }
-    this.statusRevision += 1;
+    this.statusRevision = nextRuntimeStatusRevision(this.sessionId, this.userId);
     const status = this.getStatus();
     const event: RuntimeStatusEvent = {
       type: 'runtime_status',
@@ -1920,6 +1921,7 @@ async function createRuntime(sessionId: string, userId: string): Promise<LivePiR
 
 type RuntimeStore = {
   runtimes: Map<string, Promise<LivePiRuntime>>;
+  statusRevisions: Map<string, number>;
   cleanupStarted: boolean;
 };
 
@@ -1931,6 +1933,7 @@ function getStore(): RuntimeStore {
   if (!globalStore.__canvasPiRuntimeStore) {
     globalStore.__canvasPiRuntimeStore = {
       runtimes: new Map<string, Promise<LivePiRuntime>>(),
+      statusRevisions: new Map<string, number>(),
       cleanupStarted: false,
     };
   }
@@ -1980,6 +1983,18 @@ function getStore(): RuntimeStore {
 
 function getRuntimeKey(sessionId: string, userId: string) {
   return `${userId}:${sessionId}`;
+}
+
+function currentRuntimeStatusRevision(sessionId: string, userId: string): number {
+  return getStore().statusRevisions.get(getRuntimeKey(sessionId, userId)) || 0;
+}
+
+function nextRuntimeStatusRevision(sessionId: string, userId: string): number {
+  const store = getStore();
+  const key = getRuntimeKey(sessionId, userId);
+  const revision = (store.statusRevisions.get(key) || 0) + 1;
+  store.statusRevisions.set(key, revision);
+  return revision;
 }
 
 async function evictPiRuntimeInstance(
@@ -2200,7 +2215,7 @@ export async function getPiRuntimeStatus(sessionId: string, userId: string): Pro
 
   return {
     sessionId,
-    revision: 0,
+    revision: currentRuntimeStatusRevision(sessionId, userId),
     ...(browserSnapshot.running ? { browser: browserSnapshot } : {}),
     phase: 'idle',
     activeTool: null,

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -172,6 +172,8 @@ type RuntimePhase = 'idle' | 'streaming' | 'running_tool' | 'aborting';
 
 export type PiRuntimeStatus = {
   sessionId: string;
+  /** Monotonically increasing server revision for causally ordered UI state. */
+  revision: number;
   browser?: BrowserSessionSnapshot;
   phase: RuntimePhase;
   activeTool: { toolCallId: string; name: string } | null;
@@ -324,17 +326,24 @@ function countMessageAttachments(message: Extract<AgentMessage, { role: 'user' }
 }
 
 function buildQueuePreview(message: Extract<AgentMessage, { role: 'user' }>): RuntimeQueuePreview {
+  const clientMessageId = typeof (message as { clientMessageId?: unknown }).clientMessageId === 'string'
+    ? (message as { clientMessageId: string }).clientMessageId.trim() || undefined
+    : undefined;
   return {
     id: `queue-${message.timestamp}-${Math.random().toString(36).slice(2, 8)}`,
     text: extractUserMessageText(message),
     attachmentCount: countMessageAttachments(message),
+    ...(clientMessageId ? { clientMessageId } : {}),
     messageTimestamp: message.timestamp,
     signature: getMessageSignature(message),
   };
 }
 
 function getMessageSignature(message: Extract<AgentMessage, { role: 'user' }>): string {
-  return `${message.timestamp}:${extractUserMessageText(message)}:${countMessageAttachments(message)}`;
+  const clientMessageId = typeof (message as { clientMessageId?: unknown }).clientMessageId === 'string'
+    ? (message as { clientMessageId: string }).clientMessageId.trim()
+    : '';
+  return `${clientMessageId}:${message.timestamp}:${extractUserMessageText(message)}:${countMessageAttachments(message)}`;
 }
 
 function sanitizeUserMessage(
@@ -439,6 +448,7 @@ class LivePiRuntime {
   private persistLock = false;
   private persistPending: 'turn_end' | 'agent_end' | 'error' | null = null;
   private lastBroadcastStatusSignature: string | null = null;
+  private statusRevision = 0;
   private currentUserPromptText = '';
   private currentUserPromptSignature: string | null = null;
   private syntheticContinuationCount = 0;
@@ -548,6 +558,7 @@ class LivePiRuntime {
 
     return {
       sessionId: this.sessionId,
+      revision: this.statusRevision,
       ...(this.browserSnapshot ? { browser: this.browserSnapshot } : {}),
       phase: this.abortRequested || hasPendingReplace
         ? 'aborting'
@@ -1606,6 +1617,12 @@ class LivePiRuntime {
   }
 
   private publishStatus() {
+    const currentStatus = this.getStatus();
+    const signature = getRuntimeStatusSignature(currentStatus);
+    if (signature === this.lastBroadcastStatusSignature) {
+      return;
+    }
+    this.statusRevision += 1;
     const status = this.getStatus();
     const event: RuntimeStatusEvent = {
       type: 'runtime_status',
@@ -1613,12 +1630,6 @@ class LivePiRuntime {
     };
 
     this.publish(event);
-
-    const signature = getRuntimeStatusSignature(status);
-    if (signature === this.lastBroadcastStatusSignature) {
-      return;
-    }
-
     this.lastBroadcastStatusSignature = signature;
     this.emitRuntimeEvent(event);
   }
@@ -2189,6 +2200,7 @@ export async function getPiRuntimeStatus(sessionId: string, userId: string): Pro
 
   return {
     sessionId,
+    revision: 0,
     ...(browserSnapshot.running ? { browser: browserSnapshot } : {}),
     phase: 'idle',
     activeTool: null,

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -327,7 +327,7 @@ function countMessageAttachments(message: Extract<AgentMessage, { role: 'user' }
 
 function buildQueuePreview(message: Extract<AgentMessage, { role: 'user' }>): RuntimeQueuePreview {
   const clientMessageId = typeof (message as { clientMessageId?: unknown }).clientMessageId === 'string'
-    ? (message as { clientMessageId: string }).clientMessageId.trim() || undefined
+    ? (message as unknown as { clientMessageId: string }).clientMessageId.trim() || undefined
     : undefined;
   return {
     id: `queue-${message.timestamp}-${Math.random().toString(36).slice(2, 8)}`,
@@ -341,7 +341,7 @@ function buildQueuePreview(message: Extract<AgentMessage, { role: 'user' }>): Ru
 
 function getMessageSignature(message: Extract<AgentMessage, { role: 'user' }>): string {
   const clientMessageId = typeof (message as { clientMessageId?: unknown }).clientMessageId === 'string'
-    ? (message as { clientMessageId: string }).clientMessageId.trim()
+    ? (message as unknown as { clientMessageId: string }).clientMessageId.trim()
     : '';
   return `${clientMessageId}:${message.timestamp}:${extractUserMessageText(message)}:${countMessageAttachments(message)}`;
 }

--- a/app/lib/pi/runtime-queue.ts
+++ b/app/lib/pi/runtime-queue.ts
@@ -5,6 +5,7 @@ export type RuntimeQueuePreview = {
   id: string;
   text: string;
   attachmentCount: number;
+  clientMessageId?: string;
   messageTimestamp?: number;
   signature?: string;
 };

--- a/app/lib/websocket/protocol.ts
+++ b/app/lib/websocket/protocol.ts
@@ -29,6 +29,7 @@ export type ClientMessage =
       requestId?: string;
       sessionId: string;
       agentId?: string;
+      clientMessageId?: string;
       message: AgentMessage;
       context?: ChatRequestContext;
     }
@@ -135,6 +136,9 @@ export function parseClientMessage(value: unknown): ClientMessageParseResult {
       }
       if (!isOptionalBoundedString(value.agentId, MAX_IDENTIFIER_LENGTH)) {
         return invalid('agentId must be a non-empty bounded string');
+      }
+      if (!isOptionalBoundedString(value.clientMessageId, MAX_IDENTIFIER_LENGTH)) {
+        return invalid('clientMessageId must be a non-empty bounded string');
       }
       if (value.context !== undefined && !isRecord(value.context)) {
         return invalid('context must be an object');

--- a/scripts/websocket-protocol-contract-test.ts
+++ b/scripts/websocket-protocol-contract-test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { isRuntimeStatusStale, type RuntimeStatus } from '../app/lib/chat/runtime-status';
 import {
   CHAT_WEBSOCKET_CLOSE_CODES,
   CHAT_WEBSOCKET_PATH,
@@ -11,6 +12,20 @@ assert.equal(CHAT_WEBSOCKET_PROTOCOL, 'canvas-chat-v1');
 assert.equal(CHAT_WEBSOCKET_CLOSE_CODES.serviceRestart, 1012);
 assert.equal(CHAT_WEBSOCKET_CLOSE_CODES.unauthorized, 4001);
 assert.equal(CHAT_WEBSOCKET_CLOSE_CODES.licenseRequired, 4003);
+assert.equal(
+  isRuntimeStatusStale(
+    { sessionId: 'session-a', revision: 4 } as RuntimeStatus,
+    { sessionId: 'session-a', revision: 3 } as RuntimeStatus,
+  ),
+  true,
+);
+assert.equal(
+  isRuntimeStatusStale(
+    { sessionId: 'session-a', revision: 4 } as RuntimeStatus,
+    { sessionId: 'session-a', revision: 4 } as RuntimeStatus,
+  ),
+  false,
+);
 
 for (const message of [
   { type: 'subscribe_session', requestId: 'subscribe-1', sessionId: 'session-a' },

--- a/scripts/websocket-protocol-contract-test.ts
+++ b/scripts/websocket-protocol-contract-test.ts
@@ -20,6 +20,7 @@ for (const message of [
     type: 'send_message',
     requestId: 'send-1',
     sessionId: 'session-a',
+    clientMessageId: 'pending-1',
     message: { role: 'user', content: 'hello', timestamp: Date.now() },
   },
   { type: 'control', sessionId: 'session-a', action: 'abort' },
@@ -35,6 +36,8 @@ for (const message of [
   { type: 'subscribe_session', sessionId: '' },
   { type: 'subscribe_session', sessionId: 'x'.repeat(257) },
   { type: 'send_message', sessionId: 'session-a', message: 'hello' },
+  { type: 'send_message', sessionId: 'session-a', clientMessageId: '', message: { role: 'user', content: 'hello', timestamp: Date.now() } },
+  { type: 'send_message', sessionId: 'session-a', clientMessageId: 'x'.repeat(257), message: { role: 'user', content: 'hello', timestamp: Date.now() } },
   { type: 'control', sessionId: 'session-a', action: 'delete_everything' },
 ]) {
   assert.equal(parseClientMessage(message).ok, false, 'expected invalid message');

--- a/server/websocket-server.ts
+++ b/server/websocket-server.ts
@@ -110,6 +110,7 @@ function summarizeClientMessage(message: ClientMessage | { type?: unknown }): Re
     requestId?: unknown;
     sessionId?: unknown;
     agentId?: unknown;
+    clientMessageId?: unknown;
     action?: unknown;
     queueItemId?: unknown;
     message?: { role?: unknown; content?: unknown };
@@ -122,6 +123,7 @@ function summarizeClientMessage(message: ClientMessage | { type?: unknown }): Re
   if (typeof input.requestId === 'string') summary.requestId = input.requestId;
   if (typeof input.sessionId === 'string') summary.sessionId = input.sessionId;
   if (typeof input.agentId === 'string') summary.agentId = input.agentId;
+  if (typeof input.clientMessageId === 'string') summary.clientMessageId = input.clientMessageId;
   if (typeof input.action === 'string') summary.action = input.action;
   if (typeof input.queueItemId === 'string') summary.queueItemId = input.queueItemId;
   if (input.message) {
@@ -785,6 +787,7 @@ async function handleMessage(connection: WebSocketConnection, message: ClientMes
           channelSessionKey: webChannelSessionKey(userId),
           requestedSessionId: message.sessionId,
           agentId,
+          ...(typeof message.clientMessageId === 'string' ? { clientMessageId: message.clientMessageId } : {}),
           ...(agentMessageTimestamp ? { agentMessageTimestamp } : {}),
           userId,
           text: typeof message.message.content === 'string' ? message.message.content : '',

--- a/tests/pi-chat.spec.ts
+++ b/tests/pi-chat.spec.ts
@@ -26,6 +26,7 @@ const EMPTY_USAGE = {
 function createMockRuntimeStatus(sessionId: string, overrides: Partial<PiRuntimeStatus> = {}): PiRuntimeStatus {
   return {
     sessionId,
+    revision: 0,
     phase: 'idle',
     activeTool: null,
     pendingToolCalls: 0,
@@ -1760,6 +1761,7 @@ contentKind: document
     const sessionId = 'sess-runtime-status';
     let currentStatus: PiRuntimeStatus = {
       sessionId,
+      revision: 0,
       phase: 'running_tool',
       activeTool: { toolCallId: 'tool-1', name: 'read' },
       pendingToolCalls: 1,
@@ -2466,6 +2468,7 @@ contentKind: document
     const sessionId = 'sess-compact-break';
     let currentStatus: PiRuntimeStatus = {
       sessionId,
+      revision: 0,
       phase: 'idle',
       activeTool: null,
       pendingToolCalls: 0,


### PR DESCRIPTION
## Summary
- add monotonic runtime status revisions so delayed status responses cannot overwrite newer socket state
- carry client message IDs through the WebSocket/runtime queue contract for deterministic optimistic-message matching
- serialize client message IDs in the mobile chat API contract

## Validation
- npm run test:websocket:protocol
- npm run test:pi:queue
- npx tsc --noEmit
- npm run lint

Note: the isolated worktree build cannot follow its temporary external node_modules symlink; source checks above passed.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes runtime-status ordering by assigning monotonic revisions that survive runtime recreation and rejecting delayed older snapshots on the client. It also propagates stable client message IDs through WebSocket, queue, normalization, and mobile serialization contracts.
- Maintains revisions per user/session in the process-global runtime store.
- Reconciles HTTP and socket statuses against the latest accepted revision.
- Carries bounded client message IDs into queued and serialized user messages.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/components/canvas-agent-chat/useChatRuntimeEvents.ts | Applies revision-aware stale-status rejection before updating runtime state, history, and queued-message reconciliation. |
| app/lib/chat/runtime-status.ts | Extends the shared runtime status contract with an optional revision and centralizes stale-status comparison. |
| app/lib/pi/live-runtime.ts | Allocates monotonic per-user/session revisions from the process-global runtime store so revisions survive runtime eviction and recreation. |
| app/lib/websocket/protocol.ts | Adds bounded optional client message IDs to the validated send-message protocol. |
| server/websocket-server.ts | Propagates validated client message IDs from WebSocket requests into normalized inbound messages. |
| app/lib/mobile/chat.ts | Serializes bounded client message IDs for deterministic mobile optimistic-message matching. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant WebSocket
    participant Runtime
    participant RevisionStore
    Runtime->>RevisionStore: Allocate next session revision
    Runtime->>WebSocket: runtime_status(revision, state)
    WebSocket->>Client: Newer socket status
    Client->>Client: Accept and record revision
    WebSocket-->>Client: Delayed status response
    Client->>Client: Reject when revision is older
```
</details>

<sub>Reviews (3): Last reviewed commit: ["preserve runtime revision across recreat..."](https://github.com/canvascoding/canvas-notebook/commit/5b08446fbdc698d5c3085744b6ab737667c81a2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55522246)</sub>

<!-- /greptile_comment -->