### PR TITLE
Preserve Marp Markdown editor roundtrips

### DIFF
--- a/app/api/files/collaboration/session/route.ts
+++ b/app/api/files/collaboration/session/route.ts
@@ -108,6 +108,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: false,
       error: error instanceof Error ? error.message : 'Could not start collaboration.',
+      ...(error instanceof CollaborationSessionError && error.code ? { code: error.code } : {}),
     }, { status });
   }
 }

--- a/app/api/files/upload/route.ts
+++ b/app/api/files/upload/route.ts
@@ -143,7 +143,12 @@ export async function POST(request: NextRequest) {
         fileOptions,
         actorUserId: workspaceResult.session.user.id,
         targetPath,
-        write: () => writeFile(targetPath, normalized.buffer, fileOptions),
+        write: (onBeforeReplace) => writeFile(
+          targetPath,
+          normalized.buffer,
+          fileOptions,
+          onBeforeReplace,
+        ),
       });
       uploadedFiles.push(filename);
       uploadedPaths.push(targetPath);

--- a/app/api/files/uploads/[id]/complete/route.ts
+++ b/app/api/files/uploads/[id]/complete/route.ts
@@ -44,7 +44,12 @@ export async function POST(
           fileOptions,
           actorUserId: workspaceResult.session.user.id,
           targetPath: file.targetPath,
-          write: () => replaceWorkspaceFileFromPath(sourcePath, file.targetPath, fileOptions),
+          write: (onBeforeReplace) => replaceWorkspaceFileFromPath(
+            sourcePath,
+            file.targetPath,
+            fileOptions,
+            onBeforeReplace,
+          ),
         });
       },
     });

--- a/app/api/mobile/v1/notebook/collaboration/session/route.ts
+++ b/app/api/mobile/v1/notebook/collaboration/session/route.ts
@@ -21,6 +21,8 @@ import {
   requireTeamRuntimeLicense,
 } from '@/app/lib/license/entitlements';
 import { issueMobileCollaborationTicket } from '@/app/lib/mobile/collaboration-ticket';
+import { readFile } from '@/app/lib/filesystem/workspace-files';
+import { analyzeMarkdownRichMode } from '@/app/lib/markdown/rich-markdown-codec';
 import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export const dynamic = 'force-dynamic';
