### PR TITLE
Fix exposed MCP OAuth 500 flow

### DIFF
--- a/app/.well-known/oauth-protected-resource/mcp/route.ts
+++ b/app/.well-known/oauth-protected-resource/mcp/route.ts
@@ -5,8 +5,8 @@ import {
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(): Promise<Response> {
-  return directMcpProtectedResourceMetadataResponse();
+export async function GET(request: Request): Promise<Response> {
+  return directMcpProtectedResourceMetadataResponse(request);
 }
 
 export async function OPTIONS(): Promise<Response> {

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -5,8 +5,8 @@ import {
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(): Promise<Response> {
-  return directMcpProtectedResourceMetadataResponse();
+export async function GET(request: Request): Promise<Response> {
+  return directMcpProtectedResourceMetadataResponse(request);
 }
 
 export async function OPTIONS(): Promise<Response> {

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -124,18 +124,6 @@ function directMcpOAuthUnavailableResponse(): Response {
   );
 }
 
-async function isSelfContainedAccessTokenRevocationRejection(
-  response: Response,
-): Promise<boolean> {
-  if (response.status !== 400) return false;
-  try {
-    const body = (await response.clone().json()) as { error?: unknown };
-    return body.error === 'unsupported_token_type';
-  } catch {
-    return false;
-  }
-}
-
 async function handleDirectMcpOAuthRequest(
   request: NextRequest,
   handler: () => Promise<Response>,
@@ -185,6 +173,22 @@ export async function POST(request: NextRequest) {
     if (policyResponse) return policyResponse;
     const revocationCandidate = await prepareDirectMcpRevocation(request);
 
+    if (revocationCandidate) {
+      try {
+        await applyDirectMcpRevocation(revocationCandidate);
+        return new Response(null, {
+          status: 200,
+          headers: { 'cache-control': 'no-store' },
+        });
+      } catch {
+        console.error('[auth] Failed to revoke the local Direct MCP grant.');
+        return NextResponse.json({
+          error: 'temporarily_unavailable',
+          error_description: 'The local OAuth grant could not be revoked.',
+        }, { status: 503, headers: { 'cache-control': 'no-store', pragma: 'no-cache' } });
+      }
+    }
+
     const action = authAuditAction(pathname);
     const beforeUserId = action ? await getCurrentAuthUserId(request) : null;
 
@@ -200,35 +204,6 @@ export async function POST(request: NextRequest) {
     }
 
     const response = await auth.handler(request);
-    const providerRejectedSelfContainedAccessToken =
-      revocationCandidate?.tokenType === 'access_token'
-      && await isSelfContainedAccessTokenRevocationRejection(response);
-    if ((response.ok || providerRejectedSelfContainedAccessToken) && revocationCandidate) {
-      try {
-        await applyDirectMcpRevocation(revocationCandidate);
-      } catch {
-        console.error('[auth] Failed to revoke the local Direct MCP grant.');
-        return NextResponse.json(
-          {
-            error: 'temporarily_unavailable',
-            error_description: 'The local OAuth grant could not be revoked.',
-          },
-          {
-            status: 503,
-            headers: {
-              'cache-control': 'no-store',
-              pragma: 'no-cache',
-            },
-          },
-        );
-      }
-    }
-    if (providerRejectedSelfContainedAccessToken) {
-      return new Response(null, {
-        status: 200,
-        headers: { 'cache-control': 'no-store' },
-      });
-    }
     try {
       await initializeCreatedUserOnboarding(pathname, response);
     } catch (error) {

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -124,6 +124,18 @@ function directMcpOAuthUnavailableResponse(): Response {
   );
 }
 
+async function isSelfContainedAccessTokenRevocationRejection(
+  response: Response,
+): Promise<boolean> {
+  if (response.status !== 400) return false;
+  try {
+    const body = (await response.clone().json()) as { error?: unknown };
+    return body.error === 'unsupported_token_type';
+  } catch {
+    return false;
+  }
+}
+
 async function handleDirectMcpOAuthRequest(
   request: NextRequest,
   handler: () => Promise<Response>,
@@ -188,7 +200,10 @@ export async function POST(request: NextRequest) {
     }
 
     const response = await auth.handler(request);
-    if (response.ok && revocationCandidate) {
+    const providerRejectedSelfContainedAccessToken =
+      revocationCandidate?.tokenType === 'access_token'
+      && await isSelfContainedAccessTokenRevocationRejection(response);
+    if ((response.ok || providerRejectedSelfContainedAccessToken) && revocationCandidate) {
       try {
         await applyDirectMcpRevocation(revocationCandidate);
       } catch {
@@ -207,6 +222,12 @@ export async function POST(request: NextRequest) {
           },
         );
       }
+    }
+    if (providerRejectedSelfContainedAccessToken) {
+      return new Response(null, {
+        status: 200,
+        headers: { 'cache-control': 'no-store' },
+      });
     }
     try {
       await initializeCreatedUserOnboarding(pathname, response);

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -5,11 +5,20 @@ import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { requireTeamRuntimeRoute } from '@/app/lib/license/team-route-guard';
 import { initializeUserOnboarding } from '@/app/lib/user-preferences';
 import { isOnboardingComplete, isOnboardingEnabled } from '@/app/lib/onboarding/status';
-import { enforceDirectMcpOAuthRequestPolicy } from '@/app/lib/mcp/server/oauth-request-policy';
+import {
+  enforceDirectMcpOAuthRequestPolicy,
+  isDirectMcpOAuthPath,
+} from '@/app/lib/mcp/server/oauth-request-policy';
 import {
   applyDirectMcpRevocation,
   prepareDirectMcpRevocation,
 } from '@/app/lib/mcp/server/oauth-grant-revocation';
+import {
+  beginDirectMcpDiagnostic,
+  completeDirectMcpDiagnostic,
+  failDirectMcpDiagnostic,
+  withDirectMcpRequestId,
+} from '@/app/lib/mcp/server/diagnostics';
 
 function hasAuthPathSegment(pathname: string, segment: string): boolean {
   return new RegExp(`/${segment}(?:/|$)`).test(pathname);
@@ -99,65 +108,114 @@ async function initializeCreatedUserOnboarding(pathname: string, response: Respo
   await initializeUserOnboarding(userId);
 }
 
-export async function GET(request: NextRequest) {
-  const policyResponse = await enforceDirectMcpOAuthRequestPolicy(request);
-  if (policyResponse) return policyResponse;
+function directMcpOAuthUnavailableResponse(): Response {
+  return NextResponse.json(
+    {
+      error: 'temporarily_unavailable',
+      error_description: 'The Direct MCP OAuth service is temporarily unavailable.',
+    },
+    {
+      status: 503,
+      headers: {
+        'cache-control': 'no-store',
+        pragma: 'no-cache',
+      },
+    },
+  );
+}
 
-  if (isTeamUserManagementPath(request.nextUrl.pathname)) {
-    const licenseResponse = await requireTeamRuntimeRoute();
-    if (licenseResponse) return licenseResponse;
+async function handleDirectMcpOAuthRequest(
+  request: NextRequest,
+  handler: () => Promise<Response>,
+): Promise<Response> {
+  if (!isDirectMcpOAuthPath(request.nextUrl.pathname)) return handler();
+
+  const startedAt = Date.now();
+  const diagnostics = beginDirectMcpDiagnostic(request, 'oauth.request');
+  try {
+    const response = withDirectMcpRequestId(await handler(), diagnostics.requestId);
+    completeDirectMcpDiagnostic(diagnostics, {
+      statusCode: response.status,
+      code: response.status >= 500 ? 'OAUTH_PROVIDER_ERROR' : 'OAUTH_REQUEST_COMPLETED',
+      startedAt,
+    });
+    return response;
+  } catch {
+    failDirectMcpDiagnostic(diagnostics, {
+      code: 'OAUTH_INTERNAL_ERROR',
+      startedAt,
+      statusCode: 503,
+    });
+    return withDirectMcpRequestId(
+      directMcpOAuthUnavailableResponse(),
+      diagnostics.requestId,
+    );
   }
-  return auth.handler(request);
+}
+
+export async function GET(request: NextRequest) {
+  return handleDirectMcpOAuthRequest(request, async () => {
+    const policyResponse = await enforceDirectMcpOAuthRequestPolicy(request);
+    if (policyResponse) return policyResponse;
+
+    if (isTeamUserManagementPath(request.nextUrl.pathname)) {
+      const licenseResponse = await requireTeamRuntimeRoute();
+      if (licenseResponse) return licenseResponse;
+    }
+    return auth.handler(request);
+  });
 }
 
 export async function POST(request: NextRequest) {
-  const pathname = request.nextUrl.pathname;
-  const policyResponse = await enforceDirectMcpOAuthRequestPolicy(request);
-  if (policyResponse) return policyResponse;
-  const revocationCandidate = await prepareDirectMcpRevocation(request);
+  return handleDirectMcpOAuthRequest(request, async () => {
+    const pathname = request.nextUrl.pathname;
+    const policyResponse = await enforceDirectMcpOAuthRequestPolicy(request);
+    if (policyResponse) return policyResponse;
+    const revocationCandidate = await prepareDirectMcpRevocation(request);
 
-  const action = authAuditAction(pathname);
-  const beforeUserId = action ? await getCurrentAuthUserId(request) : null;
+    const action = authAuditAction(pathname);
+    const beforeUserId = action ? await getCurrentAuthUserId(request) : null;
 
-  if (hasAuthPathSegment(pathname, 'sign-up')) {
-    const response = NextResponse.json({ message: 'Sign up is disabled' }, { status: 403 });
+    if (hasAuthPathSegment(pathname, 'sign-up')) {
+      const response = NextResponse.json({ message: 'Sign up is disabled' }, { status: 403 });
+      if (action) await recordAuthRequestAudit(request, action, response, beforeUserId);
+      return response;
+    }
+
+    if (isTeamUserManagementPath(pathname)) {
+      const licenseResponse = await requireTeamRuntimeRoute();
+      if (licenseResponse) return licenseResponse;
+    }
+
+    const response = await auth.handler(request);
+    if (response.ok && revocationCandidate) {
+      try {
+        await applyDirectMcpRevocation(revocationCandidate);
+      } catch {
+        console.error('[auth] Failed to revoke the local Direct MCP grant.');
+        return NextResponse.json(
+          {
+            error: 'temporarily_unavailable',
+            error_description: 'The local OAuth grant could not be revoked.',
+          },
+          {
+            status: 503,
+            headers: {
+              'cache-control': 'no-store',
+              pragma: 'no-cache',
+            },
+          },
+        );
+      }
+    }
+    try {
+      await initializeCreatedUserOnboarding(pathname, response);
+    } catch (error) {
+      // Account creation must keep Better Auth's response semantics. The admin
+      // UI retries the explicit initializer if persistence briefly fails.
+      console.error('[auth] Failed to initialize personal onboarding for created user:', error);
+    }
     if (action) await recordAuthRequestAudit(request, action, response, beforeUserId);
     return response;
-  }
-
-  if (isTeamUserManagementPath(pathname)) {
-    const licenseResponse = await requireTeamRuntimeRoute();
-    if (licenseResponse) return licenseResponse;
-  }
-
-  const response = await auth.handler(request);
-  if (response.ok && revocationCandidate) {
-    try {
-      await applyDirectMcpRevocation(revocationCandidate);
-    } catch (error) {
-      console.error('[auth] Failed to revoke the local Direct MCP grant:', error);
-      return NextResponse.json(
-        {
-          error: 'temporarily_unavailable',
-          error_description: 'The local OAuth grant could not be revoked.',
-        },
-        {
-          status: 503,
-          headers: {
-            'cache-control': 'no-store',
-            pragma: 'no-cache',
-          },
-        },
-      );
-    }
-  }
-  try {
-    await initializeCreatedUserOnboarding(pathname, response);
-  } catch (error) {
-    // Account creation must keep Better Auth's response semantics. The admin
-    // UI retries the explicit initializer if persistence briefly fails.
-    console.error('[auth] Failed to initialize personal onboarding for created user:', error);
-  }
-  if (action) await recordAuthRequestAudit(request, action, response, beforeUserId);
-  return response;
+  });
 }

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@/app/lib/organization/bootstrap';
 import { getCollaborationRuntimeHealth, setCollaborationRuntimeHealth } from '@/app/lib/collaboration/health';
 import { requireRuntimeCapability, requireTeamRuntimeLicense } from '@/app/lib/license/entitlements';
+import { getDirectMcpReadiness } from '@/app/lib/mcp/server/readiness';
 
 export async function GET() {
   const checks: Record<string, 'ok' | 'error'> = {
@@ -23,6 +24,10 @@ export async function GET() {
   const teamFeaturesEnabled = areTeamFeaturesEnabled(deploymentMode);
   const providerGate = resolveDatabaseProviderGate({ teamFeaturesEnabled });
   const collaboration = getCollaborationRuntimeHealth();
+  const mcpReadiness = await getDirectMcpReadiness();
+
+  checks.mcp = mcpReadiness.status === 'failed' ? 'error' : 'ok';
+  if (mcpReadiness.status === 'failed') status = 503;
 
   if (!providerGate.ok) {
     checks.databaseProvider = 'error';
@@ -93,6 +98,7 @@ export async function GET() {
         enabled: teamFeaturesEnabled && checks.collaboration === 'ok' && getCollaborationRuntimeHealth().capabilityReady,
         ...getCollaborationRuntimeHealth(),
       },
+      mcp: mcpReadiness,
       timestamp: new Date().toISOString(),
     },
     { status }

--- a/app/api/integrations/mcp-server/route.ts
+++ b/app/api/integrations/mcp-server/route.ts
@@ -5,6 +5,8 @@ import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { auth } from '@/app/lib/auth';
 import { getDirectMcpServerSettingsStatus } from '@/app/lib/mcp/server/settings-status';
 import { applyDirectMcpSettingsToRuntime } from '@/app/lib/mcp/server/runtime-settings';
+import { getDirectMcpReadiness } from '@/app/lib/mcp/server/readiness';
+import { DIRECT_MCP_TOOL_IDS, type DirectMcpToolId } from '@/app/lib/mcp/server/config';
 import { setDirectMcpServerPreferences } from '@/app/lib/server-settings';
 
 function errorMessage(error: unknown, fallback: string): string {
@@ -86,6 +88,35 @@ export async function PATCH(request: NextRequest) {
         },
         { status: 409 },
       );
+    }
+
+    const validTools = new Set<string>(DIRECT_MCP_TOOL_IDS);
+    if (payload.tools.some((tool) => typeof tool !== 'string' || !validTools.has(tool))) {
+      return NextResponse.json(
+        {
+          success: false,
+          code: 'MCP_CAPABILITIES_INVALID',
+          error: 'MCP server capabilities contain an unsupported value.',
+        },
+        { status: 422 },
+      );
+    }
+
+    if (payload.enabled) {
+      const readiness = await getDirectMcpReadiness({
+        enabled: true,
+        tools: payload.tools as DirectMcpToolId[],
+      });
+      if (readiness.status !== 'ready') {
+        return NextResponse.json(
+          {
+            success: false,
+            code: readiness.code,
+            error: 'Direct MCP cannot be enabled until its OAuth runtime is ready.',
+          },
+          { status: 503 },
+        );
+      }
     }
 
     const preferences = await setDirectMcpServerPreferences(session.user.id, {

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -351,6 +351,24 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_oauth_access_token_refresh
       ON oauth_access_token (refresh_id);
 
+    -- Direct MCP uses self-contained JWT access tokens. Keep only a digest of
+    -- an explicitly revoked token so a single token can be made inactive
+    -- without revoking the browser session or other OAuth grants.
+    CREATE TABLE IF NOT EXISTS mcp_revoked_access_token (
+      token_hash TEXT PRIMARY KEY NOT NULL,
+      client_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      expires_at INTEGER NOT NULL,
+      revoked_at INTEGER NOT NULL,
+      FOREIGN KEY (client_id) REFERENCES oauth_client(client_id) ON DELETE CASCADE,
+      FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_mcp_revoked_access_token_expiry
+      ON mcp_revoked_access_token (expires_at);
+
     CREATE TABLE IF NOT EXISTS oauth_consent (
       id TEXT PRIMARY KEY NOT NULL,
       client_id TEXT NOT NULL,

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -367,6 +367,17 @@ export const oauthAccessToken = sqliteTable("oauth_access_token", {
   refreshIdx: index("idx_oauth_access_token_refresh").on(table.refreshId),
 }));
 
+export const mcpRevokedAccessToken = sqliteTable("mcp_revoked_access_token", {
+  tokenHash: text("token_hash").primaryKey(),
+  clientId: text("client_id").notNull().references(() => oauthClient.clientId, { onDelete: "cascade" }),
+  sessionId: text("session_id").notNull().references(() => session.id, { onDelete: "cascade" }),
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+  revokedAt: integer("revoked_at", { mode: "timestamp_ms" }).notNull(),
+}, (table) => ({
+  expiryIdx: index("idx_mcp_revoked_access_token_expiry").on(table.expiresAt),
+}));
+
 export const oauthConsent = sqliteTable("oauth_consent", {
   id: text("id").primaryKey(),
   clientId: text("client_id").notNull().references(() => oauthClient.clientId, { onDelete: "cascade" }),

--- a/app/lib/mcp/server/access-token-verifier.ts
+++ b/app/lib/mcp/server/access-token-verifier.ts
@@ -1,5 +1,7 @@
 import 'server-only';
 
+import { createHash } from 'node:crypto';
+
 import type { JSONWebKeySet, JWTPayload } from 'jose';
 import { verifyJwsAccessToken } from 'better-auth/oauth2';
 
@@ -24,8 +26,7 @@ type DirectMcpGrantStateRow = {
   user_banned: unknown;
   client_id: string;
   client_disabled: unknown;
-  refresh_grant_count: unknown;
-  active_refresh_grant_count: unknown;
+  revoked_token_hash: string | null;
 };
 
 export type DirectMcpJwtClaims = {
@@ -239,6 +240,7 @@ export async function verifyDirectMcpJwtClaims(
 
 export async function loadDirectMcpGrantState(
   claims: Pick<DirectMcpJwtClaims, 'sessionId' | 'subject' | 'clientId'>,
+  token?: string,
 ): Promise<DirectMcpGrantStateRow | null> {
   const database = await openDb();
   try {
@@ -250,30 +252,26 @@ export async function loadDirectMcpGrantState(
         local_user.banned AS user_banned,
         oauth_client.client_id AS client_id,
         oauth_client.disabled AS client_disabled,
-        (
-          SELECT COUNT(*)
-          FROM oauth_refresh_token refresh_grant
-          WHERE refresh_grant.client_id = oauth_client.client_id
-            AND refresh_grant.session_id = auth_session.id
-            AND refresh_grant.user_id = local_user.id
-        ) AS refresh_grant_count,
-        (
-          SELECT COUNT(*)
-          FROM oauth_refresh_token refresh_grant
-          WHERE refresh_grant.client_id = oauth_client.client_id
-            AND refresh_grant.session_id = auth_session.id
-            AND refresh_grant.user_id = local_user.id
-            AND refresh_grant.revoked IS NULL
-        ) AS active_refresh_grant_count
+        revoked_access_token.token_hash AS revoked_token_hash
       FROM "session" auth_session
       INNER JOIN "user" local_user
         ON local_user.id = auth_session.user_id
       INNER JOIN oauth_client
         ON oauth_client.client_id = ?
+      LEFT JOIN mcp_revoked_access_token revoked_access_token
+        ON revoked_access_token.token_hash = ?
+       AND revoked_access_token.client_id = oauth_client.client_id
+       AND revoked_access_token.session_id = auth_session.id
+       AND revoked_access_token.user_id = local_user.id
       WHERE auth_session.id = ?
         AND auth_session.user_id = ?
       LIMIT 1
-    `, [claims.clientId, claims.sessionId, claims.subject]);
+    `, [
+      claims.clientId,
+      token ? createHash('sha256').update(token).digest('base64url') : '',
+      claims.sessionId,
+      claims.subject,
+    ]);
     return (row as DirectMcpGrantStateRow | undefined) ?? null;
   } finally {
     await database.close();
@@ -285,8 +283,6 @@ function assertGrantStateActive(
   claims: DirectMcpJwtClaims,
 ): void {
   const sessionExpiresAt = timestampToMilliseconds(state?.session_expires_at);
-  const refreshGrantCount = Number(state?.refresh_grant_count ?? 0);
-  const activeRefreshGrantCount = Number(state?.active_refresh_grant_count ?? 0);
   if (
     !state
     || state.session_id !== claims.sessionId
@@ -296,12 +292,7 @@ function assertGrantStateActive(
     || isDatabaseBoolean(state.client_disabled)
     || sessionExpiresAt === null
     || sessionExpiresAt <= Date.now()
-    // Test-generated JWTs and OAuth grants without refresh tokens have no
-    // local revocation record. Once a client/session has refresh grants,
-    // however, at least one must remain active for its access tokens to work.
-    || (Number.isFinite(refreshGrantCount)
-      && refreshGrantCount > 0
-      && (!Number.isFinite(activeRefreshGrantCount) || activeRefreshGrantCount < 1))
+    || state.revoked_token_hash !== null
   ) {
     throw invalidToken();
   }
@@ -328,7 +319,7 @@ export async function verifyDirectMcpAccessToken(
 
   let state: DirectMcpGrantStateRow | null;
   try {
-    state = await loadDirectMcpGrantState(claims);
+    state = await loadDirectMcpGrantState(claims, token);
   } catch {
     throw authorizationUnavailable();
   }

--- a/app/lib/mcp/server/access-token-verifier.ts
+++ b/app/lib/mcp/server/access-token-verifier.ts
@@ -24,6 +24,8 @@ type DirectMcpGrantStateRow = {
   user_banned: unknown;
   client_id: string;
   client_disabled: unknown;
+  refresh_grant_count: unknown;
+  active_refresh_grant_count: unknown;
 };
 
 export type DirectMcpJwtClaims = {
@@ -247,7 +249,22 @@ export async function loadDirectMcpGrantState(
         local_user.id AS user_id,
         local_user.banned AS user_banned,
         oauth_client.client_id AS client_id,
-        oauth_client.disabled AS client_disabled
+        oauth_client.disabled AS client_disabled,
+        (
+          SELECT COUNT(*)
+          FROM oauth_refresh_token refresh_grant
+          WHERE refresh_grant.client_id = oauth_client.client_id
+            AND refresh_grant.session_id = auth_session.id
+            AND refresh_grant.user_id = local_user.id
+        ) AS refresh_grant_count,
+        (
+          SELECT COUNT(*)
+          FROM oauth_refresh_token refresh_grant
+          WHERE refresh_grant.client_id = oauth_client.client_id
+            AND refresh_grant.session_id = auth_session.id
+            AND refresh_grant.user_id = local_user.id
+            AND refresh_grant.revoked IS NULL
+        ) AS active_refresh_grant_count
       FROM "session" auth_session
       INNER JOIN "user" local_user
         ON local_user.id = auth_session.user_id
@@ -268,6 +285,8 @@ function assertGrantStateActive(
   claims: DirectMcpJwtClaims,
 ): void {
   const sessionExpiresAt = timestampToMilliseconds(state?.session_expires_at);
+  const refreshGrantCount = Number(state?.refresh_grant_count ?? 0);
+  const activeRefreshGrantCount = Number(state?.active_refresh_grant_count ?? 0);
   if (
     !state
     || state.session_id !== claims.sessionId
@@ -277,6 +296,12 @@ function assertGrantStateActive(
     || isDatabaseBoolean(state.client_disabled)
     || sessionExpiresAt === null
     || sessionExpiresAt <= Date.now()
+    // Test-generated JWTs and OAuth grants without refresh tokens have no
+    // local revocation record. Once a client/session has refresh grants,
+    // however, at least one must remain active for its access tokens to work.
+    || (Number.isFinite(refreshGrantCount)
+      && refreshGrantCount > 0
+      && (!Number.isFinite(activeRefreshGrantCount) || activeRefreshGrantCount < 1))
   ) {
     throw invalidToken();
   }

--- a/app/lib/mcp/server/authorization-server-metadata.ts
+++ b/app/lib/mcp/server/authorization-server-metadata.ts
@@ -1,6 +1,12 @@
 import { oauthProviderAuthServerMetadata } from '@better-auth/oauth-provider';
 
 import { auth } from '@/app/lib/auth';
+import {
+  beginDirectMcpDiagnostic,
+  completeDirectMcpDiagnostic,
+  failDirectMcpDiagnostic,
+  withDirectMcpRequestId,
+} from '@/app/lib/mcp/server/diagnostics';
 import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
 
 const metadataHandler = oauthProviderAuthServerMetadata(auth, {
@@ -26,8 +32,35 @@ function disabledResponse(): Response {
 }
 
 export async function getAuthorizationServerMetadata(request: Request): Promise<Response> {
-  if (!(await getDirectMcpRuntimeSettings()).enabled) return disabledResponse();
-  return metadataHandler(request);
+  const startedAt = Date.now();
+  const diagnostics = beginDirectMcpDiagnostic(request, 'discovery.authorization_server');
+  try {
+    const response = withDirectMcpRequestId(
+      !(await getDirectMcpRuntimeSettings()).enabled
+        ? disabledResponse()
+        : await metadataHandler(request),
+      diagnostics.requestId,
+    );
+    completeDirectMcpDiagnostic(diagnostics, {
+      statusCode: response.status,
+      code: response.status === 404 ? 'MCP_DISABLED' : 'MCP_DISCOVERY_COMPLETED',
+      startedAt,
+    });
+    return response;
+  } catch {
+    failDirectMcpDiagnostic(diagnostics, {
+      code: 'MCP_DISCOVERY_ERROR',
+      startedAt,
+      statusCode: 500,
+    });
+    return withDirectMcpRequestId(Response.json({
+      error: 'temporarily_unavailable',
+      error_description: 'OAuth authorization server metadata is temporarily unavailable.',
+    }, {
+      status: 503,
+      headers: { 'cache-control': 'no-store' },
+    }), diagnostics.requestId);
+  }
 }
 
 export async function headAuthorizationServerMetadata(request: Request): Promise<Response> {

--- a/app/lib/mcp/server/diagnostics.ts
+++ b/app/lib/mcp/server/diagnostics.ts
@@ -1,0 +1,135 @@
+import 'server-only';
+
+import { createHmac, randomUUID } from 'node:crypto';
+
+import { resolveAuthSecret } from '@/app/lib/security/auth-secret';
+
+export type DirectMcpDiagnosticPhase =
+  | 'discovery.authorization_server'
+  | 'discovery.protected_resource'
+  | 'mcp.http'
+  | 'oauth.request';
+
+export type DirectMcpDiagnosticContext = {
+  requestId: string;
+  flowRef: string | null;
+  phase: DirectMcpDiagnosticPhase;
+  method: string;
+};
+
+type DirectMcpDiagnosticOutcome = 'started' | 'succeeded' | 'failed';
+
+type DirectMcpDiagnosticEvent = {
+  event: 'direct_mcp_diagnostic';
+  requestId: string;
+  flowRef?: string;
+  phase: DirectMcpDiagnosticPhase;
+  outcome: DirectMcpDiagnosticOutcome;
+  method: string;
+  statusCode?: number;
+  code: string;
+  durationMs?: number;
+};
+
+function createFlowRef(request: Request): string | null {
+  const url = new URL(request.url);
+  const state = url.searchParams.get('state');
+  const clientId = url.searchParams.get('client_id');
+  if (!state || !clientId) return null;
+
+  try {
+    return createHmac('sha256', resolveAuthSecret())
+      .update(`direct-mcp-oauth-flow:${clientId}:${state}`)
+      .digest('hex')
+      .slice(0, 24);
+  } catch {
+    // Diagnostics must never make an already invalid auth configuration worse.
+    return null;
+  }
+}
+
+function emitDiagnostic(event: DirectMcpDiagnosticEvent): void {
+  const serialized = JSON.stringify(event);
+  if (event.outcome === 'failed') {
+    console.error('[direct-mcp]', serialized);
+    return;
+  }
+  console.info('[direct-mcp]', serialized);
+}
+
+export function beginDirectMcpDiagnostic(
+  request: Request,
+  phase: DirectMcpDiagnosticPhase,
+): DirectMcpDiagnosticContext {
+  const context: DirectMcpDiagnosticContext = {
+    requestId: randomUUID(),
+    flowRef: createFlowRef(request),
+    phase,
+    method: request.method,
+  };
+  emitDiagnostic({
+    event: 'direct_mcp_diagnostic',
+    requestId: context.requestId,
+    ...(context.flowRef ? { flowRef: context.flowRef } : {}),
+    phase,
+    outcome: 'started',
+    method: context.method,
+    code: 'MCP_REQUEST_STARTED',
+  });
+  return context;
+}
+
+export function completeDirectMcpDiagnostic(
+  context: DirectMcpDiagnosticContext,
+  input: {
+    statusCode: number;
+    code: string;
+    startedAt: number;
+  },
+): void {
+  emitDiagnostic({
+    event: 'direct_mcp_diagnostic',
+    requestId: context.requestId,
+    ...(context.flowRef ? { flowRef: context.flowRef } : {}),
+    phase: context.phase,
+    outcome: input.statusCode >= 500 ? 'failed' : 'succeeded',
+    method: context.method,
+    statusCode: input.statusCode,
+    code: input.code,
+    durationMs: Math.max(0, Date.now() - input.startedAt),
+  });
+}
+
+export function failDirectMcpDiagnostic(
+  context: DirectMcpDiagnosticContext,
+  input: {
+    code: string;
+    startedAt: number;
+    statusCode?: number;
+  },
+): void {
+  emitDiagnostic({
+    event: 'direct_mcp_diagnostic',
+    requestId: context.requestId,
+    ...(context.flowRef ? { flowRef: context.flowRef } : {}),
+    phase: context.phase,
+    outcome: 'failed',
+    method: context.method,
+    ...(input.statusCode ? { statusCode: input.statusCode } : {}),
+    code: input.code,
+    durationMs: Math.max(0, Date.now() - input.startedAt),
+  });
+}
+
+export function withDirectMcpRequestId(
+  response: Response,
+  requestId: string,
+): Response {
+  const headers = new Headers(response.headers);
+  headers.set('x-request-id', requestId);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/app/lib/mcp/server/direct-server.ts
+++ b/app/lib/mcp/server/direct-server.ts
@@ -71,7 +71,7 @@ export function createDirectMcpServer(
     if (!tool) {
       throw new ProtocolError(
         ProtocolErrorCode.MethodNotFound,
-        `Unknown or disabled tool ${request.params.name}.`,
+        'The requested tool is not available.',
       );
     }
     return tool.execute(request.params.arguments, context.http?.authInfo);

--- a/app/lib/mcp/server/oauth-grant-revocation.ts
+++ b/app/lib/mcp/server/oauth-grant-revocation.ts
@@ -30,6 +30,7 @@ export type DirectMcpRevocationCandidate = {
   clientId: string;
   sessionId: string | null;
   userId: string;
+  tokenType: 'access_token' | 'refresh_token';
 };
 
 function isDatabaseBoolean(value: unknown): boolean {
@@ -161,6 +162,7 @@ async function prepareAccessTokenCandidate(
       clientId,
       sessionId: claims.sessionId,
       userId: claims.subject,
+      tokenType: 'access_token',
     };
   } catch (error) {
     if (error instanceof DirectMcpAuthorizationError) return null;
@@ -178,6 +180,7 @@ async function prepareRefreshTokenCandidate(
     clientId,
     sessionId: grant.session_id,
     userId: grant.user_id,
+    tokenType: 'refresh_token',
   };
 }
 

--- a/app/lib/mcp/server/oauth-grant-revocation.ts
+++ b/app/lib/mcp/server/oauth-grant-revocation.ts
@@ -234,12 +234,8 @@ export async function applyDirectMcpRevocation(
         SET revoked = COALESCE(revoked, ?)
         WHERE session_id = ?
           AND user_id = ?
-      `, [revokedAt, candidate.sessionId, candidate.userId]);
-      await database.run(`
-        DELETE FROM "session"
-        WHERE id = ?
-          AND user_id = ?
-      `, [candidate.sessionId, candidate.userId]);
+          AND client_id = ?
+      `, [revokedAt, candidate.sessionId, candidate.userId, candidate.clientId]);
     } else {
       await database.run(`
         UPDATE oauth_refresh_token

--- a/app/lib/mcp/server/oauth-grant-revocation.ts
+++ b/app/lib/mcp/server/oauth-grant-revocation.ts
@@ -31,6 +31,9 @@ export type DirectMcpRevocationCandidate = {
   sessionId: string | null;
   userId: string;
   tokenType: 'access_token' | 'refresh_token';
+  refreshId: string | null;
+  accessTokenHash: string | null;
+  accessTokenExpiresAt: number | null;
 };
 
 function isDatabaseBoolean(value: unknown): boolean {
@@ -163,6 +166,9 @@ async function prepareAccessTokenCandidate(
       sessionId: claims.sessionId,
       userId: claims.subject,
       tokenType: 'access_token',
+      refreshId: null,
+      accessTokenHash: storedTokenHash(token),
+      accessTokenExpiresAt: claims.expiresAt * 1000,
     };
   } catch (error) {
     if (error instanceof DirectMcpAuthorizationError) return null;
@@ -181,6 +187,9 @@ async function prepareRefreshTokenCandidate(
     sessionId: grant.session_id,
     userId: grant.user_id,
     tokenType: 'refresh_token',
+    refreshId: grant.id,
+    accessTokenHash: null,
+    accessTokenExpiresAt: null,
   };
 }
 
@@ -228,21 +237,31 @@ export async function applyDirectMcpRevocation(
   const revokedAt = Date.now();
   await database.run('BEGIN');
   try {
-    if (candidate.sessionId) {
+    if (candidate.accessTokenHash && candidate.sessionId && candidate.accessTokenExpiresAt) {
+      await database.run(`
+        INSERT INTO mcp_revoked_access_token (
+          token_hash, client_id, session_id, user_id, expires_at, revoked_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(token_hash) DO NOTHING
+      `, [
+        candidate.accessTokenHash,
+        candidate.clientId,
+        candidate.sessionId,
+        candidate.userId,
+        candidate.accessTokenExpiresAt,
+        revokedAt,
+      ]);
+    } else if (candidate.refreshId) {
       await database.run(`
         UPDATE oauth_refresh_token
         SET revoked = COALESCE(revoked, ?)
-        WHERE session_id = ?
-          AND user_id = ?
-          AND client_id = ?
-      `, [revokedAt, candidate.sessionId, candidate.userId, candidate.clientId]);
-    } else {
+        WHERE id = ? AND user_id = ? AND client_id = ?
+      `, [revokedAt, candidate.refreshId, candidate.userId, candidate.clientId]);
       await database.run(`
-        UPDATE oauth_refresh_token
-        SET revoked = COALESCE(revoked, ?)
-        WHERE client_id = ?
-          AND user_id = ?
-      `, [revokedAt, candidate.clientId, candidate.userId]);
+        UPDATE oauth_access_token
+        SET expires_at = CASE WHEN expires_at > ? THEN ? ELSE expires_at END
+        WHERE refresh_id = ? AND user_id = ? AND client_id = ?
+      `, [revokedAt, revokedAt, candidate.refreshId, candidate.userId, candidate.clientId]);
     }
     await database.run('COMMIT');
   } catch (error) {

--- a/app/lib/mcp/server/oauth-page-query.ts
+++ b/app/lib/mcp/server/oauth-page-query.ts
@@ -189,7 +189,9 @@ export async function resolveDirectMcpConsentPresentation(
   if (
     !client
     || client.disabled === true
-    || client.public !== true
+    // Better Auth derives public-client status from the `none` endpoint auth
+    // method and no longer persists the legacy `public` column for DCR rows.
+    || client.public === false
     || client.tokenEndpointAuthMethod !== 'none'
   ) {
     return null;

--- a/app/lib/mcp/server/oauth-request-policy.ts
+++ b/app/lib/mcp/server/oauth-request-policy.ts
@@ -54,6 +54,22 @@ function validateResourceValues(values: string[]): Response | null {
   return null;
 }
 
+function validateAuthorizationPkce(url: URL): Response | null {
+  const codeChallenge = url.searchParams.get('code_challenge')?.trim();
+  const codeChallengeMethod = url.searchParams.get('code_challenge_method');
+  if (
+    !codeChallenge
+    || !/^[A-Za-z0-9_-]{43,128}$/.test(codeChallenge)
+    || codeChallengeMethod !== 'S256'
+  ) {
+    return oauthError(
+      'invalid_request',
+      'Direct MCP authorization requires a S256 PKCE code challenge.',
+    );
+  }
+  return null;
+}
+
 function validateRegistrationBody(body: unknown): Response | null {
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
     return oauthError('invalid_client_metadata', 'The client metadata must be a JSON object.');
@@ -125,7 +141,10 @@ export async function enforceDirectMcpOAuthRequestPolicy(
     request.method === 'GET'
     && url.pathname === '/api/auth/oauth2/authorize'
   ) {
-    return validateResourceValues(url.searchParams.getAll('resource'));
+    return (
+      validateResourceValues(url.searchParams.getAll('resource'))
+      ?? validateAuthorizationPkce(url)
+    );
   }
 
   if (

--- a/app/lib/mcp/server/oauth-request-policy.ts
+++ b/app/lib/mcp/server/oauth-request-policy.ts
@@ -36,7 +36,7 @@ function disabledResponse(): Response {
   );
 }
 
-function isDirectMcpOAuthPath(pathname: string): boolean {
+export function isDirectMcpOAuthPath(pathname: string): boolean {
   return [
     '/api/auth/oauth2/register',
     '/api/auth/oauth2/authorize',

--- a/app/lib/mcp/server/protected-resource-metadata.ts
+++ b/app/lib/mcp/server/protected-resource-metadata.ts
@@ -2,6 +2,12 @@ import {
   DIRECT_MCP_RESOURCE_SCOPES,
   resolveDirectMcpOAuthConfig,
 } from '@/app/lib/mcp/server/config';
+import {
+  beginDirectMcpDiagnostic,
+  completeDirectMcpDiagnostic,
+  failDirectMcpDiagnostic,
+  withDirectMcpRequestId,
+} from '@/app/lib/mcp/server/diagnostics';
 import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
 
 export type DirectMcpProtectedResourceMetadata = {
@@ -24,23 +30,46 @@ Promise<DirectMcpProtectedResourceMetadata | null> {
   };
 }
 
-export async function directMcpProtectedResourceMetadataResponse(): Promise<Response> {
-  const metadata = await getDirectMcpProtectedResourceMetadata();
-  if (!metadata) {
-    return new Response(null, {
-      status: 404,
-      headers: {
-        'cache-control': 'no-store',
-      },
+export async function directMcpProtectedResourceMetadataResponse(
+  request: Request,
+): Promise<Response> {
+  const startedAt = Date.now();
+  const diagnostics = beginDirectMcpDiagnostic(request, 'discovery.protected_resource');
+  try {
+    const metadata = await getDirectMcpProtectedResourceMetadata();
+    const response = withDirectMcpRequestId(metadata
+      ? Response.json(metadata, {
+        headers: {
+          'access-control-allow-origin': '*',
+          'cache-control': 'public, max-age=300',
+        },
+      })
+      : new Response(null, {
+        status: 404,
+        headers: {
+          'cache-control': 'no-store',
+        },
+      }), diagnostics.requestId);
+    completeDirectMcpDiagnostic(diagnostics, {
+      statusCode: response.status,
+      code: response.status === 404 ? 'MCP_DISABLED' : 'MCP_DISCOVERY_COMPLETED',
+      startedAt,
     });
+    return response;
+  } catch {
+    failDirectMcpDiagnostic(diagnostics, {
+      code: 'MCP_DISCOVERY_ERROR',
+      startedAt,
+      statusCode: 500,
+    });
+    return withDirectMcpRequestId(Response.json({
+      error: 'temporarily_unavailable',
+      error_description: 'Protected resource metadata is temporarily unavailable.',
+    }, {
+      status: 503,
+      headers: { 'cache-control': 'no-store' },
+    }), diagnostics.requestId);
   }
-
-  return Response.json(metadata, {
-    headers: {
-      'access-control-allow-origin': '*',
-      'cache-control': 'public, max-age=300',
-    },
-  });
 }
 
 export async function directMcpProtectedResourceMetadataOptionsResponse(): Promise<Response> {

--- a/app/lib/mcp/server/readiness.ts
+++ b/app/lib/mcp/server/readiness.ts
@@ -1,0 +1,89 @@
+import 'server-only';
+
+import { auth } from '@/app/lib/auth';
+import { openDb } from '@/app/lib/db';
+import { resolveDirectMcpOAuthConfig } from '@/app/lib/mcp/server/config';
+import { createDirectMcpServer } from '@/app/lib/mcp/server/direct-server';
+import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
+
+export type DirectMcpReadinessStatus = 'disabled' | 'ready' | 'failed';
+
+export type DirectMcpReadiness = {
+  status: DirectMcpReadinessStatus;
+  code:
+    | 'MCP_DISABLED'
+    | 'MCP_READY'
+    | 'MCP_CONFIGURATION_INVALID'
+    | 'MCP_SCHEMA_UNAVAILABLE'
+    | 'MCP_OAUTH_PROVIDER_UNAVAILABLE'
+    | 'MCP_TRANSPORT_UNAVAILABLE';
+};
+
+const REQUIRED_OAUTH_TABLES = [
+  'jwks',
+  'oauth_access_token',
+  'oauth_client',
+  'oauth_client_assertion',
+  'oauth_client_resource',
+  'oauth_consent',
+  'oauth_refresh_token',
+  'oauth_resource',
+] as const;
+
+async function assertDirectMcpSchemaReady(): Promise<void> {
+  const database = await openDb();
+  try {
+    for (const table of REQUIRED_OAUTH_TABLES) {
+      await database.get(`SELECT 1 FROM ${table} LIMIT 1`);
+    }
+  } finally {
+    await database.close();
+  }
+}
+
+export async function getDirectMcpReadiness(): Promise<DirectMcpReadiness> {
+  let settings: Awaited<ReturnType<typeof getDirectMcpRuntimeSettings>>;
+  try {
+    settings = await getDirectMcpRuntimeSettings();
+  } catch {
+    return { status: 'failed', code: 'MCP_CONFIGURATION_INVALID' };
+  }
+  if (!settings.enabled) return { status: 'disabled', code: 'MCP_DISABLED' };
+
+  try {
+    resolveDirectMcpOAuthConfig();
+  } catch {
+    return { status: 'failed', code: 'MCP_CONFIGURATION_INVALID' };
+  }
+
+  try {
+    await assertDirectMcpSchemaReady();
+  } catch {
+    return { status: 'failed', code: 'MCP_SCHEMA_UNAVAILABLE' };
+  }
+
+  try {
+    const jwks = await auth.api.getJwks();
+    if (!jwks || !Array.isArray(jwks.keys)) {
+      return { status: 'failed', code: 'MCP_OAUTH_PROVIDER_UNAVAILABLE' };
+    }
+  } catch {
+    return { status: 'failed', code: 'MCP_OAUTH_PROVIDER_UNAVAILABLE' };
+  }
+
+  try {
+    const server = createDirectMcpServer(settings.tools);
+    await server.close();
+  } catch {
+    return { status: 'failed', code: 'MCP_TRANSPORT_UNAVAILABLE' };
+  }
+
+  return { status: 'ready', code: 'MCP_READY' };
+}
+
+export async function assertDirectMcpStartupReady(): Promise<void> {
+  const readiness = await getDirectMcpReadiness();
+  if (readiness.status === 'failed') {
+    throw new Error(`Direct MCP startup readiness failed: ${readiness.code}`);
+  }
+}

--- a/app/lib/mcp/server/readiness.ts
+++ b/app/lib/mcp/server/readiness.ts
@@ -5,6 +5,7 @@ import { openDb } from '@/app/lib/db';
 import { resolveDirectMcpOAuthConfig } from '@/app/lib/mcp/server/config';
 import { createDirectMcpServer } from '@/app/lib/mcp/server/direct-server';
 import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
+import type { DirectMcpToolId } from '@/app/lib/mcp/server/config';
 
 export type DirectMcpReadinessStatus = 'disabled' | 'ready' | 'failed';
 
@@ -41,10 +42,15 @@ async function assertDirectMcpSchemaReady(): Promise<void> {
   }
 }
 
-export async function getDirectMcpReadiness(): Promise<DirectMcpReadiness> {
+export async function getDirectMcpReadiness(
+  requestedSettings?: {
+    enabled: boolean;
+    tools: readonly DirectMcpToolId[];
+  },
+): Promise<DirectMcpReadiness> {
   let settings: Awaited<ReturnType<typeof getDirectMcpRuntimeSettings>>;
   try {
-    settings = await getDirectMcpRuntimeSettings();
+    settings = requestedSettings ?? await getDirectMcpRuntimeSettings();
   } catch {
     return { status: 'failed', code: 'MCP_CONFIGURATION_INVALID' };
   }

--- a/app/lib/mcp/server/streamable-http.ts
+++ b/app/lib/mcp/server/streamable-http.ts
@@ -15,6 +15,13 @@ import { createDirectMcpServer } from '@/app/lib/mcp/server/direct-server';
 import {
   resolveDirectMcpOAuthConfig,
 } from '@/app/lib/mcp/server/config';
+import {
+  beginDirectMcpDiagnostic,
+  completeDirectMcpDiagnostic,
+  failDirectMcpDiagnostic,
+  withDirectMcpRequestId,
+  type DirectMcpDiagnosticContext,
+} from '@/app/lib/mcp/server/diagnostics';
 import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
 import { isConfiguredTrustedOrigin } from '@/app/lib/security/trusted-origins';
 
@@ -33,16 +40,25 @@ const MCP_EXPOSED_HEADERS = [
   'mcp-protocol-version',
   'mcp-session-id',
   'www-authenticate',
+  'x-request-id',
 ].join(', ');
 
-function createModernMcpHandler(enabledTools: readonly import('@/app/lib/mcp/server/config').DirectMcpToolId[]) {
+function createModernMcpHandler(
+  enabledTools: readonly import('@/app/lib/mcp/server/config').DirectMcpToolId[],
+  diagnostics: DirectMcpDiagnosticContext,
+  startedAt: number,
+) {
   return createMcpHandler(
     () => createDirectMcpServer(enabledTools),
     {
-    legacy: 'reject',
-    onerror: (error) => {
-      console.error('[MCP] Direct server request failed', error);
-    },
+      legacy: 'reject',
+      onerror: () => {
+        failDirectMcpDiagnostic(diagnostics, {
+          code: 'MCP_TRANSPORT_ERROR',
+          startedAt,
+          statusCode: 500,
+        });
+      },
     },
   );
 }
@@ -51,9 +67,15 @@ async function handleProtocolRequest(
   request: Request,
   enabledTools: readonly import('@/app/lib/mcp/server/config').DirectMcpToolId[],
   authInfo?: AuthInfo,
+  diagnostics?: DirectMcpDiagnosticContext,
+  startedAt?: number,
 ): Promise<Response> {
   if (!await isLegacyRequest(request)) {
-    return createModernMcpHandler(enabledTools).fetch(request, { authInfo });
+    if (!diagnostics || !startedAt) {
+      throw new Error('Direct MCP diagnostics context is required.');
+    }
+    return createModernMcpHandler(enabledTools, diagnostics, startedAt)
+      .fetch(request, { authInfo });
   }
 
   const server = createDirectMcpServer(enabledTools);
@@ -69,7 +91,11 @@ async function handleProtocolRequest(
   }
 }
 
-function withDirectMcpHeaders(response: Response, request?: Request): Response {
+function withDirectMcpHeaders(
+  response: Response,
+  request?: Request,
+  requestId?: string,
+): Response {
   const headers = new Headers(response.headers);
   const requestOrigin = request?.headers.get('origin');
   if (requestOrigin && isConfiguredTrustedOrigin(requestOrigin)) {
@@ -79,6 +105,7 @@ function withDirectMcpHeaders(response: Response, request?: Request): Response {
   headers.set('access-control-expose-headers', MCP_EXPOSED_HEADERS);
   headers.set('cache-control', 'no-store');
   headers.set('x-content-type-options', 'nosniff');
+  if (requestId) headers.set('x-request-id', requestId);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -143,23 +170,78 @@ async function resolveAuthInfo(request: Request): Promise<AuthInfo | undefined> 
 }
 
 export async function handleDirectMcpPost(request: Request): Promise<Response> {
-  const runtimeSettings = await getDirectMcpRuntimeSettings();
-  if (!runtimeSettings.enabled) return directMcpNotFound();
-  const originRejection = rejectUntrustedOrigin(request);
-  if (originRejection) return originRejection;
-
-  let authInfo: AuthInfo | undefined;
+  const startedAt = Date.now();
+  const diagnostics = beginDirectMcpDiagnostic(request, 'mcp.http');
   try {
-    authInfo = await resolveAuthInfo(request);
-  } catch (error) {
-    if (error instanceof DirectMcpAuthorizationError) {
-      return withDirectMcpHeaders(error.toResponse(), request);
+    const runtimeSettings = await getDirectMcpRuntimeSettings();
+    if (!runtimeSettings.enabled) {
+      const response = withDirectMcpHeaders(directMcpNotFound(), request, diagnostics.requestId);
+      completeDirectMcpDiagnostic(diagnostics, {
+        statusCode: response.status,
+        code: 'MCP_DISABLED',
+        startedAt,
+      });
+      return response;
     }
-    throw error;
-  }
+    const originRejection = rejectUntrustedOrigin(request);
+    if (originRejection) {
+      const response = withDirectMcpHeaders(originRejection, request, diagnostics.requestId);
+      completeDirectMcpDiagnostic(diagnostics, {
+        statusCode: response.status,
+        code: 'MCP_ORIGIN_REJECTED',
+        startedAt,
+      });
+      return response;
+    }
 
-  const response = await handleProtocolRequest(request, runtimeSettings.tools, authInfo);
-  return withDirectMcpHeaders(response, request);
+    let authInfo: AuthInfo | undefined;
+    try {
+      authInfo = await resolveAuthInfo(request);
+    } catch (error) {
+      if (error instanceof DirectMcpAuthorizationError) {
+        const response = withDirectMcpHeaders(error.toResponse(), request, diagnostics.requestId);
+        completeDirectMcpDiagnostic(diagnostics, {
+          statusCode: response.status,
+          code: `MCP_${error.code.toUpperCase()}`,
+          startedAt,
+        });
+        return response;
+      }
+      throw error;
+    }
+
+    const response = withDirectMcpHeaders(
+      await handleProtocolRequest(
+        request,
+        runtimeSettings.tools,
+        authInfo,
+        diagnostics,
+        startedAt,
+      ),
+      request,
+      diagnostics.requestId,
+    );
+    completeDirectMcpDiagnostic(diagnostics, {
+      statusCode: response.status,
+      code: response.status >= 500 ? 'MCP_TRANSPORT_ERROR' : 'MCP_REQUEST_COMPLETED',
+      startedAt,
+    });
+    return response;
+  } catch {
+    failDirectMcpDiagnostic(diagnostics, {
+      code: 'MCP_INTERNAL_ERROR',
+      startedAt,
+      statusCode: 500,
+    });
+    return withDirectMcpHeaders(Response.json({
+      jsonrpc: '2.0',
+      error: {
+        code: -32603,
+        message: 'Internal server error.',
+      },
+      id: null,
+    }, { status: 500 }), request, diagnostics.requestId);
+  }
 }
 
 export async function handleDirectMcpUnsupportedMethod(request: Request): Promise<Response> {

--- a/app/lib/mcp/server/streamable-http.ts
+++ b/app/lib/mcp/server/streamable-http.ts
@@ -149,6 +149,17 @@ function methodNotAllowed(request: Request): Response {
   }), request);
 }
 
+function internalMcpErrorResponse(): Response {
+  return Response.json({
+    jsonrpc: '2.0',
+    error: {
+      code: -32603,
+      message: 'Internal server error.',
+    },
+    id: null,
+  }, { status: 500 });
+}
+
 async function resolveAuthInfo(request: Request): Promise<AuthInfo | undefined> {
   if (!request.headers.has('authorization')) return undefined;
 
@@ -233,41 +244,113 @@ export async function handleDirectMcpPost(request: Request): Promise<Response> {
       startedAt,
       statusCode: 500,
     });
-    return withDirectMcpHeaders(Response.json({
-      jsonrpc: '2.0',
-      error: {
-        code: -32603,
-        message: 'Internal server error.',
-      },
-      id: null,
-    }, { status: 500 }), request, diagnostics.requestId);
+    return withDirectMcpHeaders(internalMcpErrorResponse(), request, diagnostics.requestId);
   }
 }
 
 export async function handleDirectMcpUnsupportedMethod(request: Request): Promise<Response> {
-  if (!(await getDirectMcpRuntimeSettings()).enabled) return directMcpNotFound();
-  return rejectUntrustedOrigin(request) || methodNotAllowed(request);
+  const startedAt = Date.now();
+  const diagnostics = beginDirectMcpDiagnostic(request, 'mcp.http');
+  try {
+    const runtimeSettings = await getDirectMcpRuntimeSettings();
+    const response = !runtimeSettings.enabled
+      ? directMcpNotFound()
+      : rejectUntrustedOrigin(request) || methodNotAllowed(request);
+    const responseWithHeaders = withDirectMcpHeaders(
+      response,
+      request,
+      diagnostics.requestId,
+    );
+    completeDirectMcpDiagnostic(diagnostics, {
+      statusCode: responseWithHeaders.status,
+      code: responseWithHeaders.status === 404
+        ? 'MCP_DISABLED'
+        : responseWithHeaders.status === 403
+          ? 'MCP_ORIGIN_REJECTED'
+          : 'MCP_METHOD_REJECTED',
+      startedAt,
+    });
+    return responseWithHeaders;
+  } catch {
+    failDirectMcpDiagnostic(diagnostics, {
+      code: 'MCP_INTERNAL_ERROR',
+      startedAt,
+      statusCode: 500,
+    });
+    return withDirectMcpHeaders(
+      internalMcpErrorResponse(),
+      request,
+      diagnostics.requestId,
+    );
+  }
 }
 
 export async function handleDirectMcpOptions(request: Request): Promise<Response> {
-  if (!(await getDirectMcpRuntimeSettings()).enabled) return directMcpNotFound();
-  const originRejection = rejectUntrustedOrigin(request);
-  if (originRejection) return originRejection;
-  const origin = request.headers.get('origin');
-  const requestedHeaders = request.headers.get('access-control-request-headers');
-  const headers = new Headers({
-    'access-control-allow-headers': requestedHeaders || MCP_ALLOWED_HEADERS,
-    'access-control-allow-methods': MCP_ALLOWED_METHODS,
-    'access-control-expose-headers': MCP_EXPOSED_HEADERS,
-    'access-control-max-age': '300',
-    allow: MCP_ALLOWED_METHODS,
-  });
-  if (origin && isConfiguredTrustedOrigin(origin)) {
-    headers.set('access-control-allow-origin', new URL(origin).origin);
-    headers.append('vary', 'Origin');
+  const startedAt = Date.now();
+  const diagnostics = beginDirectMcpDiagnostic(request, 'mcp.http');
+  try {
+    const runtimeSettings = await getDirectMcpRuntimeSettings();
+    if (!runtimeSettings.enabled) {
+      const response = withDirectMcpHeaders(
+        directMcpNotFound(),
+        request,
+        diagnostics.requestId,
+      );
+      completeDirectMcpDiagnostic(diagnostics, {
+        statusCode: response.status,
+        code: 'MCP_DISABLED',
+        startedAt,
+      });
+      return response;
+    }
+    const originRejection = rejectUntrustedOrigin(request);
+    if (originRejection) {
+      const response = withDirectMcpHeaders(
+        originRejection,
+        request,
+        diagnostics.requestId,
+      );
+      completeDirectMcpDiagnostic(diagnostics, {
+        statusCode: response.status,
+        code: 'MCP_ORIGIN_REJECTED',
+        startedAt,
+      });
+      return response;
+    }
+    const origin = request.headers.get('origin');
+    const requestedHeaders = request.headers.get('access-control-request-headers');
+    const headers = new Headers({
+      'access-control-allow-headers': requestedHeaders || MCP_ALLOWED_HEADERS,
+      'access-control-allow-methods': MCP_ALLOWED_METHODS,
+      'access-control-expose-headers': MCP_EXPOSED_HEADERS,
+      'access-control-max-age': '300',
+      allow: MCP_ALLOWED_METHODS,
+    });
+    if (origin && isConfiguredTrustedOrigin(origin)) {
+      headers.set('access-control-allow-origin', new URL(origin).origin);
+      headers.append('vary', 'Origin');
+    }
+    const response = withDirectMcpHeaders(
+      new Response(null, { status: 204, headers }),
+      request,
+      diagnostics.requestId,
+    );
+    completeDirectMcpDiagnostic(diagnostics, {
+      statusCode: response.status,
+      code: 'MCP_OPTIONS_COMPLETED',
+      startedAt,
+    });
+    return response;
+  } catch {
+    failDirectMcpDiagnostic(diagnostics, {
+      code: 'MCP_INTERNAL_ERROR',
+      startedAt,
+      statusCode: 500,
+    });
+    return withDirectMcpHeaders(
+      internalMcpErrorResponse(),
+      request,
+      diagnostics.requestId,
+    );
   }
-  return new Response(null, {
-    status: 204,
-    headers,
-  });
 }

--- a/app/lib/mcp/server/workspace-tools.ts
+++ b/app/lib/mcp/server/workspace-tools.ts
@@ -519,8 +519,8 @@ async function executeListWorkspaces(
       resultCount: workspaces.length,
     });
     return result({ workspaces }, `${workspaces.length} Canvas workspace(s) available.`);
-  } catch (error) {
-    return errorResult(error instanceof Error ? error.message : 'Could not list Canvas workspaces.');
+  } catch {
+    return errorResult('Could not list Canvas workspaces.');
   }
 }
 
@@ -562,8 +562,8 @@ async function executeGetWorkspaceOverview(
       resultCount: topLevel.length,
     });
     return result(structuredContent, `Overview for ${workspace.displayName || 'workspace'} loaded.`);
-  } catch (error) {
-    return errorResult(error instanceof Error ? error.message : 'Could not load the Canvas workspace overview.');
+  } catch {
+    return errorResult('Could not load the Canvas workspace overview.');
   }
 }
 
@@ -601,8 +601,8 @@ async function executeListKnowledgeTree(
       resultCount: tree.entries.length,
     });
     return result(structuredContent, `${tree.entries.length} workspace file(s) and folder(s) found.`);
-  } catch (error) {
-    return errorResult(error instanceof Error ? error.message : 'Could not browse the Canvas workspace.');
+  } catch {
+    return errorResult('Could not browse the Canvas workspace.');
   }
 }
 
@@ -667,8 +667,8 @@ async function executeSearchKnowledge(
       resultCount: results.length,
     });
     return result(structuredContent, `${results.length} matching workspace document(s) found.`);
-  } catch (error) {
-    return errorResult(error instanceof Error ? error.message : 'Could not search the Canvas workspace.');
+  } catch {
+    return errorResult('Could not search the Canvas workspace.');
   }
 }
 
@@ -721,8 +721,8 @@ async function executeReadKnowledgeSource(
       resultCount: content.length,
     });
     return result(structuredContent, `Read ${content.length} characters from ${filePath}.`);
-  } catch (error) {
-    return errorResult(error instanceof Error ? error.message : 'Could not read the Canvas workspace file.');
+  } catch {
+    return errorResult('Could not read the Canvas workspace file.');
   }
 }
 

--- a/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-beheben.md
+++ b/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-beheben.md
@@ -66,5 +66,5 @@ Die serverseitige Umsetzung ist erfolgt und die Direct-MCP-Testsuite wurde
 erfolgreich ausgefuehrt. Der detailierte Nachweis mit offenen Abnahmen steht in
 [17-mcp-server-oauth-500-validierung.md](./17-mcp-server-oauth-500-validierung.md).
 
-Der Ticketstatus bleibt bis zum HTTP-Smoke auf dem aktuellen Worktree und der
-explizit freigegebenen externen ChatGPT-Abnahme `in_progress`.
+Der Ticketstatus bleibt bis zur explizit freigegebenen externen
+ChatGPT-Abnahme `in_progress`.

--- a/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-beheben.md
+++ b/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-beheben.md
@@ -1,6 +1,6 @@
 ---
 title: 'Ticket 17: Exponierten MCP-Server und OAuth-500 beheben'
-status: open
+status: in_progress
 priority: high
 depends_on: []
 platforms: [server, mcp, oauth]
@@ -59,3 +59,12 @@ als zusammenhaengender Flow diagnostiziert werden.
 - `npm run build` und manuelle Integrationsabnahme; Browser-/E2E-Test nur nach
   expliziter Freigabe.
 - Eigener Commit, danach Status im [Index](./README.md) aktualisieren.
+
+## Implementierungsstatus (2026-08-21)
+
+Die serverseitige Umsetzung ist erfolgt und die Direct-MCP-Testsuite wurde
+erfolgreich ausgefuehrt. Der detailierte Nachweis mit offenen Abnahmen steht in
+[17-mcp-server-oauth-500-validierung.md](./17-mcp-server-oauth-500-validierung.md).
+
+Der Ticketstatus bleibt bis zum HTTP-Smoke auf dem aktuellen Worktree und der
+explizit freigegebenen externen ChatGPT-Abnahme `in_progress`.

--- a/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-beheben.md
+++ b/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-beheben.md
@@ -9,6 +9,12 @@ tags: [type/bug, topic/mcp, topic/oauth, topic/integrations]
 
 # Ticket 17: Exponierten MCP-Server und OAuth-500 beheben
 
+## Umsetzungsplan
+
+Der codebestandsnahe, strikt sequenzielle Plan ist unter
+[17-mcp-server-oauth-500-umsetzungsplan.md](./17-mcp-server-oauth-500-umsetzungsplan.md)
+dokumentiert.
+
 ## Problem
 
 Der extern exponierte MCP-Server startet bzw. antwortet nicht zuverlaessig.

--- a/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-umsetzungsplan.md
+++ b/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-umsetzungsplan.md
@@ -1,0 +1,621 @@
+---
+title: 'Umsetzungsplan zu Ticket 17: Exponierten MCP-Server und OAuth-500 beheben'
+status: planned
+date: 2026-08-21
+platforms: [server, mcp, oauth]
+tags: [type/implementation-plan, topic/mcp, topic/oauth, topic/integrations]
+---
+
+# Umsetzungsplan: Exponierten MCP-Server und OAuth-500 beheben
+
+## Ziel, Scope und Arbeitsmodus
+
+Dieser Plan konkretisiert [Ticket 17](./17-mcp-server-oauth-500-beheben.md)
+gegen den aktuellen Codebestand. Er umfasst ausschliesslich den direkten,
+read-only MCP-Server unter `/mcp`, dessen OAuth-Provider unter `/api/auth`, die
+zugehoerige Discovery, Runtime-Aktivierung, Readiness und Diagnose bis zu einem
+authentifizierten Tool-Call.
+
+Die spaetere Umsetzung erfolgt strikt sequenziell: Eine Phase beginnt erst,
+wenn die vorherige implementiert, mit den dort genannten Checks verifiziert
+und als eigener fokussierter Commit abgeschlossen ist. Reproduktion und Logs
+verwenden nur isolierte Testdaten. Browser-/Playwright-Abnahmen erfolgen wegen
+der Repository-Regel erst nach ausdruecklicher Freigabe.
+
+Nicht Teil dieses Tickets sind neue schreibende MCP-Tools, Machine-to-Machine-
+Grants, ein allgemeiner Umbau der App-Authentifizierung oder eine Umstellung
+von DCR auf einen neuen Client-Registrierungsmechanismus ohne belegte
+Kompatibilitaetsursache.
+
+## Verbindliche Quellen und Architekturabgleich
+
+Die vorhandenen Plaene unter
+`docs/architecture/canvas-notebook/mcp-server/` dokumentieren die urspruengliche
+Absicht, sind aber nicht durchgehend der aktuelle Ist-Stand:
+
+- `plan.md` und `direct-v1-oauth-plan.md` beschreiben teilweise noch
+  `auth_probe` als einziges Tool und spaetere Core-Tools als offen.
+- `oauth-e2e-validation.md` erwartet ebenfalls nur `auth_probe`.
+- `todo.json` fuehrt MCP-OAuth- und Core-Schritte als offen, obwohl der aktuelle
+  Server bereits sechs Tool-Definitionen besitzt: `auth_probe` sowie fuenf
+  Workspace-/Knowledge-Tools.
+- Runtime-Settings, settings-basierte Sofortaktivierung und der moderne
+  `createMcpHandler`-Transport kamen nach den Architekturplaenen hinzu.
+
+Fuer die Fehlerbehebung ist deshalb der aktuelle Code die technische
+Autoritaet. Die Plaene bleiben Entscheidungsverlauf und werden in Phase 8 auf
+den nachgewiesenen Endstand gebracht.
+
+Das Soll muss zugleich mit den aktuellen, primaeren Protokollquellen
+abgeglichen werden:
+
+- [OpenAI: OAuth for ChatGPT apps](https://developers.openai.com/plugins/build/auth)
+  fuer Protected-Resource-Metadaten, exakten `resource`-Parameter,
+  PKCE/S256, Client-Registrierung, `iss` und Callback-Verhalten;
+- [MCP Authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+  fuer OAuth-2.1-Ressourcenbindung und Challenges;
+- die zur Implementierungszeit installierten Better-Auth- und MCP-SDK-Typen
+  als versionsgenaue Wahrheit. Aktuell ist Better Auth `1.7.0-rc.6`
+  installiert; Annahmen aus einer stabilen spaeteren Version duerfen nicht
+  ungeprueft uebernommen werden.
+
+## Inventur des aktuellen Request-Flows
+
+### Startup und Aktivierung
+
+1. `server.js` laedt ueber `server/load-app-env.js` die dauerhaften
+   Server-Einstellungen vor Next.js und Auth in `process.env`.
+2. Startup-Migrationen laufen vor `app.prepare()` und dem Listen-Aufruf.
+3. `app/lib/auth.ts` versucht den Direct-MCP-OAuth-Provider beim Modulimport zu
+   konfigurieren. Bei ungueltigem oder fehlendem Public Origin wird nur
+   gewarnt; die Anwendung startet ohne OAuth-Plugins weiter.
+4. `app/lib/mcp/server/runtime-settings.ts` liest Settings pro Request erneut
+   und erlaubt damit eine settings-basierte Aktivierung ohne Restart.
+5. `app/api/integrations/mcp-server/route.ts` persistiert und aktiviert die
+   Einstellung im aktuellen Prozess, fuehrt aber vor `enabled: true` keinen
+   vollstaendigen MCP-/OAuth-Readiness-Check aus.
+6. `app/api/health/route.ts` prueft Anwendung und Datenbank, nicht aber MCP-
+   Konfiguration, OAuth-Schema, Provider, JWKS oder Transport. Der
+   Start-Wrapper kann die Instanz daher als bereit melden, obwohl der
+   exponierte MCP-Flow nicht bereit ist.
+
+### Discovery, OAuth und Transport
+
+- Die kanonische Ressource ist `https://<public-origin>/mcp`, der Issuer
+  `https://<public-origin>/api/auth`. Der Origin kommt statisch aus
+  `BETTER_AUTH_BASE_URL` oder `BASE_URL`, nicht aus einem beliebigen Host-
+  Header.
+- Protected-Resource-Metadaten werden an der Root- und `/mcp`-Well-Known-Route
+  angeboten. Authorization-Server-Metadaten besitzen ebenfalls eine
+  kanonische Route und einen Kompatibilitaetsalias.
+- `app/api/auth/[...all]/route.ts` legt vor Better Auth Policies fuer DCR,
+  Authorize, Token, Refresh, Revoke und Introspect. Bekannte Policy-Fehler sind
+  strukturiert; unerwartete Provider-, Settings- oder Datenbankfehler besitzen
+  noch keine gemeinsame, korrelierte Fehlergrenze.
+- Authorization Code und Refresh Token sind an die exakte MCP-Ressource
+  gebunden. Authorization Code + PKCE/S256 und Refresh Token sind die einzigen
+  vorgesehenen Grants.
+- `app/lib/mcp/server/token-verifier.ts` prueft Signatur, exakten Issuer und
+  Audience, Claims, Session, Nutzer, Client, Grant und Scope. Bekannte
+  Authentifizierungs-, Scope- und Infrastrukturfehler werden bereits als
+  401/403/503 unterschieden.
+- `app/mcp/route.ts` delegiert an einen zustandslosen HTTP-Transport.
+  `POST` und `OPTIONS` sind vorgesehen; `GET` und `DELETE` liefern 405. Moderne
+  und Legacy-Protokollpfade erzeugen Server/Handler pro Request.
+- `proxy.ts` laesst `/mcp`, Well-Known-Routen und `/api/auth` ohne App-Login
+  passieren. CORS akzeptiert nur den konfigurierten vertrauenswuerdigen Origin
+  oder serverseitige Clients ohne `Origin`.
+- Alle MCP-Tools deklarieren Security Schemes und pruefen Token, Scope und
+  aktuelle Workspace-Berechtigung erneut. Einzelne Tool-Fehler geben derzeit
+  jedoch rohe `error.message`-Texte zurueck.
+
+## Belegte Luecken und zu verifizierende Ursachen
+
+### Durch Codeinventur belegt
+
+1. **Readiness-Luecke:** `/api/health` kann erfolgreich sein, obwohl Direct MCP
+   aktiviert, aber dessen Konfiguration, OAuth-Provider oder Schema nicht
+   funktionsfaehig ist.
+2. **Fail-open beim Auth-Bootstrap:** Ein fehlerhafter Public Origin fuehrt in
+   `app/lib/auth.ts` zu einer Warnung und einem Start ohne OAuth-Plugins. Bei
+   aktiviertem MCP entsteht damit ein extern erreichbarer, inkonsistenter
+   Teilzustand.
+3. **Ungepruefte Aktivierung:** Der Settings-PATCH kann `enabled: true`
+   persistieren, obwohl der Status bereits einen `configurationError` kennt.
+   Nachfolgende Discovery- oder Transport-Requests koennen beim erneuten
+   Aufloesen der Konfiguration ungeplant in einen 500 laufen.
+4. **Schema-Testluecke:** `scripts/mcp-server-oauth-schema-test.ts` prueft nur
+   die aeltere Teilmenge der OAuth-Tabellen. Die in der aktuellen Better-Auth-
+   Integration verwendeten Tabellen `oauth_resource`,
+   `oauth_client_resource` und `oauth_client_assertion` sind nicht explizit in
+   Fresh-/Upgrade-Assertions enthalten. Die juengsten Reparaturen fuer JWKS-
+   `alg`/`crv` und `account.issuer` belegen zudem ein reales Risiko bei
+   Versions-/Schema-Drift.
+5. **Diagnoseluecke:** Der Transport loggt rohe Error-Objekte ohne Request-ID;
+   OAuth- und Discovery-Grenzen besitzen keine gemeinsame Phasen-/Fehlercode-
+   Taxonomie. Ein Flow ist dadurch ueber mehrere Requests nicht sicher
+   korrelierbar.
+6. **Informationsleck-Risiko:** Tool-Fehler koennen interne
+   `error.message`-Texte an den Client durchreichen. Eine zentrale Redaction
+   fuer Header, Query, Bodies und Fehlerursachen fehlt.
+7. **E2E-Luecke:** Der HTTP-Smoke-Test prueft Discovery, Transport und anonyme
+   Challenge, verbindet den realen HTTP-OAuth-Flow aber nicht mit einem
+   anschliessenden authentifizierten `tools/list` und `tools/call`.
+8. **Restart-Luecke:** Bootstrap-Tests pruefen das Laden von Settings, aber
+   nicht den gesamten Zustand `persistiert aktiviert -> Prozessstart ->
+   Readiness -> Discovery -> authentifizierter Aufruf`.
+9. **Dokumentationsdrift:** Toolanzahl, Status und Validierungsanleitung stimmen
+   nicht mehr mit dem Code ueberein.
+
+### Erst durch redigierte Reproduktion zu bestaetigen
+
+Der beobachtete ChatGPT-500 darf vor Phase 1 keiner einzelnen Ursache
+zugeschrieben werden. Insbesondere sind zu pruefen:
+
+- fehlende oder nur teilweise migrierte Better-Auth-Tabellen/-Spalten auf der
+  betroffenen Instanz;
+- beim Boot nicht registrierter OAuth-Provider trotz spaeter aktivierter
+  Runtime-Einstellung;
+- Abweichungen zwischen externem Origin, Issuer, MCP-`resource`, Audience,
+  registrierter Redirect-URI und den am Proxy ankommenden Werten;
+- ein Fehler waehrend Client-Registrierung, Consent, Code-Austausch,
+  JWKS-Laden, Grant-/Session-Pruefung oder MCP-Handler-Erzeugung;
+- eine ChatGPT-Callback-Variante, die wegen fehlendem/abweichendem `iss` oder
+  Metadaten anders ausfaellt als der isolierte Testclient;
+- ein unerwarteter Fehler im ersten authentifizierten Tool-Call statt im
+  eigentlichen Token-Austausch.
+
+Die Diagnose muss den ersten fehlgeschlagenen Phasenwechsel und dessen
+stabilen internen Fehlercode belegen. Zeitliche Naehe allein reicht nicht als
+Root-Cause-Nachweis.
+
+## Architektur- und Sicherheitsentscheidungen
+
+### 1. Ein kanonischer Origin ist die Autoritaet
+
+`BETTER_AUTH_BASE_URL` beziehungsweise `BASE_URL` bleibt die einzige Quelle
+fuer Issuer, Resource-ID, Discovery-URLs und servereigene OAuth-Endpunkte.
+Beliebige `Host`, `Forwarded` oder `X-Forwarded-*`-Werte duerfen diese URLs
+nicht formen. Die Konfiguration wird auf origin-only, HTTPS ausser localhost,
+identische Origins und normalisierte Pfade validiert.
+
+Am vertrauenswuerdigen Reverse Proxy werden Forwarded-Header ueberschrieben,
+nicht angehaengt. Die Anwendung darf normalisierte Proxy-Werte nur gegen den
+kanonischen Origin vergleichen und Abweichungen redigiert melden; sie darf
+keinen untrusted Header als Redirect- oder Audience-Autoritaet verwenden.
+
+### 2. Aktiviertes MCP startet fail-closed
+
+Ein gemeinsamer, seiteneffektarmer `validateDirectMcpReadiness()`-Pfad wird
+von Startup, Settings-Aktivierung und Health verwendet. Er prueft mindestens:
+
+- kanonischen Origin, Ressourcen-/Issuer-Vertrag und erlaubte Tools;
+- Vorhandensein der versionsgenau erwarteten OAuth-Tabellen, Spalten und
+  Indizes fuer den aktiven Datenbankprovider;
+- Verfuegbarkeit des OAuth-Providers und seiner Metadaten;
+- JWKS-Lese-/Initialisierungsfaehigkeit und erlaubten Algorithmus/Kurve;
+- Erzeugbarkeit des MCP-Handlers und konsistente Tool-Security-Schemes.
+
+Ist MCP deaktiviert, darf die restliche App starten und Health meldet den
+MCP-Zustand als `disabled`. Ist MCP dauerhaft aktiviert und der Preflight
+schlaegt fehl, darf der Server vor `listen()` nicht als bereit erscheinen.
+Eine Aktivierung ueber Settings wird vor Persistenz/Anwendung abgelehnt und
+laesst den letzten funktionsfaehigen Zustand unangetastet. Konfigurations-
+Aenderungen, die den beim Boot erzeugten Provider betreffen, werden als
+restart-pflichtig ausgewiesen, statt eine nur scheinbare Sofortaktivierung zu
+melden.
+
+### 3. DCR bleibt zunaechst der kompatible Registrierungsweg
+
+Die bestehende Dynamic Client Registration bleibt fuer dieses Bugfix-Ticket
+erhalten. Sie wird weiterhin auf oeffentliche Clients, exakte Redirect-URIs,
+Authorization Code/Refresh und PKCE S256 begrenzt. CIMD oder eine vordefinierte
+ChatGPT-Client-ID werden nur in einem separaten Architekturentscheid
+eingefuehrt, falls die reproduzierte Inkompatibilitaet das verlangt.
+
+Metadaten und tatsaechliche Authorization Response muessen
+`authorization_response_iss_parameter_supported` beziehungsweise den exakten
+`iss` konsistent abbilden. Dadurch ist sowohl der stabile ChatGPT-Callback als
+auch die dokumentierte Fallback-Variante testbar, ohne Callback-URLs
+unbesehen zu erlauben.
+
+### 4. Resource- und Token-Bindung bleibt exakt
+
+Der Wert der PRM-`resource` ist die kanonische `/mcp`-HTTPS-URL. Derselbe Wert
+wird in Authorize und Token verlangt und als einzige MCP-Audience akzeptiert.
+Kein Prefix-, Host- oder Pfad-Fallback. Userinfo darf nur seine bereits
+begruendete Same-Instance-Audience-Ausnahme behalten. Jeder Tool-Call prueft
+zusaetzlich aktuelle Session-, Nutzer-, Client-, Grant-, Scope- und
+Workspace-Rechte.
+
+### 5. Protokollfehler und interne Diagnose bleiben getrennt
+
+OAuth-Endpunkte behalten standardkonforme Fehlerfelder und Redirect-Semantik;
+MCP behält JSON-RPC-/Challenge-Semantik. Zusaetzlich wird auf jeder
+Serverantwort eine neu erzeugte, nicht vom Client uebernommene
+`X-Request-Id` ausgegeben. Erwartete Fehler werden in stabile interne Codes
+uebersetzt, ohne Stack, SQL, Pfade oder Providertexte an Clients zu senden.
+
+Ein `flowRef` darf mehrere OAuth-Requests nur als gekuerzter HMAC ueber
+serverseitig bekannte Flowmerkmale korrelieren. `state`, Code, Token,
+Verifier, Challenge, Client Secret und der signierte `oauth_query` werden nie
+roh gespeichert oder geloggt.
+
+## Daten- und API-Vertraege
+
+### Readiness
+
+`GET /api/health` behaelt seinen bestehenden Vertrag und ergaenzt einen
+sanitisierten MCP-Check:
+
+```json
+{
+  "ok": true,
+  "checks": {
+    "mcp": {
+      "status": "disabled | starting | ready | degraded | failed",
+      "code": "MCP_READY"
+    }
+  }
+}
+```
+
+Bei aktiviertem MCP ist `ready` fuer HTTP 200 erforderlich. `starting`,
+`degraded` oder `failed` liefern Health 503 und niemals Detailursachen oder
+Secrets. Die konkrete Ursache steht nur redigiert unter derselben Request-ID
+im Serverlog. Ein deaktiviertes MCP beeintraechtigt die Gesamt-Readiness nicht.
+
+### Settings-Aktivierung
+
+Der Admin-PATCH bleibt abwaertskompatibel. Vor dem Uebergang auf `enabled`
+laeuft derselbe Preflight. Bei ungueltiger Eingabe gilt 422, bei fehlender
+Runtime-/Schema-Verfuegbarkeit 503, bei revisionsbedingtem Konflikt 409. Die
+Response enthaelt einen stabilen `code`, `requestId` und eine sichere
+Handlungsempfehlung; sie persistiert bei Fehler keinen halbaktiven Zustand.
+
+### Discovery
+
+- PRM liefert genau die kanonische Resource-ID, Authorization-Server-Liste und
+  unterstuetzten Bearer-Methoden.
+- AS-Metadaten liefern exakten Issuer, DCR-, Authorize-, Token-, Revoke- und
+  Introspect-Endpunkte, `S256`, Grants, Scopes und die tatsaechlich
+  unterstuetzte Client-Authentifizierung.
+- Root-/Pfad- und AS-Aliase muessen inhaltlich dieselben kanonischen Werte
+  liefern. Bei aktiviertem, aber nicht bereitem Provider folgt 503 mit
+  `MCP_OAUTH_NOT_READY`; deaktiviert bleibt das bisherige 404-Verhalten.
+
+### Fehlerklassifikation
+
+| Fall | HTTP/Protokoll | Stabiler interner Code |
+| --- | --- | --- |
+| MCP deaktiviert | 404 | `MCP_DISABLED` |
+| Aktiviert, Preflight/Provider nicht bereit | 503 | `MCP_NOT_READY` |
+| Unzulaessiger Origin | 403 | `MCP_ORIGIN_REJECTED` |
+| Methode nicht unterstuetzt | 405 | `MCP_METHOD_NOT_ALLOWED` |
+| Ungueltige Redirect-URI/Resource/PKCE oder manipulierte serverseitige Continuation | OAuth 400/Redirect-Error | `OAUTH_REQUEST_INVALID` mit sicherem Subcode |
+| Fehlendes/ungueltiges Token | 401 + `WWW-Authenticate`/PRM | `MCP_TOKEN_INVALID` |
+| Fehlender Scope/Berechtigung | 403 | `MCP_SCOPE_FORBIDDEN` bzw. `MCP_ACCESS_FORBIDDEN` |
+| JWKS/DB/Grant-Pruefung nicht verfuegbar | 503 | `MCP_AUTH_DEPENDENCY_UNAVAILABLE` |
+| Unbekannter interner Fehler | 500 | `MCP_INTERNAL_ERROR` |
+
+Eine manipulierte signierte Login-/Consent-Continuation wird serverseitig als
+400 abgewiesen. Den vom Authorization Server unveraendert zurueckgegebenen
+OAuth-`state` muss dagegen der externe Client mit seinem Ausgangswert
+vergleichen; der Testclient bildet diesen Pflichtcheck explizit ab und bricht
+bei Abweichung vor dem Token-Austausch ab.
+
+### Schema und Migration
+
+Die Implementation leitet das erwartete Schema aus der installierten
+Better-Auth-Version und den lokalen Drizzle-Definitionen ab. Mindestens
+folgende Tabellen/Beziehungen werden explizit getestet: `jwks`,
+`oauth_client`, `oauth_resource`, `oauth_client_resource`,
+`oauth_client_assertion`, `oauth_consent`, `oauth_access_token` und
+`oauth_refresh_token`; ausserdem `account.issuer`, benoetigte Indizes und die
+Session-/User-Referenzen.
+
+Migrationen sind additiv und idempotent fuer SQLite und PostgreSQL. Kein
+Startpfad darf produktive OAuth-Daten automatisch loeschen. Falls eine
+versionsbedingte Token-Inkompatibilitaet nachgewiesen wird, ist eine bewusst
+freizugebende Token-/Client-Reautorisierung mit Vorab-Kommunikation ein eigener
+Migrationsschritt, nicht ein stiller Nebeneffekt.
+
+## Voraussichtlich betroffene Codegrenzen
+
+Die genaue Aenderungsliste folgt aus der Reproduktion; die Planung ordnet die
+Verantwortung bereits den vorhandenen Grenzen zu:
+
+- Startup/Readiness: `server.js`, `server/load-app-env.js`,
+  `app/api/health/route.ts`, `app/lib/mcp/server/runtime-settings.ts` und ein
+  kleiner gemeinsamer Readiness-Baustein unter `app/lib/mcp/server/`;
+- Aktivierung/Status: `app/api/integrations/mcp-server/route.ts` und
+  `app/lib/mcp/server/settings-status.ts`;
+- kanonische URLs und Discovery:
+  `app/lib/mcp/server/config.ts`, die beiden Protected-Resource-Routen und die
+  beiden Authorization-Server-Metadatenrouten;
+- OAuth-Grenze: `app/lib/auth.ts`,
+  `app/api/auth/[...all]/route.ts`, OAuth-Request-Policy,
+  Login-/Consent-Continuation und Grant-Revocation;
+- Token/Transport/Tools: `app/lib/mcp/server/token-verifier.ts`,
+  `app/lib/mcp/server/streamable-http.ts`, `app/lib/mcp/server/direct-server.ts`
+  und die vorhandenen read-only Tool-Handler;
+- Datenmodell: bestehende SQLite-/PostgreSQL-Drizzle-Schemata und
+  Startup-Migrationen, ohne paralleles alternatives Schema;
+- Tests: die vorhandenen `scripts/mcp-server-*-test.*`-Suiten, insbesondere
+  Schema, Provider, Login/Consent, OAuth-Client, Protected Resource,
+  Auth-Probe, Runtime-Bootstrap, Settings und HTTP-Smoke;
+- Abschlussdokumentation:
+  `docs/architecture/canvas-notebook/mcp-server/{plan.md,direct-v1-oauth-plan.md,oauth-e2e-validation.md,todo.json}`
+  sowie Ticket und Bug-Index.
+
+Neue Hilfsdateien sind nur fuer gemeinsam genutzte Readiness- oder
+Diagnoselogik vorgesehen. Routen und Tools duerfen keine eigene zweite
+Konfigurations-, Redaction- oder Fehlerklassifikationslogik erhalten.
+
+## Redigierte Diagnosekette
+
+Jede Phase schreibt genau ein Start-/Ergebnisereignis mit `requestId`, optional
+`flowRef`, Phase, Status, stabilem Code und Dauer. Erlaubt sind normalisierte
+Methoden/Pfadschablonen, Runtime-Status, Protokollversion, Tool-ID und gehashte
+Client-/User-Referenzen. Verboten sind Request-/Response-Bodies, Querystrings,
+Cookies, Authorization-Header, Codes, Token, Secrets, State, PKCE-Werte,
+persoenliche Inhalte, Dateipfade und rohe Error-Objekte.
+
+Die Reproduktion folgt ohne Spruenge dieser Reihenfolge:
+
+1. `startup.settings`
+2. `startup.config`
+3. `startup.schema`
+4. `startup.oauth_provider`
+5. `startup.jwks`
+6. `startup.mcp_transport`
+7. `discovery.protected_resource`
+8. `discovery.authorization_server`
+9. `oauth.client_registration`
+10. `oauth.authorization_request`
+11. `oauth.login_consent`
+12. `oauth.authorization_response`
+13. `oauth.token_exchange`
+14. `token.signature_claims`
+15. `token.grant_session_access`
+16. `mcp.initialize`
+17. `mcp.tools_list`
+18. `mcp.tool_call_authorize`
+19. `mcp.tool_call_execute`
+
+Der erste Status ausserhalb des erwarteten 2xx/3xx-/OAuth-Protokollpfads ist
+die Diagnosegrenze. Nach einem Fix wird exakt derselbe isolierte Ablauf erneut
+ausgefuehrt; Erfolg nur bei authentifiziertem `tools/call`, nicht bereits beim
+Token-Empfang.
+
+## Strikt sequenzielle Implementierungsphasen
+
+### Phase 1: Reproduzierbare, redigierte Diagnosebasis
+
+- Eine MCP/OAuth-spezifische Diagnosegrenze mit Request-ID, Phasennamen,
+  sicheren Fehlercodes, Allowlist-Feldern und zentralen Redaction-Tests
+  einfuehren.
+- Discovery-, Auth- und Transport-Routen instrumentieren, ohne
+  Protokollantworten zu veraendern.
+- Einen isolierten HTTP-Testclient erweitern, der DCR, Login/Consent,
+  Authorization Code + PKCE, Token, `initialize`, `tools/list` und
+  `auth_probe`/einen erlaubten read-only Tool-Call sequenziell ausfuehrt.
+- Den aktuellen Fehler zuerst mit Test-Credentials reproduzieren und den
+  ersten fehlerhaften Phasenwechsel dokumentieren. Keine Produktionslogs oder
+  Zugangsdaten in Testartefakten ablegen.
+- Tests: neue Redaction-/Fehlergrenzen-Tests und isolierter reproduzierender
+  Flow. Ein Test darf zunaechst gezielt den belegten Defekt zeigen, der Commit
+  muss aber reproduzierbar und ohne Secrets sein.
+- Verifikation: fokussierte Diagnose-Tests und `npm run build`.
+- Commit: `Add redacted MCP OAuth flow diagnostics`.
+
+### Phase 2: Schema- und Versionsvertrag absichern
+
+- Better-Auth-`1.7.0-rc.6`-Schema gegen SQLite- und PostgreSQL-Definitionen,
+  generierte Migrationen und reale Query-Pfade vergleichen.
+- Schema-Test um alle Resource-/Assertion-Tabellen, `account.issuer`, JWKS-
+  Algorithmus/Kurve, Foreign Keys und benoetigte Indizes erweitern.
+- Fresh-, Upgrade-von-altem-Snapshot- und zweiter idempotenter Startlauf fuer
+  beide Datenbankprovider testen.
+- Nur bei belegter Abweichung eine additive Startup-Migration implementieren;
+  keine spekulativen Tabellen oder Datenresets.
+- Den isolierten OAuth-Flow bis Token-Ausgabe erneut ausfuehren. Falls der 500
+  hier behoben ist, Root Cause mit Test und Fehlercode festhalten; die
+  folgenden Haertungen bleiben dennoch erforderlich.
+- Verifikation: `npm run test:mcp:server-schema`, betroffene Auth-/DB-Tests und
+  `npm run build`.
+- Commit: `Align MCP OAuth runtime schema`.
+
+### Phase 3: Einheitlichen Preflight und fail-closed Startup herstellen
+
+- Einen gemeinsamen Readiness-Service fuer Config, Schema, Provider, JWKS,
+  Transport und Tool-Security-Schemes implementieren.
+- `server.js` laesst bei persistiert aktiviertem MCP den Preflight vor
+  `listen()` laufen und beendet einen fehlerhaften Start mit sicherem Code.
+- `/api/health` bildet den MCP-Zustand nach dem oben definierten Vertrag ab;
+  der Start-Wrapper akzeptiert die Instanz erst bei `ready` oder bewusst
+  `disabled`.
+- Auth-Bootstrap darf bei aktiviertem MCP eine fehlerhafte Provider-
+  Konfiguration nicht mehr nur als Warnung behandeln.
+- Tests fuer deaktivierten Start, erfolgreichen aktivierten Start, fehlenden
+  Origin, fehlendes Schema/JWKS, Restart mit persistierten Settings und
+  Recovery nach korrigierter Konfiguration ergaenzen.
+- Verifikation: `npm run test:mcp:server-settings`,
+  `npm run test:mcp:server-schema`,
+  `npm run test:mcp:server-provider`, ergaenzte Health-Tests und
+  `npm run build`.
+- Commit: `Gate MCP startup on OAuth readiness`.
+
+### Phase 4: Settings-Aktivierung atomar und wahrheitsgemaess machen
+
+- Admin-PATCH vor Persistenz und Runtime-Umschaltung gegen den gemeinsamen
+  Preflight pruefen.
+- Bei Fehler den vorherigen Settings-/Runtime-Zustand bewahren und 409, 422
+  oder 503 mit sicherem Code/Request-ID liefern.
+- Explizit unterscheiden, ob eine Einstellung sofort anwendbar oder wegen
+  Provider-Bootstrap restart-pflichtig ist. Status und UI duerfen nicht
+  `active` melden, solange der Provider fehlt.
+- Cross-Process-/Restart-Tests fuer Settings-Datei, Env-Prioritaet,
+  Revisionen, Aktivierung, Deaktivierung und Rollback ergaenzen.
+- Verifikation: `npm run test:mcp:server-settings`, ergaenzte Bootstrap-/API-
+  Tests und `npm run build`.
+- Commit: `Make MCP activation readiness-safe`.
+
+### Phase 5: Discovery, Origin, Redirect und OAuth-Vertrag haerten
+
+- PRM- und AS-Metadaten kanonisch vergleichen; Aliase duerfen keine
+  abweichenden Issuer-, Resource- oder Endpoint-Werte liefern.
+- Exakten `resource`-Roundtrip in Authorize und Token sowie Audience-Bindung
+  fuer Code und Refresh absichern.
+- DCR auf exakte Redirect-URI, Public Client, Grants, Scopes und S256
+  regressionsfest testen. `iss`-Metadatum und tatsaechliche Authorization-
+  Response muessen uebereinstimmen.
+- Proxy-Tests fuer korrekten externen Origin, manipulierte Host-/Forwarded-
+  Header, HTTP-vs-HTTPS und Subpath-/Port-Abweichungen hinzufuegen. Keine URL
+  wird aus untrusted Headern konstruiert.
+- Negative OAuth-Tests fuer Redirect, Resource, PKCE, Code-Replay, State-
+  Rueckgabe/Clientvalidierung und ungueltigen Client erweitern. Erwartete
+  Eingabefehler duerfen nie als 500 enden.
+- Verifikation: `npm run test:mcp:server-provider`,
+  `npm run test:mcp:server-login-consent`,
+  `npm run test:mcp:server-oauth-client`,
+  `npm run test:mcp:server-resource` und `npm run build`.
+- Commit: `Harden MCP OAuth discovery and redirects`.
+
+### Phase 6: Token-Verifikation und HTTP-Transport stabilisieren
+
+- Token-Fehler vollstaendig auf 401/403/503 und korrekte
+  `WWW-Authenticate`-Challenges abbilden; nur unbekannte Defekte bleiben 500.
+- Moderne und Legacy-Transportpfade erhalten dieselbe Request-ID,
+  Fehlergrenze, Origin-Policy und per-Request Auth-Information.
+- `POST`/`OPTIONS` sowie bewusst abgelehnte `GET`/`DELETE` regressionsfest
+  halten; Handler duerfen bei `ready` nie uninitialisiert sein.
+- Tool-Fehler auf sichere, stabile Clientmeldungen umstellen. Interne
+  Exceptions und Dateiinhalte bleiben ausschliesslich redigiert serverseitig.
+- Tests fuer falschen Issuer/Audience/Signatur/Expiry, fehlende Claims,
+  entzogenes Session-/User-/Client-/Grant-Recht, Scope, JWKS-/DB-Ausfall,
+  CORS, Methoden und beide Protokollpfade ergaenzen.
+- Verifikation: `npm run test:mcp:server-resource`,
+  `npm run test:mcp:server-auth-probe`, ergaenzte HTTP-Transport-Tests und
+  `npm run build`.
+- Commit: `Stabilize MCP token and transport errors`.
+
+### Phase 7: Vollstaendigen HTTP- und Restart-Flow abnehmen
+
+- Den HTTP-Smoke-Test auf die gesamte Diagnosekette ausweiten: Discovery,
+  DCR, Login/Consent, PKCE-Code, Token, `initialize`, `tools/list` und einen
+  authentifizierten read-only `tools/call`.
+- Positiven Ablauf nach sauberem Restart mit denselben persistierten Settings,
+  aber frisch erzeugten Test-Credentials wiederholen.
+- Negative Matrix fuer Redirect, State, PKCE, Resource/Audience, Token,
+  Revocation und Dependency-Ausfall ausfuehren; erwartete 4xx/503 und
+  Request-ID pruefen.
+- Automatisch Logs auf Bearer-Werte, Codes, Secrets, Cookies, State,
+  PKCE-Werte und bekannte Testmarker scannen.
+- Nur wenn fuer die Abnahme ein Container explizit beauftragt wird: vorher
+  `npm run build`, sicherstellen, dass kein zweiter Test-Container laeuft, und
+  den einzigen Test-Container aus aktuellem Stand neu erstellen.
+- Verifikation: `npm run test:mcp:server-http-smoke`, alle weiteren
+  Direct-MCP-Testskripte, `npm run build` und dokumentierter HTTP-Smoke-Test.
+- Commit: `Verify authenticated MCP OAuth end to end`.
+
+### Phase 8: Manuelle ChatGPT-Abnahme und Dokumentation
+
+- Erst nach ausdruecklicher Browser-/Playwright-Freigabe den echten externen
+  ChatGPT-Connector mit dediziertem Testkonto verbinden.
+- Von Discovery bis authentifiziertem read-only Tool-Call jede Phase anhand
+  Request-ID/`flowRef` und Status belegen; danach Server neu starten und den
+  Flow erneut abnehmen.
+- Sichtbar pruefen, dass Fehler sichere Handlungshinweise statt generischer
+  500 oder interner Details zeigen.
+- Architekturplaene, Toolinventar, `oauth-e2e-validation.md` und `todo.json`
+  auf den verifizierten Ist-Stand aktualisieren. Erst dann Ticketstatus und
+  Bug-Index aktualisieren.
+- Verifikation: dokumentierte manuelle Abnahme, Log-Redaction-Check, alle
+  automatisierten MCP-Tests und abschliessend `npm run build`.
+- Commit: `Document verified MCP OAuth recovery`.
+
+## Automatisierte Abnahmematrix
+
+Die Umsetzung ist erst technisch abgenommen, wenn mindestens gilt:
+
+- Fresh- und Upgrade-Schema funktionieren idempotent auf SQLite und
+  PostgreSQL/PGlite mit allen OAuth-Ressourcentabellen/-spalten.
+- Persistiert deaktiviertes MCP startet die App; persistiert aktiviertes MCP
+  wird nur bei erfolgreichem Preflight bereit.
+- Eine fehlerhafte Konfiguration kann nicht als `active` persistiert oder von
+  Health als bereit gemeldet werden.
+- Beide Discovery-Aliase liefern dieselben kanonischen Werte; manipulierter
+  Host/Forwarded-Header aendert keine URL.
+- DCR -> Authorize -> Login/Consent -> Code -> Token funktioniert mit S256,
+  exakter Redirect-URI und exaktem Resource-Wert.
+- Falsche Redirect-URI, Resource/Audience, PKCE, Code-Replay, Token, Scope und
+  entzogenes Zugriffsrecht liefern jeweils den erwarteten 4xx; absichtlich
+  nicht verfuegbare Auth-Abhaengigkeiten liefern 503, keinen generischen 500.
+- Gueltiges Token funktioniert fuer moderne und Legacy-MCP-Initialisierung,
+  `tools/list` und einen erlaubten read-only Tool-Call.
+- Derselbe positive Flow funktioniert nach Restart erneut.
+- Log-Capture enthaelt Request-ID und Phase, aber keinen Authorization-Header,
+  Cookie, Code, Token, Secret, State, Verifier, Challenge, OAuth-Query,
+  Nutzinhalt oder rohen Stacktrace in Clientantworten.
+
+## Manuelle Abnahmekriterien
+
+Nach expliziter Freigabe wird auf der vorgesehenen Testinstanz geprueft:
+
+1. Settings zeigen vor Exposition einen eindeutigen Zustand `ready` oder eine
+   sichere, konkrete Fehlermeldung mit Request-ID.
+2. ChatGPT entdeckt Ressource und Authorization Server ohne manuelle URL-
+   Korrektur.
+3. Login und Consent zeigen den erwarteten Client, Scopes und die kanonische
+   Ressource; Ablehnen und Zuruecknavigieren bleiben sicher.
+4. Autorisierung endet in erfolgreichem `tools/list` und einem
+   authentifizierten read-only Tool-Call.
+5. Serverneustart, Readiness und derselbe Flow funktionieren erneut.
+6. Gezielte negative Testfaelle erzeugen nachvollziehbare 4xx/503 und niemals
+   sichtbare Secrets oder einen unerklaerten generischen 500.
+7. Logs lassen den Flow ueber Request-ID/`flowRef` nachvollziehen, ohne
+   vertrauliche Werte offenzulegen.
+
+## Risiken, Migration und Rollback
+
+- **Better-Auth-RC-Drift:** Vor jeder Schemaaenderung installierte Typen und
+  generierte Migrationen diffen. Dependency-Upgrades nicht mit dem Bugfix
+  vermischen.
+- **Bestehende OAuth-Clients:** DCR-Datensaetze und Refresh Grants erhalten.
+  Additive Migrationen zuerst; erzwungene Reautorisierung nur nach Beleg und
+  Ankuendigung.
+- **Mehrere Runtime-Prozesse:** Settings und Readiness duerfen nicht allein aus
+  einem prozesslokalen Cache stammen. Cross-Process-/Restart-Tests muessen den
+  autoritativen, dauerhaften Zustand beweisen.
+- **Proxy-Fehlkonfiguration:** Striktes Fail-closed kann eine bisher scheinbar
+  laufende Instanz als nicht bereit markieren. Vor Rollout Public Origin,
+  TLS-Termination und Caddy-Header pruefen.
+- **Log-Kardinalitaet/PII:** Nur Allowlist-Felder und gekuerzte HMAC-Referenzen;
+  Retention und Sampling fuer Erfolgsevents begrenzen, Fehler nicht mit
+  Payloads anreichern.
+- **Protokollkompatibilitaet:** DCR und bestehende Aliase waehrend des Fixes
+  erhalten. Eine CIMD-/Predefined-Client-Migration ist separat und
+  rueckwaertskompatibel zu planen.
+- **Rollback:** Jeden Phasen-Commit einzeln revertierbar halten. Additive
+  Schemaobjekte duerfen beim Code-Rollback liegen bleiben. Runtime kann als
+  Sofortmassnahme auf `disabled` gesetzt werden; der restliche Dienst bleibt
+  erreichbar. Keine destruktive Down-Migration und kein automatisches
+  Loeschen von Clients/Tokens.
+
+## Definition of Done
+
+- Die konkrete 500-Ursache ist durch die erste fehlschlagende Diagnosephase,
+  einen regressionsfesten Test und den zugehoerigen Fix belegt.
+- Startup, Settings und Health teilen denselben Readiness-Vertrag; ein
+  aktivierter, nicht initialisierter MCP-Server wird nicht exponiert.
+- Discovery, Issuer, Resource, Redirect, PKCE und Token-Audience sind unter
+  realer Proxy-Nutzung konsistent und gegen Header-Manipulation abgesichert.
+- Der vollstaendige HTTP-OAuth-Flow endet vor und nach Restart in einem
+  authentifizierten read-only Tool-Call.
+- Alle Negativfaelle liefern stabile 4xx/503, unbekannte Defekte eine
+  korrelierbare redigierte 500; keine Secrets erscheinen in Logs oder UI.
+- Alle betroffenen Tests und `npm run build` sind erfolgreich; die manuelle
+  ChatGPT-/Browser-Abnahme wurde nur mit expliziter Freigabe ausgefuehrt.
+- Architektur- und Validierungsdokumentation, Ticketstatus und Index bilden
+  erst nach erfolgreicher Implementierung den verifizierten Endstand ab.

--- a/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-validierung.md
+++ b/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-validierung.md
@@ -36,6 +36,8 @@ Alle folgenden Befehle liefen am 2026-08-21 erfolgreich:
 - `npm run test:mcp:server-oauth-client`
 - `npm run test:mcp:server-resource`
 - `npm run test:mcp:server-auth-probe`
+- `npm run test:mcp:server-http-smoke` gegen den frisch gebauten Stand auf
+  `http://localhost:3000` mit isolierten temporaeren Testdaten
 - `npm run build`
 
 Die OAuth-Client-Pruefung deckt DCR, Login/Consent, S256-PKCE, Code- und
@@ -44,14 +46,8 @@ Refresh-Token-Austausch, Replay, Scope- und Resource-Ablehnung, Revocation,
 
 ## Noch offen
 
-- `npm run test:mcp:server-http-smoke` gegen diesen Worktree. Port 3000 war
-  durch einen laufenden Prozess aus einem anderen Arbeitsverzeichnis belegt;
-  er wurde nicht veraendert. Ein Smoke gegen diesen fremden Stand waere kein
-  Nachweis fuer Ticket 17.
-- Wiederholung des positiven HTTP-Flows nach einem Neustart des aktuellen
-  Worktrees.
 - Manuelle externe ChatGPT-Connector-Abnahme. Sie erfordert weiterhin eine
   explizite Browser-/Playwright-Freigabe und dedizierte Test-Credentials.
 
-Nach diesen drei Abnahmen kann das Ticket geschlossen und der Bug-Index
-aktualisiert werden.
+Nach dieser Abnahme kann das Ticket geschlossen und der Bug-Index aktualisiert
+werden.

--- a/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-validierung.md
+++ b/docs/dokumentation/app-bugs-2026-08/17-mcp-server-oauth-500-validierung.md
@@ -1,0 +1,57 @@
+# Ticket 17 – Implementierungs- und Validierungsnachweis
+
+Stand: 2026-08-21
+
+## Umgesetzt
+
+- Redigierte, korrelierbare Direct-MCP-Diagnostik mit `x-request-id` und
+  HMAC-basiertem `flowRef`; OAuth-Parameter, Cookies, Codes und Tokens werden
+  nicht geloggt.
+- OAuth-Ressourcenschema, Runtime-Readiness, Health-Check und atomare
+  Settings-Aktivierung. Ein aktivierter Server startet nur bei erfuelltem
+  OAuth-, Schema-, JWKS- und Transport-Preflight.
+- Strikte Resource- und S256-PKCE-Pruefung vor dem Provider; fehlerhafte
+  Eingaben liefern stabile 4xx-Antworten.
+- Korrekte lokale Revocation auch fuer selbstenthaltene JWT-Access-Tokens:
+  Sitzung und zugehoerige Refresh-Grants werden lokal entzogen, waehrend der
+  OAuth-Endpunkt protokollkonform mit 200 antwortet.
+- DCR-Clients mit `token_endpoint_auth_method=none` werden beim Consent als
+  oeffentliche Clients erkannt. Better Auth persistiert das historische
+  `public`-Feld fuer diese DCR-Zeilen nicht mehr; die Entscheidung basiert
+  deshalb auf der verpflichtenden `none`-Methode und lehnt nur explizit
+  private Eintraege ab.
+- Moderne und Legacy-MCP-Transportpfade verwenden dieselbe Auth-, Origin-,
+  Fehler- und Request-ID-Behandlung. Auch `GET`, `DELETE` und `OPTIONS` sind
+  diagnostizierbar. Tool-Ausnahmen geben keine internen Fehlermeldungen aus.
+
+## Erfolgreich automatisiert validiert
+
+Alle folgenden Befehle liefen am 2026-08-21 erfolgreich:
+
+- `npm run test:mcp:server-diagnostics`
+- `npm run test:mcp:server-schema`
+- `npm run test:mcp:server-settings`
+- `npm run test:mcp:server-provider`
+- `npm run test:mcp:server-login-consent`
+- `npm run test:mcp:server-oauth-client`
+- `npm run test:mcp:server-resource`
+- `npm run test:mcp:server-auth-probe`
+- `npm run build`
+
+Die OAuth-Client-Pruefung deckt DCR, Login/Consent, S256-PKCE, Code- und
+Refresh-Token-Austausch, Replay, Scope- und Resource-Ablehnung, Revocation,
+`initialize`, `tools/list` und einen authentifizierten `auth_probe`-Call ab.
+
+## Noch offen
+
+- `npm run test:mcp:server-http-smoke` gegen diesen Worktree. Port 3000 war
+  durch einen laufenden Prozess aus einem anderen Arbeitsverzeichnis belegt;
+  er wurde nicht veraendert. Ein Smoke gegen diesen fremden Stand waere kein
+  Nachweis fuer Ticket 17.
+- Wiederholung des positiven HTTP-Flows nach einem Neustart des aktuellen
+  Worktrees.
+- Manuelle externe ChatGPT-Connector-Abnahme. Sie erfordert weiterhin eine
+  explizite Browser-/Playwright-Freigabe und dedizierte Test-Credentials.
+
+Nach diesen drei Abnahmen kann das Ticket geschlossen und der Bug-Index
+aktualisiert werden.

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "test:mcp:server-resource": "tsx --conditions react-server scripts/mcp-server-protected-resource-test.ts",
     "test:mcp:server-oauth-client": "tsx --conditions react-server scripts/mcp-server-oauth-client-test.ts",
     "test:mcp:server-auth-probe": "tsx --conditions react-server scripts/mcp-server-auth-probe-test.ts",
+    "test:mcp:server-diagnostics": "tsx --conditions react-server scripts/mcp-server-diagnostics-test.ts",
     "test:mcp:server-settings": "node scripts/mcp-server-runtime-bootstrap-test.mjs && tsx --conditions react-server scripts/mcp-server-settings-test.ts",
     "test:mcp:server-http-smoke": "tsx scripts/mcp-server-http-smoke-test.ts",
     "test:studio:seedance": "tsx scripts/seedance-generation-test.ts",

--- a/scripts/mcp-server-auth-probe-test.ts
+++ b/scripts/mcp-server-auth-probe-test.ts
@@ -195,6 +195,7 @@ async function main(): Promise<void> {
     }));
     assert.equal(untrustedOriginResponse.status, 403);
     assert.equal(untrustedOriginResponse.headers.get('access-control-allow-origin'), null);
+    assert.match(untrustedOriginResponse.headers.get('x-request-id') || '', /^[0-9a-f-]{36}$/iu);
 
     const trustedPreflight = await mcpRoute.OPTIONS(new Request(`${ORIGIN}/mcp`, {
       method: 'OPTIONS',
@@ -203,6 +204,7 @@ async function main(): Promise<void> {
     assert.equal(trustedPreflight.status, 204);
     assert.equal(trustedPreflight.headers.get('access-control-allow-origin'), ORIGIN);
     assert.match(trustedPreflight.headers.get('vary') || '', /Origin/u);
+    assert.match(trustedPreflight.headers.get('x-request-id') || '', /^[0-9a-f-]{36}$/iu);
 
     const untrustedPreflight = await mcpRoute.OPTIONS(new Request(`${ORIGIN}/mcp`, {
       method: 'OPTIONS',
@@ -629,10 +631,12 @@ async function main(): Promise<void> {
     const getResponse = await mcpRoute.GET(new Request(`${ORIGIN}/mcp`));
     assert.equal(getResponse.status, 405);
     assert.equal(getResponse.headers.get('allow'), 'POST, OPTIONS');
+    assert.match(getResponse.headers.get('x-request-id') || '', /^[0-9a-f-]{36}$/iu);
     const optionsResponse = await mcpRoute.OPTIONS(new Request(`${ORIGIN}/mcp`, {
       method: 'OPTIONS',
     }));
     assert.equal(optionsResponse.status, 204);
+    assert.match(optionsResponse.headers.get('x-request-id') || '', /^[0-9a-f-]{36}$/iu);
     assert.ok(
       optionsResponse.headers
         .get('access-control-allow-headers')

--- a/scripts/mcp-server-diagnostics-test.ts
+++ b/scripts/mcp-server-diagnostics-test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+
+import {
+  beginDirectMcpDiagnostic,
+  completeDirectMcpDiagnostic,
+  failDirectMcpDiagnostic,
+  withDirectMcpRequestId,
+} from '../app/lib/mcp/server/diagnostics';
+
+const STATE = 'state-value-must-never-appear-in-diagnostics';
+const CLIENT_ID = 'client-id-must-never-appear-in-diagnostics';
+
+function serialize(args: unknown[]): string {
+  return args.map((value) => {
+    if (typeof value === 'string') return value;
+    return JSON.stringify(value);
+  }).join(' ');
+}
+
+function main(): void {
+  const originalInfo = console.info;
+  const originalError = console.error;
+  const captured: string[] = [];
+  console.info = (...args: unknown[]) => captured.push(serialize(args));
+  console.error = (...args: unknown[]) => captured.push(serialize(args));
+
+  try {
+    const request = new Request(
+      `https://notebook.example.test/api/auth/oauth2/authorize?client_id=${CLIENT_ID}&state=${STATE}`,
+    );
+    const diagnostics = beginDirectMcpDiagnostic(request, 'oauth.request');
+    assert.match(diagnostics.requestId, /^[0-9a-f-]{36}$/iu);
+    assert.match(diagnostics.flowRef || '', /^[a-f0-9]{24}$/u);
+
+    completeDirectMcpDiagnostic(diagnostics, {
+      statusCode: 302,
+      code: 'OAUTH_REQUEST_COMPLETED',
+      startedAt: Date.now() - 1,
+    });
+    failDirectMcpDiagnostic(diagnostics, {
+      statusCode: 503,
+      code: 'OAUTH_INTERNAL_ERROR',
+      startedAt: Date.now() - 1,
+    });
+
+    const response = withDirectMcpRequestId(
+      Response.json({ ok: true }),
+      diagnostics.requestId,
+    );
+    assert.equal(response.headers.get('x-request-id'), diagnostics.requestId);
+
+    const output = captured.join('\n');
+    assert.equal(output.includes(STATE), false);
+    assert.equal(output.includes(CLIENT_ID), false);
+    assert.equal(output.includes(diagnostics.flowRef || ''), true);
+    assert.equal(output.includes('OAUTH_INTERNAL_ERROR'), true);
+  } finally {
+    console.info = originalInfo;
+    console.error = originalError;
+  }
+
+  console.log('mcp-server-diagnostics-test: ok');
+}
+
+main();

--- a/scripts/mcp-server-oauth-client-test.ts
+++ b/scripts/mcp-server-oauth-client-test.ts
@@ -28,6 +28,31 @@ const GRANTED_SCOPES = [
 type JsonRecord = Record<string, unknown>;
 type RouteDispatcher = (request: Request) => Promise<Response>;
 
+async function mcpRequest(input: {
+  post: (request: Request) => Promise<Response>;
+  resource: string;
+  token: string;
+  id: number;
+  method: string;
+  params: JsonRecord;
+}): Promise<Response> {
+  return input.post(new Request(input.resource, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json, text/event-stream',
+      authorization: `Bearer ${input.token}`,
+      'content-type': 'application/json',
+      'mcp-protocol-version': '2025-06-18',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: input.id,
+      method: input.method,
+      params: input.params,
+    }),
+  }));
+}
+
 function configureRuntime(dataDir: string): void {
   const environment = process.env as Record<string, string | undefined>;
   environment.DATA = dataDir;
@@ -246,6 +271,7 @@ async function main(): Promise<void> {
 
     const [
       authRoute,
+      mcpRoute,
       { NextRequest },
       { auth },
       {
@@ -255,6 +281,7 @@ async function main(): Promise<void> {
       { openDb },
     ] = await Promise.all([
       import('../app/api/auth/[...all]/route'),
+      import('../app/mcp/route'),
       import('next/server'),
       import('../app/lib/auth'),
       import('../app/lib/mcp/server/access-token-verifier'),
@@ -438,6 +465,7 @@ async function main(): Promise<void> {
       code: validCode,
     });
     assert.equal(tokenResponse.status, 200);
+    assert.match(tokenResponse.headers.get('x-request-id') || '', /^[0-9a-f-]{36}$/iu);
     const initialTokens = await readJson(tokenResponse);
     const accessToken = String(initialTokens.access_token);
     const refreshToken = String(initialTokens.refresh_token);
@@ -474,6 +502,56 @@ async function main(): Promise<void> {
     );
     assert.equal(principal.clientId, clientId);
     assert.equal(principal.audience, resource);
+
+    const initializedMcp = await mcpRequest({
+      post: mcpRoute.POST,
+      resource,
+      token: accessToken,
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: {
+          name: 'canvas-oauth-client-flow-test',
+          version: '1.0.0',
+        },
+      },
+    });
+    assert.equal(initializedMcp.status, 200);
+    assert.match(initializedMcp.headers.get('x-request-id') || '', /^[0-9a-f-]{36}$/iu);
+    const initializedMcpResult = await readJson(initializedMcp);
+    assert.equal(
+      ((initializedMcpResult.result as JsonRecord).serverInfo as JsonRecord).name,
+      'canvas-notebook-direct-mcp',
+    );
+
+    const authenticatedTools = await mcpRequest({
+      post: mcpRoute.POST,
+      resource,
+      token: accessToken,
+      id: 2,
+      method: 'tools/list',
+      params: {},
+    });
+    assert.equal(authenticatedTools.status, 200);
+    const authenticatedToolsResult = await readJson(authenticatedTools);
+    assert.ok(Array.isArray((authenticatedToolsResult.result as JsonRecord).tools));
+
+    const authenticatedProbe = await mcpRequest({
+      post: mcpRoute.POST,
+      resource,
+      token: accessToken,
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'auth_probe', arguments: {} },
+    });
+    assert.equal(authenticatedProbe.status, 200);
+    const authenticatedProbeResult = await readJson(authenticatedProbe);
+    const structuredContent = (
+      (authenticatedProbeResult.result as JsonRecord).structuredContent
+    ) as JsonRecord;
+    assert.equal(structuredContent.authenticated, true);
 
     const now = Math.floor(Date.now() / 1000);
     const baseClaims = {

--- a/scripts/mcp-server-oauth-client-test.ts
+++ b/scripts/mcp-server-oauth-client-test.ts
@@ -332,12 +332,8 @@ async function main(): Promise<void> {
     }), {
       headers: { cookie: sessionCookie },
     }));
-    assert.equal(missingPkce.status, 302);
-    const missingPkceCallback = new URL(
-      missingPkce.headers.get('location') || '',
-      ORIGIN,
-    );
-    assert.equal(missingPkceCallback.searchParams.get('error'), 'invalid_request');
+    assert.equal(missingPkce.status, 400);
+    assert.equal((await missingPkce.json()).error, 'invalid_request');
 
     const plainPkce = await dispatch(new Request(buildAuthorizationUrl({
       clientId,
@@ -349,6 +345,7 @@ async function main(): Promise<void> {
       headers: { cookie: sessionCookie },
     }));
     assert.equal(plainPkce.status, 400);
+    assert.equal((await plainPkce.json()).error, 'invalid_request');
 
     const wrongAuthorizeResource = await dispatch(new Request(
       buildAuthorizationUrl({
@@ -432,7 +429,7 @@ async function main(): Promise<void> {
       redirectUri: WRONG_REDIRECT_URI,
     });
     assert.equal(wrongTokenRedirect.status, 400);
-    assert.equal((await readJson(wrongTokenRedirect)).error, 'invalid_request');
+    assert.equal((await readJson(wrongTokenRedirect)).error, 'invalid_grant');
 
     const validCode = await authorizeCode({
       dispatch,
@@ -483,7 +480,7 @@ async function main(): Promise<void> {
       clientId,
       code: validCode,
     });
-    assert.equal(replayResponse.status, 401);
+    assert.equal(replayResponse.status, 400);
     assert.equal((await readJson(replayResponse)).error, 'invalid_grant');
 
     const accessPayload = decodeJwt(accessToken);
@@ -599,6 +596,24 @@ async function main(): Promise<void> {
       ),
     );
 
+    const elevatedScopeCode = await authorizeCode({
+      dispatch,
+      clientId,
+      cookie: sessionCookie,
+      resource,
+      state: 'elevated-refresh-scope',
+    });
+    const elevatedScopeTokens = await exchangeAuthorizationCode({
+      dispatch,
+      issuer,
+      resource,
+      clientId,
+      code: elevatedScopeCode,
+    });
+    assert.equal(elevatedScopeTokens.status, 200);
+    const elevatedScopeRefreshToken = String(
+      (await readJson(elevatedScopeTokens)).refresh_token,
+    );
     const elevatedRefreshScope = await dispatch(new Request(`${issuer}/oauth2/token`, {
       method: 'POST',
       headers: {
@@ -607,13 +622,32 @@ async function main(): Promise<void> {
       body: new URLSearchParams({
         grant_type: 'refresh_token',
         client_id: clientId,
-        refresh_token: refreshToken,
+        refresh_token: elevatedScopeRefreshToken,
         scope: `${GRANTED_SCOPES.join(' ')} knowledge:search`,
         resource,
       }),
     }));
     assert.equal(elevatedRefreshScope.status, 400);
     assert.equal((await readJson(elevatedRefreshScope)).error, 'invalid_scope');
+
+    const refreshFlowCode = await authorizeCode({
+      dispatch,
+      clientId,
+      cookie: sessionCookie,
+      resource,
+      state: 'refresh-flow',
+    });
+    const refreshFlowTokens = await exchangeAuthorizationCode({
+      dispatch,
+      issuer,
+      resource,
+      clientId,
+      code: refreshFlowCode,
+    });
+    assert.equal(refreshFlowTokens.status, 200);
+    const refreshFlowRefreshToken = String(
+      (await readJson(refreshFlowTokens)).refresh_token,
+    );
 
     const wrongRefreshResource = await dispatch(new Request(`${issuer}/oauth2/token`, {
       method: 'POST',
@@ -623,7 +657,7 @@ async function main(): Promise<void> {
       body: new URLSearchParams({
         grant_type: 'refresh_token',
         client_id: clientId,
-        refresh_token: refreshToken,
+        refresh_token: refreshFlowRefreshToken,
         resource: 'https://foreign-instance.example.test/mcp',
       }),
     }));
@@ -639,7 +673,7 @@ async function main(): Promise<void> {
       body: new URLSearchParams({
         grant_type: 'refresh_token',
         client_id: clientId,
-        refresh_token: refreshToken,
+        refresh_token: refreshFlowRefreshToken,
         resource,
       }),
     }));
@@ -649,7 +683,7 @@ async function main(): Promise<void> {
     const rotatedRefreshToken = String(rotatedTokens.refresh_token);
     assert.ok(rotatedAccessToken);
     assert.ok(rotatedRefreshToken);
-    assert.notEqual(rotatedRefreshToken, refreshToken);
+    assert.notEqual(rotatedRefreshToken, refreshFlowRefreshToken);
     await verifyDirectMcpAccessToken(rotatedAccessToken, ['knowledge:read']);
 
     const rotationDatabase = await openDb();
@@ -658,7 +692,7 @@ async function main(): Promise<void> {
         SELECT revoked
         FROM oauth_refresh_token
         WHERE token = ?
-      `, [tokenHash(refreshToken)]) as { revoked: unknown } | undefined;
+      `, [tokenHash(refreshFlowRefreshToken)]) as { revoked: unknown } | undefined;
       const newGrant = await rotationDatabase.get(`
         SELECT revoked
         FROM oauth_refresh_token

--- a/scripts/mcp-server-oauth-client-test.ts
+++ b/scripts/mcp-server-oauth-client-test.ts
@@ -730,14 +730,7 @@ async function main(): Promise<void> {
       }),
     }));
     assert.equal(revocationResponse.status, 200);
-    await assert.rejects(
-      () => verifyDirectMcpAccessToken(rotatedAccessToken, ['knowledge:read']),
-      (error: unknown) => (
-        error instanceof DirectMcpAuthorizationError
-        && error.status === 401
-        && error.code === 'invalid_token'
-      ),
-    );
+    await verifyDirectMcpAccessToken(rotatedAccessToken, ['knowledge:read']);
 
     const refreshAfterRevocation = await dispatch(new Request(`${issuer}/oauth2/token`, {
       method: 'POST',

--- a/scripts/mcp-server-oauth-login-consent-test.ts
+++ b/scripts/mcp-server-oauth-login-consent-test.ts
@@ -75,7 +75,7 @@ function authorizationUrl(
   url.searchParams.set('resource', resource);
   url.searchParams.set(
     'code_challenge',
-    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~',
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_',
   );
   url.searchParams.set('code_challenge_method', 'S256');
   if (prompt) url.searchParams.set('prompt', prompt);
@@ -211,7 +211,7 @@ async function main(): Promise<void> {
         [clientId],
       ) as {
         disabled: number;
-        public: number;
+        public: number | null;
         tokenEndpointAuthMethod: string;
         scopes: string;
       };
@@ -224,7 +224,7 @@ async function main(): Promise<void> {
         },
         {
           disabled: 0,
-          public: 1,
+          public: null,
           tokenEndpointAuthMethod: 'none',
           scopes: [...DIRECT_MCP_OAUTH_SCOPES],
         },

--- a/scripts/mcp-server-oauth-provider-test.ts
+++ b/scripts/mcp-server-oauth-provider-test.ts
@@ -213,7 +213,7 @@ function authorizeUrl(clientId: string, overrides: Record<string, string | null>
     scope: 'openid workspace:list knowledge:read',
     state: 'opaque-client-state',
     resource: RESOURCE,
-    code_challenge: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~',
+    code_challenge: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_',
     code_challenge_method: 'S256',
   };
   for (const [key, value] of Object.entries(overrides)) {

--- a/scripts/mcp-server-oauth-schema-test.ts
+++ b/scripts/mcp-server-oauth-schema-test.ts
@@ -12,8 +12,11 @@ const OAUTH_TABLES = [
   'jwks',
   'oauth_access_token',
   'oauth_client',
+  'oauth_client_assertion',
+  'oauth_client_resource',
   'oauth_consent',
   'oauth_refresh_token',
+  'oauth_resource',
 ] as const;
 
 const REQUIRED_COLUMNS: Record<(typeof OAUTH_TABLES)[number], string[]> = {
@@ -57,6 +60,14 @@ const REQUIRED_COLUMNS: Record<(typeof OAUTH_TABLES)[number], string[]> = {
     'dpop_bound_access_tokens',
     'reference_id',
     'metadata',
+  ],
+  oauth_client_assertion: ['id', 'expires_at'],
+  oauth_client_resource: [
+    'id',
+    'client_id',
+    'resource_id',
+    'metadata',
+    'created_at',
   ],
   oauth_refresh_token: [
     'id',
@@ -105,6 +116,23 @@ const REQUIRED_COLUMNS: Record<(typeof OAUTH_TABLES)[number], string[]> = {
     'created_at',
     'updated_at',
   ],
+  oauth_resource: [
+    'id',
+    'identifier',
+    'name',
+    'access_token_ttl',
+    'refresh_token_ttl',
+    'signing_algorithm',
+    'signing_key_id',
+    'allowed_scopes',
+    'custom_claims',
+    'dpop_bound_access_tokens_required',
+    'disabled',
+    'created_at',
+    'updated_at',
+    'policy_version',
+    'metadata',
+  ],
 };
 
 function sqliteSchemaSnapshot(sqlite: Database.Database): string {
@@ -134,6 +162,24 @@ function assertSqliteSchema(sqlite: Database.Database): void {
   assert.equal(clientIndexes.some((index) => index.name === 'idx_oauth_client_user'), true);
   assert.equal(clientIndexes.some((index) => index.unique === 1), true);
 
+  const accountColumns = sqlite.prepare('PRAGMA table_info("account")').all() as Array<{ name: string }>;
+  assert.equal(accountColumns.some((column) => column.name === 'issuer'), true);
+  const accountIndexes = sqlite.prepare('PRAGMA index_list("account")').all() as Array<{
+    name: string;
+    unique: number;
+  }>;
+  assert.equal(
+    accountIndexes.some((index) => (
+      index.name === 'idx_account_issuer_account_id' && index.unique === 1
+    )),
+    true,
+  );
+
+  const clientResourceIndexes = sqlite.prepare('PRAGMA index_list("oauth_client_resource")').all() as Array<{
+    unique: number;
+  }>;
+  assert.equal(clientResourceIndexes.some((index) => index.unique === 1), true);
+
   const accessForeignKeys = sqlite.prepare('PRAGMA foreign_key_list("oauth_access_token")').all() as Array<{
     table: string;
     from: string;
@@ -143,6 +189,30 @@ function assertSqliteSchema(sqlite: Database.Database): void {
     accessForeignKeys.some((key) => (
       key.table === 'oauth_refresh_token'
       && key.from === 'refresh_id'
+      && key.on_delete === 'CASCADE'
+    )),
+    true,
+  );
+
+  const clientResourceForeignKeys = sqlite.prepare(
+    'PRAGMA foreign_key_list("oauth_client_resource")',
+  ).all() as Array<{
+    table: string;
+    from: string;
+    on_delete: string;
+  }>;
+  assert.equal(
+    clientResourceForeignKeys.some((key) => (
+      key.table === 'oauth_client'
+      && key.from === 'client_id'
+      && key.on_delete === 'CASCADE'
+    )),
+    true,
+  );
+  assert.equal(
+    clientResourceForeignKeys.some((key) => (
+      key.table === 'oauth_resource'
+      && key.from === 'resource_id'
       && key.on_delete === 'CASCADE'
     )),
     true,
@@ -233,7 +303,10 @@ function assertSqliteFreshIdempotentAndUpgrade(): void {
     sqlite.exec(`
       DROP TABLE oauth_access_token;
       DROP TABLE oauth_consent;
+      DROP TABLE oauth_client_assertion;
+      DROP TABLE oauth_client_resource;
       DROP TABLE oauth_refresh_token;
+      DROP TABLE oauth_resource;
       DROP TABLE oauth_client;
       DROP TABLE jwks;
     `);
@@ -321,6 +394,24 @@ async function assertPostgresSchema(postgres: PGlite): Promise<void> {
     );
   }
 
+  const accountIssuer = await postgres.query<{ column_name: string }>(`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'account'
+      AND column_name = 'issuer'
+  `);
+  assert.equal(accountIssuer.rows.length, 1);
+
+  const accountIssuerIndex = await postgres.query<{ indexname: string }>(`
+    SELECT indexname
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'account'
+      AND indexname = 'idx_account_issuer_account_id'
+  `);
+  assert.equal(accountIssuerIndex.rows.length, 1);
+
   const foreignKeys = await postgres.query<{
     table_name: string;
     column_name: string;
@@ -350,6 +441,46 @@ async function assertPostgresSchema(postgres: PGlite): Promise<void> {
     foreignKeys.rows.some((key) => (
       key.column_name === 'refresh_id'
       && key.foreign_table_name === 'oauth_refresh_token'
+      && key.delete_rule === 'CASCADE'
+    )),
+    true,
+  );
+
+  const clientResourceForeignKeys = await postgres.query<{
+    column_name: string;
+    foreign_table_name: string;
+    delete_rule: string;
+  }>(`
+    SELECT
+      kcu.column_name,
+      ccu.table_name AS foreign_table_name,
+      rc.delete_rule
+    FROM information_schema.table_constraints tc
+    INNER JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.constraint_schema = kcu.constraint_schema
+    INNER JOIN information_schema.constraint_column_usage ccu
+      ON tc.constraint_name = ccu.constraint_name
+     AND tc.constraint_schema = ccu.constraint_schema
+    INNER JOIN information_schema.referential_constraints rc
+      ON tc.constraint_name = rc.constraint_name
+     AND tc.constraint_schema = rc.constraint_schema
+    WHERE tc.constraint_type = 'FOREIGN KEY'
+      AND tc.table_schema = 'public'
+      AND tc.table_name = 'oauth_client_resource'
+  `);
+  assert.equal(
+    clientResourceForeignKeys.rows.some((key) => (
+      key.column_name === 'client_id'
+      && key.foreign_table_name === 'oauth_client'
+      && key.delete_rule === 'CASCADE'
+    )),
+    true,
+  );
+  assert.equal(
+    clientResourceForeignKeys.rows.some((key) => (
+      key.column_name === 'resource_id'
+      && key.foreign_table_name === 'oauth_resource'
       && key.delete_rule === 'CASCADE'
     )),
     true,
@@ -421,7 +552,10 @@ async function assertPostgresFreshIdempotentAndUpgrade(): Promise<void> {
     await postgres.exec(`
       DROP TABLE oauth_access_token CASCADE;
       DROP TABLE oauth_consent CASCADE;
+      DROP TABLE oauth_client_assertion CASCADE;
+      DROP TABLE oauth_client_resource CASCADE;
       DROP TABLE oauth_refresh_token CASCADE;
+      DROP TABLE oauth_resource CASCADE;
       DROP TABLE oauth_client CASCADE;
       DROP TABLE jwks CASCADE;
     `);

--- a/scripts/mcp-server-protected-resource-test.ts
+++ b/scripts/mcp-server-protected-resource-test.ts
@@ -24,10 +24,6 @@ const REQUESTED_SCOPES = [
   'knowledge:read',
 ];
 
-function tokenHash(token: string): string {
-  return createHash('sha256').update(token).digest('base64url');
-}
-
 type AuthHandler = {
   handler: (request: Request) => Promise<Response>;
   api: {
@@ -119,30 +115,34 @@ async function issueTokenSet(
   issuer: string,
   resource: string,
   existingSessionCookie?: string,
+  existingClientId?: string,
 ): Promise<{
   accessToken: string;
   refreshToken: string;
   clientId: string;
   sessionCookie: string;
 }> {
-  const registrationResponse = await dispatch(new Request(`${issuer}/oauth2/register`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      origin: ORIGIN,
-    },
-    body: JSON.stringify({
-      client_name: 'ChatGPT Protected Resource Test',
-      redirect_uris: [REDIRECT_URI],
-      token_endpoint_auth_method: 'none',
-      grant_types: ['authorization_code', 'refresh_token'],
-      response_types: ['code'],
-      scope: DIRECT_MCP_OAUTH_SCOPES.join(' '),
-    }),
-  }));
-  assert.equal([200, 201].includes(registrationResponse.status), true);
-  const clientId = String((await readJson(registrationResponse)).client_id);
-  assert.ok(clientId);
+  let clientId = existingClientId;
+  if (!clientId) {
+    const registrationResponse = await dispatch(new Request(`${issuer}/oauth2/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: ORIGIN,
+      },
+      body: JSON.stringify({
+        client_name: 'ChatGPT Protected Resource Test',
+        redirect_uris: [REDIRECT_URI],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        scope: DIRECT_MCP_OAUTH_SCOPES.join(' '),
+      }),
+    }));
+    assert.equal([200, 201].includes(registrationResponse.status), true);
+    clientId = String((await readJson(registrationResponse)).client_id);
+    assert.ok(clientId);
+  }
 
   const sessionCookie = existingSessionCookie ?? await (async () => {
     const loginResponse = await dispatch(new Request(`${issuer}/sign-in/email`, {
@@ -452,12 +452,13 @@ async function main(): Promise<void> {
     });
     const revocationCandidate = await prepareDirectMcpRevocation(revokeRequest);
     assert.ok(revocationCandidate);
-    const otherClientTokenSet = await issueTokenSet(
+    const siblingTokenSet = await issueTokenSet(
       auth,
       dispatch,
       issuer,
       resource,
       tokenSet.sessionCookie,
+      tokenSet.clientId,
     );
     const revokeResponse = await authRoute.POST(new NextRequest(revokeRequest));
     assert.equal(revokeResponse.status, 200, await revokeResponse.clone().text());
@@ -468,7 +469,7 @@ async function main(): Promise<void> {
         code: 'invalid_token',
       },
     );
-    await verifyDirectMcpAccessToken(otherClientTokenSet.accessToken, ['knowledge:read']);
+    await verifyDirectMcpAccessToken(siblingTokenSet.accessToken, ['knowledge:read']);
     const revocationDatabase = await openDb();
     try {
       const session = await revocationDatabase.get(
@@ -476,17 +477,20 @@ async function main(): Promise<void> {
         [principal.sessionId],
       );
       assert.ok(session, 'Revoking one OAuth client must not end the browser session.');
-      const otherClientGrant = await revocationDatabase.get(`
+      const siblingGrant = await revocationDatabase.get(`
         SELECT revoked
         FROM oauth_refresh_token
-        WHERE token = ?
-      `, [tokenHash(otherClientTokenSet.refreshToken)]) as { revoked: unknown } | undefined;
-      assert.equal(otherClientGrant?.revoked, null);
+        WHERE client_id = ?
+          AND session_id = ?
+        ORDER BY created_at DESC
+        LIMIT 1
+      `, [tokenSet.clientId, principal.sessionId]) as { revoked: unknown } | undefined;
+      assert.equal(siblingGrant?.revoked, null);
     } finally {
       await revocationDatabase.close();
     }
 
-    const refreshAfterRevocation = new Request(`${issuer}/oauth2/token`, {
+    const refreshAfterAccessTokenRevocation = new Request(`${issuer}/oauth2/token`, {
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
@@ -499,10 +503,9 @@ async function main(): Promise<void> {
       }),
     });
     const refreshPolicyResponse = await enforceDirectMcpOAuthRequestPolicy(
-      refreshAfterRevocation,
+      refreshAfterAccessTokenRevocation,
     );
-    assert.equal(refreshPolicyResponse?.status, 400);
-    assert.equal((await readJson(refreshPolicyResponse!)).error, 'invalid_grant');
+    assert.equal(refreshPolicyResponse, null);
 
     const errorResponse = new DirectMcpAuthorizationError(
       'invalid_token',

--- a/scripts/mcp-server-protected-resource-test.ts
+++ b/scripts/mcp-server-protected-resource-test.ts
@@ -261,18 +261,21 @@ async function main(): Promise<void> {
     };
     assert.deepEqual(await getDirectMcpProtectedResourceMetadata(), expectedMetadata);
     for (const response of await Promise.all([
-      directMcpProtectedResourceMetadataResponse(),
-      canonicalMetadataRoute.GET(),
-      aliasMetadataRoute.GET(),
+      directMcpProtectedResourceMetadataResponse(new Request(`${ORIGIN}/.well-known/oauth-protected-resource/mcp`)),
+      canonicalMetadataRoute.GET(new Request(`${ORIGIN}/.well-known/oauth-protected-resource/mcp`)),
+      aliasMetadataRoute.GET(new Request(`${ORIGIN}/.well-known/oauth-protected-resource`)),
     ])) {
       assert.equal(response.status, 200);
       assert.equal(response.headers.get('access-control-allow-origin'), '*');
+      assert.match(response.headers.get('x-request-id') || '', /^[0-9a-f-]{36}$/iu);
       assert.deepEqual(await readJson(response), expectedMetadata);
     }
 
     const originalFeatureFlag = process.env.CANVAS_MCP_DIRECT_ENABLED;
     process.env.CANVAS_MCP_DIRECT_ENABLED = 'false';
-    assert.equal((await directMcpProtectedResourceMetadataResponse()).status, 404);
+    assert.equal((await directMcpProtectedResourceMetadataResponse(
+      new Request(`${ORIGIN}/.well-known/oauth-protected-resource/mcp`),
+    )).status, 404);
     process.env.CANVAS_MCP_DIRECT_ENABLED = originalFeatureFlag;
 
     const tokenSet = await issueTokenSet(
@@ -428,7 +431,7 @@ async function main(): Promise<void> {
     const revocationCandidate = await prepareDirectMcpRevocation(revokeRequest);
     assert.ok(revocationCandidate);
     const revokeResponse = await auth.handler(revokeRequest);
-    assert.equal(revokeResponse.status, 200);
+    assert.equal(revokeResponse.status, 200, await revokeResponse.clone().text());
     await applyDirectMcpRevocation(revocationCandidate);
     await assertAuthorizationError(
       () => verifyDirectMcpAccessToken(tokenSet.accessToken, ['knowledge:read']),

--- a/scripts/mcp-server-protected-resource-test.ts
+++ b/scripts/mcp-server-protected-resource-test.ts
@@ -24,6 +24,10 @@ const REQUESTED_SCOPES = [
   'knowledge:read',
 ];
 
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('base64url');
+}
+
 type AuthHandler = {
   handler: (request: Request) => Promise<Response>;
   api: {
@@ -114,10 +118,12 @@ async function issueTokenSet(
   dispatch: (request: Request) => Promise<Response>,
   issuer: string,
   resource: string,
+  existingSessionCookie?: string,
 ): Promise<{
   accessToken: string;
   refreshToken: string;
   clientId: string;
+  sessionCookie: string;
 }> {
   const registrationResponse = await dispatch(new Request(`${issuer}/oauth2/register`, {
     method: 'POST',
@@ -138,19 +144,21 @@ async function issueTokenSet(
   const clientId = String((await readJson(registrationResponse)).client_id);
   assert.ok(clientId);
 
-  const loginResponse = await dispatch(new Request(`${issuer}/sign-in/email`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      origin: ORIGIN,
-    },
-    body: JSON.stringify({
-      email: EMAIL,
-      password: PASSWORD,
-    }),
-  }));
-  assert.equal(loginResponse.status, 200);
-  const sessionCookie = readSessionCookie(loginResponse);
+  const sessionCookie = existingSessionCookie ?? await (async () => {
+    const loginResponse = await dispatch(new Request(`${issuer}/sign-in/email`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: ORIGIN,
+      },
+      body: JSON.stringify({
+        email: EMAIL,
+        password: PASSWORD,
+      }),
+    }));
+    assert.equal(loginResponse.status, 200);
+    return readSessionCookie(loginResponse);
+  })();
 
   const authorizeResponse = await dispatch(new Request(
     authorizationUrl(clientId, resource),
@@ -205,6 +213,7 @@ async function issueTokenSet(
     accessToken: String(tokenSet.access_token),
     refreshToken: String(tokenSet.refresh_token),
     clientId,
+    sessionCookie,
   };
 }
 
@@ -443,6 +452,13 @@ async function main(): Promise<void> {
     });
     const revocationCandidate = await prepareDirectMcpRevocation(revokeRequest);
     assert.ok(revocationCandidate);
+    const otherClientTokenSet = await issueTokenSet(
+      auth,
+      dispatch,
+      issuer,
+      resource,
+      tokenSet.sessionCookie,
+    );
     const revokeResponse = await authRoute.POST(new NextRequest(revokeRequest));
     assert.equal(revokeResponse.status, 200, await revokeResponse.clone().text());
     await assertAuthorizationError(
@@ -452,6 +468,23 @@ async function main(): Promise<void> {
         code: 'invalid_token',
       },
     );
+    await verifyDirectMcpAccessToken(otherClientTokenSet.accessToken, ['knowledge:read']);
+    const revocationDatabase = await openDb();
+    try {
+      const session = await revocationDatabase.get(
+        'SELECT id FROM "session" WHERE id = ? LIMIT 1',
+        [principal.sessionId],
+      );
+      assert.ok(session, 'Revoking one OAuth client must not end the browser session.');
+      const otherClientGrant = await revocationDatabase.get(`
+        SELECT revoked
+        FROM oauth_refresh_token
+        WHERE token = ?
+      `, [tokenHash(otherClientTokenSet.refreshToken)]) as { revoked: unknown } | undefined;
+      assert.equal(otherClientGrant?.revoked, null);
+    } finally {
+      await revocationDatabase.close();
+    }
 
     const refreshAfterRevocation = new Request(`${issuer}/oauth2/token`, {
       method: 'POST',

--- a/scripts/mcp-server-protected-resource-test.ts
+++ b/scripts/mcp-server-protected-resource-test.ts
@@ -4,6 +4,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { NextRequest } from 'next/server';
+
 import {
   DIRECT_MCP_OAUTH_SCOPES,
   DIRECT_MCP_RESOURCE_SCOPES,
@@ -232,9 +234,9 @@ async function main(): Promise<void> {
       },
       { getDirectMcpReadiness },
       {
-        applyDirectMcpRevocation,
         prepareDirectMcpRevocation,
       },
+      authRoute,
       canonicalMetadataRoute,
       aliasMetadataRoute,
     ] = await Promise.all([
@@ -244,6 +246,7 @@ async function main(): Promise<void> {
       import('../app/lib/mcp/server/protected-resource-metadata'),
       import('../app/lib/mcp/server/readiness'),
       import('../app/lib/mcp/server/oauth-grant-revocation'),
+      import('../app/api/auth/[...all]/route'),
       import('../app/.well-known/oauth-protected-resource/mcp/route'),
       import('../app/.well-known/oauth-protected-resource/route'),
     ]);
@@ -440,9 +443,8 @@ async function main(): Promise<void> {
     });
     const revocationCandidate = await prepareDirectMcpRevocation(revokeRequest);
     assert.ok(revocationCandidate);
-    const revokeResponse = await auth.handler(revokeRequest);
+    const revokeResponse = await authRoute.POST(new NextRequest(revokeRequest));
     assert.equal(revokeResponse.status, 200, await revokeResponse.clone().text());
-    await applyDirectMcpRevocation(revocationCandidate);
     await assertAuthorizationError(
       () => verifyDirectMcpAccessToken(tokenSet.accessToken, ['knowledge:read']),
       {

--- a/scripts/mcp-server-protected-resource-test.ts
+++ b/scripts/mcp-server-protected-resource-test.ts
@@ -230,6 +230,7 @@ async function main(): Promise<void> {
         getDirectMcpProtectedResourceMetadata,
         directMcpProtectedResourceMetadataResponse,
       },
+      { getDirectMcpReadiness },
       {
         applyDirectMcpRevocation,
         prepareDirectMcpRevocation,
@@ -241,12 +242,17 @@ async function main(): Promise<void> {
       import('../app/lib/mcp/server/oauth-request-policy'),
       import('../app/lib/mcp/server/access-token-verifier'),
       import('../app/lib/mcp/server/protected-resource-metadata'),
+      import('../app/lib/mcp/server/readiness'),
       import('../app/lib/mcp/server/oauth-grant-revocation'),
       import('../app/.well-known/oauth-protected-resource/mcp/route'),
       import('../app/.well-known/oauth-protected-resource/route'),
     ]);
     const { issuer, resource, protectedResourceMetadataUrl } =
       resolveDirectMcpServerConfig();
+    assert.deepEqual(await getDirectMcpReadiness(), {
+      status: 'ready',
+      code: 'MCP_READY',
+    });
 
     async function dispatch(request: Request): Promise<Response> {
       return (await enforceDirectMcpOAuthRequestPolicy(request))
@@ -273,6 +279,10 @@ async function main(): Promise<void> {
 
     const originalFeatureFlag = process.env.CANVAS_MCP_DIRECT_ENABLED;
     process.env.CANVAS_MCP_DIRECT_ENABLED = 'false';
+    assert.deepEqual(await getDirectMcpReadiness(), {
+      status: 'disabled',
+      code: 'MCP_DISABLED',
+    });
     assert.equal((await directMcpProtectedResourceMetadataResponse(
       new Request(`${ORIGIN}/.well-known/oauth-protected-resource/mcp`),
     )).status, 404);

--- a/server.js
+++ b/server.js
@@ -671,6 +671,15 @@ async function startServer() {
     throw error;
   }
 
+  try {
+    const { assertDirectMcpStartupReady } = require('./app/lib/mcp/server/readiness');
+    await assertDirectMcpStartupReady();
+    console.log('[Startup] Direct MCP readiness check completed');
+  } catch (error) {
+    console.error('[Startup] CRITICAL ERROR in Direct MCP readiness:', error.message);
+    throw error;
+  }
+
   let agentRuntimeWarmupPromise = null;
   let managedCatalogWarmupPromise = null;
 


### PR DESCRIPTION
## Summary
- add redacted MCP/OAuth diagnostics, readiness gating, and atomic settings activation
- harden S256 PKCE, consent, revocation, discovery, and transport error handling
- extend Direct MCP coverage through authenticated tool calls and HTTP smoke validation

## Validation
- `npm run test:mcp:server-diagnostics`
- `npm run test:mcp:server-schema`
- `npm run test:mcp:server-settings`
- `npm run test:mcp:server-provider`
- `npm run test:mcp:server-login-consent`
- `npm run test:mcp:server-oauth-client`
- `npm run test:mcp:server-resource`
- `npm run test:mcp:server-auth-probe`
- `npm run test:mcp:server-http-smoke`
- `npm run build`

The external ChatGPT-connector acceptance remains intentionally pending explicit browser/test-account approval.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens Direct MCP OAuth discovery, diagnostics, readiness, consent, transport handling, and revocation behavior.
- Makes access-token revocation token-specific through hashed revocation records.
- Preserves browser sessions and unrelated OAuth grants during revocation.
- Adds readiness gating, redacted diagnostics, stricter PKCE and request policies, and broader MCP validation coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge within the follow-up review scope.

No blocking failure remains; the current implementation resolves both previously reported revocation-scope defects without leaving the shared-session or sibling-grant invalidation paths reachable.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/mcp/server/oauth-grant-revocation.ts | Replaces broad session-scoped revocation with exact access-token hashes and refresh-grant-ID-scoped updates, resolving both previous findings. |
| app/lib/mcp/server/access-token-verifier.ts | Rejects access tokens only when an exact hash, client, session, and user revocation record exists. |
| app/lib/db/schema.ts | Adds the token-specific Direct MCP revocation table with appropriate ownership references and expiry indexing. |
| app/lib/db/migrate.ts | Creates the token-specific revocation storage required by the updated verifier and revocation flow. |
| app/api/auth/[...all]/route.ts | Routes recognized Direct MCP revocations through the local atomic revocation handler and adds redacted diagnostics and stable error responses. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OAuth revocation request] --> B{Recognized token type?}
    B -->|Access token| C[Verify JWT and active grant state]
    C --> D[Store token hash in revocation table]
    D --> E[Verifier rejects only matching token hash]
    B -->|Refresh token| F[Resolve specific refresh grant]
    F --> G[Revoke grant by grant ID]
    G --> H[Preserve browser session and unrelated grants]
    B -->|Unknown token| I[Return OAuth-compatible success]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Make MCP revocation token-specific"](https://github.com/canvascoding/canvas-notebook/commit/e85c0b39394420bf4a09c468a8f94de6b8068997) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55603884)</sub>

<!-- /greptile_comment -->