### PR TITLE
Unify notification and todo read states

### DIFF
--- a/app/api/mobile/v1/inbox/route.ts
+++ b/app/api/mobile/v1/inbox/route.ts
@@ -39,6 +39,7 @@ export async function PATCH(request: NextRequest) {
       workspace: workspaceResult.workspace,
       action: payload.action,
       itemId: payload.itemId,
+      read: payload.read,
     });
     return NextResponse.json({ success: true, data }, { headers: mobileInboxResponseHeaders });
   } catch (error) {

--- a/app/api/mobile/v1/todos/[todoId]/route.ts
+++ b/app/api/mobile/v1/todos/[todoId]/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { getMobileTodo, MobileTodoError, serializeMobileTodo } from '@/app/lib/mobile/todos';
 import { mobileTodosErrorResponse, mobileTodosResponseHeaders } from '@/app/lib/mobile/todos-route';
+import { setTodoReadStateForUser } from '@/app/lib/todos/read-state-actions';
 import { archiveTodo, updateTodo, type TodoFileLinkInput, type TodoPriority, type TodoStatus } from '@/app/lib/todos/store';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
-import { requireRequestWorkspace } from '@/app/lib/workspaces/request';
+import { requireRequestWorkspace, requireSessionWorkspace } from '@/app/lib/workspaces/request';
 
 type RouteContext = { params: Promise<{ todoId: string }> };
 
@@ -14,6 +15,21 @@ function dateValue(value: unknown): Date | null {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) throw new MobileTodoError('INVALID_DATE', 'Date value must be an ISO date.', 400);
   return date;
+}
+
+function hasTodoUpdate(payload: Record<string, unknown>): boolean {
+  return [
+    'title', 'description', 'priority', 'dueAt', 'status', 'assigneeUserId',
+    'completionComment', 'fileLinks',
+  ].some((key) => payload[key] !== undefined);
+}
+
+function requestedReadState(payload: Record<string, unknown>): boolean | undefined {
+  if (payload.read !== undefined) {
+    if (typeof payload.read !== 'boolean') throw new MobileTodoError('INVALID_READ_STATE', 'read must be a boolean.', 400);
+    return payload.read;
+  }
+  return payload.markSeen === true ? true : undefined;
 }
 
 export async function GET(request: NextRequest, context: RouteContext) {
@@ -31,26 +47,45 @@ export async function GET(request: NextRequest, context: RouteContext) {
 }
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
-  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canWrite' });
+  const workspaceResult = await requireRequestWorkspace(request, { permissions: 'canRead' });
   if (workspaceResult.response) return workspaceResult.response;
   const limited = rateLimit(request, { limit: 60, windowMs: 60_000, keyPrefix: 'mobile-todo-patch' });
   if (!limited.ok) return limited.response;
   try {
     const { todoId } = await context.params;
-    await getMobileTodo({ userId: workspaceResult.session.user.id, workspace: workspaceResult.workspace, todoId });
+    const existingTodo = await getMobileTodo({ userId: workspaceResult.session.user.id, workspace: workspaceResult.workspace, todoId });
     const payload = await request.json() as Record<string, unknown>;
-    const todo = await updateTodo(workspaceResult.session.user.id, todoId, {
-      ...(payload.title !== undefined ? { title: String(payload.title) } : {}),
-      ...(payload.description !== undefined ? { description: typeof payload.description === 'string' ? payload.description : null } : {}),
-      ...(payload.priority !== undefined ? { priority: payload.priority as TodoPriority } : {}),
-      ...(payload.dueAt !== undefined ? { dueAt: dateValue(payload.dueAt) } : {}),
-      ...(payload.status !== undefined ? { status: payload.status as TodoStatus } : {}),
-      ...(payload.assigneeUserId !== undefined ? { assigneeUserId: typeof payload.assigneeUserId === 'string' ? payload.assigneeUserId : null } : {}),
-      ...(payload.markSeen === true ? { seenAt: new Date() } : {}),
-      ...(payload.completionComment !== undefined ? { completionComment: typeof payload.completionComment === 'string' ? payload.completionComment : null } : {}),
-      ...(payload.fileLinks !== undefined ? { fileLinks: Array.isArray(payload.fileLinks) ? payload.fileLinks as TodoFileLinkInput[] : [] } : {}),
-    });
-    if (!todo) throw new Error('To-do disappeared during update.');
+    const shouldUpdateTodo = hasTodoUpdate(payload);
+    const read = requestedReadState(payload);
+    if (shouldUpdateTodo) {
+      const writeWorkspace = await requireSessionWorkspace(workspaceResult.session, {
+        workspaceId: workspaceResult.workspace.workspaceId,
+        permissions: 'canWrite',
+      });
+      if (writeWorkspace.response) return writeWorkspace.response;
+    }
+    let todo = existingTodo;
+    if (shouldUpdateTodo) {
+      const updatedTodo = await updateTodo(workspaceResult.session.user.id, todoId, {
+        ...(payload.title !== undefined ? { title: String(payload.title) } : {}),
+        ...(payload.description !== undefined ? { description: typeof payload.description === 'string' ? payload.description : null } : {}),
+        ...(payload.priority !== undefined ? { priority: payload.priority as TodoPriority } : {}),
+        ...(payload.dueAt !== undefined ? { dueAt: dateValue(payload.dueAt) } : {}),
+        ...(payload.status !== undefined ? { status: payload.status as TodoStatus } : {}),
+        ...(payload.assigneeUserId !== undefined ? { assigneeUserId: typeof payload.assigneeUserId === 'string' ? payload.assigneeUserId : null } : {}),
+        ...(payload.completionComment !== undefined ? { completionComment: typeof payload.completionComment === 'string' ? payload.completionComment : null } : {}),
+        ...(payload.fileLinks !== undefined ? { fileLinks: Array.isArray(payload.fileLinks) ? payload.fileLinks as TodoFileLinkInput[] : [] } : {}),
+      });
+      if (!updatedTodo) throw new Error('To-do disappeared during update.');
+      todo = updatedTodo;
+    }
+    if (read !== undefined) {
+      todo = (await setTodoReadStateForUser({
+        userId: workspaceResult.session.user.id,
+        todoId,
+        read,
+      })).todo;
+    }
     return NextResponse.json({ success: true, todo: serializeMobileTodo(todo) }, { headers: mobileTodosResponseHeaders });
   } catch (error) {
     return mobileTodosErrorResponse(error, '[API] Mobile To-do PATCH failed:');

--- a/app/api/notifications/summary/route.ts
+++ b/app/api/notifications/summary/route.ts
@@ -43,16 +43,32 @@ export async function GET(request: NextRequest) {
     if (!limited.ok) return limited.response;
 
     const scope = await loadMobileInboxScope(session.user);
-    const inbox = await listMobileAggregateInbox({
-      userId: session.user.id,
-      workspaces: scope.includedWorkspaces,
-      limit: 12,
-    });
+    const [inbox, todosInbox] = await Promise.all([
+      listMobileAggregateInbox({
+        userId: session.user.id,
+        workspaces: scope.includedWorkspaces,
+        limit: 12,
+      }),
+      // Persistent To-dos must not be crowded out by recent event notifications.
+      listMobileAggregateInbox({
+        userId: session.user.id,
+        workspaces: scope.includedWorkspaces,
+        filter: 'todos',
+        limit: 50,
+      }),
+    ]);
     const workspaceNames = new Map(scope.sources.map((source) => [source.id, source.name]));
-    const items = inbox.items.map((item) => ({
+    const notificationItems = inbox.items
+      .filter((item) => item.target.kind !== 'todo')
+      .map((item) => ({
+        ...item,
+        workspaceName: workspaceNames.get(item.workspaceId) ?? null,
+      }));
+    const todoItems = todosInbox.items.map((item) => ({
       ...item,
       workspaceName: workspaceNames.get(item.workspaceId) ?? null,
     }));
+    const items = [...notificationItems, ...todoItems];
 
     return NextResponse.json({
       success: true,
@@ -63,8 +79,8 @@ export async function GET(request: NextRequest) {
         // center can render its persistent To-do section independently.
         items,
         sections: {
-          notifications: items.filter((item) => item.target.kind !== 'todo'),
-          todos: items.filter((item) => item.target.kind === 'todo'),
+          notifications: notificationItems,
+          todos: todoItems,
         },
       },
     });

--- a/app/api/notifications/summary/route.ts
+++ b/app/api/notifications/summary/route.ts
@@ -12,9 +12,10 @@ import { loadMobileInboxScope } from '@/app/lib/mobile/inbox-scope';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 
 type PatchPayload = {
-  action?: 'mark_all_read' | 'mark_item_read' | 'dismiss_item';
+  action?: 'mark_all_read' | 'mark_item_read' | 'set_item_read_state' | 'dismiss_item';
   itemId?: string;
   workspaceId?: string;
+  read?: boolean;
 };
 
 function mobileInboxErrorResponse(error: unknown) {
@@ -93,7 +94,7 @@ export async function PATCH(request: NextRequest) {
     }
 
     if (
-      (payload.action === 'mark_item_read' || payload.action === 'dismiss_item')
+      (payload.action === 'mark_item_read' || payload.action === 'set_item_read_state' || payload.action === 'dismiss_item')
       && payload.itemId
       && payload.workspaceId
     ) {
@@ -106,6 +107,7 @@ export async function PATCH(request: NextRequest) {
         workspace,
         action: payload.action,
         itemId: payload.itemId,
+        read: payload.read,
       });
       return NextResponse.json({ success: true, data });
     }

--- a/app/api/notifications/summary/route.ts
+++ b/app/api/notifications/summary/route.ts
@@ -49,16 +49,23 @@ export async function GET(request: NextRequest) {
       limit: 12,
     });
     const workspaceNames = new Map(scope.sources.map((source) => [source.id, source.name]));
+    const items = inbox.items.map((item) => ({
+      ...item,
+      workspaceName: workspaceNames.get(item.workspaceId) ?? null,
+    }));
 
     return NextResponse.json({
       success: true,
       data: {
         unreadCount: inbox.counts.unread,
         counts: inbox.counts,
-        items: inbox.items.map((item) => ({
-          ...item,
-          workspaceName: workspaceNames.get(item.workspaceId) ?? null,
-        })),
+        // Keep `items` for existing dashboard consumers while the notification
+        // center can render its persistent To-do section independently.
+        items,
+        sections: {
+          notifications: items.filter((item) => item.target.kind !== 'todo'),
+          todos: items.filter((item) => item.target.kind === 'todo'),
+        },
       },
     });
   } catch (error) {

--- a/app/api/notifications/summary/route.ts
+++ b/app/api/notifications/summary/route.ts
@@ -47,6 +47,7 @@ export async function GET(request: NextRequest) {
       listMobileAggregateInbox({
         userId: session.user.id,
         workspaces: scope.includedWorkspaces,
+        filter: 'notifications',
         limit: 12,
       }),
       // Persistent To-dos must not be crowded out by recent event notifications.
@@ -58,12 +59,10 @@ export async function GET(request: NextRequest) {
       }),
     ]);
     const workspaceNames = new Map(scope.sources.map((source) => [source.id, source.name]));
-    const notificationItems = inbox.items
-      .filter((item) => item.target.kind !== 'todo')
-      .map((item) => ({
-        ...item,
-        workspaceName: workspaceNames.get(item.workspaceId) ?? null,
-      }));
+    const notificationItems = inbox.items.map((item) => ({
+      ...item,
+      workspaceName: workspaceNames.get(item.workspaceId) ?? null,
+    }));
     const todoItems = todosInbox.items.map((item) => ({
       ...item,
       workspaceName: workspaceNames.get(item.workspaceId) ?? null,

--- a/app/api/todos/[id]/follow-up/route.ts
+++ b/app/api/todos/[id]/follow-up/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@/app/lib/pi/session-runtime-access';
 import { applyTodoRateLimit, requireTodoSession, todoErrorResponse } from '@/app/lib/todos/api';
 import { getTodo, updateTodo } from '@/app/lib/todos/store';
+import { setTodoReadStateForUser } from '@/app/lib/todos/read-state-actions';
 import { buildChatSessionHref } from '@/app/lib/chat/chat-navigation-intent';
 import { getUserPreferredLocale } from '@/app/lib/user-preferences';
 
@@ -97,7 +98,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     const preparedTodo = await updateTodo(session.user.id, todo.id, {
       status: 'done',
-      seenAt: new Date(),
       completionComment: comment,
       followUpError: null,
     });
@@ -105,6 +105,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     if (!preparedTodo) {
       return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
     }
+    await setTodoReadStateForUser({ userId: session.user.id, todoId: todo.id, read: true });
 
     const timestamp = Date.now();
     const message: Extract<AgentMessage, { role: 'user' }> = {

--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -13,6 +13,7 @@ import {
   type TodoPriority,
   type TodoStatus,
 } from '@/app/lib/todos/store';
+import { setTodoReadStateForUser } from '@/app/lib/todos/read-state-actions';
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -32,6 +33,26 @@ function parsePriority(value: unknown): TodoPriority | undefined {
 
 function parseFileLinks(value: unknown): TodoFileLinkInput[] | undefined {
   return Array.isArray(value) ? value as TodoFileLinkInput[] : undefined;
+}
+
+function parseRequestedReadState(payload: Record<string, unknown>): { read: boolean; readAt?: Date } | undefined {
+  if (payload.read !== undefined) {
+    if (typeof payload.read !== 'boolean') throw new Error('read must be a boolean.');
+    return { read: payload.read };
+  }
+  if (payload.markSeen === true) return { read: true };
+  if (payload.seenAt !== undefined) {
+    const readAt = parseOptionalDate(payload.seenAt);
+    return readAt ? { read: true, readAt } : { read: false };
+  }
+  return undefined;
+}
+
+function hasTodoUpdate(payload: Record<string, unknown>): boolean {
+  return [
+    'title', 'description', 'categoryId', 'priority', 'dueAt', 'status',
+    'assigneeUserId', 'completionComment', 'fileLinks',
+  ].some((key) => payload[key] !== undefined);
 }
 
 async function requireTodoWriteWorkspace(
@@ -84,37 +105,45 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   }
 
   try {
-    const payload = await request.json();
+    const payload = await request.json() as Record<string, unknown>;
     const { id } = await context.params;
     const existingTodo = await getTodo(session.user.id, id);
     if (!existingTodo) {
       return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
     }
-    const permissionResponse = await requireTodoWriteWorkspace(session, existingTodo);
-    if (permissionResponse) {
-      return permissionResponse;
+    const requestedReadState = parseRequestedReadState(payload);
+    const shouldUpdateTodo = hasTodoUpdate(payload);
+    if (shouldUpdateTodo) {
+      const permissionResponse = await requireTodoWriteWorkspace(session, existingTodo);
+      if (permissionResponse) return permissionResponse;
     }
 
-    const todo = await updateTodo(session.user.id, id, {
-      ...(payload?.title !== undefined ? { title: String(payload.title) } : {}),
-      ...(payload?.description !== undefined ? { description: typeof payload.description === 'string' ? payload.description : null } : {}),
-      ...(payload?.categoryId !== undefined ? { categoryId: typeof payload.categoryId === 'string' ? payload.categoryId : null } : {}),
-      ...(payload?.priority !== undefined ? { priority: parsePriority(payload.priority) } : {}),
-      ...(payload?.dueAt !== undefined ? { dueAt: parseOptionalDate(payload.dueAt) ?? null } : {}),
-      ...(payload?.status !== undefined ? { status: parseStatus(payload.status) } : {}),
-      ...(payload?.assigneeUserId !== undefined ? {
+    let todo = existingTodo;
+    if (shouldUpdateTodo) {
+      const updatedTodo = await updateTodo(session.user.id, id, {
+        ...(payload.title !== undefined ? { title: String(payload.title) } : {}),
+        ...(payload.description !== undefined ? { description: typeof payload.description === 'string' ? payload.description : null } : {}),
+        ...(payload.categoryId !== undefined ? { categoryId: typeof payload.categoryId === 'string' ? payload.categoryId : null } : {}),
+        ...(payload.priority !== undefined ? { priority: parsePriority(payload.priority) } : {}),
+        ...(payload.dueAt !== undefined ? { dueAt: parseOptionalDate(payload.dueAt) ?? null } : {}),
+        ...(payload.status !== undefined ? { status: parseStatus(payload.status) } : {}),
+        ...(payload.assigneeUserId !== undefined ? {
         assigneeUserId: typeof payload.assigneeUserId === 'string' ? payload.assigneeUserId : null,
       } : {}),
-      ...(payload?.markSeen === true ? { seenAt: new Date() } : {}),
-      ...(payload?.seenAt !== undefined ? { seenAt: parseOptionalDate(payload.seenAt) ?? null } : {}),
-      ...(payload?.completionComment !== undefined ? {
+        ...(payload.completionComment !== undefined ? {
         completionComment: typeof payload.completionComment === 'string' ? payload.completionComment : null,
       } : {}),
-      ...(payload?.fileLinks !== undefined ? { fileLinks: parseFileLinks(payload.fileLinks) ?? [] } : {}),
-    });
-
-    if (!todo) {
-      return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
+        ...(payload.fileLinks !== undefined ? { fileLinks: parseFileLinks(payload.fileLinks) ?? [] } : {}),
+      });
+      if (!updatedTodo) return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });
+      todo = updatedTodo;
+    }
+    if (requestedReadState) {
+      todo = (await setTodoReadStateForUser({
+        userId: session.user.id,
+        todoId: id,
+        ...requestedReadState,
+      })).todo;
     }
 
     return NextResponse.json({ success: true, data: todo });

--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -128,11 +128,11 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         ...(payload.dueAt !== undefined ? { dueAt: parseOptionalDate(payload.dueAt) ?? null } : {}),
         ...(payload.status !== undefined ? { status: parseStatus(payload.status) } : {}),
         ...(payload.assigneeUserId !== undefined ? {
-        assigneeUserId: typeof payload.assigneeUserId === 'string' ? payload.assigneeUserId : null,
-      } : {}),
+          assigneeUserId: typeof payload.assigneeUserId === 'string' ? payload.assigneeUserId : null,
+        } : {}),
         ...(payload.completionComment !== undefined ? {
-        completionComment: typeof payload.completionComment === 'string' ? payload.completionComment : null,
-      } : {}),
+          completionComment: typeof payload.completionComment === 'string' ? payload.completionComment : null,
+        } : {}),
         ...(payload.fileLinks !== undefined ? { fileLinks: parseFileLinks(payload.fileLinks) ?? [] } : {}),
       });
       if (!updatedTodo) return NextResponse.json({ success: false, error: 'Todo not found.' }, { status: 404 });

--- a/app/components/notifications/NotificationBell.tsx
+++ b/app/components/notifications/NotificationBell.tsx
@@ -27,9 +27,10 @@ import {
 } from './notification-summary';
 
 type NotificationMutation = {
-  action: 'mark_all_read' | 'mark_item_read' | 'dismiss_item';
+  action: 'mark_all_read' | 'mark_item_read' | 'set_item_read_state' | 'dismiss_item';
   itemId?: string;
   workspaceId?: string;
+  read?: boolean;
 };
 
 function formatBadgeCount(count: number) {
@@ -174,6 +175,21 @@ export function NotificationBell() {
     }
   }, [mutateInbox, refresh]);
 
+  const setTodoReadState = useCallback(async (item: NotificationItem, read: boolean) => {
+    setIsMutating(true);
+    try {
+      await mutateInbox({
+        action: 'set_item_read_state',
+        itemId: item.id,
+        workspaceId: item.workspaceId,
+        read,
+      });
+    } finally {
+      setIsMutating(false);
+      await refresh();
+    }
+  }, [mutateInbox, refresh]);
+
   const openItem = useCallback(async (item: NotificationItem) => {
     setOpen(false);
     try {
@@ -200,6 +216,70 @@ export function NotificationBell() {
     if (dispatchOpenChatSession(item.target.sessionId, 'notification', item.workspaceId)) return;
     window.location.assign(notificationHref(item));
   }, [markItemRead]);
+
+  const notificationItems = summary?.sections.notifications ?? summary?.items.filter((item) => item.target.kind !== 'todo') ?? [];
+  const todoItems = summary?.sections.todos ?? summary?.items.filter((item) => item.target.kind === 'todo') ?? [];
+
+  const renderItem = (item: NotificationItem) => {
+    const Icon = notificationIcon(item);
+    const isTodo = item.target.kind === 'todo';
+    return (
+      <div key={`${item.workspaceId}:${item.id}`} className="group flex items-start gap-2 rounded-md px-2 py-2 hover:bg-accent">
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-start gap-2 text-left"
+          onClick={() => void openItem(item)}
+        >
+          <span className={cn(
+            'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-sm',
+            item.priority === 'high' ? 'bg-destructive/10 text-destructive' : 'bg-muted text-muted-foreground',
+          )}>
+            <Icon className="h-3.5 w-3.5" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="flex items-center gap-1.5">
+              {item.unread ? <Circle className="h-2 w-2 shrink-0 fill-primary text-primary" aria-label={t('unread')} /> : null}
+              <span className="truncate text-sm font-medium">{item.title}</span>
+              {item.priority === 'high' ? <CircleAlert className="h-3.5 w-3.5 shrink-0 text-destructive" aria-label={t('highPriority')} /> : null}
+            </span>
+            <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+              {item.detail || t(`types.${item.target.kind}`)}
+            </span>
+            <span className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+              <FolderKanban className="h-3 w-3 shrink-0" />
+              <span className="truncate">{item.workspaceName || t('workspaceFallback')}</span>
+              <span aria-hidden="true">·</span>
+              <span>{formatDate(item.occurredAt, locale) || t('recent')}</span>
+            </span>
+          </span>
+        </button>
+        {isTodo ? (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="shrink-0"
+            onClick={() => void setTodoReadState(item, item.unread)}
+            disabled={isMutating}
+            aria-label={item.unread ? t('markRead') : t('markUnread')}
+          >
+            {item.unread ? <Check className="h-3.5 w-3.5" /> : <Circle className="h-3.5 w-3.5" />}
+          </Button>
+        ) : null}
+        {isDismissible(item) ? (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+            onClick={() => void dismissItem(item)}
+            disabled={isMutating}
+            aria-label={t('dismiss')}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        ) : null}
+      </div>
+    );
+  };
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -241,61 +321,26 @@ export function NotificationBell() {
         </div>
 
         <div className="max-h-[70vh] overflow-y-auto p-2">
-          {!summary || summary.items.length === 0 ? (
+          {!summary || (notificationItems.length === 0 && todoItems.length === 0) ? (
             <div className="flex min-h-36 flex-col items-center justify-center px-4 text-center">
               <Check className="h-7 w-7 text-muted-foreground" />
               <p className="mt-2 text-sm font-medium">{t('empty.title')}</p>
               <p className="mt-1 text-xs text-muted-foreground">{t('empty.description')}</p>
             </div>
           ) : (
-            <div className="space-y-1">
-              {summary.items.map((item) => {
-                const Icon = notificationIcon(item);
-                return (
-                  <div key={`${item.workspaceId}:${item.id}`} className="group flex items-start gap-2 rounded-md px-2 py-2 hover:bg-accent">
-                    <button
-                      type="button"
-                      className="flex min-w-0 flex-1 items-start gap-2 text-left"
-                      onClick={() => void openItem(item)}
-                    >
-                      <span className={cn(
-                        'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-sm',
-                        item.priority === 'high' ? 'bg-destructive/10 text-destructive' : 'bg-muted text-muted-foreground',
-                      )}>
-                        <Icon className="h-3.5 w-3.5" />
-                      </span>
-                      <span className="min-w-0 flex-1">
-                        <span className="flex items-center gap-1.5">
-                          {item.unread ? <Circle className="h-2 w-2 shrink-0 fill-primary text-primary" aria-label={t('unread')} /> : null}
-                          <span className="truncate text-sm font-medium">{item.title}</span>
-                          {item.priority === 'high' ? <CircleAlert className="h-3.5 w-3.5 shrink-0 text-destructive" aria-label={t('highPriority')} /> : null}
-                        </span>
-                        <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-                          {item.detail || t(`types.${item.target.kind}`)}
-                        </span>
-                        <span className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
-                          <FolderKanban className="h-3 w-3 shrink-0" />
-                          <span className="truncate">{item.workspaceName || t('workspaceFallback')}</span>
-                          <span aria-hidden="true">·</span>
-                          <span>{formatDate(item.occurredAt, locale) || t('recent')}</span>
-                        </span>
-                      </span>
-                    </button>
-                    {isDismissible(item) ? (
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-                        onClick={() => void dismissItem(item)}
-                        disabled={isMutating}
-                        aria-label={t('dismiss')}
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </Button>
-                    ) : null}
-                  </div>
-                );
-              })}
+            <div className="space-y-4">
+              {notificationItems.length > 0 ? (
+                <section aria-labelledby="notification-center-notifications">
+                  <h3 id="notification-center-notifications" className="px-2 pb-1 text-xs font-semibold text-muted-foreground">{t('sections.notifications')}</h3>
+                  <div className="space-y-1">{notificationItems.map(renderItem)}</div>
+                </section>
+              ) : null}
+              {todoItems.length > 0 ? (
+                <section aria-labelledby="notification-center-todos">
+                  <h3 id="notification-center-todos" className="px-2 pb-1 text-xs font-semibold text-muted-foreground">{t('sections.todos')}</h3>
+                  <div className="space-y-1">{todoItems.map(renderItem)}</div>
+                </section>
+              ) : null}
             </div>
           )}
         </div>

--- a/app/components/notifications/notification-summary.ts
+++ b/app/components/notifications/notification-summary.ts
@@ -23,6 +23,7 @@ export type NotificationSummary = {
     unread: number;
     chat: number;
     todos: number;
+    todoUnread: number;
     studio: number;
     automation: number;
   };

--- a/app/components/notifications/notification-summary.ts
+++ b/app/components/notifications/notification-summary.ts
@@ -27,6 +27,10 @@ export type NotificationSummary = {
     automation: number;
   };
   items: NotificationItem[];
+  sections: {
+    notifications: NotificationItem[];
+    todos: NotificationItem[];
+  };
 };
 
 type ApiResponse<T> = {

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -1213,6 +1213,17 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       FOREIGN KEY (category_id) REFERENCES todo_categories(id)
     );
 
+    CREATE TABLE IF NOT EXISTS todo_read_states (
+      user_id TEXT NOT NULL,
+      todo_id TEXT NOT NULL,
+      read_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (user_id, todo_id),
+      FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
+      FOREIGN KEY (todo_id) REFERENCES todo_items(id) ON DELETE CASCADE
+    );
+
     CREATE TABLE IF NOT EXISTS todo_file_links (
       id TEXT PRIMARY KEY NOT NULL,
       todo_id TEXT NOT NULL,
@@ -2357,6 +2368,8 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_todo_items_project_status ON todo_items (project_id, status, updated_at);
     CREATE INDEX IF NOT EXISTS idx_todo_items_assignee_status ON todo_items (assignee_user_id, status, updated_at);
     CREATE INDEX IF NOT EXISTS idx_todo_items_category ON todo_items (category_id);
+    CREATE INDEX IF NOT EXISTS idx_todo_read_states_user_read ON todo_read_states (user_id, read_at);
+    CREATE INDEX IF NOT EXISTS idx_todo_read_states_todo ON todo_read_states (todo_id);
     CREATE INDEX IF NOT EXISTS idx_todo_file_links_todo ON todo_file_links (todo_id);
     CREATE INDEX IF NOT EXISTS idx_todo_file_links_user_path ON todo_file_links (user_id, workspace_path);
     CREATE INDEX IF NOT EXISTS idx_todo_file_links_workspace_path ON todo_file_links (organization_id, workspace_id, workspace_path);
@@ -3348,6 +3361,31 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
   `);
 
   // ── One-time data fixes ───────────────────────────────────────────────────────
+
+  // To-do read state used to be stored globally on todo_items or in the generic
+  // mobile inbox table. Keep both legacy sources readable while seeding the
+  // canonical, per-user state. INSERT OR IGNORE makes this safe on every startup.
+  sqlite.exec(`
+    INSERT OR IGNORE INTO todo_read_states (
+      user_id, todo_id, read_at, created_at, updated_at
+    )
+    SELECT user_id, id, seen_at, seen_at, seen_at
+    FROM todo_items
+    WHERE seen_at IS NOT NULL;
+
+    INSERT OR IGNORE INTO todo_read_states (
+      user_id, todo_id, read_at, created_at, updated_at
+    )
+    SELECT read_state.user_id,
+      todo.id,
+      read_state.read_at,
+      read_state.created_at,
+      read_state.updated_at
+    FROM mobile_inbox_read_states read_state
+    INNER JOIN todo_items todo
+      ON read_state.item_key = 'todo:' || todo.id
+    WHERE read_state.dismissed_at IS NULL;
+  `);
 
   try {
     sqlite.exec(`

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -1359,6 +1359,18 @@ export const todoItems = sqliteTable("todo_items", {
   categoryIdx: index("idx_todo_items_category").on(table.categoryId),
 }));
 
+export const todoReadStates = sqliteTable("todo_read_states", {
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  todoId: text("todo_id").notNull().references(() => todoItems.id, { onDelete: "cascade" }),
+  readAt: integer("read_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.userId, table.todoId] }),
+  userReadIdx: index("idx_todo_read_states_user_read").on(table.userId, table.readAt),
+  todoIdx: index("idx_todo_read_states_todo").on(table.todoId),
+}));
+
 export const todoFileLinks = sqliteTable("todo_file_links", {
   id: text("id").primaryKey(),
   todoId: text("todo_id").notNull().references(() => todoItems.id),

--- a/app/lib/mobile/inbox.ts
+++ b/app/lib/mobile/inbox.ts
@@ -38,7 +38,7 @@ const MAX_SOURCE_ITEMS = 200;
 const INITIAL_UNREAD_WINDOW_MS = 24 * 60 * 60 * 1_000;
 const TODO_PRESENTATION_GROUP_WINDOW_MS = 5 * 60 * 1_000;
 
-export const MOBILE_INBOX_FILTERS = ['all', 'unread', 'chat', 'todos', 'studio', 'automation'] as const;
+export const MOBILE_INBOX_FILTERS = ['all', 'unread', 'notifications', 'chat', 'todos', 'studio', 'automation'] as const;
 export type MobileInboxFilter = typeof MOBILE_INBOX_FILTERS[number];
 
 export type MobileInboxItem = {
@@ -420,6 +420,7 @@ async function collectInboxItems(input: { userId: string; workspace: WorkspaceCo
 function matchesFilter(item: MobileInboxItem, filter: MobileInboxFilter): boolean {
   if (filter === 'all') return true;
   if (filter === 'unread') return item.unread;
+  if (filter === 'notifications') return item.target.kind !== 'todo';
   if (filter === 'chat') return item.target.kind === 'chat';
   if (filter === 'todos') return item.target.kind === 'todo';
   if (filter === 'studio') return item.target.kind === 'studio';

--- a/app/lib/mobile/inbox.ts
+++ b/app/lib/mobile/inbox.ts
@@ -443,6 +443,7 @@ export async function listMobileInbox(input: {
     unread: allItems.filter((item) => item.unread).length,
     chat: allItems.filter((item) => item.target.kind === 'chat').length,
     todos: allItems.filter((item) => item.target.kind === 'todo').length,
+    todoUnread: allItems.filter((item) => item.target.kind === 'todo' && item.unread).length,
     studio: allItems.filter((item) => item.target.kind === 'studio').length,
     automation: allItems.filter((item) => item.target.kind === 'automation').length,
   };
@@ -602,6 +603,7 @@ export async function listMobileAggregateInbox(input: {
     unread: allItems.filter((item) => item.unread).length,
     chat: allItems.filter((item) => item.target.kind === 'chat').length,
     todos: allItems.filter((item) => item.target.kind === 'todo').length,
+    todoUnread: allItems.filter((item) => item.target.kind === 'todo' && item.unread).length,
     studio: allItems.filter((item) => item.target.kind === 'studio').length,
     automation: allItems.filter((item) => item.target.kind === 'automation').length,
   };
@@ -816,6 +818,6 @@ export async function markMobileInboxRead(input: {
     throw new MobileInboxError('INVALID_ITEM', 'The Inbox item is invalid.', 400);
   }
   return requestedRead
-    ? { itemId: input.itemId, readAt: now.toISOString() }
-    : { itemId: input.itemId, read: false };
+    ? { itemId: input.itemId, read: true, readAt: now.toISOString() }
+    : { itemId: input.itemId, read: false, readAt: null };
 }

--- a/app/lib/mobile/inbox.ts
+++ b/app/lib/mobile/inbox.ts
@@ -27,10 +27,10 @@ import {
   piSessions,
   studioGenerationOutputs,
   studioGenerations,
-  todoItems,
 } from '@/app/lib/db/schema';
 import { DEFAULT_SESSION_TITLE } from '@/app/lib/pi/session-titles';
-import { getTodo, listTodos, markTodoSeen, type TodoWithRelations } from '@/app/lib/todos/store';
+import { setTodoReadStateForUser } from '@/app/lib/todos/read-state-actions';
+import { getTodo, listTodos, type TodoWithRelations } from '@/app/lib/todos/store';
 import type { WorkspaceContext } from '@/app/lib/workspaces/types';
 
 const BASELINE_KEY = '__baseline__';
@@ -273,9 +273,6 @@ function genericUnread(itemKey: string, occurredAt: Date, state: Awaited<ReturnT
 
 async function collectInboxItems(input: { userId: string; workspace: WorkspaceContext }) {
   const state = await readState({ userId: input.userId, workspaceId: input.workspace.workspaceId });
-  const endOfToday = new Date();
-  endOfToday.setHours(23, 59, 59, 999);
-
   const [sessionRows, todos, generationRows, automationRows] = await Promise.all([
     db.select({
       sessionId: piSessions.sessionId,
@@ -364,21 +361,17 @@ async function collectInboxItems(input: { userId: string; workspace: WorkspaceCo
     });
   }
   for (const todo of todos) {
-    const isDue = todo.status === 'open' && Boolean(todo.dueAt && todo.dueAt <= endOfToday);
     const itemKey = `todo:${todo.id}`;
-    const unread = input.workspace.workspaceType === 'personal'
-      ? !todo.seenAt
-      : genericUnread(itemKey, todo.updatedAt, state);
-    if (todo.status !== 'open' || (!unread && !isDue)) continue;
+    const unread = todo.readState === 'unread';
     items.push({
       id: itemKey,
       type: 'todo.attention',
       title: todo.title,
-      detail: todo.category?.name || (isDue ? 'Due today' : 'To-do'),
+      detail: todo.category?.name || (todo.status === 'done' ? 'Completed To-do' : 'To-do'),
       previewUrl: null,
       occurredAt: todo.updatedAt.toISOString(),
       unread,
-      priority: todo.priority === 'high' || isDue ? 'high' : 'normal',
+      priority: todo.priority === 'high' ? 'high' : 'normal',
       target: { kind: 'todo', todoId: todo.id },
       todoPresentationCandidate: todoPresentationCandidate(todo),
     });
@@ -735,18 +728,15 @@ export async function markMobileInboxRead(input: {
   workspace: WorkspaceContext;
   action: unknown;
   itemId?: unknown;
+  read?: unknown;
 }) {
   const now = new Date();
   if (input.action === 'mark_all_read') {
-    const personalTodoRead = input.workspace.workspaceType === 'personal'
-      ? db.update(todoItems).set({ seenAt: now, updatedAt: now }).where(and(
-          eq(todoItems.userId, input.userId),
-          eq(todoItems.workspaceType, 'personal'),
-          workspaceCondition(todoItems.workspaceId, input.workspace),
-          eq(todoItems.status, 'open'),
-          isNull(todoItems.seenAt),
-        ))
-      : Promise.resolve();
+    const todos = await listTodos(input.userId, {
+      ...todoWorkspaceOptions(input.workspace),
+      status: 'active',
+      limit: MAX_SOURCE_ITEMS,
+    });
     await Promise.all([
       db.update(piSessions).set({ lastViewedAt: piSessionReadCursorSql(), updatedAt: now }).where(and(
         eq(piSessions.userId, input.userId),
@@ -754,7 +744,14 @@ export async function markMobileInboxRead(input: {
         workspaceCondition(piSessions.workspaceId, input.workspace),
         isNotNull(piSessions.lastMessageAt),
       )),
-      personalTodoRead,
+      ...todos
+        .filter((todo) => todo.readState === 'unread')
+        .map((todo) => setTodoReadStateForUser({
+          userId: input.userId,
+          todoId: todo.id,
+          read: true,
+          readAt: now,
+        })),
       upsertReadState(input.userId, input.workspace.workspaceId, BASELINE_KEY, now),
     ]);
     return { readAt: now.toISOString() };
@@ -774,12 +771,20 @@ export async function markMobileInboxRead(input: {
     await upsertDismissedState(input.userId, input.workspace.workspaceId, input.itemId, now);
     return { itemId: input.itemId, dismissedAt: now.toISOString() };
   }
-  if (input.action !== 'mark_item_read' || typeof input.itemId !== 'string') {
+  const requestedRead = input.action === 'mark_item_read'
+    ? true
+    : input.action === 'set_item_read_state' && typeof input.read === 'boolean'
+      ? input.read
+      : null;
+  if (requestedRead === null || typeof input.itemId !== 'string') {
     throw new MobileInboxError('INVALID_ACTION', 'The Inbox read action is invalid.', 400);
   }
   const [kind, entityId] = input.itemId.split(':', 2);
   if (!entityId) throw new MobileInboxError('INVALID_ITEM', 'The Inbox item is invalid.', 400);
   if (kind === 'chat') {
+    if (!requestedRead) {
+      throw new MobileInboxError('ITEM_READ_STATE_NOT_SUPPORTED', 'Chat items can only be marked read.', 400);
+    }
     const result = await db.update(piSessions).set({ lastViewedAt: piSessionReadCursorSql(), updatedAt: now }).where(and(
       eq(piSessions.userId, input.userId),
       eq(piSessions.sessionId, entityId),
@@ -792,12 +797,16 @@ export async function markMobileInboxRead(input: {
     if (!todoBelongsToWorkspace(todo, input.workspace)) {
       throw new MobileInboxError('ITEM_NOT_FOUND', 'The Inbox item was not found.', 404);
     }
-    if (input.workspace.workspaceType === 'personal') {
-      await markTodoSeen(input.userId, entityId, now);
-    } else {
-      await upsertReadState(input.userId, input.workspace.workspaceId, input.itemId, now);
-    }
+    await setTodoReadStateForUser({
+      userId: input.userId,
+      todoId: entityId,
+      read: requestedRead,
+      readAt: now,
+    });
   } else if (kind === 'studio' || kind === 'automation') {
+    if (!requestedRead) {
+      throw new MobileInboxError('ITEM_READ_STATE_NOT_SUPPORTED', 'Only To-dos can be marked unread.', 400);
+    }
     const items = await collectInboxItems(input);
     if (!items.some((item) => item.id === input.itemId)) {
       throw new MobileInboxError('ITEM_NOT_FOUND', 'The Inbox item was not found.', 404);
@@ -806,5 +815,7 @@ export async function markMobileInboxRead(input: {
   } else {
     throw new MobileInboxError('INVALID_ITEM', 'The Inbox item is invalid.', 400);
   }
-  return { itemId: input.itemId, readAt: now.toISOString() };
+  return requestedRead
+    ? { itemId: input.itemId, readAt: now.toISOString() }
+    : { itemId: input.itemId, read: false };
 }

--- a/app/lib/mobile/todos.ts
+++ b/app/lib/mobile/todos.ts
@@ -27,6 +27,8 @@ export type MobileTodo = {
   priority: 'low' | 'normal' | 'high';
   dueAt: string | null;
   seenAt: string | null;
+  readAt: string | null;
+  readState: 'read' | 'unread';
   completedAt: string | null;
   completionComment: string | null;
   followUpSentAt: string | null;
@@ -100,6 +102,8 @@ export function serializeMobileTodo(todo: TodoWithRelations): MobileTodo {
     priority: todo.priority as MobileTodo['priority'],
     dueAt: iso(todo.dueAt),
     seenAt: iso(todo.seenAt),
+    readAt: iso(todo.readAt),
+    readState: todo.readState,
     completedAt: iso(todo.completedAt),
     completionComment: todo.completionComment,
     followUpSentAt: iso(todo.followUpSentAt),

--- a/app/lib/todos/read-state-actions.ts
+++ b/app/lib/todos/read-state-actions.ts
@@ -1,0 +1,38 @@
+import { clearTodoReadState, setTodoReadState } from './read-state-store';
+import { getTodo, TodoStoreError, type TodoWithRelations } from './store';
+
+export type TodoReadStateActionResult = {
+  todo: TodoWithRelations;
+  read: boolean;
+  readAt: Date | null;
+};
+
+/**
+ * Changes only the current user's presentation state. Reading a shared To-do
+ * therefore needs read access, but never changes the shared Todo updatedAt.
+ */
+export async function setTodoReadStateForUser(input: {
+  userId: string;
+  todoId: string;
+  read: boolean;
+  readAt?: Date;
+}): Promise<TodoReadStateActionResult> {
+  const todo = await getTodo(input.userId, input.todoId);
+  if (!todo) {
+    throw new TodoStoreError('Todo not found.', 'TODO_NOT_FOUND');
+  }
+
+  const readAt = input.read
+    ? await setTodoReadState(input.userId, input.todoId, input.readAt ?? new Date())
+    : null;
+  if (!input.read) {
+    await clearTodoReadState(input.userId, input.todoId);
+  }
+
+  const updatedTodo = await getTodo(input.userId, input.todoId);
+  if (!updatedTodo) {
+    throw new TodoStoreError('Todo not found.', 'TODO_NOT_FOUND');
+  }
+
+  return { todo: updatedTodo, read: input.read, readAt };
+}

--- a/app/lib/todos/read-state-store.ts
+++ b/app/lib/todos/read-state-store.ts
@@ -1,0 +1,53 @@
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { db } from '@/app/lib/db';
+import { todoReadStates } from '@/app/lib/db/schema';
+
+export type TodoReadState = typeof todoReadStates.$inferSelect;
+
+export async function listTodoReadStates(userId: string, todoIds: string[]): Promise<Map<string, Date>> {
+  const uniqueTodoIds = [...new Set(todoIds)];
+  if (uniqueTodoIds.length === 0) return new Map();
+
+  const rows = await db
+    .select({ todoId: todoReadStates.todoId, readAt: todoReadStates.readAt })
+    .from(todoReadStates)
+    .where(and(
+      eq(todoReadStates.userId, userId),
+      inArray(todoReadStates.todoId, uniqueTodoIds),
+    ));
+
+  return new Map(rows.map((row) => [row.todoId, row.readAt]));
+}
+
+export async function getTodoReadState(userId: string, todoId: string): Promise<Date | null> {
+  const [state] = await db
+    .select({ readAt: todoReadStates.readAt })
+    .from(todoReadStates)
+    .where(and(eq(todoReadStates.userId, userId), eq(todoReadStates.todoId, todoId)))
+    .limit(1);
+
+  return state?.readAt ?? null;
+}
+
+export async function setTodoReadState(userId: string, todoId: string, readAt = new Date()): Promise<Date> {
+  await db.insert(todoReadStates).values({
+    userId,
+    todoId,
+    readAt,
+    createdAt: readAt,
+    updatedAt: readAt,
+  }).onConflictDoUpdate({
+    target: [todoReadStates.userId, todoReadStates.todoId],
+    set: { readAt, updatedAt: readAt },
+  });
+
+  return readAt;
+}
+
+export async function clearTodoReadState(userId: string, todoId: string): Promise<void> {
+  await db.delete(todoReadStates).where(and(
+    eq(todoReadStates.userId, userId),
+    eq(todoReadStates.todoId, todoId),
+  ));
+}

--- a/app/lib/todos/store.ts
+++ b/app/lib/todos/store.ts
@@ -20,6 +20,11 @@ import {
   getDefaultTodoCategoryKey,
   resolveDefaultTodoCategoryName,
 } from './default-categories';
+import {
+  clearTodoReadState,
+  listTodoReadStates,
+  setTodoReadState,
+} from './read-state-store';
 import type { TodoScopeKind } from './scope';
 
 export type { TodoScopeKind } from './scope';
@@ -69,6 +74,8 @@ export type TodoItem = typeof todoItems.$inferSelect;
 export type TodoFileLink = typeof todoFileLinks.$inferSelect;
 
 export type TodoWithRelations = TodoItem & {
+  readAt: Date | null;
+  readState: 'read' | 'unread';
   category: TodoCategory | null;
   fileLinks: TodoFileLink[];
   createdBy: TodoUserSummary | null;
@@ -763,7 +770,8 @@ export async function createTodo(userId: string, input: CreateTodoInput): Promis
     sourceType: normalizeTodoSourceType(input.sourceType),
     sourceAgentId: normalizeOptionalText(input.sourceAgentId, 120),
     sourceSessionId: normalizeOptionalText(input.sourceSessionId, 160),
-    seenAt: normalizeDate(input.seenAt),
+    // Read state is per user and intentionally lives outside the shared to-do row.
+    seenAt: null,
     completedAt: null,
     completionComment: null,
     followUpSentAt: null,
@@ -776,6 +784,10 @@ export async function createTodo(userId: string, input: CreateTodoInput): Promis
   }).returning();
 
   await replaceFileLinks(created.id, userId, scope, fileLinks, now);
+  const initialReadAt = normalizeDate(input.seenAt);
+  if (initialReadAt) {
+    await setTodoReadState(userId, created.id, initialReadAt);
+  }
   const hydrated = await getTodo(userId, created.id);
   if (!hydrated) {
     throw new TodoStoreError('Todo not found after creation', 'TODO_NOT_FOUND');
@@ -785,8 +797,10 @@ export async function createTodo(userId: string, input: CreateTodoInput): Promis
   return (await getTodo(userId, created.id)) ?? hydrated;
 }
 
-async function hydrateTodos(rows: TodoItem[]): Promise<TodoWithRelations[]> {
+async function hydrateTodos(rows: TodoItem[], userId: string): Promise<TodoWithRelations[]> {
   if (rows.length === 0) return [];
+
+  const readStateByTodoId = await listTodoReadStates(userId, rows.map((row) => row.id));
 
   const categoryIds = Array.from(new Set(rows.map((row) => row.categoryId).filter(Boolean))) as string[];
   const categories = categoryIds.length
@@ -827,6 +841,11 @@ async function hydrateTodos(rows: TodoItem[]): Promise<TodoWithRelations[]> {
 
   return rows.map((row) => ({
     ...row,
+    // `seenAt` is retained as a compatibility alias while API clients migrate to
+    // the explicit per-user `readAt` / `readState` fields.
+    seenAt: readStateByTodoId.get(row.id) ?? null,
+    readAt: readStateByTodoId.get(row.id) ?? null,
+    readState: readStateByTodoId.has(row.id) ? 'read' : 'unread' as const,
     category: row.categoryId ? categoryById.get(row.categoryId) ?? null : null,
     fileLinks: linksByTodoId.get(row.id) ?? [],
     createdBy: userById.get(row.createdByUserId || row.userId) ?? null,
@@ -848,7 +867,7 @@ export async function getTodo(userId: string, todoId: string): Promise<TodoWithR
   });
   if (!todo) return null;
   await assertCanReadTodo(userId, todo);
-  const [hydrated] = await hydrateTodos([todo]);
+  const [hydrated] = await hydrateTodos([todo], userId);
   return hydrated;
 }
 
@@ -994,7 +1013,7 @@ export async function listTodos(userId: string, options: ListTodosOptions = {}):
     .orderBy(desc(todoItems.updatedAt), desc(todoItems.id))
     .limit(limit);
 
-  return hydrateTodos(rows);
+  return hydrateTodos(rows, userId);
 }
 
 export async function updateTodo(userId: string, todoId: string, input: UpdateTodoInput): Promise<TodoWithRelations | null> {
@@ -1026,9 +1045,6 @@ export async function updateTodo(userId: string, todoId: string, input: UpdateTo
   }
   if (input.dueAt !== undefined) {
     updates.dueAt = normalizeDate(input.dueAt);
-  }
-  if (input.seenAt !== undefined) {
-    updates.seenAt = normalizeDate(input.seenAt);
   }
   if (input.completionComment !== undefined) {
     updates.completionComment = normalizeOptionalText(input.completionComment, DESCRIPTION_MAX_LENGTH);
@@ -1097,5 +1113,15 @@ export async function restoreTodo(userId: string, todoId: string): Promise<TodoW
 }
 
 export async function markTodoSeen(userId: string, todoId: string, seenAt = new Date()): Promise<TodoWithRelations | null> {
-  return updateTodo(userId, todoId, { seenAt });
+  const todo = await getTodo(userId, todoId);
+  if (!todo) return null;
+  await setTodoReadState(userId, todoId, seenAt);
+  return getTodo(userId, todoId);
+}
+
+export async function markTodoUnread(userId: string, todoId: string): Promise<TodoWithRelations | null> {
+  const todo = await getTodo(userId, todoId);
+  if (!todo) return null;
+  await clearTodoReadState(userId, todoId);
+  return getTodo(userId, todoId);
 }

--- a/docs/dokumentation/app-bugs-2026-08/02-notification-todo-umsetzungsplan.md
+++ b/docs/dokumentation/app-bugs-2026-08/02-notification-todo-umsetzungsplan.md
@@ -1,0 +1,324 @@
+---
+title: 'Umsetzungsplan zu Ticket 02: Notification- und To-do-Status vereinheitlichen'
+status: planned
+date: 2026-08-21
+branch: ticket/02-notification-todo-status
+platforms: [web, server, mobile-api]
+tags: [type/implementation-plan, topic/notifications, topic/todos]
+---
+
+# Umsetzungsplan: Notification- und To-do-Status vereinheitlichen
+
+## Ziel und Arbeitsmodus
+
+Dieser Plan setzt [Ticket 02](./02-notification-und-todo-status-vereinheitlichen.md)
+auf dem nach Ticket 01 gemergten Stand um. Die Phasen werden streng
+sequenziell implementiert, getestet und jeweils als eigener Commit
+abgeschlossen. Ticket 03 beginnt erst nach der Abnahme dieses Tickets.
+
+Die fachliche Trennung lautet:
+
+- Der **To-do-Lebenszyklus** (`open`, `done`, `archived`) entscheidet, ob ein
+  To-do fachlich aktiv und auffindbar ist.
+- Der **Aufmerksamkeitsstatus** (`read`/`unread`) ist nutzerbezogen und
+  entscheidet nur ueber Darstellung und Counter.
+- Notification-Actions pruefen Ownership und Workspace-Zugriff und
+  orchestrieren die Statusaenderung.
+- Ein gemeinsamer Read-State-Store kapselt die wiederverwendbare Persistenz.
+  Web-, Mobile- und To-do-APIs duerfen keine eigene Statusmechanik besitzen.
+
+## Inventur des bestehenden Stands
+
+Bereits vorhanden und weiterzuverwenden:
+
+- `todo_items` kennt `status`, `seen_at`, `completed_at` und `archived_at`.
+- `app/lib/todos/store.ts` besitzt To-do-CRUD, Scope-Pruefungen und
+  `markTodoSeen`.
+- `app/lib/mobile/inbox.ts` sammelt Chat-, To-do-, Studio- und
+  Automation-Eintraege fuer Web und Mobile.
+- `GET/PATCH /api/notifications/summary` verwendet bereits dieselbe
+  Aggregation wie die Mobile-Inbox.
+- `GET/PATCH /api/mobile/v1/inbox` sowie der Aggregate-Endpunkt besitzen
+  Filter, Counts, Pagination und Read-Actions.
+- `NotificationBell` zeigt die Web Notification Central und markiert einen
+  Eintrag beim Oeffnen als gelesen.
+- `scripts/mobile-inbox-todos-test.ts` prueft Inbox, Aggregate-Inbox,
+  Notification Summary und To-do-Serialisierung bereits gemeinsam.
+
+Die konkrete Fehlerursache liegt heute an drei Stellen:
+
+1. `collectInboxItems` nimmt ein To-do nur auf, wenn es `open` und entweder
+   ungelesen oder faellig ist. Ein gelesenes, nicht faelliges To-do
+   verschwindet daher aus Web und Mobile.
+2. Persoenliche To-dos verwenden `todo_items.seen_at`, geteilte To-dos dagegen
+   `mobile_inbox_read_states`. Dadurch haben To-do-API und Inbox nicht fuer
+   jeden Workspace dieselbe Wahrheit.
+3. Es existiert nur `mark_item_read`; ein idempotenter, nutzerbezogener Weg
+   zurueck auf `unread` fehlt in Notification- und Mobile-Inbox-API.
+
+## Fachliche Entscheidungen
+
+### 1. Sichtbarkeit und Aufmerksamkeit sind unabhaengig
+
+Fuer Ticket 02 gilt folgende Matrix:
+
+| To-do-Status | In To-do-Sektion sichtbar | Kann unread sein | Zaehlt im Unread-Badge |
+| --- | --- | --- | --- |
+| `open` | ja | ja | ja, wenn unread |
+| `done` | ja | ja | ja, wenn unread |
+| `archived` | nein | technisch gespeichert | nein |
+
+Damit bleiben gelesene und erledigte To-dos auffindbar. Archivieren ist die
+einzige Aktion, die sie aus der aktiven Inbox entfernt. Eine spaetere
+Retention fuer erledigte To-dos ist nicht Teil dieses Tickets.
+
+Chat-Hinweise bleiben ereignisorientiert: Nur ungelesene Chat-Antworten
+erscheinen in der aktiven Notification-Liste. Nach dem Lesen verschwinden sie.
+
+### 2. Read-State ist pro Nutzer, nicht am gemeinsamen To-do
+
+`todo_items.seen_at` kann bei Team- und Projekt-To-dos keinen individuellen
+Status fuer mehrere Nutzer darstellen. Deshalb wird eine kanonische Tabelle
+eingefuehrt:
+
+```text
+todo_read_states
+  user_id       TEXT NOT NULL
+  todo_id       TEXT NOT NULL
+  read_at       INTEGER NOT NULL
+  created_at    INTEGER NOT NULL
+  updated_at    INTEGER NOT NULL
+  PRIMARY KEY (user_id, todo_id)
+```
+
+- Vorhandene persoenliche `seen_at`-Werte werden fuer den bisherigen
+  `todo_items.user_id` migriert.
+- Bestehende `mobile_inbox_read_states` mit `item_key = todo:<id>` werden,
+  soweit To-do und Nutzer noch lesbar sind, uebernommen.
+- Lesen ist ein Upsert; als ungelesen markieren loescht den nutzerbezogenen
+  Read-State. Beide Operationen sind idempotent.
+- `todo_items.seen_at` bleibt zunaechst als Legacy-Spalte erhalten, ist nach
+  der Migration aber nicht mehr die fachliche Quelle fuer API-Ausgaben.
+- Das Aendern des Read-State darf `todo_items.updated_at` nicht veraendern,
+  damit Sortierung, Unread-Berechnung und fachliche Aenderungen getrennt
+  bleiben.
+
+### 3. Action und Store bleiben getrennt
+
+Neue Module:
+
+- `app/lib/todos/read-state-store.ts`
+  - liest, setzt und entfernt Read-State mit expliziten IDs;
+  - kennt keine HTTP-Payloads und entscheidet keine Berechtigungen.
+- `app/lib/todos/read-state-actions.ts`
+  - laedt das To-do und prueft `canRead` im aktuellen Nutzer-/Workspace-Scope;
+  - setzt `read` oder `unread` ueber den Store;
+  - liefert einen stabilen, serialisierbaren Status zurueck.
+
+Inbox, Web-API, Mobile-API und To-do-Routen verwenden dieselbe Action. Alte
+Sonderwege in `markMobileInboxRead` und `markTodoSeen` werden erst entfernt,
+nachdem alle Aufrufer migriert und getestet sind.
+
+## Zielvertraege
+
+### Notification Summary
+
+`GET /api/notifications/summary` bleibt additiv kompatibel und liefert:
+
+```json
+{
+  "success": true,
+  "data": {
+    "unreadCount": 3,
+    "counts": {
+      "unread": 3,
+      "chat": 1,
+      "todos": 8,
+      "todoUnread": 2,
+      "studio": 0,
+      "automation": 0
+    },
+    "sections": {
+      "notifications": [],
+      "todos": []
+    },
+    "items": []
+  }
+}
+```
+
+`items` bleibt waehrend Ticket 02 als kompatible, zusammengefuehrte Ansicht
+erhalten. `sections.todos` enthaelt `open` und `done` unabhaengig vom
+Read-State. `sections.notifications` enthaelt weiterhin nur aktive
+ereignisbasierte Hinweise.
+
+To-do-Eintraege erhalten mindestens:
+
+```json
+{
+  "id": "todo:<id>",
+  "unread": false,
+  "readAt": "2026-08-21T12:00:00.000Z",
+  "lifecycleStatus": "open",
+  "target": { "kind": "todo", "todoId": "<id>" }
+}
+```
+
+### Read-/Unread-Mutation
+
+Web und Mobile akzeptieren denselben fachlichen Vertrag:
+
+```json
+{
+  "action": "set_item_read_state",
+  "itemId": "todo:<id>",
+  "workspaceId": "<workspace>",
+  "read": false
+}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "itemId": "todo:<id>",
+    "read": false,
+    "readAt": null
+  }
+}
+```
+
+`mark_item_read` bleibt fuer bestehende Clients als Alias fuer
+`set_item_read_state` mit `read: true` erhalten. `read: false` ist nur fuer
+To-dos zulaessig; Chat-, Studio- und Automation-Eintraege koennen dadurch
+nicht kuenstlich wieder erzeugt werden.
+
+Die direkten To-do-Endpunkte geben ebenfalls `readState` und `readAt` aus und
+akzeptieren `read: boolean`. Bestehendes `markSeen: true` wird kompatibel auf
+`read: true` abgebildet.
+
+## Sequenzielle Implementierungsphasen
+
+### Phase 1: Kanonische Read-State-Persistenz
+
+- `todo_read_states` in Drizzle-Schema und SQLite-Migration ergaenzen.
+- Fremdschluessel und Indizes fuer `user_id`, `todo_id` und `read_at`
+  definieren.
+- Bestandsdaten aus `todo_items.seen_at` und kompatiblen Inbox-Read-States
+  idempotent migrieren.
+- `read-state-store.ts` mit Batch-Lesen, Upsert und Delete implementieren.
+- Store-Tests fuer persoenliche und geteilte To-dos, Mehrbenutzer-Isolation,
+  Idempotenz und Migration ergaenzen.
+- Verifikation: `test:todos:store`, Migrations-Test und TypeScript.
+- Commit: `Add per-user todo read state`.
+
+### Phase 2: Gemeinsame Read-State-Action und To-do-APIs
+
+- `read-state-actions.ts` mit zentraler Ownership-/Scope-Pruefung bauen.
+- `listTodos`/`getTodo` um den effektiven Read-State des anfragenden Nutzers
+  ergaenzen, ohne `todo_items.updated_at` anzufassen.
+- Web- und Mobile-To-do-Serialisierung auf `readState`/`readAt` umstellen.
+- `PATCH /api/todos/[id]` und
+  `PATCH /api/mobile/v1/todos/[todoId]` um `read: boolean` ergaenzen.
+- `markSeen: true` als Kompatibilitaetsalias beibehalten; widerspruechliche
+  Payloads mit stabilem `400`-Fehler ablehnen.
+- Neue, vom Nutzer selbst erstellte To-dos fuer den Ersteller initial als
+  gelesen markieren; Agent-To-dos bleiben initial ungelesen.
+- Negative Tests fuer fremde Nutzer, nicht lesbare Workspaces und unbekannte
+  To-dos ergaenzen.
+- Verifikation: `test:todos:store`, `test:todos:api`, Mobile-To-do-Tests und
+  TypeScript.
+- Commit: `Unify todo read state actions`.
+
+### Phase 3: Persistente To-do-Sektion in der Inbox
+
+- `collectInboxItems` so aendern, dass nicht archivierte To-dos unabhaengig
+  von `read` und Faelligkeit gesammelt werden.
+- `open` und `done` serialisieren; `archived` konsequent ausschliessen.
+- Read-State in persoenlichen, Team-, Organisations- und Projekt-Workspaces
+  ausschliesslich ueber die gemeinsame Action/Batch-Abfrage aufloesen.
+- Counts trennen: Gesamt-To-dos, ungelesene To-dos und gesamte ungelesene
+  Aufmerksamkeit.
+- Pagination so pruefen, dass persistente To-dos Chat-Hinweise nicht aus dem
+  Ergebnis verdraengen; pro Sektion eigene Limits/Cursor verwenden oder die
+  Summary bewusst separat laden.
+- `mark_all_read` markiert To-dos nur gelesen und entfernt sie nicht aus der
+  To-do-Sektion.
+- Verifikation: erweiterter `test:mobile:inbox` mit gelesenem offenen,
+  gelesenem erledigten und archivierten To-do sowie Cross-Workspace-Faellen.
+- Commit: `Keep todos visible in notification inbox`.
+
+### Phase 4: Einheitlicher Read-/Unread-Vertrag
+
+- `set_item_read_state` in Web Notification Summary sowie Workspace- und
+  Aggregate-Mobile-Inbox implementieren.
+- `read: false` serverseitig auf To-do-Eintraege begrenzen.
+- Bestehende `mark_item_read`, `mark_all_read` und `dismiss_item` kompatibel
+  erhalten.
+- Mutationsantworten in allen Endpunkten angleichen und nach erfolgreicher
+  Mutation die aktualisierten Counts bzw. den Item-State liefern.
+- Einen fokussierten Notification-Summary-API-Test als eigenes npm-Script
+  registrieren; bestehende Mobile-Inbox-Tests nicht mit Web-spezifischen
+  Assertions ueberladen.
+- Verifikation: Summary-, Mobile-Inbox-, Auth-, Scope- und Idempotenztests.
+- Commit: `Add todo read and unread inbox actions`.
+
+### Phase 5: Web Notification Central
+
+- `NotificationBell` visuell in `Notifications` und `To-dos` strukturieren,
+  ohne die Tab-Navigation aus Ticket 03 vorwegzunehmen.
+- Gelesene To-dos weiterhin darstellen; Unread-Markierung nur visuell
+  aendern.
+- Pro To-do eine Aktion `Als gelesen` bzw. `Als ungelesen` anbieten.
+- Klick auf ein To-do darf es weiter als gelesen markieren und zur To-do-App
+  navigieren; ein explizites Zuruecksetzen bleibt danach moeglich.
+- `Alle als gelesen` beeinflusst Counter und Darstellung, nicht die
+  To-do-Sichtbarkeit.
+- Deutsche/englische Texte, Tastaturbedienung und Accessibility-Labels
+  ergaenzen.
+- Verifikation: Komponenten-/Contract-Test, gezieltes ESLint und TypeScript.
+  Browser-/Playwright-Abnahme nur nach expliziter Freigabe.
+- Commit: `Separate todos in notification center`.
+
+### Phase 6: Mobile-Vertrag, Gesamtabnahme und Ticketabschluss
+
+- Den finalen Mobile-Vertrag mit Beispielen fuer `filter=todos`, Counts,
+  Pagination und `set_item_read_state` dokumentieren.
+- Sicherstellen, dass die Expo-App ohne sofortige Client-Aenderung weiterhin
+  `mark_item_read` verwenden kann; die eigentliche Tab-UI folgt in Ticket 03.
+- Gesamte relevante Testgruppe ausfuehren:
+  - To-do-Store, API, Agent-Tool und Assignees;
+  - Mobile Inbox und Mobile To-dos;
+  - Notification Summary und Web-Mapping;
+  - Auth-, Workspace- und Mehrbenutzer-Isolation.
+- Gezieltes ESLint fuer alle geaenderten Dateien und abschliessend
+  `npm run build` ausfuehren.
+- Ticketstatus und Index erst danach auf `erledigt` setzen.
+- Abschlusscommit: `Complete notification todo status ticket`.
+
+## Testmatrix
+
+| Bereich | Positiver Fall | Negativer/Sicherheitsfall |
+| --- | --- | --- |
+| Sichtbarkeit | gelesenes `open`/`done` bleibt in To-do-Sektion | `archived` erscheint nicht |
+| Toggle | read -> unread -> read ist sofort in Web/Mobile sichtbar | fremder Nutzer oder Workspace erhaelt 404/403 |
+| Mehrbenutzer | Teammitglieder haben getrennte Read-States | ein Nutzer veraendert nicht den Status anderer |
+| Chat | ungelesene Antwort erscheint und verschwindet nach Lesen | To-do wird durch Chat-Aktion nicht entfernt |
+| Mark all | Counter wird null, To-dos bleiben sichtbar | archivierte Items werden nicht reaktiviert |
+| Kompatibilitaet | `mark_item_read` und `markSeen` funktionieren weiter | widerspruechliche Payload wird abgewiesen |
+| Sortierung | Read-Toggle aendert nicht `todo.updatedAt` | Pagination erzeugt keine Duplikate/Luecken |
+
+## Definition of Done
+
+- Web und Mobile verwenden dieselbe nutzerbezogene Read-State-Quelle.
+- `open` und `done` bleiben unabhaengig vom Read-State auffindbar;
+  `archived` bleibt ausgeschlossen.
+- To-dos koennen idempotent gelesen und ungelesen gesetzt werden.
+- Chat-Hinweise behalten ihr ereignisorientiertes Verhalten.
+- Workspace-, Projekt- und Nutzerisolation sind serverseitig getestet.
+- Bestehende Clients bleiben ueber die dokumentierten Aliase kompatibel.
+- Alle relevanten Tests, TypeScript, gezieltes ESLint und Build sind gruen.
+- Jede Phase besitzt einen eigenen fokussierten Commit; Ticket 03 bleibt bis
+  zum Abschluss unangetastet.

--- a/docs/dokumentation/app-bugs-2026-08/02-notification-todo-umsetzungsplan.md
+++ b/docs/dokumentation/app-bugs-2026-08/02-notification-todo-umsetzungsplan.md
@@ -1,6 +1,6 @@
 ---
 title: 'Umsetzungsplan zu Ticket 02: Notification- und To-do-Status vereinheitlichen'
-status: planned
+status: completed
 date: 2026-08-21
 branch: ticket/02-notification-todo-status
 platforms: [web, server, mobile-api]
@@ -26,6 +26,20 @@ Die fachliche Trennung lautet:
   orchestrieren die Statusaenderung.
 - Ein gemeinsamer Read-State-Store kapselt die wiederverwendbare Persistenz.
   Web-, Mobile- und To-do-APIs duerfen keine eigene Statusmechanik besitzen.
+
+## Abschluss am 21.08.2026
+
+Alle Phasen wurden umgesetzt. Die fokussierten Commits sind:
+
+1. `ca6f5f66 Add per-user todo read state`
+2. `289c06c7 Unify todo read state actions`
+3. `dff8dcc2 Keep todos visible in notification inbox`
+4. `55b23dbf Separate todos in notification center`
+
+Der finale Vertrag liefert `counts.todoUnread` sowie getrennte
+`sections.notifications` und `sections.todos`; die bestehende zusammengefuehrte
+`items`-Liste bleibt kompatibel. Der Notification-Summary lädt die To-do-Sektion
+separat, damit sie nicht durch ereignisbasierte Hinweise verdraengt wird.
 
 ## Inventur des bestehenden Stands
 

--- a/docs/dokumentation/app-bugs-2026-08/02-notification-und-todo-status-vereinheitlichen.md
+++ b/docs/dokumentation/app-bugs-2026-08/02-notification-und-todo-status-vereinheitlichen.md
@@ -1,6 +1,6 @@
 ---
 title: 'Ticket 02: Notification- und To-do-Status vereinheitlichen'
-status: open
+status: erledigt
 priority: high
 depends_on: ['01-sub-agent-steuerung-und-darstellung']
 platforms: [web, server, mobile-api]
@@ -31,18 +31,17 @@ gelesen/ungelesen ist zwischen den Clients inkonsistent.
 
 ## Umsetzung
 
-- Bestehendes To-do-Modell und die Planung in
-  `docs/dokumentation/todo-notification-center-plan.md` inventarisieren; eine
-  eindeutige Trennung zwischen Lebenszyklus (`open`, `done`, `archived`) und
-  Aufmerksamkeitsstatus (`seenAt`/ungelesen) festlegen.
-- API-Listen typbasiert ausliefern: Chat-Notifications nach ungelesen, To-dos
-  nach Lebenszyklus und nicht nach Lese-Status filtern.
-- Idempotente Serveraktion zum Setzen von gelesen/ungelesen fuer To-dos bauen;
-  Nutzer-, Workspace- und Ownership-Scope serverseitig erzwingen.
-- Web Notification Central in getrennte Chat- und To-do-Bereiche aufteilen und
-  einen sichtbaren Status sowie Toggle ergaenzen.
-- Mobile-Vertrag inklusive Filter, Counts und Mutationsresponse versioniert
-  dokumentieren, damit Ticket 03 darauf aufbauen kann.
+- Kanonische, nutzerbezogene `todo_read_states`-Persistenz mit idempotenter
+  Migration aus den bisherigen `seen_at`- und Inbox-Read-States eingefuehrt.
+- Read/Unread wird ueber eine gemeinsame, berechtigte Serveraktion gesetzt;
+  `todo_items.updated_at` bleibt dabei unveraendert.
+- Web-, Mobile- und Inbox-APIs liefern `readAt`/`readState`; `markSeen` und
+  `mark_item_read` bleiben kompatible Read-Aliase.
+- Open und done To-dos bleiben als eigene Inbox-Sektion sichtbar; archived
+  To-dos bleiben ausgeschlossen. Counter unterscheiden Gesamt-To-dos und
+  ungelesene To-dos.
+- Die Web Notification Central trennt Benachrichtigungen und To-dos und
+  bietet pro To-do einen Gelesen/Ungelesen-Schalter.
 
 ## Abnahmekriterien
 
@@ -55,8 +54,7 @@ gelesen/ungelesen ist zwischen den Clients inkonsistent.
 
 ## Tests und Abschluss
 
-- API-/Integrationstests fuer Typfilter, Lebenszyklus, Read/Unread-Toggle,
-  Idempotenz und Scope-Isolation.
-- `npm run build` nach Server-/Web-Aenderungen.
-- Manuelle Web-Abnahme; Mobile-Vertrag mit dem Expo-Repository abgleichen.
-- Eigener Commit, danach Status im [Index](./README.md) aktualisieren.
+- `npm run test:todos:store`, `npm run test:mobile:inbox` und ESLint erfolgreich.
+- `npm run build` erfolgreich (inklusive Lizenz- und TypeScript-Pruefung).
+- Browser-/Playwright-Abnahme wurde nicht ausgefuehrt, weil sie laut
+  Repository-Regel erst nach expliziter Freigabe erfolgen darf.

--- a/docs/dokumentation/app-bugs-2026-08/02-notification-und-todo-status-vereinheitlichen.md
+++ b/docs/dokumentation/app-bugs-2026-08/02-notification-und-todo-status-vereinheitlichen.md
@@ -9,6 +9,9 @@ tags: [type/bug, topic/notifications, topic/todos]
 
 # Ticket 02: Notification- und To-do-Status vereinheitlichen
 
+> Detaillierter, am aktuellen Codebestand ausgerichteter Umsetzungsplan:
+> [02-notification-todo-umsetzungsplan.md](./02-notification-todo-umsetzungsplan.md)
+
 ## Problem
 
 Die Notification Central behandelt Chat-Hinweise und To-dos gleich. Dadurch

--- a/docs/dokumentation/app-bugs-2026-08/README.md
+++ b/docs/dokumentation/app-bugs-2026-08/README.md
@@ -19,7 +19,7 @@ abgeschlossen sind.
 | Reihenfolge | Ticket | Status | Abhaengigkeit |
 | --- | --- | --- | --- |
 | 01 | [Sub-Agent-Steuerung und Darstellung](./01-sub-agent-steuerung-und-darstellung.md) | erledigt | – |
-| 02 | [Notification- und To-do-Status vereinheitlichen](./02-notification-und-todo-status-vereinheitlichen.md) | offen | 01 |
+| 02 | [Notification- und To-do-Status vereinheitlichen](./02-notification-und-todo-status-vereinheitlichen.md) | erledigt | 01 |
 | 03 | [Mobile Inbox mit Kategorien und Badges](./03-mobile-inbox-tabs-und-badges.md) | offen | 02 |
 | 04 | [Mobile Chat und Browser-Use stabilisieren](./04-mobile-chat-und-browser-use-stabilisieren.md) | offen | 03 |
 | 05 | [Files-Tab automatisch aktualisieren](./05-files-tab-automatisch-aktualisieren.md) | offen | 04 |

--- a/messages/de.json
+++ b/messages/de.json
@@ -2210,11 +2210,17 @@
     "loading": "Wird aktualisiert...",
     "summary": "{count} ungelesen",
     "markAllRead": "Alle gelesen",
+    "markRead": "Als gelesen markieren",
+    "markUnread": "Als ungelesen markieren",
     "unread": "Ungelesen",
     "highPriority": "Hohe Priorität",
     "dismiss": "Aus Benachrichtigungen entfernen",
     "workspaceFallback": "Workspace",
     "recent": "Kürzlich",
+    "sections": {
+      "notifications": "Benachrichtigungen",
+      "todos": "To-dos"
+    },
     "types": {
       "chat": "Neue Agent-Antwort",
       "todo": "To-do benötigt Aufmerksamkeit",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2211,11 +2211,17 @@
     "loading": "Updating...",
     "summary": "{count} unread",
     "markAllRead": "Mark all read",
+    "markRead": "Mark read",
+    "markUnread": "Mark unread",
     "unread": "Unread",
     "highPriority": "High priority",
     "dismiss": "Remove from notifications",
     "workspaceFallback": "Workspace",
     "recent": "Recent",
+    "sections": {
+      "notifications": "Notifications",
+      "todos": "To-dos"
+    },
     "types": {
       "chat": "New agent response",
       "todo": "To-do needs attention",

--- a/scripts/mobile-inbox-todos-test.ts
+++ b/scripts/mobile-inbox-todos-test.ts
@@ -112,6 +112,7 @@ async function main() {
 
     const inbox = await listMobileInbox({ userId: 'mobile-attention-user', workspace, limit: 20 });
     assert.equal(inbox.counts.unread, 5);
+    assert.equal(inbox.counts.todoUnread, 1);
     assert.equal(await countMobileUnreadMessages({ userId: 'mobile-attention-user', workspaces: [workspace] }), 2);
     assert.equal(inbox.items.some((item) => item.id === 'chat:attention-session'), true);
     assert.equal(inbox.items.some((item) => item.id === 'chat:historic-unread-session'), true);

--- a/scripts/mobile-inbox-todos-test.ts
+++ b/scripts/mobile-inbox-todos-test.ts
@@ -245,6 +245,8 @@ async function main() {
     assert.equal(notificationSummary.data.items.some((item: { id: string }) => item.id === `todo:${firstTodo.id}`), true);
     assert.equal(notificationSummary.data.items.some((item: { id: string }) => item.id === 'studio:generation-ready'), true);
     assert.equal(notificationSummary.data.items.some((item: { id: string }) => item.id === 'automation:run-failed'), true);
+    assert.equal(notificationSummary.data.sections.notifications.some((item: { id: string }) => item.id === 'chat:attention-session'), true);
+    assert.equal(notificationSummary.data.sections.todos.some((item: { id: string }) => item.id === `todo:${firstTodo.id}`), true);
     const studioNotification = notificationSummary.data.items.find((item: { id: string }) => item.id === 'studio:generation-ready');
     assert.equal(typeof studioNotification?.workspaceId, 'string');
 

--- a/scripts/mobile-inbox-todos-test.ts
+++ b/scripts/mobile-inbox-todos-test.ts
@@ -209,6 +209,11 @@ async function main() {
     );
     await setUserInboxExcludedWorkspaceIds('mobile-attention-user', []);
 
+    await Promise.all(Array.from({ length: 12 }, (_, index) => createTodo('mobile-attention-user', {
+      title: `Read background task ${index + 1}`,
+      seenAt: new Date(),
+    })));
+
     const { auth } = await import('../app/lib/auth');
     let badgeSession: {
       user: { id: string; email: string; role: string };

--- a/scripts/mobile-inbox-todos-test.ts
+++ b/scripts/mobile-inbox-todos-test.ts
@@ -77,7 +77,7 @@ async function main() {
     await database.close();
 
     const { createLegacyPersonalWorkspaceContext } = await import('../app/lib/workspaces/context');
-    const { createTodo } = await import('../app/lib/todos/store');
+    const { createTodo, updateTodo } = await import('../app/lib/todos/store');
     const { getMobileTodo, listMobileTodos } = await import('../app/lib/mobile/todos');
     const {
       countMobileUnreadMessages,
@@ -104,6 +104,11 @@ async function main() {
       fileLinks: [{ workspacePath: 'Clients/Acme/brief.md', label: 'Brief' }],
     });
     await createTodo('mobile-attention-user', { title: 'Prepare screenshots', seenAt: new Date() });
+    const completedTodo = await createTodo('mobile-attention-user', {
+      title: 'Confirm launch checklist',
+      seenAt: new Date(),
+    });
+    await updateTodo('mobile-attention-user', completedTodo.id, { status: 'done' });
 
     const inbox = await listMobileInbox({ userId: 'mobile-attention-user', workspace, limit: 20 });
     assert.equal(inbox.counts.unread, 5);
@@ -111,6 +116,7 @@ async function main() {
     assert.equal(inbox.items.some((item) => item.id === 'chat:attention-session'), true);
     assert.equal(inbox.items.some((item) => item.id === 'chat:historic-unread-session'), true);
     assert.equal(inbox.items.some((item) => item.id === `todo:${firstTodo.id}`), true);
+    assert.equal(inbox.items.some((item) => item.id === `todo:${completedTodo.id}`), true);
     assert.equal(inbox.items.some((item) => item.id === 'studio:generation-ready'), true);
     assert.equal(inbox.items.some((item) => item.id === 'automation:run-failed'), true);
     assert.equal(
@@ -279,6 +285,26 @@ async function main() {
         && error.code === 'ITEM_NOT_DISMISSIBLE'
       ),
     );
+
+    await markMobileInboxRead({
+      userId: 'mobile-attention-user',
+      workspace,
+      action: 'mark_item_read',
+      itemId: `todo:${firstTodo.id}`,
+    });
+    const afterTodoRead = await listMobileInbox({ userId: 'mobile-attention-user', workspace });
+    assert.equal(afterTodoRead.items.some((item) => item.id === `todo:${firstTodo.id}`), true);
+    const afterTodoReadUnread = await listMobileInbox({ userId: 'mobile-attention-user', workspace, filter: 'unread' });
+    assert.equal(afterTodoReadUnread.items.some((item) => item.id === `todo:${firstTodo.id}`), false);
+    await markMobileInboxRead({
+      userId: 'mobile-attention-user',
+      workspace,
+      action: 'set_item_read_state',
+      itemId: `todo:${firstTodo.id}`,
+      read: false,
+    });
+    const afterTodoUnread = await listMobileInbox({ userId: 'mobile-attention-user', workspace, filter: 'unread' });
+    assert.equal(afterTodoUnread.items.some((item) => item.id === `todo:${firstTodo.id}`), true);
 
     const readAllResponse = await notificationSummaryRoute.PATCH(
       new NextRequest('http://localhost/api/notifications/summary', {

--- a/scripts/todo-email-notification-test.ts
+++ b/scripts/todo-email-notification-test.ts
@@ -128,6 +128,8 @@ async function main() {
     updatedAt: now,
   }).returning();
   const todoRelations = {
+    readAt: null,
+    readState: 'unread' as const,
     category: null,
     fileLinks: [],
     createdBy: { id: userId, name: 'Todo Email User', email: 'owner@example.test' },

--- a/scripts/todo-store-test.ts
+++ b/scripts/todo-store-test.ts
@@ -28,6 +28,7 @@ async function main() {
     listTodoReadStates,
     setTodoReadState,
   } = await import('../app/lib/todos/read-state-store');
+  const { setTodoReadStateForUser } = await import('../app/lib/todos/read-state-actions');
   const {
     DEFAULT_TODO_CATEGORY_NAME,
     getDefaultTodoCategoryKey,
@@ -35,6 +36,7 @@ async function main() {
     archiveTodo,
     createTodo,
     ensureTodoCategories,
+    getTodo,
     listTodos,
     markTodoSeen,
     normalizeWorkspaceTodoPath,
@@ -368,6 +370,21 @@ async function main() {
   assert.equal(teamTodo.assignee?.id, 'other-user');
   assert.equal(teamTodo.fileLinks[0].workspaceType, 'team');
   assert.equal(teamTodo.fileLinks[0].workspaceId, 'team-workspace');
+
+  const sharedTodoUpdatedAt = teamTodo.updatedAt.toISOString();
+  const readonlyRead = await setTodoReadStateForUser({
+    userId: 'readonly-user',
+    todoId: teamTodo.id,
+    read: true,
+    readAt: new Date('2026-05-31T12:03:00.000Z'),
+  });
+  assert.equal(readonlyRead.todo.readState, 'read');
+  assert.equal(readonlyRead.todo.readAt?.toISOString(), '2026-05-31T12:03:00.000Z');
+  assert.equal((await getTodoReadState('todo-user', teamTodo.id)), null);
+  assert.equal((await getTodoReadState('readonly-user', teamTodo.id))?.toISOString(), '2026-05-31T12:03:00.000Z');
+  const readonlyUnread = await setTodoReadStateForUser({ userId: 'readonly-user', todoId: teamTodo.id, read: false });
+  assert.equal(readonlyUnread.todo.readState, 'unread');
+  assert.equal((await getTodo('todo-user', teamTodo.id))?.updatedAt.toISOString(), sharedTodoUpdatedAt);
 
   const memberTeamTodos = await listTodos('other-user', {
     status: 'all',

--- a/scripts/todo-store-test.ts
+++ b/scripts/todo-store-test.ts
@@ -19,8 +19,15 @@ async function main() {
     canvasProjects,
     canvasWorkspaces,
     organizationUserPermissions,
+    todoReadStates,
     user,
   } = await import('../app/lib/db/schema');
+  const {
+    clearTodoReadState,
+    getTodoReadState,
+    listTodoReadStates,
+    setTodoReadState,
+  } = await import('../app/lib/todos/read-state-store');
   const {
     DEFAULT_TODO_CATEGORY_NAME,
     getDefaultTodoCategoryKey,
@@ -297,6 +304,17 @@ async function main() {
   assert.equal(created.fileLinks.length, 1);
   assert.equal(created.fileLinks[0].workspacePath, 'docs/brief.md');
   assert.equal(created.fileLinks[0].workspaceId, null);
+
+  const firstReadAt = new Date('2026-05-31T12:01:00.000Z');
+  const replacementReadAt = new Date('2026-05-31T12:02:00.000Z');
+  await setTodoReadState('todo-user', created.id, firstReadAt);
+  assert.equal((await getTodoReadState('todo-user', created.id))?.toISOString(), firstReadAt.toISOString());
+  await setTodoReadState('todo-user', created.id, replacementReadAt);
+  assert.equal((await getTodoReadState('todo-user', created.id))?.toISOString(), replacementReadAt.toISOString());
+  assert.equal((await listTodoReadStates('other-user', [created.id])).size, 0);
+  await clearTodoReadState('todo-user', created.id);
+  assert.equal(await getTodoReadState('todo-user', created.id), null);
+  assert.equal((await db.select().from(todoReadStates)).length, 0);
 
   const todos = await listTodos('todo-user');
   assert.equal(todos.length, 1);


### PR DESCRIPTION
## Summary
- persist a per-user read state for To-dos and migrate legacy state safely
- keep open and completed To-dos visible in Mobile Inbox and Notification Central
- add shared read/unread actions, separate web sections, counters, and compatible API aliases

## Verification
- `npm run test:todos:store`
- `npm run test:mobile:inbox`
- `npm run lint -- --quiet`
- `npm run build`

## Notes
- Browser/Playwright UI checks were not run because repository guidance requires explicit authorization.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR unifies To-do read state as per-user persisted data and exposes it consistently through web and mobile notification APIs.
- Adds the `todo_read_states` schema, migration, storage helpers, and compatibility aliases.
- Separates notifications and persistent To-dos in Notification Central while preserving the combined `items` response.
- Adds shared read/unread actions and updates mobile inbox behavior, UI counters, localization, and focused tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; both previously reported issues are fixed in the current code.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/notifications/summary/route.ts | Uses independently filtered notification and To-do queries, resolving the previously reported mixed-limit behavior while retaining compatibility fields. |
| app/api/todos/[id]/route.ts | Separates content updates from per-user read-state changes and correctly fixes the previously reported nested payload indentation. |
| app/lib/mobile/inbox.ts | Adds notification-only filtering, persistent To-do visibility, per-user read actions, and To-do unread counts. |
| app/lib/todos/read-state-store.ts | Implements per-user To-do read-state lookup, upsert, and deletion. |
| app/lib/todos/store.ts | Hydrates To-dos with per-user read state while retaining `seenAt` as a compatibility alias. |
| app/lib/db/migrate.ts | Creates the read-state table and safely seeds it from both legacy read-state sources. |
| app/components/notifications/NotificationBell.tsx | Renders separate notification and To-do sections and supports toggling To-do read state. |

</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/canvascoding/canvas-notebook/commit/9247040001f7edb3d2f0d4c093c4a6dd7676bba2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55533564)</sub>

<!-- /greptile_comment -->