@@ -57,10 +59,27 @@ export async function POST(request: NextRequest) {
 
   const body = await readJsonBody<{ path?: unknown }>(request);
   const requestedPath = typeof body.path === 'string' ? body.path.trim().toLowerCase() : '';
-  const collaborationRequest = parseCollaborationSessionRequest({
+  const preliminaryRequest = parseCollaborationSessionRequest({
     path: body.path,
     provider: 'yjs',
     representation: requestedPath.endsWith('.txt') ? 'plain_text' : 'tiptap_xml',
+  });
+  if (!preliminaryRequest) {
+    return NextResponse.json(
+      { success: false, error: 'A supported Markdown or plain-text path is required.' },
+      { status: 400 },
+    );
+  }
+  const fileOptions = workspaceFileOptions(workspaceResult.workspace);
+  const representation = requestedPath.endsWith('.txt')
+    ? 'plain_text'
+    : analyzeMarkdownRichMode((await readFile(preliminaryRequest.path, fileOptions)).toString('utf8')).mode === 'source'
+      ? 'plain_text'
+      : 'tiptap_xml';
+  const collaborationRequest = parseCollaborationSessionRequest({
+    path: body.path,
+    provider: 'yjs',
+    representation,
   });
   if (!collaborationRequest) {
     return NextResponse.json(
@@ -72,7 +91,7 @@ export async function POST(request: NextRequest) {
   try {
     const grant = await createCollaborationSessionGrant({
       workspace: workspaceResult.workspace,
-      fileOptions: workspaceFileOptions(workspaceResult.workspace),
+      fileOptions,
       request: collaborationRequest,
     });
     const sessionId = String((workspaceResult.session.session as { id?: string }).id || '');
@@ -135,6 +154,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: false,
       error: error instanceof Error ? error.message : 'Could not start collaboration.',
+      ...(error instanceof CollaborationSessionError && error.code ? { code: error.code } : {}),
     }, { status });
   }
 }

--- a/app/components/editor/MarkdownEditor.tsx
+++ b/app/components/editor/MarkdownEditor.tsx
@@ -133,7 +133,6 @@ import {
   hasMobileToolbarPressMoved,
   isMobileToolbarReleaseInside,
 } from '@/app/lib/editor/mobile-toolbar-gesture';
-import { getMarkdownSourceModeReason } from '@/app/lib/editor/text-editor-guards';
 import {
   createCurrentBlockCommandTarget,
   createInsertedBlockCommandTarget,
@@ -159,7 +158,6 @@ import {
   scrollToMarkdownHeadingAnchor,
 } from '@/app/lib/markdown/heading-anchor';
 import { MarkdownHeadingAnchors } from '@/app/lib/markdown/tiptap-heading-anchors';
-import { hasObsidianRichEditorUnsupportedSyntax } from '@/app/lib/markdown/obsidian-flavored-markdown';
 import {
   buildObsidianWikiLinkTarget,
   findObsidianWikiCompletionContext,
@@ -170,6 +168,11 @@ import {
   parseCanvasMarkdownDocument,
   splitCanvasMarkdownForRichEditor,
 } from '@/app/lib/markdown/obsidian-metadata';
+import {
+  analyzeMarkdownRichMode,
+  restoreRichMarkdownFinalLineEnding,
+  type MarkdownRichModeReason,
+} from '@/app/lib/markdown/rich-markdown-codec';
 import { openWorkspaceMarkdownTarget } from '@/app/lib/markdown/workspace-markdown-navigation-client';
 import {
   getWorkspaceWikiCompletionItems,
@@ -5055,7 +5058,10 @@ function RichMarkdownEditor({
       const markdownEditor = asMarkdownEditor(updateEditor);
       const markdown = markdownEditor?.getMarkdown() ?? '';
       const currentParts = splitCanvasMarkdownForRichEditor(latestValueRef.current);
-      const nextValue = composeCanvasMarkdownDocument(currentParts.prefix, markdown);
+      const nextValue = composeCanvasMarkdownDocument(
+        currentParts.prefix,
+        restoreRichMarkdownFinalLineEnding(currentParts.body, markdown),
+      );
       if (nextValue !== latestValueRef.current) {
         latestValueRef.current = nextValue;
         onChange?.(nextValue);
@@ -5088,7 +5094,11 @@ function RichMarkdownEditor({
     if (!collaboration) return;
     const frontmatter = collaboration.doc.getText('frontmatter');
     const updateValue = () => {
-      const body = asMarkdownEditor(editor)?.getMarkdown() ?? '';
+      const currentParts = splitCanvasMarkdownForRichEditor(latestValueRef.current);
+      const body = restoreRichMarkdownFinalLineEnding(
+        currentParts.body,
+        asMarkdownEditor(editor)?.getMarkdown() ?? '',
+      );
       const nextValue = composeCanvasMarkdownDocument(frontmatter.toString(), body);
       latestValueRef.current = nextValue;
       onChange?.(nextValue);
@@ -5623,14 +5633,17 @@ function SourceMarkdownEditor({
   onRichMode,
   markdownNavigationTarget,
   collaborationEnabled = false,
+  sourceModeReason,
 }: MarkdownEditorProps & {
   initiallyShowMobileToolbar?: boolean;
   richModeAvailable: boolean;
   isMobileKeyboardActive: boolean;
   markdownNavigationTarget?: WorkspaceMarkdownLocation | null;
   onRichMode: () => void;
+  sourceModeReason?: MarkdownRichModeReason;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const t = useTranslations('notebook');
   const releaseInteractionTimeoutRef = useRef<number | null>(null);
   const [isSourceFocused, setIsSourceFocused] = useState(initiallyShowMobileToolbar);
   const [isInteractingWithToolbar, setIsInteractingWithToolbar] = useState(false);
@@ -5688,6 +5701,16 @@ function SourceMarkdownEditor({
           onRichMode={onRichMode}
         />
       ) : null}
+      {sourceModeReason ? (
+        <div
+          className="mx-3 mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-foreground"
+          data-testid="markdown-source-preservation-warning"
+          role="status"
+        >
+          <BadgeInfo aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-amber-700 dark:text-amber-300" />
+          <span>{t('markdownEditorSourcePreservationNotice')}</span>
+        </div>
+      ) : null}
       <div className="min-h-0 flex-1 overflow-hidden">
         <CodeEditor
           value={value}
@@ -5718,12 +5741,8 @@ export function MarkdownEditor({
 
   const isMobileKeyboardActive = useMobileKeyboardActive();
   const parsedDocument = useMemo(() => parseCanvasMarkdownDocument(value), [value]);
-  const sourceModeReason = useMemo(() => getMarkdownSourceModeReason(value), [value]);
-  const omfSourceModeRequired = useMemo(
-    () => hasObsidianRichEditorUnsupportedSyntax(parsedDocument.body),
-    [parsedDocument.body],
-  );
-  const sourceModeRequired = parsedDocument.error !== null || sourceModeReason !== null || omfSourceModeRequired;
+  const richModeAnalysis = useMemo(() => analyzeMarkdownRichMode(value), [value]);
+  const sourceModeRequired = richModeAnalysis.mode === 'source';
   const [mode, setMode] = useState<EditorMode>(() => (
     sourceModeRequired || shouldDefaultToSource(readOnly, filePath) ? 'source' : 'rich'
   ));
@@ -5798,6 +5817,7 @@ export function MarkdownEditor({
         onRichMode={switchToRichMode}
         markdownNavigationTarget={markdownNavigationTarget}
         collaborationEnabled={collaborationEnabled}
+        sourceModeReason={richModeAnalysis.mode === 'source' ? richModeAnalysis.reason : undefined}
       />
     );
   }

--- a/app/lib/collaboration/markdown-state.ts
+++ b/app/lib/collaboration/markdown-state.ts
@@ -1,14 +1,6 @@
 import 'server-only';
 
-import Image from '@tiptap/extension-image';
-import Link from '@tiptap/extension-link';
-import Mathematics from '@tiptap/extension-mathematics';
-import { TableKit } from '@tiptap/extension-table';
-import TaskItem from '@tiptap/extension-task-item';
-import TaskList from '@tiptap/extension-task-list';
-import UniqueID, { generateUniqueIds } from '@tiptap/extension-unique-id';
-import { Markdown, MarkdownManager } from '@tiptap/markdown';
-import StarterKit from '@tiptap/starter-kit';
+import { generateUniqueIds } from '@tiptap/extension-unique-id';
 import { getSchema } from '@tiptap/core';
 import type * as YTypes from 'yjs';
 
@@ -16,35 +8,19 @@ import {
   composeCanvasMarkdownDocument,
   splitCanvasMarkdownForRichEditor,
 } from '@/app/lib/markdown/obsidian-metadata';
-import { canvasRichMarkdownExtensions } from '@/app/lib/markdown/canvas-rich-markdown-extensions';
+import {
+  createRichMarkdownManager,
+  richMarkdownCodecExtensions,
+  restoreRichMarkdownFinalLineEnding,
+} from '@/app/lib/markdown/rich-markdown-codec';
 import { TiptapTransformer, Y, YProsemirror } from './server-runtime';
 
-export const RICH_MARKDOWN_UNIQUE_ID_TYPES = 'all' as const;
-
 export function richMarkdownSchemaExtensions() {
-  return [
-    StarterKit.configure({ link: false, paragraph: false }),
-    ...canvasRichMarkdownExtensions(),
-    Link.configure({ openOnClick: false, autolink: false }),
-    Image,
-    Mathematics,
-    TaskList,
-    TaskItem.configure({ nested: true }),
-    TableKit,
-    UniqueID.configure({ types: RICH_MARKDOWN_UNIQUE_ID_TYPES }),
-    Markdown.configure({
-      markedOptions: { gfm: true, breaks: false },
-      indentation: { style: 'space', size: 2 },
-    }),
-  ];
+  return richMarkdownCodecExtensions();
 }
 
 function markdownManager() {
-  return new MarkdownManager({
-    extensions: richMarkdownSchemaExtensions(),
-    markedOptions: { gfm: true, breaks: false },
-    indentation: { style: 'space', size: 2 },
-  });
+  return createRichMarkdownManager();
 }
 
 export function createRichMarkdownYDoc(markdown: string): YTypes.Doc {
@@ -54,12 +30,18 @@ export function createRichMarkdownYDoc(markdown: string): YTypes.Doc {
   const json = generateUniqueIds(manager.parse(parts.body), extensions);
   const doc = TiptapTransformer.toYdoc(json, 'body', extensions);
   if (parts.prefix) doc.getText('frontmatter').insert(0, parts.prefix);
+  const finalLineEnding = parts.body.match(/(\r?\n)$/u)?.[1];
+  if (finalLineEnding) doc.getText('bodyFinalLineEnding').insert(0, finalLineEnding);
   return doc;
 }
 
 export function richMarkdownFromYDoc(doc: YTypes.Doc): string {
   const json = TiptapTransformer.fromYdoc(doc, 'body');
-  const body = markdownManager().serialize(json);
+  const serializedBody = markdownManager().serialize(json);
+  const body = restoreRichMarkdownFinalLineEnding(
+    doc.getText('bodyFinalLineEnding').toString(),
+    serializedBody,
+  );
   return composeCanvasMarkdownDocument(doc.getText('frontmatter').toString(), body);
 }
 
@@ -90,6 +72,10 @@ export function replaceRichMarkdownInYDoc(
       const frontmatter = doc.getText('frontmatter');
       if (frontmatter.length > 0) frontmatter.delete(0, frontmatter.length);
       if (parts.prefix) frontmatter.insert(0, parts.prefix);
+      const bodyFinalLineEnding = doc.getText('bodyFinalLineEnding');
+      if (bodyFinalLineEnding.length > 0) bodyFinalLineEnding.delete(0, bodyFinalLineEnding.length);
+      const finalLineEnding = parts.body.match(/(\r?\n)$/u)?.[1];
+      if (finalLineEnding) bodyFinalLineEnding.insert(0, finalLineEnding);
     }, origin);
   } finally {
     replacement.destroy();

--- a/app/lib/collaboration/session-service.ts
+++ b/app/lib/collaboration/session-service.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { readFile, type WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 import { getFileCollaborationState } from '@/app/lib/files/collaboration-policy';
 import { importPortableExcalidrawAssets } from '@/app/lib/excalidraw-collaboration/assets';
+import { analyzeMarkdownRichMode } from '@/app/lib/markdown/rich-markdown-codec';
 import {
   ensureExcalidrawScene,
   loadExcalidrawScene,
@@ -19,11 +20,17 @@ const MAX_COLLABORATION_TEXT_BYTES = 5 * 1024 * 1024;
 
 export class CollaborationSessionError extends Error {
   readonly status: 400 | 404 | 409 | 413;
+  readonly code?: 'source_representation_required';
 
-  constructor(message: string, status: CollaborationSessionError['status']) {
+  constructor(
+    message: string,
+    status: CollaborationSessionError['status'],
+    code?: CollaborationSessionError['code'],
+  ) {
     super(message);
     this.name = 'CollaborationSessionError';
     this.status = status;
+    this.code = code;
   }
 }
 
@@ -142,6 +149,13 @@ export async function createCollaborationSessionGrant(input: {
         throw new CollaborationSessionError(
           'Live collaboration supports text files up to 5 MiB.',
           413,
+        );
+      }
+      if (request.representation === 'tiptap_xml' && analyzeMarkdownRichMode(initialContent).mode === 'source') {
+        throw new CollaborationSessionError(
+          'This Markdown document can only collaborate in source mode so its representation is preserved.',
+          409,
+          'source_representation_required',
         );
       }
       state = await ensureCollaborationState({

--- a/app/lib/collaboration/session-service.ts
+++ b/app/lib/collaboration/session-service.ts
@@ -130,6 +130,14 @@ export async function createCollaborationSessionGrant(input: {
     }
     lifecycleGeneration = state.lifecycleGeneration;
   } else {
+    const initialContent = (await readFile(request.path, fileOptions)).toString('utf8');
+    if (request.representation === 'tiptap_xml' && analyzeMarkdownRichMode(initialContent).mode === 'source') {
+      throw new CollaborationSessionError(
+        'This Markdown document can only collaborate in source mode so its representation is preserved.',
+        409,
+        'source_representation_required',
+      );
+    }
     let state = await loadCollaborationState(collaboration.document.id);
     if (state) {
       if (
@@ -144,18 +152,10 @@ export async function createCollaborationSessionGrant(input: {
         );
       }
     } else {
-      const initialContent = (await readFile(request.path, fileOptions)).toString('utf8');
       if (Buffer.byteLength(initialContent, 'utf8') > MAX_COLLABORATION_TEXT_BYTES) {
         throw new CollaborationSessionError(
           'Live collaboration supports text files up to 5 MiB.',
           413,
-        );
-      }
-      if (request.representation === 'tiptap_xml' && analyzeMarkdownRichMode(initialContent).mode === 'source') {
-        throw new CollaborationSessionError(
-          'This Markdown document can only collaborate in source mode so its representation is preserved.',
-          409,
-          'source_representation_required',
         );
       }
       state = await ensureCollaborationState({

--- a/app/lib/files/revision-guard.ts
+++ b/app/lib/files/revision-guard.ts
@@ -144,3 +144,27 @@ export async function assertWorkspaceFileRevisionAllowed(params: {
 
   return currentRevision;
 }
+
+/**
+ * Verifies that a previously observed revision is still current immediately
+ * before an atomic replacement. Unlike `assertWorkspaceFileRevisionAllowed`,
+ * this also treats a file created after an absent observation as a conflict.
+ */
+export async function assertWorkspaceFileRevisionUnchanged(params: {
+  path: string;
+  expectedRevision: WorkspaceFileRevision | null;
+  options?: WorkspaceFileOperationOptions;
+}): Promise<WorkspaceFileRevision | null> {
+  const currentRevision = await getWorkspaceFileRevision(params.path, params.options);
+  if (params.expectedRevision?.sha256 === currentRevision?.sha256) return currentRevision;
+
+  throw new WorkspaceFileRevisionError({
+    code: 'FILE_REVISION_CONFLICT',
+    status: 409,
+    message: 'File revision conflict: this file changed while the upload was in progress.',
+    path: params.path,
+    expectedSha256: params.expectedRevision?.sha256 ?? null,
+    currentSha256: currentRevision?.sha256 ?? null,
+    currentStats: currentRevision?.stats ?? null,
+  });
+}

--- a/app/lib/files/revision-guard.ts
+++ b/app/lib/files/revision-guard.ts
@@ -104,7 +104,7 @@ export async function assertWorkspaceFileRevisionAllowed(params: {
   const currentRevision = await getWorkspaceFileRevision(params.path, params.options);
 
   if (!currentRevision) {
-    if (params.requireExpectedRevision && expectedSha256) {
+    if (expectedSha256) {
       throw new WorkspaceFileRevisionError({
         code: 'FILE_REVISION_CONFLICT',
         status: 409,
@@ -116,10 +116,6 @@ export async function assertWorkspaceFileRevisionAllowed(params: {
       });
     }
     return null;
-  }
-
-  if (!params.requireExpectedRevision) {
-    return currentRevision;
   }
 
   if (expectedSha256 && expectedSha256 !== currentRevision.sha256) {

--- a/app/lib/files/workspace-upload-flow.ts
+++ b/app/lib/files/workspace-upload-flow.ts
@@ -3,7 +3,10 @@ import 'server-only';
 import path from 'node:path';
 
 import { createDirectory, type WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
-import { getWorkspaceFileRevision } from '@/app/lib/files/revision-guard';
+import {
+  assertWorkspaceFileRevisionUnchanged,
+  getWorkspaceFileRevision,
+} from '@/app/lib/files/revision-guard';
 import {
   acquireFileLock,
   assertFileCollaborationWriteAllowed,
@@ -20,7 +23,7 @@ export async function runWorkspaceUploadWrite(params: {
   fileOptions: WorkspaceFileOperationOptions;
   actorUserId: string;
   targetPath: string;
-  write: () => Promise<void>;
+  write: (onBeforeReplace: () => Promise<void>) => Promise<void>;
 }): Promise<void> {
   const parentDir = path.posix.dirname(params.targetPath);
   if (parentDir !== '.' && parentDir !== '/') {
@@ -63,15 +66,23 @@ export async function runWorkspaceUploadWrite(params: {
       }
     }
 
-    assertFileCollaborationWriteAllowed({
-      workspace: params.workspace,
-      path: params.targetPath,
-      actorUserId: params.actorUserId,
-      actorType: 'user',
-      baseRevisionId: storedBaseRevision?.id ?? null,
-    });
+    const assertUploadStillAllowed = async () => {
+      await assertWorkspaceFileRevisionUnchanged({
+        path: params.targetPath,
+        expectedRevision: beforeRevision,
+        options: params.fileOptions,
+      });
+      assertFileCollaborationWriteAllowed({
+        workspace: params.workspace,
+        path: params.targetPath,
+        actorUserId: params.actorUserId,
+        actorType: 'user',
+        baseRevisionId: storedBaseRevision?.id ?? null,
+      });
+    };
 
-    await params.write();
+    await assertUploadStillAllowed();
+    await params.write(assertUploadStillAllowed);
     const afterRevision = await getWorkspaceFileRevision(params.targetPath, params.fileOptions);
     if (afterRevision) {
       ensureFileRevisionForCurrentContent({

--- a/app/lib/files/write-service.ts
+++ b/app/lib/files/write-service.ts
@@ -72,8 +72,7 @@ function existingFileError(path: string, existing: Awaited<ReturnType<typeof get
   });
 }
 
-export async function writeWorkspaceFileContent(input: WriteWorkspaceFileContentInput) {
-  return withWorkspaceFileWriteLock(input.workspace.workspaceId, input.path, async () => {
+async function writeWorkspaceFileContentUnlocked(input: WriteWorkspaceFileContentInput) {
   if (input.createOnly) {
     const existing = await getWorkspaceFileRevision(input.path, input.fileOptions);
     if (existing) {
@@ -119,7 +118,15 @@ export async function writeWorkspaceFileContent(input: WriteWorkspaceFileContent
       throw error;
     }
   } else {
-    await writeFile(input.path, input.content, input.fileOptions);
+    await writeFile(input.path, input.content, input.fileOptions, async () => {
+      if (!input.expectedSha256) return;
+      await assertWorkspaceFileRevisionAllowed({
+        path: input.path,
+        expectedSha256: input.expectedSha256,
+        options: input.fileOptions,
+        requireExpectedRevision: true,
+      });
+    });
   }
   const contentBuffer = Buffer.isBuffer(input.content) ? input.content : Buffer.from(input.content);
   const afterRevision = await getWorkspaceFileRevision(input.path, input.fileOptions);
@@ -183,5 +190,12 @@ export async function writeWorkspaceFileContent(input: WriteWorkspaceFileContent
     revision,
     collaboration,
   };
-  });
+}
+
+export async function writeWorkspaceFileContent(input: WriteWorkspaceFileContentInput) {
+  return withWorkspaceFileWriteLock(
+    input.workspace.workspaceId,
+    input.path,
+    () => writeWorkspaceFileContentUnlocked(input),
+  );
 }

--- a/app/lib/files/write-service.ts
+++ b/app/lib/files/write-service.ts
@@ -37,6 +37,29 @@ export type WriteWorkspaceFileContentInput = {
   ensureCollaborationDocument?: boolean;
 };
 
+const fileWriteLocks = new Map<string, Promise<void>>();
+
+async function withWorkspaceFileWriteLock<T>(
+  workspaceId: string,
+  filePath: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const key = `${workspaceId}\0${filePath}`;
+  const previous = fileWriteLocks.get(key) ?? Promise.resolve();
+  let releaseCurrent!: () => void;
+  const current = new Promise<void>((resolve) => { releaseCurrent = resolve; });
+  const queued = previous.then(() => current);
+  fileWriteLocks.set(key, queued);
+
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    releaseCurrent();
+    if (fileWriteLocks.get(key) === queued) fileWriteLocks.delete(key);
+  }
+}
+
 function existingFileError(path: string, existing: Awaited<ReturnType<typeof getWorkspaceFileRevision>>) {
   return new WorkspaceFileRevisionError({
     code: 'FILE_REVISION_CONFLICT',
@@ -50,6 +73,7 @@ function existingFileError(path: string, existing: Awaited<ReturnType<typeof get
 }
 
 export async function writeWorkspaceFileContent(input: WriteWorkspaceFileContentInput) {
+  return withWorkspaceFileWriteLock(input.workspace.workspaceId, input.path, async () => {
   if (input.createOnly) {
     const existing = await getWorkspaceFileRevision(input.path, input.fileOptions);
     if (existing) {
@@ -159,4 +183,5 @@ export async function writeWorkspaceFileContent(input: WriteWorkspaceFileContent
     revision,
     collaboration,
   };
+  });
 }

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -454,6 +454,19 @@ export async function renameFile(
   overwrite = false,
   options?: WorkspaceFileOperationOptions
 ): Promise<void> {
+  return withWorkspaceFileMutationLock(
+    newPath,
+    options,
+    () => renameFileUnlocked(oldPath, newPath, overwrite, options),
+  );
+}
+
+async function renameFileUnlocked(
+  oldPath: string,
+  newPath: string,
+  overwrite = false,
+  options?: WorkspaceFileOperationOptions,
+): Promise<void> {
   const fullOldPath = await resolveExistingWorkspacePath(oldPath, options);
   const fullNewPath = validatePath(newPath, options);
 

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -181,7 +181,8 @@ export async function createReadStream(
 export async function writeFile(
   filePath: string,
   content: Buffer | string,
-  options?: WorkspaceFileOperationOptions
+  options?: WorkspaceFileOperationOptions,
+  onBeforeReplace?: () => Promise<void>,
 ): Promise<void> {
   const fullPath = await resolveWritableWorkspacePath(filePath, options);
   const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
@@ -202,6 +203,7 @@ export async function writeFile(
     await handle.sync();
     await handle.close();
     handle = null;
+    await onBeforeReplace?.();
     await fs.rename(stagingPath, fullPath);
 
     const directoryHandle = await fs.open(path.dirname(fullPath), 'r');

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -185,7 +185,35 @@ export async function writeFile(
 ): Promise<void> {
   const fullPath = await resolveWritableWorkspacePath(filePath, options);
   const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
-  await fs.writeFile(fullPath, buffer);
+  const stagingPath = `${fullPath}.canvas-write-${randomUUID()}.tmp`;
+  let handle: Awaited<ReturnType<typeof fs.open>> | null = null;
+  try {
+    let mode = 0o666;
+    try {
+      mode = (await fs.stat(fullPath)).mode & 0o777;
+    } catch (error) {
+      if (!error || typeof error !== 'object' || !('code' in error) || error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+
+    handle = await fs.open(stagingPath, 'wx', mode);
+    await handle.writeFile(buffer);
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await fs.rename(stagingPath, fullPath);
+
+    const directoryHandle = await fs.open(path.dirname(fullPath), 'r');
+    try {
+      await directoryHandle.sync();
+    } finally {
+      await directoryHandle.close();
+    }
+  } finally {
+    await handle?.close().catch(() => undefined);
+    await fs.rm(stagingPath, { force: true }).catch(() => undefined);
+  }
 }
 
 export async function replaceWorkspaceFileFromPath(

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -257,11 +257,12 @@ export async function replaceWorkspaceFileFromPath(
   sourcePath: string,
   filePath: string,
   options?: WorkspaceFileOperationOptions,
+  onBeforeReplace?: () => Promise<void>,
 ): Promise<void> {
   return withWorkspaceFileMutationLock(
     filePath,
     options,
-    () => replaceWorkspaceFileFromPathUnlocked(sourcePath, filePath, options),
+    () => replaceWorkspaceFileFromPathUnlocked(sourcePath, filePath, options, onBeforeReplace),
   );
 }
 
@@ -269,6 +270,7 @@ async function replaceWorkspaceFileFromPathUnlocked(
   sourcePath: string,
   filePath: string,
   options?: WorkspaceFileOperationOptions,
+  onBeforeReplace?: () => Promise<void>,
 ): Promise<void> {
   const sourceStats = await fs.stat(sourcePath);
   if (!sourceStats.isFile()) {
@@ -297,6 +299,7 @@ async function replaceWorkspaceFileFromPathUnlocked(
         createLocalWriteStream(stagingPath, { flags: 'wx', mode: 0o644 }),
       );
     }
+    await onBeforeReplace?.();
     await fs.rename(stagingPath, fullPath);
     await fs.chmod(fullPath, 0o644);
   } finally {

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -41,6 +41,28 @@ const IGNORED_WORKSPACE_DIRS = new Set(['node_modules', '.next', '.git', 'dist',
 const HIDDEN_WORKSPACE_METADATA_FILES = new Set(['.gitkeep', '.keep']);
 const FILE_METADATA_CONCURRENCY = 32;
 const FILE_TREE_DIRECTORY_CONCURRENCY = 16;
+const workspaceFileMutationLocks = new Map<string, Promise<void>>();
+
+async function withWorkspaceFileMutationLock<T>(
+  filePath: string,
+  options: WorkspaceFileOperationOptions | undefined,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const key = `${getWorkspace(options).workspaceId}\0${filePath}`;
+  const previous = workspaceFileMutationLocks.get(key) ?? Promise.resolve();
+  let releaseCurrent!: () => void;
+  const current = new Promise<void>((resolve) => { releaseCurrent = resolve; });
+  const queued = previous.then(() => current);
+  workspaceFileMutationLocks.set(key, queued);
+
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    releaseCurrent();
+    if (workspaceFileMutationLocks.get(key) === queued) workspaceFileMutationLocks.delete(key);
+  }
+}
 
 async function mapWithConcurrency<T, R>(
   items: T[],
@@ -184,6 +206,19 @@ export async function writeFile(
   options?: WorkspaceFileOperationOptions,
   onBeforeReplace?: () => Promise<void>,
 ): Promise<void> {
+  return withWorkspaceFileMutationLock(
+    filePath,
+    options,
+    () => writeFileUnlocked(filePath, content, options, onBeforeReplace),
+  );
+}
+
+async function writeFileUnlocked(
+  filePath: string,
+  content: Buffer | string,
+  options?: WorkspaceFileOperationOptions,
+  onBeforeReplace?: () => Promise<void>,
+): Promise<void> {
   const fullPath = await resolveWritableWorkspacePath(filePath, options);
   const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
   const stagingPath = `${fullPath}.canvas-write-${randomUUID()}.tmp`;
@@ -219,6 +254,18 @@ export async function writeFile(
 }
 
 export async function replaceWorkspaceFileFromPath(
+  sourcePath: string,
+  filePath: string,
+  options?: WorkspaceFileOperationOptions,
+): Promise<void> {
+  return withWorkspaceFileMutationLock(
+    filePath,
+    options,
+    () => replaceWorkspaceFileFromPathUnlocked(sourcePath, filePath, options),
+  );
+}
+
+async function replaceWorkspaceFileFromPathUnlocked(
   sourcePath: string,
   filePath: string,
   options?: WorkspaceFileOperationOptions,

--- a/app/lib/markdown/rich-markdown-codec.ts
+++ b/app/lib/markdown/rich-markdown-codec.ts
@@ -1,0 +1,130 @@
+import Image from '@tiptap/extension-image';
+import Link from '@tiptap/extension-link';
+import Mathematics from '@tiptap/extension-mathematics';
+import { TableKit } from '@tiptap/extension-table';
+import TaskItem from '@tiptap/extension-task-item';
+import TaskList from '@tiptap/extension-task-list';
+import UniqueID from '@tiptap/extension-unique-id';
+import { Markdown, MarkdownManager } from '@tiptap/markdown';
+import StarterKit from '@tiptap/starter-kit';
+
+import { getMarkdownSourceModeReason } from '@/app/lib/editor/text-editor-guards';
+import { canvasRichMarkdownExtensions } from '@/app/lib/markdown/canvas-rich-markdown-extensions';
+import { hasObsidianRichEditorUnsupportedSyntax } from '@/app/lib/markdown/obsidian-flavored-markdown';
+import {
+  parseCanvasMarkdownDocument,
+  splitCanvasMarkdownForRichEditor,
+} from '@/app/lib/markdown/obsidian-metadata';
+
+export const RICH_MARKDOWN_UNIQUE_ID_TYPES = 'all' as const;
+
+export type MarkdownRichModeReason =
+  | 'invalid_frontmatter'
+  | 'document_too_large'
+  | 'long_line'
+  | 'unsafe_slash_run'
+  | 'unsupported_marp_directive'
+  | 'unsupported_obsidian_syntax'
+  | 'parse_failed'
+  | 'roundtrip_changed';
+
+export type MarkdownRichModeAnalysis =
+  | {
+      mode: 'rich';
+      body: string;
+      prefix: string;
+    }
+  | {
+      mode: 'source';
+      reason: MarkdownRichModeReason;
+    };
+
+export function richMarkdownCodecExtensions() {
+  return [
+    StarterKit.configure({ link: false, paragraph: false }),
+    ...canvasRichMarkdownExtensions(),
+    Link.configure({ openOnClick: false, autolink: false }),
+    Image,
+    Mathematics,
+    TaskList,
+    TaskItem.configure({ nested: true }),
+    TableKit,
+    UniqueID.configure({ types: RICH_MARKDOWN_UNIQUE_ID_TYPES }),
+    Markdown.configure({
+      markedOptions: { gfm: true, breaks: false },
+      indentation: { style: 'space', size: 2 },
+    }),
+  ];
+}
+
+export function createRichMarkdownManager() {
+  return new MarkdownManager({
+    extensions: richMarkdownCodecExtensions(),
+    markedOptions: { gfm: true, breaks: false },
+    indentation: { style: 'space', size: 2 },
+  });
+}
+
+/**
+ * TipTap's Markdown serializer omits a final line ending. Keeping the
+ * pre-existing terminator is lossless and avoids a whole-file diff on the
+ * first rich-editor transaction.
+ */
+export function restoreRichMarkdownFinalLineEnding(
+  originalBody: string,
+  serializedBody: string,
+): string {
+  if (serializedBody.endsWith('\n')) return serializedBody;
+  const finalLineEnding = originalBody.match(/(\r?\n)$/u)?.[1];
+  return finalLineEnding ? `${serializedBody}${finalLineEnding}` : serializedBody;
+}
+
+export function serializeRichMarkdownBody(
+  markdown: string,
+  manager = createRichMarkdownManager(),
+): string {
+  return restoreRichMarkdownFinalLineEnding(markdown, manager.serialize(manager.parse(markdown)));
+}
+
+function modeReasonFromTextGuard(markdown: string): MarkdownRichModeReason | null {
+  const reason = getMarkdownSourceModeReason(markdown);
+  if (reason === 'large-document') return 'document_too_large';
+  if (reason === 'long-line') return 'long_line';
+  if (reason === 'slash-runaway') return 'unsafe_slash_run';
+  return null;
+}
+
+function hasMarpBodyDirective(markdown: string): boolean {
+  return /<!--\s*(?:_?[a-z][\w-]*\s*:|marp\s*:)/iu.test(markdown);
+}
+
+/**
+ * Determines whether the rich editor can read and write a document without
+ * changing its source representation. This is intentionally conservative:
+ * uncertain inputs stay in Source mode rather than receiving a best-effort
+ * whole-document serialization.
+ */
+export function analyzeMarkdownRichMode(markdown: string): MarkdownRichModeAnalysis {
+  const parsed = parseCanvasMarkdownDocument(markdown);
+  if (parsed.error) return { mode: 'source', reason: 'invalid_frontmatter' };
+
+  const guardReason = modeReasonFromTextGuard(markdown);
+  if (guardReason) return { mode: 'source', reason: guardReason };
+
+  const parts = splitCanvasMarkdownForRichEditor(markdown);
+  if (hasMarpBodyDirective(parts.body)) {
+    return { mode: 'source', reason: 'unsupported_marp_directive' };
+  }
+  if (hasObsidianRichEditorUnsupportedSyntax(parts.body)) {
+    return { mode: 'source', reason: 'unsupported_obsidian_syntax' };
+  }
+
+  try {
+    const serialized = serializeRichMarkdownBody(parts.body);
+    if (serialized !== parts.body) return { mode: 'source', reason: 'roundtrip_changed' };
+  } catch {
+    return { mode: 'source', reason: 'parse_failed' };
+  }
+
+  return { mode: 'rich', prefix: parts.prefix, body: parts.body };
+}

--- a/app/lib/marp/detect.ts
+++ b/app/lib/marp/detect.ts
@@ -1,8 +1,7 @@
 const MARP_MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
 const MARP_NAMED_FILE_REGEX = /\.(marp|slides)\.(md|markdown)$/i;
 const MARP_COMMENT_REGEX = /<!--\s*marp\s*:\s*(true|yes|on)\s*-->/i;
-const MARP_FRONTMATTER_REGEX = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
-const MARP_FRONTMATTER_LINE_REGEX = /^\s*marp\s*:\s*(true|yes|on|"true"|'true')\s*$/im;
+import { parseCanvasMarkdownDocument } from '@/app/lib/markdown/obsidian-metadata';
 
 export function isMarpMarkdownPath(filePath: string): boolean {
   const lower = filePath.toLowerCase();
@@ -18,12 +17,14 @@ export function hasMarpDirective(markdown: string): boolean {
     return true;
   }
 
-  const frontmatter = markdown.match(MARP_FRONTMATTER_REGEX);
-  if (!frontmatter) {
-    return false;
-  }
+  const document = parseCanvasMarkdownDocument(markdown);
+  if (document.error || !document.frontmatter) return false;
 
-  return MARP_FRONTMATTER_LINE_REGEX.test(frontmatter[1]);
+  const marp = document.frontmatter.data.marp;
+  if (marp === true) return true;
+  if (typeof marp !== 'string') return false;
+
+  return ['true', 'yes', 'on'].includes(marp.trim().toLowerCase());
 }
 
 export function isMarpMarkdown(filePath: string, markdown?: string): boolean {

--- a/app/lib/mobile/notebook.ts
+++ b/app/lib/mobile/notebook.ts
@@ -106,6 +106,23 @@ function isMobileTextDocumentPath(filePath: string): boolean {
   return MOBILE_TEXT_DOCUMENT_EXTENSIONS.has(path.posix.extname(filePath).toLowerCase());
 }
 
+export function selectMobileCollaborationRepresentation(
+  filePath: string,
+  content: string,
+): 'plain_text' | 'tiptap_xml' {
+  return path.posix.extname(filePath).toLowerCase() === '.txt'
+    || analyzeMarkdownRichMode(content).mode === 'source'
+    ? 'plain_text'
+    : 'tiptap_xml';
+}
+
+export function shouldReadMobileCollaborationSnapshot(
+  requestedRepresentation: 'plain_text' | 'tiptap_xml',
+  persistedRepresentation: 'plain_text' | 'tiptap_xml',
+): boolean {
+  return requestedRepresentation === 'tiptap_xml' || persistedRepresentation === 'plain_text';
+}
+
 export function normalizeMobileNotebookPath(value: unknown): string {
   if (typeof value !== 'string') {
     throw new MobileNotebookError('A Markdown or plain-text path is required.', 400, 'INVALID_NOTEBOOK_PATH');
@@ -290,6 +307,8 @@ export async function readMobileNotebookDocument(input: {
     throw new MobileNotebookError('Notebook documents may be at most 2 MiB.', 413, 'DOCUMENT_TOO_LARGE');
   }
   const buffer = await readFile(filePath, input.fileOptions);
+  const sourceContent = buffer.toString('utf8');
+  const requestedRepresentation = selectMobileCollaborationRepresentation(filePath, sourceContent);
   const sha256 = sha256Buffer(buffer);
   const revision = ensureFileRevisionForCurrentContent({
     workspace: input.workspace,
@@ -309,17 +328,13 @@ export async function readMobileNotebookDocument(input: {
   if (collaboration.document) {
     let state = await loadCollaborationState(collaboration.document.id);
     if (!state) {
-      const initialContent = buffer.toString('utf8');
       state = await ensureCollaborationState({
         documentId: collaboration.document.id,
         workspaceId: input.workspace.workspaceId,
         organizationId: input.workspace.organizationId ?? null,
         path: filePath,
-        representation: path.posix.extname(filePath).toLowerCase() === '.txt'
-          || analyzeMarkdownRichMode(initialContent).mode === 'source'
-          ? 'plain_text'
-          : 'tiptap_xml',
-        initialContent,
+        representation: requestedRepresentation,
+        initialContent: sourceContent,
       });
     }
     if (state.workspaceId !== input.workspace.workspaceId || state.path !== filePath) {
@@ -329,12 +344,14 @@ export async function readMobileNotebookDocument(input: {
         'COLLABORATION_STATE_STALE',
       );
     }
-    collaborationSnapshot = await readCurrentCollaborationTextSnapshot({
-      documentId: collaboration.document.id,
-      workspace: input.workspace,
-    });
+    if (shouldReadMobileCollaborationSnapshot(requestedRepresentation, state.representation)) {
+      collaborationSnapshot = await readCurrentCollaborationTextSnapshot({
+        documentId: collaboration.document.id,
+        workspace: input.workspace,
+      });
+    }
   }
-  const content = collaborationSnapshot?.content ?? buffer.toString('utf8');
+  const content = collaborationSnapshot?.content ?? sourceContent;
   const contentBytes = Buffer.byteLength(content, 'utf8');
   const collaborationDocumentExists = Boolean(collaboration.document);
   const canWrite = input.workspace.permissions.canWrite;

--- a/app/lib/mobile/notebook.ts
+++ b/app/lib/mobile/notebook.ts
@@ -20,6 +20,7 @@ import {
   getFileCollaborationState,
 } from '@/app/lib/files/collaboration-policy';
 import { writeWorkspaceFileContent } from '@/app/lib/files/write-service';
+import { analyzeMarkdownRichMode } from '@/app/lib/markdown/rich-markdown-codec';
 import { runCollaborationDirectConnection } from '@/app/lib/collaboration/direct-connection';
 import { readCurrentCollaborationTextSnapshot } from '@/app/lib/collaboration/agent-file-edits';
 import {
@@ -308,13 +309,17 @@ export async function readMobileNotebookDocument(input: {
   if (collaboration.document) {
     let state = await loadCollaborationState(collaboration.document.id);
     if (!state) {
+      const initialContent = buffer.toString('utf8');
       state = await ensureCollaborationState({
         documentId: collaboration.document.id,
         workspaceId: input.workspace.workspaceId,
         organizationId: input.workspace.organizationId ?? null,
         path: filePath,
-        representation: path.posix.extname(filePath).toLowerCase() === '.txt' ? 'plain_text' : 'tiptap_xml',
-        initialContent: buffer.toString('utf8'),
+        representation: path.posix.extname(filePath).toLowerCase() === '.txt'
+          || analyzeMarkdownRichMode(initialContent).mode === 'source'
+          ? 'plain_text'
+          : 'tiptap_xml',
+        initialContent,
       });
     }
     if (state.workspaceId !== input.workspace.workspaceId || state.path !== filePath) {

--- a/app/store/editor-store.ts
+++ b/app/store/editor-store.ts
@@ -16,7 +16,7 @@ interface EditorState {
   clear: () => void;
 }
 
-export const useEditorStore = create<EditorState>((set) => ({
+export const useEditorStore = create<EditorState>((set, get) => ({
   activePath: null,
   draft: '',
   baseContent: '',
@@ -34,8 +34,10 @@ export const useEditorStore = create<EditorState>((set) => ({
       saveError: null,
       lastSavedAt: null,
     }),
-  updateDraft: (content: string) =>
-    set({ draft: content, isDirty: true, saveError: null }),
+  updateDraft: (content: string) => {
+    if (content === get().draft) return;
+    set({ draft: content, isDirty: true, saveError: null });
+  },
   markSaving: () => set({ isSaving: true, saveError: null }),
   markSaved: () =>
     set((state) => ({

--- a/docs/dokumentation/app-bugs-2026-08/22-marp-editor-roundtrip-umsetzungsplan.md
+++ b/docs/dokumentation/app-bugs-2026-08/22-marp-editor-roundtrip-umsetzungsplan.md
@@ -1,0 +1,641 @@
+---
+title: 'Umsetzungsplan zu Ticket 22: MARP-YAML und Formatierung beim Editorwechsel erhalten'
+status: planned
+date: 2026-08-21
+platforms: [web, server]
+tags: [type/implementation-plan, topic/marp, topic/editor, topic/frontmatter]
+---
+
+# Umsetzungsplan: MARP-Editor-Roundtrip verlustfrei machen
+
+## Ziel, Scope und Arbeitsmodus
+
+Dieser Plan konkretisiert [Ticket 22](./22-marp-editor-roundtrip-verlustfrei-machen.md)
+fuer den aktuellen Web-, Datei- und Collaboration-Code. Die Umsetzung erfolgt
+streng sequenziell: Jede Phase wird vollstaendig implementiert, automatisiert
+geprueft und als eigener fokussierter Commit abgeschlossen, bevor die naechste
+Phase beginnt.
+
+Verbindliche Produktregel ist: Ein Ansichts- oder Editorwechsel ist keine
+Inhaltsaenderung. Ohne Nutzeredit darf er weder `onChange`, Dirty-State,
+Autosave noch eine Dateirevision ausloesen. Rich Editing wird nur angeboten,
+wenn der exakt in Produktion verwendete Parser-/Serializer-Vertrag fuer das
+konkrete Dokument nachweislich sicher ist. Im Zweifel bleibt der exakte
+Source-Text die Wahrheit.
+
+Im Scope liegen:
+
+- Web-Notebook mit MARP-Preview, TipTap-Rich-Editor und Source-Editor;
+- Front Matter und Obsidian-Metadaten des Markdown-Dokuments;
+- lokale Whole-File-Saves sowie die bestehende Yjs-Representation fuer
+  kollaborative Markdown-Dateien;
+- Dirty-State, Autosave, Revision-/SHA-Konflikte und atomarer Dateiersatz;
+- automatisierte Roundtrip-Fixtures und manuelle Web-Abnahme.
+
+Nicht im Scope liegen Ticket 21, die Expo-App, ein neuer MARP-Renderer, eine
+allgemeine Markdown-Formatierungsfunktion oder eine Erweiterung des
+TipTap-Schemas um beliebige HTML-/MARP-Konstrukte. Nicht sicher darstellbare
+Syntax wird erhalten und im Source-Modus bearbeitet, statt fuer dieses Ticket
+zwanghaft in Rich-Text-Nodes uebersetzt zu werden.
+
+## Inventur des aktuellen Stands
+
+### Editor- und Vorschaudatenfluss
+
+```text
+GET /api/files/read
+  -> useFileStore.currentFile + stats.sha256 + revision
+  -> useEditorStore.setActiveFile(path, content)
+  -> draft/baseContent, isDirty=false
+
+FileEditor
+  -> isMarpMarkdown(path, draft)
+  -> MARP-Preview: MarpPreview(path, draft)
+  -> Markdown: MarkdownEditor(value=draft, onChange=updateCollaborativeDraft)
+
+MarkdownEditor
+  -> parseCanvasMarkdownDocument(value)
+  -> splitCanvasMarkdownForRichEditor(value)
+  -> exakter Front-Matter-Praefix + TipTap-Body
+  -> TipTap getMarkdown() + unveraenderter Praefix
+  -> useEditorStore.updateDraft(nextValue), isDirty=true
+
+FileEditor Autosave nach 800 ms
+  -> useFileStore.saveFile(path, draft)
+  -> POST /api/files/write mit expectedSha256/baseRevisionId
+  -> writeWorkspaceFileContent
+  -> workspace-files.writeFile -> fs.writeFile(finalPath)
+```
+
+### Bereits vorhandene, weiterzuverwendende Bausteine
+
+- `app/components/editor/FileEditor.tsx`
+  - MARP wird aus Dateiname oder Inhalt erkannt;
+  - MARP oeffnet standardmaessig die Slide-Preview;
+  - der Preview-/Markdown-Schalter aendert nur lokalen View-State;
+  - Dirty-State, 800-ms-Autosave, Save-on-Close und sichtbare externe
+    Konfliktaktionen sind bereits vorhanden.
+- `app/components/editor/MarkdownEditor.tsx`
+  - trennt valides Front Matter vor der TipTap-Initialisierung vom Body;
+  - setzt den Praefix bei `getMarkdown()` wieder vor den serialisierten Body;
+  - erzwingt Source fuer ungueltiges Front Matter, Performance-Grenzen sowie
+    einige nicht unterstuetzte Obsidian-Konstrukte;
+  - deaktiviert den lokalen Rich-/Source-Schalter bei aktiver Collaboration.
+- `app/lib/markdown/obsidian-metadata.ts`
+  - erkennt BOM, CRLF/LF-Delimiter und ein geschlossenes Front Matter bis
+    64 KiB;
+  - verwendet `yaml.parseDocument(..., keepSourceTokens: true)`;
+  - kann den unveraenderten Praefix und Body exakt wieder zusammensetzen;
+  - bewahrt bei expliziten Property-Aenderungen Kommentare und unbekannte
+    Felder bereits teilweise ueber den YAML-AST.
+- `app/lib/markdown/obsidian-flavored-markdown.ts`
+  - zwingt Obsidian-Kommentare, Block-IDs und ein zweites Front Matter im Body
+    bereits in den Source-Modus.
+- `app/lib/collaboration/markdown-state.ts`
+  - speichert bei `tiptap_xml` Front Matter separat in `Y.Text('frontmatter')`;
+  - validiert Schema, stabile IDs und einen kanonischen Rich-Roundtrip;
+  - serialisiert Checkpoints wieder aus Front Matter und TipTap-Body.
+- `app/lib/files/client.ts`, `app/store/file-store.ts`,
+  `app/lib/files/revision-guard.ts` und `app/lib/files/write-service.ts`
+  - transportieren `expectedSha256` und `baseRevisionId`;
+  - Shared Workspaces lehnen fehlende oder veraltete Revisionen ab;
+  - der Client pausiert Autosave nach erkanntem externem Konflikt und bietet
+    Reload, Merge oder Konfliktkopie an.
+- Bestehende Tests decken semantische TipTap-Nodes, Obsidian-Syntax,
+  Front-Matter-Parsing, MARP-Preview/Export und File-Revision-Guards ab.
+
+### Relevante Architekturvorgaben
+
+- `docs/architecture/canvas-notebook/team-workspace/18-collaboration-and-file-conflict-policy.md`
+  verlangt genau eine schreibbare Collaboration-Representation pro Dokument:
+  `tiptap_xml` fuer sicher serialisierbares Markdown, sonst `plain_text`.
+- Ein Representation-Wechsel ist laut dieser Policy keine lokale UI-Aktion,
+  sondern eine serverseitige Migration bei leerem Room mit bestaetigtem
+  Checkpoint und Validierung.
+- Whole-File-Autosave darf bei einem aktiven Yjs-Dokument nicht als zweite
+  Wahrheit parallel laufen. Der aktuelle `FileEditor` beachtet dies bereits.
+- CRLF und BOM werden im Collaboration-Persistenzpfad bereits als
+  Serialisierungsprofil getrennt vom kanonischen Yjs-Inhalt behandelt.
+
+## Belegte Fehlerursachen und offene Verifikation
+
+### Im Code belegt
+
+1. **Kein bytegenauer Rich-Preflight:** `MarkdownEditor` entscheidet ueber
+   Rich-Faehigkeit anhand weniger Guard-Regeln. Es vergleicht nicht, ob
+   `TipTap.parse(body) -> getMarkdown()` den konkreten Body bytegleich
+   reproduziert.
+2. **Whole-Body-Serialisierung nach jedem Rich-Edit:** Sobald TipTap ein Update
+   meldet, ersetzt `getMarkdown()` den gesamten Body. Abweichende Listenmarker,
+   Whitespace, Tabellenlayout, HTML oder andere lexikalische Details koennen
+   deshalb auch ausserhalb der beabsichtigten Aenderung normalisiert werden.
+3. **Keine erklaerbare Unsupported-UI:** Source-Pflicht wird intern berechnet.
+   Der Rich-Schalter ist dann deaktiviert oder Source wird erzwungen, ohne einen
+   stabilen Reason-Code und ohne konkrete Warnung, welche Syntax geschuetzt
+   wird.
+4. **Dirty-State akzeptiert jede Meldung als Edit:**
+   `useEditorStore.updateDraft` setzt immer `isDirty=true`; eine zentrale
+   Gleichheits- und Origin-Pruefung fehlt. Der Rich-Editor besitzt lokale
+   Gleichheitschecks, der Store-Vertrag garantiert aber nicht, dass ein
+   Remount, Plugin-Update oder Moduswechsel niemals dirty wird.
+5. **MARP-Erkennung hat einen zweiten Front-Matter-Parser:**
+   `app/lib/marp/detect.ts` nutzt strengere Regexe als
+   `parseCanvasMarkdownDocument` und akzeptiert zum Beispiel nicht alle dort
+   erlaubten Delimiter-Varianten. Erkennung, Metadaten-Split und
+   Rich-Faehigkeit koennen dadurch unterschiedliche Dokumentgrenzen sehen.
+6. **SHA-Konfliktschutz ist im Personal Workspace wirkungslos:** Der Client
+   sendet einen bekannten `expectedSha256`, aber
+   `assertWorkspaceFileRevisionAllowed` kehrt fuer Workspaces ohne
+   `requireExpectedRevision` vor dem Mismatch-Vergleich zurueck. Ein bekannter
+   veralteter SHA wird dort nicht abgelehnt.
+7. **Der finale Write ist nicht atomar:** `workspace-files.writeFile` schreibt
+   mit `fs.writeFile` direkt auf den Zielpfad. Ein Prozessabbruch kann einen
+   unvollstaendigen Zielinhalt hinterlassen; Revision-Check und Write liegen
+   ausserdem nicht in einer gemeinsamen serverseitigen Path-Critical-Section.
+8. **Vorhandene Roundtrip-Tests sind ueberwiegend semantisch:**
+   `scripts/tiptap-markdown-roundtrip-test.ts` prueft Nodes und Regexe im
+   Ergebnis, aber keine bytegleichen Fixture-Roundtrips und keine Kette
+   Preview -> Rich -> Source -> Preview ohne Edit.
+
+### Vor Implementierung mit Fixtures zu verifizieren
+
+- Ob TipTap-Initialisierung, `UniqueID` oder andere Plugins in der aktuellen
+  Version ohne Nutzerinteraktion ein `onUpdate` mit geaendertem Dokument
+  ausloesen.
+- Welche konkreten Konstrukte der produktiven Extension-Liste bytegleich
+  roundtrippen und welche normalisiert oder verworfen werden, insbesondere:
+  HTML, MARP-Kommentardirektiven, Folientrenner, Code-Fences, harte Umbrueche,
+  Tabellen, verschachtelte Listen, Escape-Sequenzen und trailing newline.
+- Wie `yaml` 2.9 bei einer gezielten Property-Aenderung Kommentare, Quotes,
+  Flow-/Block-Arrays, Anchors, unbekannte Tags, Block Scalars und CRLF
+  serialisiert. Ein nur semantisch gleiches, aber breit neu formatiertes YAML
+  gilt als nicht ausreichend.
+- Ob ein Source-only MARP-Dokument in einem bereits als `tiptap_xml`
+  initialisierten Collaboration-Dokument vorkommen kann. Dieser Zustand darf
+  nicht durch einen lokalen Representation-Wechsel kaschiert werden.
+- Die Plattformdetails fuer atomaren Ersatz auf Linux und macOS: Temp-Datei im
+  selben Verzeichnis, Rechteuebernahme, optionales `fsync`, `rename` und
+  Cleanup bei Fehlern. Windows-Verhalten ist separat zu dokumentieren, falls
+  es vom POSIX-Ersatz abweicht.
+
+## Architektur- und Sicherheitsentscheidungen
+
+### 1. Source bleibt die kanonische verlustfreie Representation
+
+Front Matter und Markdown-Body werden als Original-Source gehalten. TipTap ist
+eine abgeleitete Bearbeitungsansicht und darf den Store erst nach einer echten
+Nutzertransaktion aktualisieren. Ein Moduswechsel selbst parst hoechstens in
+einen temporaeren Kandidaten; er committed keine Konvertierung.
+
+### 2. Rich Editing nur nach demselben bytegenauen Codec-Preflight
+
+Ein gemeinsamer Codec, zum Beispiel
+`app/lib/markdown/rich-markdown-codec.ts`, kapselt die produktive Extension-
+und Markdown-Konfiguration. Client-Editor, Collaboration-Initialisierung,
+Checkpoint-Validierung und Tests duerfen keine auseinanderlaufenden
+Parserlisten pflegen.
+
+Der Preflight arbeitet auf dem vom Front Matter getrennten Body:
+
+```ts
+type MarkdownRichModeReason =
+  | 'invalid_frontmatter'
+  | 'document_too_large'
+  | 'long_line'
+  | 'unsafe_slash_run'
+  | 'unsupported_obsidian_syntax'
+  | 'unsupported_marp_directive'
+  | 'unsupported_html'
+  | 'parse_failed'
+  | 'roundtrip_changed';
+
+type MarkdownRichModeAnalysis =
+  | {
+      mode: 'rich';
+      normalization: 'none';
+      prefix: string;
+      body: string;
+    }
+  | {
+      mode: 'source';
+      reason: MarkdownRichModeReason;
+      preservation: 'byte_exact';
+    };
+```
+
+`mode: rich` gilt nur, wenn der Codec den Body parsen kann und die erneute
+Serialisierung **bytegleich** zum Body ist. Es gibt fuer Ticket 22 keine stille
+"akzeptierte Normalisierung". Eine spaetere bewusst eingefuehrte
+Normalisierung benoetigt einen benannten Profilwert, eigene Fixtures und
+sichtbare Produktdokumentation.
+
+Diese konservative Regel vermeidet einen komplexen Source-Map-/Minimal-Patch-
+Serializer. Sie kann Rich Editing fuer nicht kanonisch formatiertes Markdown
+reduzieren, bewahrt dafuer aber nachweisbar den Originaltext.
+
+### 3. Preservation-Semantik pro Aktion
+
+| Aktion | Erlaubter Diff |
+| --- | --- |
+| Preview/Rich/Source wechseln, fokussieren, scrollen | keiner; kompletter Datei-SHA bleibt identisch |
+| Rich-Preflight scheitert | keiner; Source bleibt aktiv, Reason wird angezeigt |
+| Body im Rich-Editor aendern | nur die fachlich geaenderte Markdown-Stelle und zwingend angrenzende kanonische Syntax; Front-Matter-Praefix bleibt bytegleich |
+| Body im Source-Editor aendern | exakt der vom Nutzer erzeugte Source-Diff |
+| Titel/Tags/Aliases im Properties-Panel aendern | nur der explizit geaenderte Property-Knoten plus zwingender lokaler YAML-Syntax; unbekannte Felder, Reihenfolge, Kommentare und Body bleiben unveraendert |
+| Externe Aenderung/Revision-Konflikt | kein automatischer Write; Reload, sauberer Merge oder Konfliktkopie nach Nutzeraktion |
+| Fehlgeschlagener Parse/Codec/Write | kein Teil-Commit; Originaldatei und letzter gespeicherter SHA bleiben erhalten |
+
+Der Front-Matter-Praefix umfasst BOM, Opening-Delimiter, YAML-Rohtext,
+Closing-Delimiter und die vorhandenen Leerzeilen vor dem Body. Body-Edits
+duerfen diesen Bereich niemals ueber einen YAML-Serializer schicken.
+
+### 4. Unsupported Content wird sicher und erklaerbar behandelt
+
+Der Source-Modus zeigt eine nicht-blockierende, lokalisierte Warnung mit
+Reason-Code und kurzer Erklaerung, zum Beispiel: "Diese Praesentation enthaelt
+MARP-Direktiven oder Formatierung, die der visuelle Editor nicht verlustfrei
+abbilden kann. Der Quelltext bleibt unveraendert." Der Rich-Schalter bleibt
+deaktiviert; Preview, Source-Edit und Speichern funktionieren weiter.
+
+Die Warnung zeigt niemals Dokumentinhalt oder YAML-Werte. Reason-Codes sind
+stabil und koennen getestet bzw. telemetrisch gezaehlt werden; normale Logs
+enthalten nur Pfad-Scope, Reason und Dauer, keine Source-Fragmente.
+
+### 5. MARP-Erkennung verwendet dieselbe Dokumentgrenze
+
+`app/lib/marp/detect.ts` soll fuer Front Matter auf
+`parseCanvasMarkdownDocument` beziehungsweise eine darunter extrahierte
+Boundary-Funktion aufsetzen. MARP-Erkennung liest den YAML-Map-Wert `marp`
+ohne das Dokument neu zu serialisieren. Dateinamens- und Kommentar-Erkennung
+bleiben erhalten. Serverrouten pruefen MARP weiterhin selbst; ein Client-Flag
+ist keine Autoritaet fuer Preview oder Export.
+
+Parsergrenzen bleiben verpflichtend: maximal 64 KiB Front Matter, begrenzte
+Alias-Aufloesung, keine Ausfuehrung benutzerdefinierter YAML-Tags und keine
+Source-Inhalte in Fehlerlogs.
+
+### 6. Dirty-State basiert auf Inhaltsaenderung, nicht auf Ansicht
+
+Der Store erhaelt einen idempotenten Update-Vertrag: Ist `content === draft`,
+aendert sich kein State. Editor-Adapter melden nur echte Nutzer- oder explizite
+Property-Aenderungen. Initiales Parsen, externes `setContent`, Moduswechsel und
+fehlgeschlagene Kandidaten bleiben `isDirty=false`.
+
+Vor dem Eintritt in Rich wird der exakte Source-Snapshot behalten. Scheitert
+Initialisierung oder Validierung, bleibt bzw. wechselt die UI in Source und
+verwendet denselben Snapshot. Ein Moduswechsel erzeugt keinen Undo-Schritt;
+Editor-History darf durch externe Synchronisierung nicht verschmutzt werden.
+Undo/Redo innerhalb eines Editors bleibt erhalten. Ob History ueber einen
+Remount hinweg erhalten werden muss, wird in Phase 2 mit einem expliziten Test
+entschieden; mindestens darf ein Wechsel keine Nutzeredit verlieren oder eine
+scheinbare Konvertierung in die History einfuegen.
+
+### 7. Collaboration folgt der bestehenden Representation-Policy
+
+Der gemeinsame Preflight bestimmt vor der ersten Session, ob Markdown
+`tiptap_xml` oder `plain_text` benoetigt. Der Server fuehrt dieselbe
+Klassifikation fuer den gelesenen Anfangsinhalt aus und vertraut der vom Client
+angeforderten Representation nicht blind.
+
+Ein vorhandenes Collaboration-Dokument mit abweichender Representation wird
+nicht lokal umgedeutet. Die Session liefert einen stabilen Konfliktcode und
+die UI bleibt read-only/degraded mit Wiederherstellungshinweis. Eine echte
+Migration nutzt ausschliesslich den vorhandenen serverseitigen, quieszenten
+Representation-Migrationspfad mit gesundem Checkpoint; sie ist kein normaler
+Rich-/Source-Schalter.
+
+Front Matter bleibt bei `tiptap_xml` im vorhandenen separaten Y.Text. Derselbe
+bytegenaue Prefix-Vertrag gilt fuer Browser-Updates, Agent-Preflight und
+Datei-Checkpoint.
+
+### 8. Saves pruefen bekannte Revisionen und ersetzen atomar
+
+`expectedSha256` wird immer validiert, wenn der Aufrufer ihn mitsendet, auch
+im Personal Workspace. Shared Workspaces verlangen ihn weiterhin mit 428.
+Ein Mismatch bleibt 409 `FILE_REVISION_CONFLICT` und fuehrt in die bestehende
+Reload/Merge/Copy-UI.
+
+Der Server serialisiert Check + Write pro `(workspaceId, path)` innerhalb des
+App-Prozesses; alle Canvas-internen Datei- und Checkpoint-Writer muessen diese
+gemeinsame Critical-Section verwenden. Geschrieben wird in eine zufaellige Temp-Datei im Zielverzeichnis;
+erst nach vollstaendigem Write, Rechteuebernahme und erfolgreichem Flush wird
+sie atomar auf den Zielpfad umbenannt. Fehler entfernen die Temp-Datei und
+lassen die alte Datei bestehen. Diese Critical-Section ersetzt keine
+Kooperation externer Host-Prozesse; unmittelbar vor dem Rename wird deshalb
+der erwartete Ausgangs-SHA erneut geprueft. Unkoordinierte externe Writer
+werden zusaetzlich weiter ueber File Watcher und nachfolgenden SHA-Vergleich
+sichtbar gemacht.
+
+## Daten- und API-Vertraege
+
+### Markdown-Dokumentvertrag
+
+```ts
+type LosslessMarkdownDocument = {
+  original: string;
+  prefix: string;       // byte-exaktes Front Matter inkl. Separator-Leerzeilen
+  body: string;
+  hasFrontmatter: boolean;
+  frontmatterError: string | null;
+  newline: 'lf' | 'crlf' | 'mixed' | 'none';
+  hasBom: boolean;
+};
+```
+
+Der Vertrag ist eine Analyseansicht und keine zweite gespeicherte Kopie. Das
+Zusammensetzen von unveraendertem `prefix` und `body` muss immer wieder
+`original` ergeben. Mixed Newlines werden nicht normalisiert und fuehren bei
+nicht bytegleichem Codec-Preflight zu Source-only.
+
+### Editor-Vertrag
+
+- `MarkdownEditor.value` bleibt die autoritative Source aus dem Editor-Store.
+- `onChange(nextValue)` bedeutet eine echte, vom Nutzer initiierte
+  Inhaltsaenderung oder eine explizite Property-Aenderung.
+- Ein optionales `onModeAnalysisChange` darf nur Status/Reason melden, keinen
+  Inhalt.
+- `FileEditor` muss fuer Preview und Editor denselben aktuellen `draft`
+  verwenden; der View-Schalter ruft weder `updateDraft` noch `saveFile` auf.
+
+### Write-API
+
+Der Request von `POST /api/files/write` bleibt kompatibel:
+
+```json
+{
+  "path": "slides/deck.md",
+  "content": "<vollstaendiger Markdown-Text>",
+  "expectedSha256": "<64 hex chars oder null>",
+  "baseRevisionId": "<Revision-ID oder null>"
+}
+```
+
+Verbindliche Responses:
+
+- `200`: atomarer Ersatz abgeschlossen; Response enthaelt neuen SHA und
+  Revision;
+- `409 FILE_REVISION_CONFLICT`: vorhandener SHA oder `baseRevisionId` ist
+  veraltet; keine Datei wurde ersetzt;
+- `428 FILE_REVISION_REQUIRED`: bestehende Shared-Datei ohne erwartete
+  Revision; keine Datei wurde ersetzt;
+- `500`: atomarer Write/Flush/Rename ist **vor** dem Commit fehlgeschlagen;
+  alter Zielinhalt bleibt erhalten, Temp-Datei wird bereinigt.
+
+Fehler nach einem bereits erfolgreichen Rename duerfen nicht als scheinbar
+fehlgeschlagener, gefahrlos wiederholbarer Write zurueckkommen. Der Service
+muss Revision/Audit entweder innerhalb seines bestehenden konsistenten
+Commitpfads abschliessen oder einen stabilen Fehler mit
+`writeCommitted: true` und aktuellem SHA liefern. Der Client laedt dann den
+Serverstand neu und wiederholt den Write nicht blind.
+
+### Collaboration-Session
+
+Bei `POST /api/files/collaboration/session` bleibt
+`representation: plain_text | tiptap_xml` erhalten. Ergaenzt wird ein stabiler
+Fehlervertrag fuer eine nicht passende oder unsichere Representation, zum
+Beispiel:
+
+```json
+{
+  "success": false,
+  "code": "COLLABORATION_REPRESENTATION_CONFLICT",
+  "requiredRepresentation": "plain_text",
+  "reason": "roundtrip_changed"
+}
+```
+
+Der Server gibt keine Source-Fragmente zurueck. Ein Client darf auf diesen
+Fehler nicht mit einem stillen Whole-File-Autosave ausweichen.
+
+## Geplante Dateiaenderungen
+
+Voraussichtlich betroffen:
+
+- `app/lib/markdown/obsidian-metadata.ts`: verlustfreier Dokumentvertrag und
+  gezielte Property-Patches;
+- `app/lib/markdown/rich-markdown-codec.ts` (neu): gemeinsame Extension-
+  Konfiguration, Parse/Serialize und Rich-Preflight;
+- `app/lib/marp/detect.ts`: gemeinsame Front-Matter-Grenze und YAML-basierte
+  MARP-Erkennung;
+- `app/components/editor/MarkdownEditor.tsx`: Preflight, sichere Moduswechsel,
+  Warning-UI und Update-Origin;
+- `app/components/editor/FileEditor.tsx` und `app/store/editor-store.ts`:
+  idempotenter Dirty-/Autosave-Vertrag;
+- `app/lib/collaboration/markdown-state.ts`,
+  `app/lib/collaboration/session-service.ts` und ggf. Session-Route/-Client:
+  gemeinsamer Codec und Representation-Guard;
+- `app/lib/files/revision-guard.ts`, `app/lib/files/write-service.ts` und
+  `app/lib/filesystem/workspace-files.ts`: SHA-Pruefung, Path-Serialisierung und
+  atomarer Ersatz;
+- `messages/de.json` und `messages/en.json`: Warnungen und Fehlertexte;
+- `tests/fixtures/markdown-roundtrip/` sowie fokussierte Script-/Komponenten-
+  und spaeter freigegebene E2E-Tests.
+
+Eine Datenbankmigration ist nach aktueller Inventur nicht erforderlich.
+Bestehende File-Revisions- und Collaboration-Tabellen bleiben unveraendert.
+
+## Strikt sequenzielle Implementierungsphasen
+
+### Phase 1: Fixture-Matrix und gemeinsamer Rich-Codec
+
+- Byte-Fixtures fuer LF, CRLF, BOM, fehlende letzte Newline, Leerzeilen nach
+  Front Matter und wiederholtes Umschalten anlegen.
+- Front-Matter-Varianten aufnehmen: Kommentare, unbekannte MARP-Felder,
+  Reihenfolge, Flow-/Block-Arrays, Quotes, Zahlen/Booleans, Block Scalars
+  (`|`, `>`), Anchors/Aliases und verschachtelte Maps.
+- Body-Varianten aufnehmen: MARP global/local directives, Folientrenner,
+  HTML, Kommentare, Code-Fences mit `---`, Tabellen, Task Lists,
+  verschachtelte Listen, harte Umbrueche, Escapes und Whitespace.
+- Gemeinsame produktive Codec-Konfiguration extrahieren; Client und
+  Collaboration-Server verwenden dieselben Nodes, Marks und Markdown-Optionen.
+- `analyzeMarkdownRichMode` implementieren und fuer jede Fixture Rich-safe oder
+  Source-only samt Reason pruefen.
+- Bestehende semantische Tests beibehalten; neue Tests vergleichen zusaetzlich
+  komplette Strings bzw. SHA-256.
+- Verifikation: neuer Fixture-Test,
+  `npm run test:editor:markdown`, `npm run test:markdown:obsidian` und
+  `npm run build`.
+- Commit: `Define lossless Markdown roundtrip contract`.
+
+### Phase 2: Sichere Moduswechsel, Warnungen und Dirty-State
+
+- `MarkdownEditor` vor Rich-Eintritt gegen den gemeinsamen Codec pruefen.
+- Source-only-Reason lokalisiert und barrierearm anzeigen; deaktivierten
+  Rich-Schalter mit demselben Grund erklaeren.
+- View-/Moduswechsel so kapseln, dass sie weder `onChange` noch Store-Update
+  ausloesen.
+- `updateDraft` idempotent machen und Editor-Updates nach Origin trennen.
+- Exakten Source-Snapshot bis zur erfolgreichen Rich-Initialisierung behalten;
+  Parse-/Mountfehler fuehren ohne Draft-Diff zurueck in Source.
+- Externe `setContent`-Synchronisierung ohne History-/Dirty-Eintrag anwenden;
+  Undo/Redo und Remount-Verhalten mit einem Komponenten-Test festschreiben.
+- JSDOM-/React-Test fuer Preview/Rich/Source-Zyklen ohne `onChange`, ohne
+  Dirty-State und ohne Autosave-Planung ergaenzen.
+- Verifikation: neue Komponenten-/Store-Tests, betroffene Editor-Tests und
+  `npm run build`.
+- Commit: `Guard Markdown editor mode switches`.
+
+### Phase 3: Front-Matter- und Body-Preservation
+
+- Body-Updates ausschliesslich mit dem unveraenderten Prefix des jeweils
+  neuesten akzeptierten Drafts zusammensetzen.
+- Race zwischen Property-Panel-Edit und TipTap-Update durch generation-/value-
+  gebundene Updates verhindern; kein Callback darf einen aelteren Prefix
+  wieder einsetzen.
+- Property-Panel-Aenderungen als gezielte YAML-AST-/Source-Range-Patches
+  ausfuehren. Breite Reformatierung bei komplexen Dokumenten ist verboten;
+  falls ein Zielknoten nicht lokal sicher patchbar ist, wird auf Source
+  verwiesen und nichts geaendert.
+- YAML-Kommentare, unbekannte Keys, Reihenfolge, Arrays und mehrzeilige Werte
+  mit Before/After-Fixtures bytegenau ausserhalb des Zielknotens pruefen.
+- Wiederholte Rich-Edits duerfen keinen akkumulierten Whitespace-Diff erzeugen.
+- Verifikation: Preservation-Fixtures,
+  `npm run test:markdown:obsidian`, `npm run test:editor:markdown` und
+  `npm run build`.
+- Commit: `Preserve Markdown frontmatter and source formatting`.
+
+### Phase 4: MARP-Erkennung und Collaboration-Representation
+
+- MARP-Front-Matter-Erkennung auf die gemeinsame Dokumentgrenze umstellen und
+  Dateiname, YAML-Wert und Kommentar-Direktive als getrennte, getestete
+  Erkennungswege behalten.
+- Rich-/Source-Klassifikation vor der ersten Collaboration-Session anwenden.
+- Serverseitig `tiptap_xml` nur akzeptieren, wenn der aktuelle Dateiinhalt den
+  bytegenauen Rich-Preflight besteht; ansonsten stabilen Representation-
+  Konflikt liefern.
+- Bestehende `tiptap_xml`-Checkpoints auf denselben Codec und exakten
+  Front-Matter-Prefix pruefen. Kein lokaler Fallback auf `plain_text` und kein
+  Whole-File-Autosave bei Collaboration-Fehlern.
+- Test fuer initiales Source-only-MARP, bestehende falsche Representation,
+  Checkpoint-Roundtrip, CRLF/BOM und fehlgeschlagene Migration ergaenzen.
+- Verifikation: MARP-Detection-/Preview-Tests,
+  `npm run test:files:collaboration`, `npm run test:editor:markdown` und
+  `npm run build`.
+- Commit: `Align Marp editing with collaboration representation`.
+
+### Phase 5: Konfliktsichere atomare Saves
+
+- Mitgesendeten `expectedSha256` in allen Workspace-Typen pruefen; nur die
+  Pflicht zum Mitsenden bleibt Shared-Workspace-spezifisch.
+- Serverweite per-Path-Critical-Section um initiale Revision-Pruefung,
+  unmittelbar erneute Pre-Rename-Pruefung, atomaren Ersatz und neue Revision
+  legen.
+- Same-directory Temp-Write, Rechte, Flush, Rename und Fehler-Cleanup in einer
+  kleinen Filesystem-Funktion kapseln; keine Temp-Datei ueber Workspace-
+  Grenzen oder Symlink-Aufloesungen zulassen.
+- Fehlerpfad testen: veralteter Personal-SHA, konkurrierende App-Saves,
+  externe Aenderung vor Rename, simuliertes Write-/Rename-Versagen und
+  unveraenderte Zieldatei nach jedem Fehler vor dem Commit. Ein separater Test
+  fuer Fehler nach dem Rename muss `writeCommitted: true` und einen
+  anschliessend eindeutig ladbaren Serverstand belegen.
+- Bestehende Reload/Merge/Copy-UI und Shared-Workspace-428-Vertrag unveraendert
+  weiterverwenden.
+- Verifikation: Revision-/Write-Service-/Filesystem-Tests,
+  `npm run test:file-watcher`, relevante Collaboration-Tests und
+  `npm run build`.
+- Commit: `Make Markdown saves atomic and revision safe`.
+
+### Phase 6: Integrierte Abnahme und Dokumentation
+
+- Fixture-Kette Preview -> Rich -> Source -> Preview mehrfach ausfuehren und
+  gespeicherten SHA vor/nach dem Zyklus vergleichen.
+- Einen erlaubten Rich-Body-Edit pro Rich-safe Fixture ausfuehren und den Diff
+  gegen die Preservation-Matrix pruefen.
+- Jede Source-only-Fixture auf Warnung, erhaltenen Source-Text und weiterhin
+  funktionierende MARP-Preview pruefen.
+- Manuelle Abnahme auf Desktop und responsiver Mobile-Web-Breite dokumentieren.
+  Browser-/Playwright-E2E erst nach expliziter Nutzerfreigabe ausfuehren; bei
+  Freigabe die vorhandene App auf `localhost:3000` verwenden und keinen zweiten
+  Dev-Server starten.
+- `npm run build` als finales Gate ausfuehren; kein Container-Build fuer dieses
+  Ticket, sofern er nicht separat angefordert wird.
+- Ticket und Tracker erst nach vollstaendiger Abnahme auf erledigt setzen.
+- Commit: `Document lossless Marp editor acceptance`.
+
+## Automatisierte Abnahmekriterien
+
+1. Jede Fixture erfuellt
+   `compose(split(original)) === original` inklusive BOM, Newlines und finaler
+   Newline.
+2. Fuer jede als Rich-safe klassifizierte Fixture gilt
+   `serialize(parse(body)) === body`; der Test verwendet dieselbe Extension-
+   Factory wie der produktive Editor und Collaboration-Checkpoint.
+3. Jede nicht bytegleich roundtrippende Fixture wird Source-only mit stabilem
+   Reason-Code; der Originaltext bleibt unveraendert.
+4. Mindestens drei komplette Preview/Rich/Source-Zyklen ohne Edit erzeugen
+   keinen `onChange`, keinen Dirty-State, keinen Autosave und keinen SHA-Diff.
+5. Ein Rich-Body-Edit behaelt den Front-Matter-Prefix bytegleich. Unbekannte
+   YAML-Felder, Kommentare, Reihenfolge, Arrays und Block Scalars bleiben
+   erhalten.
+6. Eine gezielte Property-Aenderung veraendert keinen Body und keine
+   unbeteiligten YAML-Knoten; unsicher patchbare Properties werden abgelehnt,
+   nicht breit reserialisiert.
+7. Unsupported MARP-Direktiven, HTML und Obsidian-Syntax zeigen eine Warnung,
+   bleiben im Source erhalten und rendern weiterhin in der Preview.
+8. Fehlgeschlagene Konvertierung oder Rich-Initialisierung laesst Draft,
+   Dirty-State, Undo-Ausgang und gespeicherte Datei unveraendert.
+9. `tiptap_xml` wird serverseitig fuer Source-only-Inhalt abgelehnt; der Client
+   faellt nicht auf Whole-File-Autosave zurueck.
+10. Veraltete mitgesendete SHA-Werte liefern in Personal- und Shared-
+    Workspaces 409; fehlender erforderlicher Shared-SHA liefert 428.
+11. Simulierte Write-, Flush- und Rename-Fehler vor dem Commit lassen den alten
+    Dateiinhalt vollstaendig erhalten und keine verwaiste Temp-Datei zurueck;
+    ein Fehler nach dem Commit wird als committed ausgewiesen und nicht blind
+    wiederholt.
+12. Alle betroffenen fokussierten Tests, Collaboration-Tests und
+    `npm run build` sind gruen.
+
+## Manuelle Abnahmekriterien
+
+- Eine realistische MARP-Datei mit komplexem YAML oeffnen, mehrfach zwischen
+  Slides, Rich (falls freigegeben) und Source wechseln, schliessen und erneut
+  oeffnen. Ohne Edit bleibt der Datei-SHA identisch und der Header zeigt nie
+  "ungespeicherte Aenderungen".
+- Bei einer Rich-safe-Datei genau einen Absatz aendern. Der sichtbare
+  Source-Diff enthaelt nur diese Aenderung; Front Matter und andere Slides sind
+  unveraendert.
+- Eine Datei mit lokalen MARP-Kommentardirektiven, Raw HTML und absichtlich
+  nicht kanonischem Whitespace oeffnen. Rich ist erklaert deaktiviert, Source
+  und Preview funktionieren, kein automatischer Rewrite findet statt.
+- Titel oder Tags einer einfachen Property gezielt aendern. Kommentare,
+  unbekannte Keys, Reihenfolge, Arrays und mehrzeilige Werte visuell und im
+  Diff pruefen.
+- Dieselbe Datei parallel extern aendern und danach lokal speichern. Autosave
+  stoppt, die Konfliktleiste erscheint, und ohne explizite Aktion wird keine
+  Version ueberschrieben.
+- Einen simulierten Save-Fehler ausloesen. Nach Reload ist entweder die alte
+  vollstaendige Datei oder der neue vollstaendige Commit vorhanden, niemals
+  ein Teilinhalt.
+
+## Risiken, Migration und Rollback
+
+| Risiko | Gegenmassnahme |
+| --- | --- |
+| Konservativer Preflight reduziert Rich-Verfuegbarkeit | Source und Preview bleiben voll funktionsfaehig; Reason wird erklaert; Rich-Freigabe wird fixturebasiert erweitert statt pauschal gelockert. |
+| Client- und Server-Codec driften auseinander | Eine gemeinsame Extension-/Codec-Factory und ein Paritaetstest sind Pflicht. |
+| Property-Patch trifft komplexe YAML-Syntax falsch | AST-Ranges validieren, Ergebnis erneut parsen, unveraenderte Bereiche vergleichen; bei Unsicherheit ohne Mutation abbrechen. |
+| Aelteres `tiptap_xml`-Dokument ist fuer Source-only-Inhalt gebunden | Kein automatischer Wechsel; sichtbarer Konflikt und vorhandener quieszenter Migrationspfad mit Checkpoint. |
+| Atomarer Rename verhaelt sich plattformspezifisch | Same-directory-Tests auf unterstuetzten Plattformen; alter Inhalt muss bei jedem Fehler erhalten bleiben. |
+| Externer Prozess schreibt ausserhalb der App-Critical-Section | SHA unmittelbar vor Commit erneut pruefen, Watcher-Konflikt erhalten und Limitierung dokumentieren; kein behaupteter globaler Lock. |
+| Neue Dirty-Origin-Logik unterdrueckt echte Edits | Komponenten- und Store-Tests fuer Tippen, Property-Edit, Paste, Undo, externe Synchronisierung und schnellen Folgesave. |
+
+Es ist keine Datenmigration vorgesehen. Bereits gespeicherte Markdown-Dateien
+werden nicht vorab normalisiert oder umgeschrieben. Rollout ist dadurch
+konservativ: Unsichere Dokumente wechseln lediglich in Source-only.
+
+Rollback erfolgt commitweise in umgekehrter Phasenreihenfolge. Vor allem die
+Codec-/Preservation-Fixtures bleiben auch bei einem UI-Rollback bestehen. Ein
+Rollback darf keine neue Normalisierung ueber Bestandsdateien laufen lassen.
+Falls der atomare Write-Pfad separat zurueckgenommen werden muss, bleiben die
+strengere SHA-Pruefung und ihre Konflikttests nach Moeglichkeit aktiv; es gibt
+keine Schema- oder Datenmigration zurueckzusetzen.
+
+## Definition of Done
+
+Ticket 22 ist erst abgeschlossen, wenn alle automatisierten Kriterien erfuellt
+sind, die manuelle Abnahme dokumentiert ist, `npm run build` erfolgreich war
+und ein no-edit Roundtrip fuer jede Referenzdatei denselben SHA-256 liefert.
+"Semantisch gleich" allein reicht fuer den no-edit-Fall nicht. Jeder erlaubte
+Diff nach einem Nutzeredit ist anhand der Preservation-Matrix erklaerbar und
+enthalt weder verlorenes Front Matter noch unerwartete Formatierungs- oder
+Whitespace-Aenderungen.

--- a/docs/dokumentation/app-bugs-2026-08/22-marp-editor-roundtrip-verlustfrei-machen.md
+++ b/docs/dokumentation/app-bugs-2026-08/22-marp-editor-roundtrip-verlustfrei-machen.md
@@ -29,6 +29,9 @@ Formatierungen veraendert werden. Der Editorwechsel ist damit nicht verlustfrei.
 
 ## Umsetzung
 
+Der codebestandsnahe, strikt sequenzielle Plan liegt in
+[22-marp-editor-roundtrip-umsetzungsplan.md](./22-marp-editor-roundtrip-umsetzungsplan.md).
+
 - Roundtrip-Fixtures fuer MARP-Front-Matter, Kommentare, unbekannte Felder,
   Direktiven, Folientrenner, HTML, Code, Tabellen und Whitespace erstellen.
 - Datenfluss in `MarkdownEditor`, Markdown-/TipTap-Serialisierung,

--- a/messages/de.json
+++ b/messages/de.json
@@ -828,6 +828,7 @@
     "markdownEditorPropertiesAliasesPlaceholder": "Alternative Namen, durch Kommas getrennt",
     "markdownEditorPropertiesAdditional": "Weitere Eigenschaften",
     "markdownEditorPropertiesSourceHint": "Im Quellmodus bearbeiten",
+    "markdownEditorSourcePreservationNotice": "Dieses Dokument bleibt im Quellmodus, damit Markdown und Präsentationsmetadaten exakt erhalten bleiben.",
     "markdownEditorBacklinks": "Querverweise",
     "markdownEditorBacklinksCount": "{count, plural, =0 {Keine Verweise} one {# Verweis} other {# Verweise}}",
     "markdownEditorBacklinksSummary": "{documents, plural, =0 {Keine Dokumente} one {# Dokument} other {# Dokumente}} · {references, plural, =0 {keine Verweise} one {# Verweis} other {# Verweise}}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -829,6 +829,7 @@
     "markdownEditorPropertiesAliasesPlaceholder": "Alternative names, separated by commas",
     "markdownEditorPropertiesAdditional": "Additional properties",
     "markdownEditorPropertiesSourceHint": "Edit these in source mode",
+    "markdownEditorSourcePreservationNotice": "This document stays in source mode so its Markdown and presentation metadata are preserved exactly.",
     "markdownEditorBacklinks": "Cross-references",
     "markdownEditorBacklinksCount": "{count, plural, =0 {No references} one {# reference} other {# references}}",
     "markdownEditorBacklinksSummary": "{documents, plural, =0 {No documents} one {# document} other {# documents}} · {references, plural, =0 {no references} one {# reference} other {# references}}",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "test:files:sort": "tsx scripts/file-sort-test.ts",
     "test:editor:markdown": "tsx scripts/tiptap-markdown-roundtrip-test.ts",
     "test:editor:preservation": "tsx scripts/markdown-roundtrip-preservation-test.ts",
+    "test:files:atomic": "tsx --conditions react-server scripts/atomic-workspace-write-test.ts",
     "test:editor:outline": "tsx scripts/markdown-outline-test.ts && tsx scripts/markdown-outline-ui-test.ts",
     "test:editor:rich-blocks": "tsx scripts/tiptap-markdown-roundtrip-test.ts && tsx --conditions react-server scripts/markdown-rich-blocks-collaboration-test.ts && tsx scripts/markdown-rich-blocks-ui-test.ts",
     "test:editor:search": "tsx scripts/markdown-search-stats-test.ts && tsx scripts/markdown-search-stats-ui-test.ts",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "test:files:zip": "tsx --conditions react-server scripts/zip-extraction-test.ts",
     "test:files:sort": "tsx scripts/file-sort-test.ts",
     "test:editor:markdown": "tsx scripts/tiptap-markdown-roundtrip-test.ts",
+    "test:editor:preservation": "tsx scripts/markdown-roundtrip-preservation-test.ts",
     "test:editor:outline": "tsx scripts/markdown-outline-test.ts && tsx scripts/markdown-outline-ui-test.ts",
     "test:editor:rich-blocks": "tsx scripts/tiptap-markdown-roundtrip-test.ts && tsx --conditions react-server scripts/markdown-rich-blocks-collaboration-test.ts && tsx scripts/markdown-rich-blocks-ui-test.ts",
     "test:editor:search": "tsx scripts/markdown-search-stats-test.ts && tsx scripts/markdown-search-stats-ui-test.ts",

--- a/scripts/atomic-workspace-write-test.ts
+++ b/scripts/atomic-workspace-write-test.ts
@@ -29,8 +29,12 @@ async function main() {
   try {
     const { writeFile } = await import('../app/lib/filesystem/workspace-files');
     await fs.writeFile(path.join(root, 'deck.md'), 'before\n', { mode: 0o640 });
-    await writeFile('deck.md', 'after\n', { workspace });
+    let beforeReplaceCalled = false;
+    await writeFile('deck.md', 'after\n', { workspace }, async () => {
+      beforeReplaceCalled = true;
+    });
 
+    assert.equal(beforeReplaceCalled, true);
     assert.equal(await fs.readFile(path.join(root, 'deck.md'), 'utf8'), 'after\n');
     assert.equal((await fs.stat(path.join(root, 'deck.md'))).mode & 0o777, 0o640);
     assert.equal((await fs.readdir(root)).some((name) => name.includes('.canvas-write-')), false);

--- a/scripts/atomic-workspace-write-test.ts
+++ b/scripts/atomic-workspace-write-test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { WorkspaceContext } from '../app/lib/workspaces/types';
+
+async function main() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-atomic-write-'));
+  const workspace: WorkspaceContext = {
+    workspaceId: 'atomic-write-test',
+    workspaceType: 'personal',
+    rootPath: root,
+    rootRelativePath: '.',
+    displayName: 'Atomic write test',
+    status: 'active',
+    organizationId: null,
+    permissions: {
+      canRead: true,
+      canWrite: true,
+      canDelete: true,
+      canCreatePublicLinks: true,
+      canManageWorkspace: true,
+      canRunAgent: true,
+    },
+    legacy: false,
+  };
+
+  try {
+    const { writeFile } = await import('../app/lib/filesystem/workspace-files');
+    await fs.writeFile(path.join(root, 'deck.md'), 'before\n', { mode: 0o640 });
+    await writeFile('deck.md', 'after\n', { workspace });
+
+    assert.equal(await fs.readFile(path.join(root, 'deck.md'), 'utf8'), 'after\n');
+    assert.equal((await fs.stat(path.join(root, 'deck.md'))).mode & 0o777, 0o640);
+    assert.equal((await fs.readdir(root)).some((name) => name.includes('.canvas-write-')), false);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+
+  console.log('atomic-workspace-write-test: ok');
+}
+
+void main();

--- a/scripts/atomic-workspace-write-test.ts
+++ b/scripts/atomic-workspace-write-test.ts
@@ -27,7 +27,8 @@ async function main() {
   };
 
   try {
-    const { writeFile } = await import('../app/lib/filesystem/workspace-files');
+    const { WorkspaceFileRevisionError, assertWorkspaceFileRevisionUnchanged, getWorkspaceFileRevision } = await import('../app/lib/files/revision-guard');
+    const { replaceWorkspaceFileFromPath, writeFile } = await import('../app/lib/filesystem/workspace-files');
     await fs.writeFile(path.join(root, 'deck.md'), 'before\n', { mode: 0o640 });
     let beforeReplaceCalled = false;
     await writeFile('deck.md', 'after\n', { workspace }, async () => {
@@ -58,6 +59,53 @@ async function main() {
     await Promise.all([firstWrite, secondWrite]);
     assert.equal(secondWriteReachedReplace, true);
     assert.equal(await fs.readFile(path.join(root, 'deck.md'), 'utf8'), 'second\n');
+
+    const uploadSource = path.join(root, 'upload-source.md');
+    await fs.writeFile(uploadSource, 'uploaded\n');
+    let releaseUploadReplace!: () => void;
+    const uploadReplaceCanFinish = new Promise<void>((resolve) => { releaseUploadReplace = resolve; });
+    let uploadReplaceReady!: () => void;
+    const uploadReplaceReadySignal = new Promise<void>((resolve) => { uploadReplaceReady = resolve; });
+    let overlappingWriteReachedReplace = false;
+    const uploadReplace = replaceWorkspaceFileFromPath(
+      uploadSource,
+      'deck.md',
+      { workspace },
+      async () => {
+        uploadReplaceReady();
+        await uploadReplaceCanFinish;
+      },
+    );
+    await uploadReplaceReadySignal;
+    const overlappingWrite = writeFile('deck.md', 'newer\n', { workspace }, async () => {
+      overlappingWriteReachedReplace = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(overlappingWriteReachedReplace, false);
+    releaseUploadReplace();
+    await Promise.all([uploadReplace, overlappingWrite]);
+    assert.equal(overlappingWriteReachedReplace, true);
+    assert.equal(await fs.readFile(path.join(root, 'deck.md'), 'utf8'), 'newer\n');
+
+    const observedDeckRevision = await getWorkspaceFileRevision('deck.md', { workspace });
+    await writeFile('deck.md', 'changed again\n', { workspace });
+    await assert.rejects(
+      () => assertWorkspaceFileRevisionUnchanged({
+        path: 'deck.md',
+        expectedRevision: observedDeckRevision,
+        options: { workspace },
+      }),
+      (error) => error instanceof WorkspaceFileRevisionError && error.code === 'FILE_REVISION_CONFLICT',
+    );
+    await writeFile('created-after-check.md', 'created\n', { workspace });
+    await assert.rejects(
+      () => assertWorkspaceFileRevisionUnchanged({
+        path: 'created-after-check.md',
+        expectedRevision: null,
+        options: { workspace },
+      }),
+      (error) => error instanceof WorkspaceFileRevisionError && error.code === 'FILE_REVISION_CONFLICT',
+    );
   } finally {
     await fs.rm(root, { recursive: true, force: true });
   }

--- a/scripts/atomic-workspace-write-test.ts
+++ b/scripts/atomic-workspace-write-test.ts
@@ -38,6 +38,26 @@ async function main() {
     assert.equal(await fs.readFile(path.join(root, 'deck.md'), 'utf8'), 'after\n');
     assert.equal((await fs.stat(path.join(root, 'deck.md'))).mode & 0o777, 0o640);
     assert.equal((await fs.readdir(root)).some((name) => name.includes('.canvas-write-')), false);
+
+    let releaseFirstWrite!: () => void;
+    const firstWriteCanFinish = new Promise<void>((resolve) => { releaseFirstWrite = resolve; });
+    let firstWriteIsReady!: () => void;
+    const firstWriteReady = new Promise<void>((resolve) => { firstWriteIsReady = resolve; });
+    let secondWriteReachedReplace = false;
+    const firstWrite = writeFile('deck.md', 'first\n', { workspace }, async () => {
+      firstWriteIsReady();
+      await firstWriteCanFinish;
+    });
+    await firstWriteReady;
+    const secondWrite = writeFile('deck.md', 'second\n', { workspace }, async () => {
+      secondWriteReachedReplace = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(secondWriteReachedReplace, false);
+    releaseFirstWrite();
+    await Promise.all([firstWrite, secondWrite]);
+    assert.equal(secondWriteReachedReplace, true);
+    assert.equal(await fs.readFile(path.join(root, 'deck.md'), 'utf8'), 'second\n');
   } finally {
     await fs.rm(root, { recursive: true, force: true });
   }

--- a/scripts/file-open-flow-test.ts
+++ b/scripts/file-open-flow-test.ts
@@ -14,6 +14,13 @@ function deferred() {
   return { promise, release };
 }
 
+function testIdenticalDraftDoesNotBecomeDirty() {
+  useEditorStore.getState().setActiveFile('slides.md', '# Slide\n');
+  useEditorStore.getState().updateDraft('# Slide\n');
+  assert.equal(useEditorStore.getState().isDirty, false);
+  assert.equal(useEditorStore.getState().draft, '# Slide\n');
+}
+
 function treeResponse(data: FileNode[]) {
   return Response.json({ success: true, data });
 }
@@ -504,6 +511,7 @@ function testExplorerPreferencesAreScopedByWorkspace() {
 
 async function main() {
   try {
+    testIdenticalDraftDoesNotBecomeDirty();
     await testConcurrentDirectoryLoadsShareTheSamePromise();
     await testLatestOpenRequestWins();
     await testCreatedEmptyFileOpensAfterCreateRefresh();

--- a/scripts/file-revision-guard-test.ts
+++ b/scripts/file-revision-guard-test.ts
@@ -71,12 +71,17 @@ async function main() {
       options: { workspace: personalWorkspace },
       requireExpectedRevision: workspaceRequiresRevisionCheck(personalWorkspace),
     }));
-    await assert.doesNotReject(() => assertWorkspaceFileRevisionAllowed({
+    await assert.rejects(() => assertWorkspaceFileRevisionAllowed({
       path: 'notes.md',
       expectedSha256: '0'.repeat(64),
       options: { workspace: personalWorkspace },
       requireExpectedRevision: workspaceRequiresRevisionCheck(personalWorkspace),
-    }));
+    }), (error) => error instanceof WorkspaceFileRevisionError && error.code === 'FILE_REVISION_CONFLICT');
+
+    await fs.chmod(path.join(personalRoot, 'notes.md'), 0o640);
+    await writeFile('notes.md', 'personal v2\n', { workspace: personalWorkspace });
+    assert.equal(await fs.readFile(path.join(personalRoot, 'notes.md'), 'utf8'), 'personal v2\n');
+    assert.equal((await fs.stat(path.join(personalRoot, 'notes.md'))).mode & 0o777, 0o640);
 
     await writeFile('team.md', 'team v1\n', { workspace: teamWorkspace });
     const teamRevision = await getWorkspaceFileRevision('team.md', { workspace: teamWorkspace });

--- a/scripts/markdown-rich-blocks-ui-test.ts
+++ b/scripts/markdown-rich-blocks-ui-test.ts
@@ -7,6 +7,10 @@ const editorSource = fs.readFileSync(
   path.join(root, 'app', 'components', 'editor', 'MarkdownEditor.tsx'),
   'utf8',
 );
+const codeEditorSource = fs.readFileSync(
+  path.join(root, 'app', 'components', 'editor', 'CodeEditor.tsx'),
+  'utf8',
+);
 const editorStyles = fs.readFileSync(path.join(root, 'app', 'globals.css'), 'utf8');
 const collaborationSource = fs.readFileSync(
   path.join(root, 'app', 'lib', 'collaboration', 'markdown-state.ts'),
@@ -135,6 +139,16 @@ assert.match(
   collaborationSource,
   /richMarkdownCodecExtensions/u,
   'the server collaboration schema must use the shared rich Markdown codec',
+);
+assert.match(
+  editorSource,
+  /<CodeEditor[\s\S]*?collaborationEnabled=\{collaborationEnabled\}/u,
+  'source-only Markdown must keep collaboration enabled through the plain-text editor',
+);
+assert.match(
+  codeEditorSource,
+  /representation:\s*'plain_text'/u,
+  'the source editor must request the plain-text collaboration representation',
 );
 
 for (const selector of [

--- a/scripts/markdown-rich-blocks-ui-test.ts
+++ b/scripts/markdown-rich-blocks-ui-test.ts
@@ -133,8 +133,8 @@ assert.match(
 );
 assert.match(
   collaborationSource,
-  /\.\.\.canvasRichMarkdownExtensions\(\)/u,
-  'the server collaboration schema must use the same rich Markdown extensions as the browser',
+  /richMarkdownCodecExtensions/u,
+  'the server collaboration schema must use the shared rich Markdown codec',
 );
 
 for (const selector of [

--- a/scripts/markdown-roundtrip-preservation-test.ts
+++ b/scripts/markdown-roundtrip-preservation-test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  analyzeMarkdownRichMode,
+  serializeRichMarkdownBody,
+} from '../app/lib/markdown/rich-markdown-codec';
+import {
+  composeCanvasMarkdownDocument,
+  splitCanvasMarkdownForRichEditor,
+} from '../app/lib/markdown/obsidian-metadata';
+
+const fixtureRoot = path.join(process.cwd(), 'tests', 'fixtures', 'markdown-roundtrip');
+
+function readFixture(name: string): string {
+  return fs.readFileSync(path.join(fixtureRoot, name), 'utf8');
+}
+
+const safeFixture = readFixture('marp-frontmatter-safe.md');
+const safeParts = splitCanvasMarkdownForRichEditor(safeFixture);
+assert.equal(composeCanvasMarkdownDocument(safeParts.prefix, safeParts.body), safeFixture);
+assert.deepEqual(analyzeMarkdownRichMode(safeFixture), {
+  mode: 'rich',
+  prefix: safeParts.prefix,
+  body: safeParts.body,
+});
+
+assert.equal(serializeRichMarkdownBody(safeParts.body), safeParts.body);
+
+const directiveFixture = readFixture('marp-directive-source-only.md');
+assert.deepEqual(analyzeMarkdownRichMode(directiveFixture), {
+  mode: 'source',
+  reason: 'unsupported_marp_directive',
+});
+
+const invalidFrontmatter = '---\n: invalid: yaml\n---\n# Body\n';
+assert.deepEqual(analyzeMarkdownRichMode(invalidFrontmatter), {
+  mode: 'source',
+  reason: 'invalid_frontmatter',
+});
+
+const crlfBody = '---\r\nmarp: true\r\n---\r\n\r\n# Slide\r\n';
+assert.equal(analyzeMarkdownRichMode(crlfBody).mode, 'rich');
+
+console.log('markdown-roundtrip-preservation-test: ok');

--- a/scripts/markdown-roundtrip-preservation-test.ts
+++ b/scripts/markdown-roundtrip-preservation-test.ts
@@ -10,6 +10,7 @@ import {
   composeCanvasMarkdownDocument,
   splitCanvasMarkdownForRichEditor,
 } from '../app/lib/markdown/obsidian-metadata';
+import { hasMarpDirective } from '../app/lib/marp/detect';
 
 const fixtureRoot = path.join(process.cwd(), 'tests', 'fixtures', 'markdown-roundtrip');
 
@@ -33,6 +34,9 @@ assert.deepEqual(analyzeMarkdownRichMode(directiveFixture), {
   mode: 'source',
   reason: 'unsupported_marp_directive',
 });
+assert.equal(hasMarpDirective(safeFixture), true);
+assert.equal(hasMarpDirective('---\nmarp: "true"\n---\n# Slide\n'), true);
+assert.equal(hasMarpDirective('---\nmarp: false\n---\n# Note\n'), false);
 
 const invalidFrontmatter = '---\n: invalid: yaml\n---\n# Body\n';
 assert.deepEqual(analyzeMarkdownRichMode(invalidFrontmatter), {

--- a/scripts/mobile-collaboration-ticket-test.ts
+++ b/scripts/mobile-collaboration-ticket-test.ts
@@ -91,7 +91,9 @@ const routeSource = readFileSync(
 );
 const serverSource = readFileSync(path.join(root, 'server/collaboration-server.ts'), 'utf8');
 assert.match(routeSource, /issueMobileCollaborationTicket/u);
-assert.match(routeSource, /requestedPath\.endsWith\('\.txt'\) \? 'plain_text' : 'tiptap_xml'/u);
+assert.match(routeSource, /analyzeMarkdownRichMode/u);
+assert.match(routeSource, /representation,/u);
+assert.match(routeSource, /error instanceof CollaborationSessionError && error\.code/u);
 assert.match(routeSource, /richTextSchemaVersion: RICH_MARKDOWN_SCHEMA_VERSION/u);
 assert.equal(RICH_MARKDOWN_SCHEMA_VERSION, 3);
 assert.match(serverSource, /consumeMobileCollaborationTicket/u);

--- a/scripts/mobile-notebook-test.ts
+++ b/scripts/mobile-notebook-test.ts
@@ -33,6 +33,8 @@ async function main() {
       normalizeMobileNotebookPath,
       readMobileNotebookDocument,
       saveMobileNotebookDocument,
+      selectMobileCollaborationRepresentation,
+      shouldReadMobileCollaborationSnapshot,
     } = await import('../app/lib/mobile/notebook');
     const workspace = createLegacyPersonalWorkspaceContext({
       userId: 'notebook-user',
@@ -54,6 +56,11 @@ async function main() {
     assert.equal(search.items.length, 1);
     assert.equal(search.items[0]?.path, 'Research/Beta.markdown');
     assert.equal(search.items[0]?.match, 'content');
+
+    const protectedSource = '---\nmarp: true\n---\n<!-- _class: lead -->\n# Exact source\n';
+    assert.equal(selectMobileCollaborationRepresentation('Protected.md', protectedSource), 'plain_text');
+    assert.equal(shouldReadMobileCollaborationSnapshot('plain_text', 'tiptap_xml'), false);
+    assert.equal(shouldReadMobileCollaborationSnapshot('plain_text', 'plain_text'), true);
 
     const loaded = await readMobileNotebookDocument({
       workspace,

--- a/tests/fixtures/markdown-roundtrip/marp-directive-source-only.md
+++ b/tests/fixtures/markdown-roundtrip/marp-directive-source-only.md
@@ -1,0 +1,10 @@
+---
+marp: true
+theme: default
+---
+
+<!-- _class: lead -->
+
+# Opening slide
+
+This directive must remain source-only.

--- a/tests/fixtures/markdown-roundtrip/marp-frontmatter-safe.md
+++ b/tests/fixtures/markdown-roundtrip/marp-frontmatter-safe.md
@@ -1,0 +1,11 @@
+---
+marp: true
+theme: default
+paginate: true
+custom-field:
+  audience: internal
+---
+
+# Opening slide
+
+Canonical **body** text.


### PR DESCRIPTION
## Summary
- add a shared, conservative lossless Markdown codec and MARP roundtrip fixtures
- keep documents requiring source preservation out of the rich editor and rich collaboration paths
- harden revision-guarded saves with per-file serialization and atomic replacement

## Validation
- npm run test:editor:preservation
- npm run test:editor:rich-blocks
- npm run test:markdown:obsidian
- npm run test:files:atomic
- npm run test:file-watcher
- npm run test:files:collaboration
- npm run build

Browser/Playwright tests were not run because no explicit approval was requested.











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds conservative Markdown roundtrip analysis so source-sensitive Marp and Obsidian documents avoid lossy rich-editor and collaboration paths. It also strengthens revision-aware file replacement.
- Shares one rich Markdown codec across editor and collaboration serialization.
- Selects collaboration representations from current source and preserves exact source on mobile reads.
- Serializes supported path mutations, revalidates uploads before replacement, and uses same-directory atomic writes.
- Adds focused roundtrip, collaboration, revision, and atomic-write regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/markdown/rich-markdown-codec.ts | Introduces the shared conservative rich-mode analysis and serialization configuration used to prevent lossy Markdown roundtrips. |
| app/lib/collaboration/session-service.ts | Enforces source-derived collaboration representation requirements before granting sessions, including existing-state paths. |
| app/lib/mobile/notebook.ts | Derives the mobile representation from current source and avoids returning incompatible rich snapshots for source-only documents. |
| app/lib/files/workspace-upload-flow.ts | Captures the initial target revision and supplies immediate pre-replacement revision and collaboration validation. |
| app/lib/filesystem/workspace-files.ts | Adds path-scoped mutation serialization and same-directory atomic replacement for supported write, upload, and overwrite-rename paths. |
| app/lib/files/write-service.ts | Serializes file saves and revalidates supplied revisions within the atomic write path. |
| app/components/editor/MarkdownEditor.tsx | Routes preservation-sensitive documents to source mode and retains final line-ending behavior for rich edits. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Read Markdown source] --> B{Lossless rich roundtrip?}
  B -- Yes --> C[Rich editor / tiptap_xml]
  B -- No --> D[Source editor / plain_text]
  C --> E[Revision-aware save]
  D --> E
  E --> F[Acquire workspace-path lock]
  F --> G[Revalidate current revision]
  G --> H[Atomic same-directory replacement]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Preserve source-only mobile notebook rea..."](https://github.com/canvascoding/canvas-notebook/commit/d25a33f77c8097f095210ffe4b5f97fb28a623de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55541841)</sub>

<!-- /greptile_comment -->