### PR TITLE
Allow personal provider credentials in team workspaces

### DIFF
--- a/app/api/agent-runtime/user-credential-grants/route.ts
+++ b/app/api/agent-runtime/user-credential-grants/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { AgentAccessError, requireAgentAccessForWorkspace } from '@/app/lib/agents/access';
+import { normalizeManagedAgentId } from '@/app/lib/agents/registry';
+import {
+  getUserProviderGrant,
+  parseUserProviderGrantUpdate,
+  revokeUserProviderGrant,
+  runtimeErrorResponse,
+  setUserProviderGrant,
+} from '@/app/lib/agent-runtime-policy/runtime-service';
+import type { AiRuntimeResolutionContext } from '@/app/lib/agent-runtime-policy/runtime-resolver';
+import { auth } from '@/app/lib/auth';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+import { requireSessionWorkspace } from '@/app/lib/workspaces/request';
+
+const INSTALLATION_ID_PATTERN = /^aip_[a-f0-9]{24}$/u;
+
+function stringParam(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function routeError(error: unknown) {
+  if (error instanceof AgentAccessError) {
+    return NextResponse.json({ success: false, code: error.code, error: error.message }, { status: error.status });
+  }
+  if (error instanceof Error && error.message === 'INVALID_AGENT_ID') {
+    return NextResponse.json({ success: false, code: 'INVALID_AGENT_ID', error: 'agentId is invalid.' }, { status: 400 });
+  }
+  const response = runtimeErrorResponse(error);
+  if (response.status >= 500) {
+    console.error('[agent-runtime/user-credential-grants] Request failed.', {
+      errorType: error instanceof Error ? error.name : 'UnknownError',
+    });
+  }
+  return NextResponse.json(
+    { success: false, code: response.code, error: response.message, ...(response.details ?? {}) },
+    { status: response.status },
+  );
+}
+
+async function requireGrantContext(request: NextRequest, input: {
+  workspaceId: string | null;
+  agentId: string | null;
+}) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return { response: NextResponse.json({ success: false, code: 'UNAUTHORIZED', error: 'Unauthorized' }, { status: 401 }) };
+  }
+  if (!input.workspaceId || !input.agentId) {
+    return { response: NextResponse.json({ success: false, code: 'INVALID_RUNTIME_INPUT', error: 'workspaceId and agentId are required.' }, { status: 400 }) };
+  }
+  let agentId: string;
+  try {
+    agentId = normalizeManagedAgentId(input.agentId);
+  } catch {
+    return { response: NextResponse.json({ success: false, code: 'INVALID_AGENT_ID', error: 'agentId is invalid.' }, { status: 400 }) };
+  }
+  const access = await requireSessionWorkspace(session, {
+    workspaceId: input.workspaceId,
+    permissions: ['canRead', 'canRunAgent'],
+  });
+  if (access.response) return { response: access.response };
+  if (!access.workspace.organizationId) {
+    return { response: NextResponse.json({ success: false, code: 'ORGANIZATION_SETUP_REQUIRED', error: 'Complete the app setup first.' }, { status: 409 }) };
+  }
+  try {
+    await requireAgentAccessForWorkspace(session.user.id, agentId, 'canUse', access.workspace);
+  } catch (error) {
+    return { response: routeError(error) };
+  }
+  const context: AiRuntimeResolutionContext = {
+    organizationId: access.workspace.organizationId,
+    userId: session.user.id,
+    workspaceId: access.workspace.workspaceId,
+    workspaceType: access.workspace.workspaceType,
+    agentId,
+    sessionId: null,
+    requestedSelection: null,
+    executionMode: 'interactive',
+    principal: {
+      type: 'user',
+      userId: session.user.id,
+      credentialSubjectUserId: session.user.id,
+    },
+  };
+  return { session, context };
+}
+
+function validInstallationId(value: string | null): value is string {
+  return Boolean(value && INSTALLATION_ID_PATTERN.test(value));
+}
+
+export async function GET(request: NextRequest) {
+  const contextResult = await requireGrantContext(request, {
+    workspaceId: stringParam(request.nextUrl.searchParams.get('workspaceId')),
+    agentId: stringParam(request.nextUrl.searchParams.get('agentId')),
+  });
+  if ('response' in contextResult) return contextResult.response;
+  const providerInstallationId = stringParam(request.nextUrl.searchParams.get('providerInstallationId'));
+  if (!validInstallationId(providerInstallationId)) {
+    return NextResponse.json({ success: false, code: 'INVALID_RUNTIME_INPUT', error: 'providerInstallationId is invalid.' }, { status: 400 });
+  }
+  const limited = rateLimit(request, {
+    limit: 120,
+    windowMs: 60_000,
+    keyPrefix: `agent-runtime-user-grant-get:${contextResult.session.user.id}`,
+  });
+  if (!limited.ok) return limited.response;
+  try {
+    const grant = await getUserProviderGrant({ context: contextResult.context, providerInstallationId });
+    return NextResponse.json({ success: true, data: { grant } });
+  } catch (error) {
+    return routeError(error);
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const payload = await request.json().catch(() => null) as Record<string, unknown> | null;
+  const contextResult = await requireGrantContext(request, {
+    workspaceId: stringParam(payload?.workspaceId),
+    agentId: stringParam(payload?.agentId),
+  });
+  if ('response' in contextResult) return contextResult.response;
+  const limited = rateLimit(request, {
+    limit: 20,
+    windowMs: 60_000,
+    keyPrefix: `agent-runtime-user-grant-put:${contextResult.session.user.id}`,
+  });
+  if (!limited.ok) return limited.response;
+  try {
+    const grant = await setUserProviderGrant({
+      context: contextResult.context,
+      update: parseUserProviderGrantUpdate(payload),
+    });
+    return NextResponse.json({ success: true, data: { grant } });
+  } catch (error) {
+    return routeError(error);
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const contextResult = await requireGrantContext(request, {
+    workspaceId: stringParam(request.nextUrl.searchParams.get('workspaceId')),
+    agentId: stringParam(request.nextUrl.searchParams.get('agentId')),
+  });
+  if ('response' in contextResult) return contextResult.response;
+  const providerInstallationId = stringParam(request.nextUrl.searchParams.get('providerInstallationId'));
+  const expectedRevisionValue = stringParam(request.nextUrl.searchParams.get('expectedRevision'));
+  const expectedRevision = expectedRevisionValue === null
+    ? undefined
+    : /^\d+$/u.test(expectedRevisionValue) ? Number(expectedRevisionValue) : null;
+  if (!validInstallationId(providerInstallationId) || expectedRevision === null || (expectedRevision !== undefined && !Number.isSafeInteger(expectedRevision))) {
+    return NextResponse.json({ success: false, code: 'INVALID_RUNTIME_INPUT', error: 'Grant parameters are invalid.' }, { status: 400 });
+  }
+  const limited = rateLimit(request, {
+    limit: 20,
+    windowMs: 60_000,
+    keyPrefix: `agent-runtime-user-grant-delete:${contextResult.session.user.id}`,
+  });
+  if (!limited.ok) return limited.response;
+  try {
+    const grant = await revokeUserProviderGrant({
+      context: contextResult.context,
+      providerInstallationId,
+      expectedRevision,
+    });
+    return NextResponse.json({ success: true, data: { grant } });
+  } catch (error) {
+    return routeError(error);
+  }
+}

--- a/app/components/settings/AgentRuntimePreferenceCard.tsx
+++ b/app/components/settings/AgentRuntimePreferenceCard.tsx
@@ -14,6 +14,7 @@ import { selectActiveWorkspace, useWorkspaceStore } from '@/app/store/workspace-
 import { Button } from '@/components/ui/button';
 
 import { AgentSettingsAccordionCard } from './AgentSettingsAccordionCard';
+import { PiOAuthButton } from './PiOAuthButton';
 
 type RuntimeResponse = {
   success?: boolean;
@@ -106,6 +107,12 @@ export function AgentRuntimePreferenceCard({
     [resolution],
   );
   const models = selectedProvider?.models.filter((model) => model.enabled) ?? [];
+  const teamUserCredentialProviders = useMemo(
+    () => activeWorkspace?.type !== 'personal'
+      ? providers.filter((provider) => provider.credentialScope === 'user' && provider.authMethod === 'oauth')
+      : [],
+    [activeWorkspace?.type, providers],
+  );
   const controlsDisabled = loading || saving || !resolution;
 
   const showSaved = useCallback(() => {
@@ -208,6 +215,54 @@ export function AgentRuntimePreferenceCard({
       showSaved();
     } catch (resetError) {
       setError(resetError instanceof Error ? resetError.message : t('errors.reset'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const enablePersonalCredential = async (provider: AiEffectiveCatalogProvider) => {
+    if (!workspaceId || saving) return;
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const currentResponse = await fetch(
+        `/api/agent-runtime/user-credential-grants?${new URLSearchParams({
+          workspaceId,
+          agentId,
+          providerInstallationId: provider.installationId,
+        }).toString()}`,
+        { credentials: 'include', cache: 'no-store' },
+      );
+      const currentPayload = await currentResponse.json().catch(() => null) as {
+        success?: boolean;
+        data?: { grant?: { revision?: number } | null };
+        error?: string;
+      } | null;
+      if (!currentResponse.ok || currentPayload?.success !== true) {
+        throw new Error(currentPayload?.error || t('errors.save'));
+      }
+      const response = await fetch('/api/agent-runtime/user-credential-grants', {
+        method: 'PUT',
+        credentials: 'include',
+        cache: 'no-store',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          workspaceId,
+          agentId,
+          providerInstallationId: provider.installationId,
+          allowedExecutionModes: ['interactive'],
+          expectedRevision: currentPayload.data?.grant?.revision ?? 0,
+        }),
+      });
+      const payload = await response.json().catch(() => null) as { success?: boolean; error?: string } | null;
+      if (!response.ok || payload?.success !== true) {
+        throw new Error(payload?.error || t('errors.save'));
+      }
+      await loadResolution();
+      showSaved();
+    } catch (grantError) {
+      setError(grantError instanceof Error ? grantError.message : t('errors.save'));
     } finally {
       setSaving(false);
     }
@@ -331,6 +386,32 @@ export function AgentRuntimePreferenceCard({
           </select>
         </label>
       </div>
+
+      {teamUserCredentialProviders.length > 0 && (
+        <div className="rounded-md border border-primary/25 bg-primary/5 p-3 text-sm">
+          <p className="font-medium">Personal OAuth credentials</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Enable a connected personal provider only for your own interactive runs in this workspace and agent.
+            It is never shared with other members, agents, or organization automations.
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {teamUserCredentialProviders.map((provider) => (
+              <div key={provider.installationId} className="flex flex-wrap items-center gap-2">
+                <PiOAuthButton activeProviderId={provider.providerId} onStatusChange={() => void loadResolution()} />
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={saving}
+                  onClick={() => void enablePersonalCredential(provider)}
+                >
+                  Enable {provider.name} for my runs
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {(error || workspaceError || (!loading && resolution && !resolution.valid)) && (
         <div className="flex min-w-0 items-start justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-950 dark:text-amber-100" role="alert">

--- a/app/lib/agent-runtime-policy/provider-runtime.ts
+++ b/app/lib/agent-runtime-policy/provider-runtime.ts
@@ -26,6 +26,7 @@ import {
 import { sessionRuntimeSnapshotFromResolvedSelection } from '@/app/lib/agent-runtime-policy/runtime-snapshot';
 import {
   readPiSessionRuntimeSnapshot,
+  readUserWorkspaceProviderGrant,
   readWorkspaceModelPolicy,
   SessionRuntimeContextRevisionConflictError,
   SessionRuntimeSnapshotConflictError,
@@ -471,6 +472,36 @@ async function materializeResolution(
         'RUNTIME_PROVIDER_CHANGED',
         'The selected provider installation changed before the request started. Try again.',
       );
+    }
+
+    // The credential lookup below may refresh OAuth state or otherwise await
+    // I/O. Re-read the owner grant immediately before the provider request so
+    // a revocation during that window cannot authorize the stale credential.
+    if (latestProvider.credentialScope === 'user' && context.workspaceType !== 'personal') {
+      const principal = resolution.context.principal;
+      if (!runtimePrincipalCanUseUserCredentials(resolution.context) || principal.type !== 'user') {
+        throw new AiRuntimeExecutionError(
+          'RUNTIME_POLICY_CHANGED',
+          'Personal provider credentials are no longer allowed for this runtime principal. Try again.',
+        );
+      }
+      const grant = await readUserWorkspaceProviderGrant({
+        organizationId: resolution.context.organizationId,
+        userId: principal.credentialSubjectUserId,
+        workspaceId: resolution.context.workspaceId,
+        agentId: resolution.context.agentId,
+        providerInstallationId: latestProvider.installationId,
+      });
+      if (
+        !grant
+        || grant.status !== 'active'
+        || !grant.allowedExecutionModes.includes(resolution.context.executionMode)
+      ) {
+        throw new AiRuntimeExecutionError(
+          'RUNTIME_POLICY_CHANGED',
+          'The personal provider credential grant is no longer active. Try again.',
+        );
+      }
     }
 
     const allowedProvider = buildEffectiveCatalogProviders({

--- a/app/lib/agent-runtime-policy/provider-runtime.ts
+++ b/app/lib/agent-runtime-policy/provider-runtime.ts
@@ -20,6 +20,7 @@ import {
   assertEffectiveRuntimeSelection,
   buildEffectiveCatalogProviders,
   resolveEffectiveAgentRuntime,
+  runtimePrincipalCanUseUserCredentials,
   type AiRuntimeResolutionContext,
 } from '@/app/lib/agent-runtime-policy/runtime-resolver';
 import { sessionRuntimeSnapshotFromResolvedSelection } from '@/app/lib/agent-runtime-policy/runtime-snapshot';
@@ -140,12 +141,27 @@ function applyOllamaEndpoint(
 
 async function runtimeAuth(input: {
   provider: AiProviderInstallation;
-  organizationId: string;
-  userId: string;
+  context: AiEffectiveRuntimeResolution['context'];
 }): Promise<ProviderInstallationRuntimeAuth> {
+  if (
+    input.provider.credentialScope === 'user'
+    && !runtimePrincipalCanUseUserCredentials(input.context)
+  ) {
+    throw new AiRuntimeExecutionError(
+      'USER_CREDENTIAL_EXECUTION_FORBIDDEN',
+      'Personal provider credentials are not available for this runtime principal.',
+    );
+  }
+  const credentialUserId = input.context.principal.type === 'user'
+    ? input.context.principal.credentialSubjectUserId
+    : input.context.userId;
   let auth: ProviderInstallationRuntimeAuth;
   try {
-    auth = await resolveProviderInstallationRuntimeAuth(input);
+    auth = await resolveProviderInstallationRuntimeAuth({
+      provider: input.provider,
+      organizationId: input.context.organizationId,
+      userId: credentialUserId,
+    });
   } catch {
     throw new AiRuntimeExecutionError(
       'CREDENTIAL_LOOKUP_FAILED',
@@ -380,8 +396,7 @@ async function materializeResolution(
     ),
     runtimeAuth({
       provider: providerInstallation,
-      organizationId: resolution.context.organizationId,
-      userId: resolution.context.userId,
+      context: resolution.context,
     }),
   ]);
 
@@ -462,6 +477,8 @@ async function materializeResolution(
       catalog: latestCatalog,
       policy: latestPolicy,
       workspaceType: context.workspaceType,
+      allowUserCredentials: runtimePrincipalCanUseUserCredentials(resolution.context)
+        && (context.workspaceType === 'personal' || latestPolicy?.allowUserCredentials === true),
     }).find((candidate) => candidate.installationId === providerInstallation.installationId);
     const allowedModel = allowedProvider?.models.find((candidate) => candidate.id === catalogModel.id);
     if (!allowedModel) {
@@ -528,8 +545,7 @@ async function materializeResolution(
     });
     const auth = await runtimeAuth({
       provider: latestProvider,
-      organizationId: resolution.context.organizationId,
-      userId: resolution.context.userId,
+      context: latestResolution.context,
     });
 
     // Credential/OAuth lookup can perform filesystem, database, or network

--- a/app/lib/agent-runtime-policy/runtime-resolver.ts
+++ b/app/lib/agent-runtime-policy/runtime-resolver.ts
@@ -14,6 +14,8 @@ import type {
   AiEffectiveRuntimeResolution,
   AiResolvedRuntimeSelection,
   AiRuntimeResolutionIssue,
+  AiRuntimeExecutionMode,
+  AiRuntimePrincipal,
   AiRuntimeSelection,
   AiRuntimeSelectionSource,
   AiSessionRuntimeSnapshot,
@@ -31,6 +33,8 @@ export type AiRuntimeResolutionContext = {
   agentId: string;
   sessionId?: string | null;
   requestedSelection?: AiRuntimeSelection | null;
+  executionMode?: AiRuntimeExecutionMode;
+  principal?: AiRuntimePrincipal;
 };
 
 export class AiRuntimePolicyError extends Error {
@@ -55,13 +59,15 @@ export function buildEffectiveCatalogProviders(input: {
   policy: AiWorkspaceModelPolicy | null;
   workspaceType: WorkspaceType;
   credentialAvailability?: ReadonlyMap<string, boolean>;
+  allowUserCredentials?: boolean;
 }): AiEffectiveCatalogProvider[] {
   const allowedModels = input.policy?.allowedModels === null || input.policy?.allowedModels === undefined
     ? null
     : new Set(input.policy.allowedModels.map((reference) => (
         modelReferenceKey(reference.providerInstallationId, reference.modelId)
       )));
-  const allowUserCredentials = input.workspaceType === 'personal' || input.policy?.allowUserCredentials === true;
+  const allowUserCredentials = input.allowUserCredentials
+    ?? (input.workspaceType === 'personal' || input.policy?.allowUserCredentials === true);
 
   return input.catalog.providers.flatMap<AiEffectiveCatalogProvider>((provider) => {
     if (!provider.enabled || (provider.credentialScope === 'user' && !allowUserCredentials)) return [];
@@ -84,6 +90,38 @@ export function buildEffectiveCatalogProviders(input: {
       models,
     }];
   });
+}
+
+function normalizedRuntimePrincipal(context: AiRuntimeResolutionContext): AiRuntimePrincipal {
+  const principal = context.principal;
+  if (!principal) {
+    return {
+      type: 'user',
+      userId: context.userId,
+      credentialSubjectUserId: context.userId,
+    };
+  }
+  if (
+    principal.type === 'user'
+    && (principal.userId !== context.userId || principal.credentialSubjectUserId !== context.userId)
+  ) {
+    throw new AiRuntimePolicyError(
+      'PROVIDER_INSTALLATION_NOT_ALLOWED',
+      'The runtime principal does not match the session owner.',
+    );
+  }
+  return principal;
+}
+
+export function runtimePrincipalCanUseUserCredentials(input: {
+  userId: string;
+  executionMode: AiRuntimeExecutionMode;
+  principal: AiRuntimePrincipal;
+}): boolean {
+  return input.principal.type === 'user'
+    && input.principal.userId === input.userId
+    && input.principal.credentialSubjectUserId === input.userId
+    && input.executionMode !== 'organization_automation';
 }
 
 function issue(
@@ -260,7 +298,14 @@ export async function resolveEffectiveAgentRuntime(
   const context = {
     ...contextInput,
     agentId: normalizeManagedAgentId(contextInput.agentId),
+    executionMode: contextInput.executionMode ?? 'interactive' as const,
   };
+  const principal = normalizedRuntimePrincipal(context);
+  const executionAllowsUserCredentials = runtimePrincipalCanUseUserCredentials({
+    userId: context.userId,
+    executionMode: context.executionMode,
+    principal,
+  });
 
   // A managed instance may receive its first chat request before anyone opens
   // the AI provider settings. Initialize the Control Plane catalog here so a
@@ -277,12 +322,14 @@ export async function resolveEffectiveAgentRuntime(
   const [catalog, policy, preference, agent, persistedSession] = await Promise.all([
     readAppRuntimeCatalog(context.organizationId),
     readWorkspaceModelPolicy(context.organizationId, context.workspaceId),
-    readUserModelPreference({
-      organizationId: context.organizationId,
-      userId: context.userId,
-      workspaceId: context.workspaceId,
-      agentId: context.agentId,
-    }),
+    principal.type === 'user'
+      ? readUserModelPreference({
+        organizationId: context.organizationId,
+        userId: principal.credentialSubjectUserId,
+        workspaceId: context.workspaceId,
+        agentId: context.agentId,
+      })
+      : Promise.resolve(null),
     getAgentProfile(context.agentId),
     context.sessionId
       ? readPiSessionRuntimeSnapshot({
@@ -296,17 +343,21 @@ export async function resolveEffectiveAgentRuntime(
 
   const credentialAvailability = new Map(await Promise.all(catalog.providers.map(async (provider) => ([
     provider.installationId,
-    await isProviderInstallationCredentialAvailable({
-      provider,
-      organizationId: context.organizationId,
-      userId: context.userId,
-    }),
+    provider.credentialScope === 'user' && !executionAllowsUserCredentials
+      ? false
+      : await isProviderInstallationCredentialAvailable({
+        provider,
+        organizationId: context.organizationId,
+        userId: principal.type === 'user' ? principal.credentialSubjectUserId : context.userId,
+      }),
   ] as const))));
   const providers = buildEffectiveCatalogProviders({
     catalog,
     policy,
     workspaceType: context.workspaceType,
     credentialAvailability,
+    allowUserCredentials: executionAllowsUserCredentials
+      && (context.workspaceType === 'personal' || policy?.allowUserCredentials === true),
   });
   const policyRevision = policy?.revision ?? 0;
   const baseIssues: AiRuntimeResolutionIssue[] = [];
@@ -367,6 +418,8 @@ export async function resolveEffectiveAgentRuntime(
       workspaceId: context.workspaceId,
       workspaceType: context.workspaceType,
       agentId: context.agentId,
+      executionMode: context.executionMode,
+      principal,
     },
     catalogRevision: catalog.revision,
     policyRevision,

--- a/app/lib/agent-runtime-policy/runtime-resolver.ts
+++ b/app/lib/agent-runtime-policy/runtime-resolver.ts
@@ -5,6 +5,7 @@ import { readAppRuntimeCatalog } from '@/app/lib/agent-runtime-policy/catalog-st
 import { isProviderInstallationCredentialAvailable } from '@/app/lib/agent-runtime-policy/installation-credentials';
 import {
   readPiSessionRuntimeSnapshot,
+  readUserWorkspaceProviderGrant,
   readUserModelPreference,
   readWorkspaceModelPolicy,
 } from '@/app/lib/agent-runtime-policy/runtime-store';
@@ -341,16 +342,31 @@ export async function resolveEffectiveAgentRuntime(
   ]);
   if (!agent) throw new Error('Agent not found.');
 
-  const credentialAvailability = new Map(await Promise.all(catalog.providers.map(async (provider) => ([
-    provider.installationId,
-    provider.credentialScope === 'user' && !executionAllowsUserCredentials
-      ? false
-      : await isProviderInstallationCredentialAvailable({
+  const credentialAvailability = new Map(await Promise.all(catalog.providers.map(async (provider) => {
+    if (provider.credentialScope === 'user' && !executionAllowsUserCredentials) {
+      return [provider.installationId, false] as const;
+    }
+    if (provider.credentialScope === 'user' && context.workspaceType !== 'personal') {
+      const grant = await readUserWorkspaceProviderGrant({
+        organizationId: context.organizationId,
+        userId: principal.type === 'user' ? principal.credentialSubjectUserId : context.userId,
+        workspaceId: context.workspaceId,
+        agentId: context.agentId,
+        providerInstallationId: provider.installationId,
+      });
+      if (!grant || grant.status !== 'active' || !grant.allowedExecutionModes.includes(context.executionMode)) {
+        return [provider.installationId, false] as const;
+      }
+    }
+    return [
+      provider.installationId,
+      await isProviderInstallationCredentialAvailable({
         provider,
         organizationId: context.organizationId,
         userId: principal.type === 'user' ? principal.credentialSubjectUserId : context.userId,
       }),
-  ] as const))));
+    ] as const;
+  })));
   const providers = buildEffectiveCatalogProviders({
     catalog,
     policy,

--- a/app/lib/agent-runtime-policy/runtime-resolver.ts
+++ b/app/lib/agent-runtime-policy/runtime-resolver.ts
@@ -116,15 +116,20 @@ function normalizedRuntimePrincipal(context: AiRuntimeResolutionContext): AiRunt
 
 export function runtimePrincipalCanUseUserCredentials(input: {
   userId: string;
+  workspaceType: WorkspaceType;
   executionMode: AiRuntimeExecutionMode;
   principal: AiRuntimePrincipal;
 }): boolean {
-  return input.principal.type === 'user'
+  const ownsCredential = input.principal.type === 'user'
     && input.principal.userId === input.userId
-    && input.principal.credentialSubjectUserId === input.userId
-    // V1 grants are deliberately interactive-only. Future execution modes
-    // must opt in through a separately reviewed policy and grant contract.
-    && input.executionMode === 'interactive';
+    && input.principal.credentialSubjectUserId === input.userId;
+  if (!ownsCredential) return false;
+
+  // Team grants are deliberately interactive-only in V1. Existing personal
+  // automations retain their owner-scoped credential behavior because they do
+  // not cross a workspace boundary or need a team grant.
+  return input.executionMode === 'interactive'
+    || (input.executionMode === 'personal_automation' && input.workspaceType === 'personal');
 }
 
 function issue(
@@ -306,6 +311,7 @@ export async function resolveEffectiveAgentRuntime(
   const principal = normalizedRuntimePrincipal(context);
   const executionAllowsUserCredentials = runtimePrincipalCanUseUserCredentials({
     userId: context.userId,
+    workspaceType: context.workspaceType,
     executionMode: context.executionMode,
     principal,
   });

--- a/app/lib/agent-runtime-policy/runtime-resolver.ts
+++ b/app/lib/agent-runtime-policy/runtime-resolver.ts
@@ -122,7 +122,9 @@ export function runtimePrincipalCanUseUserCredentials(input: {
   return input.principal.type === 'user'
     && input.principal.userId === input.userId
     && input.principal.credentialSubjectUserId === input.userId
-    && input.executionMode !== 'organization_automation';
+    // V1 grants are deliberately interactive-only. Future execution modes
+    // must opt in through a separately reviewed policy and grant contract.
+    && input.executionMode === 'interactive';
 }
 
 function issue(
@@ -323,7 +325,7 @@ export async function resolveEffectiveAgentRuntime(
   const [catalog, policy, preference, agent, persistedSession] = await Promise.all([
     readAppRuntimeCatalog(context.organizationId),
     readWorkspaceModelPolicy(context.organizationId, context.workspaceId),
-    principal.type === 'user'
+    principal.type === 'user' && executionAllowsUserCredentials
       ? readUserModelPreference({
         organizationId: context.organizationId,
         userId: principal.credentialSubjectUserId,
@@ -398,7 +400,7 @@ export async function resolveEffectiveAgentRuntime(
 
   const explicit = context.requestedSelection
     ? { selection: context.requestedSelection, source: 'session' as const, snapshot: null }
-    : persistedSession
+    : persistedSession && executionAllowsUserCredentials
       ? {
           selection: persistedSession.selection,
           source: persistedSession.selectionSource,

--- a/app/lib/agent-runtime-policy/runtime-service.ts
+++ b/app/lib/agent-runtime-policy/runtime-service.ts
@@ -4,13 +4,16 @@ import { readAppRuntimeCatalog } from '@/app/lib/agent-runtime-policy/catalog-st
 import {
   deleteWorkspaceModelPolicyStore,
   deleteUserModelPreferenceStore,
+  readUserWorkspaceProviderGrant,
   readWorkspaceModelPolicy,
+  revokeUserWorkspaceProviderGrant,
   RuntimeContextRevisionConflictError,
   RuntimeRevisionConflictError,
   RuntimeStoredDataError,
   SessionRuntimeContextRevisionConflictError,
   SessionRuntimeSnapshotConflictError,
   writeUserModelPreferenceStore,
+  writeUserWorkspaceProviderGrant,
   writeWorkspaceModelPolicyStore,
 } from '@/app/lib/agent-runtime-policy/runtime-store';
 import {
@@ -23,6 +26,8 @@ import type {
   AiEffectiveRuntimeResolution,
   AiModelReference,
   AiRuntimeSelection,
+  AiRuntimeExecutionMode,
+  AiUserWorkspaceProviderGrant,
   AiWorkspaceModelPolicy,
 } from '@/app/lib/agent-runtime-policy/types';
 import { AI_THINKING_LEVELS } from '@/app/lib/agent-runtime-policy/types';
@@ -34,6 +39,7 @@ const PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
 const MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/@+~-]{0,199}$/u;
 const INSTALLATION_ID_PATTERN = /^aip_[a-f0-9]{24}$/u;
 const MAX_POLICY_MODELS = 10_000;
+const USER_GRANT_EXECUTION_MODES = new Set<AiRuntimeExecutionMode>(['interactive']);
 
 export class AiRuntimeInputError extends Error {
   readonly status = 400;
@@ -116,6 +122,130 @@ export function parseUserPreferenceUpdate(value: unknown): AiUserPreferenceUpdat
     expectedPolicyRevision: revisionField(value.expectedPolicyRevision, 'expectedPolicyRevision'),
     selection: parseRuntimeSelection(value.selection),
   };
+}
+
+export type AiUserProviderGrantUpdate = {
+  providerInstallationId: string;
+  allowedExecutionModes: AiRuntimeExecutionMode[];
+  expectedRevision: number;
+};
+
+export function parseUserProviderGrantUpdate(value: unknown): AiUserProviderGrantUpdate {
+  if (!isRecord(value)) {
+    throw new AiRuntimeInputError('INVALID_RUNTIME_INPUT', 'User provider credential grant must be an object.');
+  }
+  assertAllowedKeys(value, [
+    'workspaceId',
+    'agentId',
+    'providerInstallationId',
+    'allowedExecutionModes',
+    'expectedRevision',
+  ]);
+  if (!Array.isArray(value.allowedExecutionModes) || value.allowedExecutionModes.length === 0) {
+    throw new AiRuntimeInputError('INVALID_RUNTIME_INPUT', 'allowedExecutionModes must be a non-empty array.');
+  }
+  const modes = Array.from(new Set(value.allowedExecutionModes.map((mode) => {
+    if (typeof mode !== 'string' || !USER_GRANT_EXECUTION_MODES.has(mode as AiRuntimeExecutionMode)) {
+      throw new AiRuntimeInputError(
+        'INVALID_RUNTIME_INPUT',
+        'Only interactive user credential grants are currently supported.',
+      );
+    }
+    return mode as AiRuntimeExecutionMode;
+  })));
+  return {
+    providerInstallationId: stringField(value.providerInstallationId, 'providerInstallationId', INSTALLATION_ID_PATTERN),
+    allowedExecutionModes: modes,
+    expectedRevision: revisionField(value.expectedRevision, 'expectedRevision'),
+  };
+}
+
+async function assertUserProviderGrantTarget(input: {
+  context: AiRuntimeResolutionContext;
+  providerInstallationId: string;
+}): Promise<void> {
+  if (input.context.workspaceType === 'personal') {
+    throw new AiRuntimePolicyError(
+      'PROVIDER_INSTALLATION_NOT_ALLOWED',
+      'Personal workspaces do not require a team credential grant.',
+    );
+  }
+  if (
+    input.context.principal?.type === 'organization_service'
+    || (input.context.principal?.type === 'user' && input.context.principal.userId !== input.context.userId)
+  ) {
+    throw new AiRuntimePolicyError('PROVIDER_INSTALLATION_NOT_ALLOWED', 'Only the credential owner can manage this grant.');
+  }
+  const [catalog, policy] = await Promise.all([
+    readAppRuntimeCatalog(input.context.organizationId),
+    readWorkspaceModelPolicy(input.context.organizationId, input.context.workspaceId),
+  ]);
+  const provider = catalog.providers.find((candidate) => candidate.installationId === input.providerInstallationId);
+  if (!provider || !provider.enabled || provider.credentialScope !== 'user' || provider.config.authMethod !== 'oauth') {
+    throw new AiRuntimePolicyError(
+      'PROVIDER_INSTALLATION_NOT_ALLOWED',
+      'The selected provider installation is not an enabled personal OAuth provider.',
+    );
+  }
+  if (!policy?.allowUserCredentials) {
+    throw new AiRuntimePolicyError(
+      'PROVIDER_INSTALLATION_NOT_ALLOWED',
+      'Personal provider credentials are disabled by this workspace policy.',
+    );
+  }
+}
+
+export async function setUserProviderGrant(input: {
+  context: AiRuntimeResolutionContext;
+  update: AiUserProviderGrantUpdate;
+}): Promise<AiUserWorkspaceProviderGrant> {
+  await assertUserProviderGrantTarget({
+    context: input.context,
+    providerInstallationId: input.update.providerInstallationId,
+  });
+  return writeUserWorkspaceProviderGrant({
+    organizationId: input.context.organizationId,
+    userId: input.context.userId,
+    workspaceId: input.context.workspaceId,
+    agentId: input.context.agentId,
+    providerInstallationId: input.update.providerInstallationId,
+    allowedExecutionModes: input.update.allowedExecutionModes,
+    expectedRevision: input.update.expectedRevision,
+  });
+}
+
+export async function getUserProviderGrant(input: {
+  context: AiRuntimeResolutionContext;
+  providerInstallationId: string;
+}): Promise<AiUserWorkspaceProviderGrant | null> {
+  return readUserWorkspaceProviderGrant({
+    organizationId: input.context.organizationId,
+    userId: input.context.userId,
+    workspaceId: input.context.workspaceId,
+    agentId: input.context.agentId,
+    providerInstallationId: input.providerInstallationId,
+  });
+}
+
+export async function revokeUserProviderGrant(input: {
+  context: AiRuntimeResolutionContext;
+  providerInstallationId: string;
+  expectedRevision?: number;
+}): Promise<AiUserWorkspaceProviderGrant | null> {
+  if (
+    input.context.principal?.type === 'organization_service'
+    || (input.context.principal?.type === 'user' && input.context.principal.userId !== input.context.userId)
+  ) {
+    throw new AiRuntimePolicyError('PROVIDER_INSTALLATION_NOT_ALLOWED', 'Only the credential owner can revoke this grant.');
+  }
+  return revokeUserWorkspaceProviderGrant({
+    organizationId: input.context.organizationId,
+    userId: input.context.userId,
+    workspaceId: input.context.workspaceId,
+    agentId: input.context.agentId,
+    providerInstallationId: input.providerInstallationId,
+    expectedRevision: input.expectedRevision,
+  });
 }
 
 function assertContextRevisions(

--- a/app/lib/agent-runtime-policy/runtime-store.ts
+++ b/app/lib/agent-runtime-policy/runtime-store.ts
@@ -1,11 +1,15 @@
 import 'server-only';
 
+import { randomUUID } from 'node:crypto';
+
 import { getDatabaseProvider, openDb } from '@/app/lib/db';
 import type {
   AiModelReference,
   AiRuntimeSelection,
+  AiRuntimeExecutionMode,
   AiRuntimeSelectionSource,
   AiSessionRuntimeSnapshot,
+  AiUserWorkspaceProviderGrant,
   AiUserModelPreference,
   AiWorkspaceModelPolicy,
 } from '@/app/lib/agent-runtime-policy/types';
@@ -18,6 +22,13 @@ const SELECTION_SOURCES = new Set<AiRuntimeSelectionSource>([
   'agent_default',
   'workspace_default',
   'app_default',
+]);
+const EXECUTION_MODES = new Set<AiRuntimeExecutionMode>([
+  'interactive',
+  'external_channel',
+  'delegation',
+  'personal_automation',
+  'organization_automation',
 ]);
 
 type WorkspacePolicyRow = {
@@ -47,6 +58,21 @@ type UserPreferenceRow = {
   updated_at: number | string;
 };
 
+type UserWorkspaceProviderGrantRow = {
+  id: string;
+  organization_id: string;
+  user_id: string;
+  workspace_id: string;
+  agent_id: string;
+  provider_installation_id: string;
+  allowed_execution_modes_json: string;
+  status: string;
+  revision: number | string;
+  granted_at: number | string;
+  revoked_at: number | string | null;
+  updated_at: number | string;
+};
+
 type SessionRuntimeRow = {
   id: number | string;
   provider: string;
@@ -63,7 +89,7 @@ export class RuntimeRevisionConflictError extends Error {
   readonly status = 409;
 
   constructor(
-    public readonly entity: 'workspace_policy' | 'user_preference',
+    public readonly entity: 'workspace_policy' | 'user_preference' | 'user_provider_grant',
     public readonly currentRevision: number,
   ) {
     super(`${entity} revision conflict. Current revision is ${currentRevision}.`);
@@ -209,6 +235,45 @@ function assertRuntimeContextRevisions(
 
 function isoTimestamp(value: unknown): string {
   return new Date(numberValue(value, Date.now())).toISOString();
+}
+
+function parseGrantModes(value: string): AiRuntimeExecutionMode[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed) || parsed.length === 0) throw new Error('invalid modes');
+    const modes = Array.from(new Set(parsed.filter((mode): mode is AiRuntimeExecutionMode => (
+      typeof mode === 'string' && EXECUTION_MODES.has(mode as AiRuntimeExecutionMode)
+    ))));
+    if (modes.length !== parsed.length || modes.includes('organization_automation')) {
+      throw new Error('invalid modes');
+    }
+    return modes;
+  } catch {
+    throw new RuntimeStoredDataError(
+      'RUNTIME_PREFERENCE_CORRUPT',
+      'Stored user provider credential grant is invalid.',
+    );
+  }
+}
+
+function grantFromRow(row: UserWorkspaceProviderGrantRow): AiUserWorkspaceProviderGrant {
+  if (row.status !== 'active' && row.status !== 'revoked') {
+    throw new RuntimeStoredDataError('RUNTIME_PREFERENCE_CORRUPT', 'Stored user provider grant status is invalid.');
+  }
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    userId: row.user_id,
+    workspaceId: row.workspace_id,
+    agentId: row.agent_id,
+    providerInstallationId: row.provider_installation_id,
+    allowedExecutionModes: parseGrantModes(row.allowed_execution_modes_json),
+    status: row.status,
+    revision: numberValue(row.revision, 0),
+    grantedAt: isoTimestamp(row.granted_at),
+    revokedAt: row.revoked_at === null ? null : isoTimestamp(row.revoked_at),
+    updatedAt: isoTimestamp(row.updated_at),
+  };
 }
 
 function storedThinkingLevel(
@@ -536,6 +601,200 @@ export async function readUserModelPreference(input: {
   } finally {
     await connection.close?.();
   }
+}
+
+export async function readUserWorkspaceProviderGrant(input: {
+  organizationId: string;
+  userId: string;
+  workspaceId: string;
+  agentId: string;
+  providerInstallationId: string;
+}): Promise<AiUserWorkspaceProviderGrant | null> {
+  const connection = await openDb();
+  try {
+    const row = await connection.get(
+      `SELECT id, organization_id, user_id, workspace_id, agent_id,
+              provider_installation_id, allowed_execution_modes_json, status,
+              revision, granted_at, revoked_at, updated_at
+       FROM ai_user_workspace_provider_grants
+       WHERE organization_id = ? AND user_id = ? AND workspace_id = ?
+         AND agent_id = ? AND provider_installation_id = ?
+       LIMIT 1`,
+      [
+        input.organizationId,
+        input.userId,
+        input.workspaceId,
+        input.agentId,
+        input.providerInstallationId,
+      ],
+    ) as UserWorkspaceProviderGrantRow | undefined;
+    return row ? grantFromRow(row) : null;
+  } finally {
+    await connection.close?.();
+  }
+}
+
+export async function writeUserWorkspaceProviderGrant(input: {
+  organizationId: string;
+  userId: string;
+  workspaceId: string;
+  agentId: string;
+  providerInstallationId: string;
+  allowedExecutionModes: AiRuntimeExecutionMode[];
+  expectedRevision: number;
+}): Promise<AiUserWorkspaceProviderGrant> {
+  const modes = Array.from(new Set(input.allowedExecutionModes));
+  if (modes.length === 0 || modes.some((mode) => !EXECUTION_MODES.has(mode) || mode === 'organization_automation')) {
+    throw new Error('Invalid user provider credential grant modes.');
+  }
+  const connection = await openDb();
+  let transactionStarted = false;
+  try {
+    await connection.run(getDatabaseProvider() === 'sqlite' ? 'BEGIN IMMEDIATE' : 'BEGIN');
+    transactionStarted = true;
+    await lockWorkspaceRuntimeContext(connection, input);
+    const current = await connection.get(
+      `SELECT id, organization_id, user_id, workspace_id, agent_id,
+              provider_installation_id, allowed_execution_modes_json, status,
+              revision, granted_at, revoked_at, updated_at
+       FROM ai_user_workspace_provider_grants
+       WHERE organization_id = ? AND user_id = ? AND workspace_id = ?
+         AND agent_id = ? AND provider_installation_id = ?
+       LIMIT 1`,
+      [
+        input.organizationId,
+        input.userId,
+        input.workspaceId,
+        input.agentId,
+        input.providerInstallationId,
+      ],
+    ) as UserWorkspaceProviderGrantRow | undefined;
+    const currentRevision = current ? numberValue(current.revision, 0) : 0;
+    if (currentRevision !== input.expectedRevision) {
+      throw new RuntimeRevisionConflictError('user_provider_grant', currentRevision);
+    }
+    const now = Date.now();
+    const nextRevision = currentRevision + 1;
+    const modesJson = JSON.stringify(modes);
+    if (current) {
+      const result = await connection.run(
+        `UPDATE ai_user_workspace_provider_grants
+         SET allowed_execution_modes_json = ?, status = 'active', revision = ?,
+             granted_at = ?, revoked_at = NULL, updated_at = ?
+         WHERE id = ? AND revision = ?`,
+        [modesJson, nextRevision, now, now, current.id, currentRevision],
+      );
+      if (changedRows(result) !== 1) {
+        throw new RuntimeRevisionConflictError('user_provider_grant', currentRevision + 1);
+      }
+    } else {
+      await connection.run(
+        `INSERT INTO ai_user_workspace_provider_grants (
+          id, organization_id, user_id, workspace_id, agent_id,
+          provider_installation_id, allowed_execution_modes_json, status,
+          revision, granted_at, revoked_at, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NULL, ?, ?)`,
+        [
+          randomUUID(),
+          input.organizationId,
+          input.userId,
+          input.workspaceId,
+          input.agentId,
+          input.providerInstallationId,
+          modesJson,
+          nextRevision,
+          now,
+          now,
+          now,
+        ],
+      );
+    }
+    await connection.run('COMMIT');
+    transactionStarted = false;
+  } catch (error) {
+    if (transactionStarted) {
+      try {
+        await connection.run('ROLLBACK');
+      } catch {
+        // Preserve the original grant error.
+      }
+    }
+    throw error;
+  } finally {
+    await connection.close?.();
+  }
+
+  const grant = await readUserWorkspaceProviderGrant(input);
+  if (!grant) throw new Error('User provider credential grant could not be loaded after update.');
+  return grant;
+}
+
+export async function revokeUserWorkspaceProviderGrant(input: {
+  organizationId: string;
+  userId: string;
+  workspaceId: string;
+  agentId: string;
+  providerInstallationId: string;
+  expectedRevision?: number;
+}): Promise<AiUserWorkspaceProviderGrant | null> {
+  const connection = await openDb();
+  let transactionStarted = false;
+  try {
+    await connection.run(getDatabaseProvider() === 'sqlite' ? 'BEGIN IMMEDIATE' : 'BEGIN');
+    transactionStarted = true;
+    await lockWorkspaceRuntimeContext(connection, input);
+    const current = await connection.get(
+      `SELECT id, organization_id, user_id, workspace_id, agent_id,
+              provider_installation_id, allowed_execution_modes_json, status,
+              revision, granted_at, revoked_at, updated_at
+       FROM ai_user_workspace_provider_grants
+       WHERE organization_id = ? AND user_id = ? AND workspace_id = ?
+         AND agent_id = ? AND provider_installation_id = ?
+       LIMIT 1`,
+      [
+        input.organizationId,
+        input.userId,
+        input.workspaceId,
+        input.agentId,
+        input.providerInstallationId,
+      ],
+    ) as UserWorkspaceProviderGrantRow | undefined;
+    if (!current) {
+      await connection.run('COMMIT');
+      transactionStarted = false;
+      return null;
+    }
+    const currentRevision = numberValue(current.revision, 0);
+    if (input.expectedRevision !== undefined && input.expectedRevision !== currentRevision) {
+      throw new RuntimeRevisionConflictError('user_provider_grant', currentRevision);
+    }
+    if (current.status === 'active') {
+      const now = Date.now();
+      const result = await connection.run(
+        `UPDATE ai_user_workspace_provider_grants
+         SET status = 'revoked', revision = ?, revoked_at = ?, updated_at = ?
+         WHERE id = ? AND revision = ?`,
+        [currentRevision + 1, now, now, current.id, currentRevision],
+      );
+      if (changedRows(result) !== 1) {
+        throw new RuntimeRevisionConflictError('user_provider_grant', currentRevision + 1);
+      }
+    }
+    await connection.run('COMMIT');
+    transactionStarted = false;
+  } catch (error) {
+    if (transactionStarted) {
+      try {
+        await connection.run('ROLLBACK');
+      } catch {
+        // Preserve the original grant error.
+      }
+    }
+    throw error;
+  } finally {
+    await connection.close?.();
+  }
+  return readUserWorkspaceProviderGrant(input);
 }
 
 export async function writeUserModelPreferenceStore(input: {

--- a/app/lib/agent-runtime-policy/types.ts
+++ b/app/lib/agent-runtime-policy/types.ts
@@ -3,11 +3,32 @@ import type { PiThinkingLevel } from '@/app/lib/pi/config';
 export const AI_PROVIDER_SOURCES = ['managed', 'built-in', 'self-hosted'] as const;
 export const AI_CREDENTIAL_SCOPES = ['managed', 'system', 'organization', 'user'] as const;
 export const AI_PROVIDER_STATUSES = ['unverified', 'ready', 'degraded', 'disabled'] as const;
+export const AI_RUNTIME_EXECUTION_MODES = [
+  'interactive',
+  'external_channel',
+  'delegation',
+  'personal_automation',
+  'organization_automation',
+] as const;
 export const AI_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const satisfies readonly PiThinkingLevel[];
 
 export type AiProviderSource = (typeof AI_PROVIDER_SOURCES)[number];
 export type AiCredentialScope = (typeof AI_CREDENTIAL_SCOPES)[number];
 export type AiProviderStatus = (typeof AI_PROVIDER_STATUSES)[number];
+export type AiRuntimeExecutionMode = (typeof AI_RUNTIME_EXECUTION_MODES)[number];
+
+export type AiRuntimePrincipal =
+  | {
+      type: 'user';
+      userId: string;
+      credentialSubjectUserId: string;
+    }
+  | {
+      type: 'organization_service';
+      serviceActorId: string;
+      responsibleUserId: string;
+      credentialSubjectUserId: null;
+    };
 
 export type AiProviderSafeConfig = {
   authMethod?: 'api-key' | 'oauth';
@@ -183,6 +204,8 @@ export type AiEffectiveRuntimeResolution = {
     workspaceId: string;
     workspaceType: 'personal' | 'organization' | 'team' | 'project';
     agentId: string;
+    executionMode: AiRuntimeExecutionMode;
+    principal: AiRuntimePrincipal;
   };
   catalogRevision: number;
   policyRevision: number;

--- a/app/lib/agent-runtime-policy/types.ts
+++ b/app/lib/agent-runtime-policy/types.ts
@@ -158,6 +158,21 @@ export type AiUserModelPreference = {
   updatedAt: string;
 };
 
+export type AiUserWorkspaceProviderGrant = {
+  id: string;
+  organizationId: string;
+  userId: string;
+  workspaceId: string;
+  agentId: string;
+  providerInstallationId: string;
+  allowedExecutionModes: AiRuntimeExecutionMode[];
+  status: 'active' | 'revoked';
+  revision: number;
+  grantedAt: string;
+  revokedAt: string | null;
+  updatedAt: string;
+};
+
 export type AiSessionRuntimeSnapshot = {
   selection: AiRuntimeSelection;
   catalogRevision: number;

--- a/app/lib/agents/model-test.ts
+++ b/app/lib/agents/model-test.ts
@@ -130,6 +130,14 @@ function extractAssistantText(message: AssistantMessage): string {
     .trim();
 }
 
+function isExpectedProbeResponse(responseText: string): boolean {
+  // Some otherwise compatible providers add a single terminal period despite
+  // the exact-response instruction. Keep the probe strict while accepting
+  // that harmless punctuation variant.
+  const normalized = responseText.toUpperCase();
+  return normalized === 'OK' || normalized === 'OK.';
+}
+
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'Unknown model test error';
 }
@@ -325,7 +333,7 @@ export async function testAgentModelConnection(params: {
         }
 
         const responseText = extractAssistantText(response);
-        if (responseText.toUpperCase() !== 'OK') {
+        if (!isExpectedProbeResponse(responseText)) {
           logWarn(runId, 'unexpected-response', {
             agentId,
             provider,

--- a/app/lib/automations/runner.ts
+++ b/app/lib/automations/runner.ts
@@ -481,6 +481,21 @@ export async function executeAutomationRun(runId: string): Promise<void> {
         workspaceType: automationWorkspace.workspaceType,
         agentId: job.agentId,
         requestedSelection: null,
+        executionMode: job.scope === 'organization'
+          ? 'organization_automation' as const
+          : 'personal_automation' as const,
+        principal: job.scope === 'organization'
+          ? {
+              type: 'organization_service' as const,
+              serviceActorId: job.serviceActorId || `org-service:${automationWorkspace.organizationId}`,
+              responsibleUserId: automationUserId,
+              credentialSubjectUserId: null,
+            }
+          : {
+              type: 'user' as const,
+              userId: automationUserId,
+              credentialSubjectUserId: automationUserId,
+            },
       };
       let executableRuntime = persistedSession
         ? await resolveAndPinSessionRuntime({ ...runtimeContext, sessionId: piSessionId })

--- a/app/lib/automations/workspace-change.ts
+++ b/app/lib/automations/workspace-change.ts
@@ -259,6 +259,21 @@ async function prepareAutomationWorkspaceChange(
         agentId: job.agentId,
         sessionId: null,
         requestedSelection: null,
+        executionMode: job.scope === 'organization'
+          ? 'organization_automation' as const
+          : 'personal_automation' as const,
+        principal: job.scope === 'organization'
+          ? {
+              type: 'organization_service' as const,
+              serviceActorId: job.serviceActorId || `org-service:${executionWorkspace.organizationId}`,
+              responsibleUserId,
+              credentialSubjectUserId: null,
+            }
+          : {
+              type: 'user' as const,
+              userId: responsibleUserId,
+              credentialSubjectUserId: responsibleUserId,
+            },
       });
     } catch (error) {
       issues.push(issue(

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -942,6 +942,27 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       FOREIGN KEY (workspace_id) REFERENCES canvas_workspaces(id) ON DELETE CASCADE
     );
 
+    CREATE TABLE IF NOT EXISTS ai_user_workspace_provider_grants (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      workspace_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      provider_installation_id TEXT NOT NULL,
+      allowed_execution_modes_json TEXT NOT NULL DEFAULT '["interactive"]',
+      status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked')),
+      revision INTEGER NOT NULL DEFAULT 1,
+      granted_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (user_id, workspace_id, agent_id, provider_installation_id),
+      FOREIGN KEY (organization_id) REFERENCES canvas_organization_settings(organization_id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
+      FOREIGN KEY (workspace_id) REFERENCES canvas_workspaces(id) ON DELETE CASCADE,
+      FOREIGN KEY (provider_installation_id) REFERENCES ai_provider_installations(id) ON DELETE CASCADE
+    );
+
     CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_provider_installations_org_binding ON ai_provider_installations (organization_id, provider_id, credential_scope);
     CREATE INDEX IF NOT EXISTS idx_ai_provider_installations_org_enabled ON ai_provider_installations (organization_id, enabled);
     CREATE INDEX IF NOT EXISTS idx_ai_provider_installations_org_status ON ai_provider_installations (organization_id, status);
@@ -950,6 +971,8 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_ai_workspace_model_policies_org ON ai_workspace_model_policies (organization_id);
     CREATE INDEX IF NOT EXISTS idx_ai_user_model_preferences_org_user ON ai_user_model_preferences (organization_id, user_id);
     CREATE INDEX IF NOT EXISTS idx_ai_user_model_preferences_workspace ON ai_user_model_preferences (workspace_id);
+    CREATE INDEX IF NOT EXISTS idx_ai_user_workspace_provider_grants_org_user ON ai_user_workspace_provider_grants (organization_id, user_id, status);
+    CREATE INDEX IF NOT EXISTS idx_ai_user_workspace_provider_grants_workspace ON ai_user_workspace_provider_grants (workspace_id, status);
 
     CREATE TABLE IF NOT EXISTS pi_sessions (
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -1031,6 +1031,30 @@ export const aiUserModelPreferences = sqliteTable("ai_user_model_preferences", {
   workspaceIdx: index("idx_ai_user_model_preferences_workspace").on(table.workspaceId),
 }));
 
+export const aiUserWorkspaceProviderGrants = sqliteTable("ai_user_workspace_provider_grants", {
+  id: text("id").primaryKey(),
+  organizationId: text("organization_id").notNull().references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: 'cascade' }),
+  workspaceId: text("workspace_id").notNull().references(() => canvasWorkspaces.id, { onDelete: 'cascade' }),
+  agentId: text("agent_id").notNull(),
+  providerInstallationId: text("provider_installation_id").notNull().references(() => aiProviderInstallations.id, { onDelete: 'cascade' }),
+  allowedExecutionModesJson: text("allowed_execution_modes_json").notNull().default('["interactive"]'),
+  status: text("status").notNull().default("active"),
+  revision: integer("revision").notNull().default(1),
+  grantedAt: integer("granted_at", { mode: "timestamp" }).notNull(),
+  revokedAt: integer("revoked_at", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  bindingIdx: uniqueIndex("idx_ai_user_workspace_provider_grants_binding")
+    .on(table.userId, table.workspaceId, table.agentId, table.providerInstallationId),
+  organizationUserIdx: index("idx_ai_user_workspace_provider_grants_org_user")
+    .on(table.organizationId, table.userId, table.status),
+  workspaceIdx: index("idx_ai_user_workspace_provider_grants_workspace")
+    .on(table.workspaceId, table.status),
+  statusCheck: check("ai_user_workspace_provider_grants_status_check", sql`${table.status} IN ('active', 'revoked')`),
+}));
+
 export const aiSessions = sqliteTable("ai_sessions", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   sessionId: text("session_id").notNull(),

--- a/app/lib/pi/delegate-task-tool.ts
+++ b/app/lib/pi/delegate-task-tool.ts
@@ -667,6 +667,12 @@ async function startEphemeralDelegatedRun(request: DelegateTaskRequest): Promise
               agentId: request.sourceAgentId,
               sessionId: null,
               requestedSelection: null,
+              executionMode: 'delegation',
+              principal: {
+                type: 'user',
+                userId: request.userId,
+                credentialSubjectUserId: request.userId,
+              },
             },
             update: {
               selection: sourceRuntime.selection.selection,
@@ -733,6 +739,12 @@ async function startEphemeralDelegatedRun(request: DelegateTaskRequest): Promise
           agentId: request.sourceAgentId,
           sessionId,
           requestedSelection: null,
+          executionMode: 'delegation',
+          principal: {
+            type: 'user',
+            userId: request.userId,
+            credentialSubjectUserId: request.userId,
+          },
         });
         throwIfDelegationAborted(execution.controller.signal);
         const provider = runtime.selection.selection.providerId;
@@ -910,6 +922,12 @@ async function ensureManagedDelegatedSession(
           agentId: targetAgentId,
           sessionId: null,
           requestedSelection: null,
+          executionMode: 'delegation',
+          principal: {
+            type: 'user',
+            userId: request.userId,
+            credentialSubjectUserId: request.userId,
+          },
         },
       });
       const refreshedScope = await resolveDelegationSourceScope(request);

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -1800,6 +1800,12 @@ async function createRuntime(sessionId: string, userId: string): Promise<LivePiR
     agentId,
     sessionId,
     requestedSelection: null,
+    executionMode: sessionRecord.sessionKind === 'delegation_worker' ? 'delegation' : 'interactive',
+    principal: {
+      type: 'user',
+      userId,
+      credentialSubjectUserId: userId,
+    },
   });
   timing.mark('runtimeResolution');
   const provider = executableRuntime.selection.selection.providerId;
@@ -2198,6 +2204,12 @@ export async function getPiRuntimeStatus(sessionId: string, userId: string): Pro
     agentId: sessionRecord.agentId,
     sessionId,
     requestedSelection: null,
+    executionMode: sessionRecord.sessionKind === 'delegation_worker' ? 'delegation' : 'interactive',
+    principal: {
+      type: 'user',
+      userId,
+      credentialSubjectUserId: userId,
+    },
   });
   const model = executableRuntime.model;
   const browserRuntimeContextBlock = buildBrowserRuntimeContextBlock(browserSnapshot);

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -58,7 +58,7 @@ import {
   resolveStudioFilePath,
   STUDIO_OUTPUTS_ROOT_DIR,
 } from '@/app/lib/integrations/studio-workspace';
-import { DEFAULT_AGENT_ID } from '@/app/lib/channels/constants';
+import { DEFAULT_AGENT_ID, normalizeStoredChannelId, WEB_CHANNEL_ID } from '@/app/lib/channels/constants';
 import { buildWorkspaceFileTreePrompt } from '@/app/lib/agents/workspace-file-tree-context';
 import { buildReferencedPluginRuntimeContext } from '@/app/lib/plugins/plugin-reference-context';
 import { createToolLoopGuard } from '@/app/lib/pi/tool-loop-guard';
@@ -104,6 +104,16 @@ const CLEANUP_INTERVAL_MS = 60 * 1000;
 const MAX_RUNTIME_INSTANCES = 20;
 const MAX_MESSAGE_CONTEXT_SNAPSHOTS = 64;
 const RUNTIME_CONTEXT_VALUE_MAX_CHARS = 2_000;
+
+function runtimeExecutionModeForSession(session: Pick<typeof piSessions.$inferSelect, 'sessionKind' | 'channelId'>) {
+  if (session.sessionKind === 'delegation_worker') {
+    return 'delegation' as const;
+  }
+
+  return normalizeStoredChannelId(session.channelId ?? 'app') === WEB_CHANNEL_ID
+    ? 'interactive' as const
+    : 'external_channel' as const;
+}
 
 function estimatePiToolSchemaTokens(tools: AgentTool[]): number {
   try {
@@ -1800,7 +1810,7 @@ async function createRuntime(sessionId: string, userId: string): Promise<LivePiR
     agentId,
     sessionId,
     requestedSelection: null,
-    executionMode: sessionRecord.sessionKind === 'delegation_worker' ? 'delegation' : 'interactive',
+    executionMode: runtimeExecutionModeForSession(sessionRecord),
     principal: {
       type: 'user',
       userId,
@@ -2204,7 +2214,7 @@ export async function getPiRuntimeStatus(sessionId: string, userId: string): Pro
     agentId: sessionRecord.agentId,
     sessionId,
     requestedSelection: null,
-    executionMode: sessionRecord.sessionKind === 'delegation_worker' ? 'delegation' : 'interactive',
+    executionMode: runtimeExecutionModeForSession(sessionRecord),
     principal: {
       type: 'user',
       userId,

--- a/docs/dokumentation/app-bugs-2026-08/16-chatgpt-abo-im-team-workspace-stabilisieren.md
+++ b/docs/dokumentation/app-bugs-2026-08/16-chatgpt-abo-im-team-workspace-stabilisieren.md
@@ -9,6 +9,9 @@ tags: [type/bug, topic/chatgpt, topic/oauth, topic/workspaces, topic/runtime]
 
 # Ticket 16: Persoenliches ChatGPT-Abo im Team-Workspace nutzbar machen
 
+> Detaillierter, am aktuellen Codebestand ausgerichteter Umsetzungsplan:
+> [16-chatgpt-abo-im-team-workspace-umsetzungsplan.md](./16-chatgpt-abo-im-team-workspace-umsetzungsplan.md)
+
 ## Problem
 
 Ein Nutzer kann sein persoenlich verbundenes ChatGPT-Abo im persoenlichen

--- a/docs/dokumentation/app-bugs-2026-08/16-chatgpt-abo-im-team-workspace-umsetzungsplan.md
+++ b/docs/dokumentation/app-bugs-2026-08/16-chatgpt-abo-im-team-workspace-umsetzungsplan.md
@@ -1,0 +1,886 @@
+---
+title: 'Umsetzungsplan zu Ticket 16: Persoenliches ChatGPT-Abo im Team-Workspace'
+status: planned
+date: 2026-08-21
+platforms: [web, server, agent-runtime]
+tags: [type/implementation-plan, topic/chatgpt, topic/oauth, topic/workspaces, topic/runtime, topic/security]
+---
+
+# Umsetzungsplan: Persoenliches ChatGPT-Abo im Team-Workspace
+
+## Ziel, Scope und Sicherheitsinvariante
+
+Dieser Plan konkretisiert [Ticket 16](./16-chatgpt-abo-im-team-workspace-stabilisieren.md)
+am aktuellen Codebestand. Er plant ausschliesslich die Nutzung der bereits
+user-scoped gespeicherten `openai-codex`-OAuth-Verbindung eines Menschen fuer
+dessen eigene, ausdruecklich autorisierte Runs in einem Team-Workspace.
+
+`openai-codex` (ChatGPT-Login) und `openai` (API-Key) bleiben unterschiedliche
+Provider-Installationen und duerfen weder in UI noch Resolver als austauschbare
+Fallbacks behandelt werden. Laut der offiziellen OpenAI-Dokumentation ist die
+Anmeldung mit ChatGPT planbasierte Authentifizierung, waehrend API-Key-Login
+nutzungsbasierte Platform-Abrechnung verwendet. Authentifizierung ersetzt
+ausserdem keine Workspace- und lokale Berechtigungspruefung:
+
+- [Codex authentication](https://learn.chatgpt.com/docs/auth)
+- [Roles and workspace permissions](https://learn.chatgpt.com/docs/enterprise/roles-and-workspace-permissions)
+- [Codex pricing](https://learn.chatgpt.com/docs/pricing)
+
+Die zentrale Sicherheitsinvariante lautet:
+
+> Eine Workspace- oder Agent-Policy kann die Nutzung eines persoenlichen
+> Credentials nur verbieten. Nutzbar wird es erst durch eine eigene,
+> serverseitig gebundene Freigabe des Credential-Inhabers fuer Workspace,
+> Agent, Provider-Installation und Ausfuehrungsart. Kein Admin, Agent,
+> Teammitglied, Session-Snapshot oder Automation-Owner kann diese Freigabe
+> stellvertretend erzeugen oder den Credential-Subject austauschen.
+
+Ein Agent erhaelt weder Token noch Credential-Referenz. Nur der serverseitige
+Provider-Broker darf das Credential unmittelbar vor genau einem ausgehenden
+Provider-Request laden. Ein Organization- oder System-Agent kann damit zwar
+als Workload eines eigenen interaktiven User-Runs ausgefuehrt werden, sofern
+alle Gates dies erlauben; das Credential wird dem Agenten dadurch aber weder
+uebereignet noch als Agent-, Workspace- oder Organization-Secret gespeichert.
+
+Nicht Teil dieses Tickets sind ein neues OpenAI-Billingmodell, das Teilen eines
+ChatGPT-Abos, eine Organization-weite Token-Migration, allgemeine Automation-
+oder Delegationserweiterungen sowie die spaetere Multi-Participant-Conversation-
+Architektur. Fuer diese angrenzenden Bereiche werden nur die notwendigen
+fail-closed Grenzen festgelegt.
+
+## Inventur des Ist-Zustands
+
+### Provider-Katalog, Policy und Auswahl
+
+- `app/lib/agent-runtime-policy/types.ts`
+  - kennt die Credential-Scopes `managed`, `system`, `organization` und `user`;
+  - speichert in `AiWorkspaceModelPolicy` nur das grobe Gate
+    `allowUserCredentials`;
+  - `AiRuntimeResolutionContext` enthaelt zwar Organization, User, Workspace,
+    Agent und optional Session, aber keine Principal-Art, Ausfuehrungsart oder
+    eigene Credential-Subject-ID;
+  - `AiSessionRuntimeSnapshot` pinnt Auswahl sowie Katalog-/Policy-Revision,
+    aber weder Credential-Subject noch Freigaberevision.
+- `app/lib/agent-runtime-policy/provider-auth-policy.ts` erzwingt fuer OAuth
+  bereits den Scope `user`. Eine OAuth-Installation kann damit nicht als
+  Organization- oder System-Credential katalogisiert werden.
+- `app/lib/agent-runtime-policy/runtime-resolver.ts`
+  - laesst User-Installationen im Personal Workspace oder bei
+    `policy.allowUserCredentials === true` zu;
+  - prueft Verfuegbarkeit anschliessend mit der einzigen `context.userId`;
+  - loest die Auswahl in der Reihenfolge Session, User Preference, Agent
+    Default, Workspace Default und App Default auf;
+  - kann nicht unterscheiden, ob `userId` Credential-Inhaber, verantwortlicher
+    Auditor einer Organization-Automation oder interaktiver Principal ist.
+- `app/api/admin/agent-runtime/workspace-policy/route.ts` ist zu Recht
+  admin-only und kann den zulaessigen Modellkatalog sowie
+  `allowUserCredentials` einschraenken. Das Flag ist aktuell jedoch zugleich
+  die einzige Team-Freigabe und bildet keine Einwilligung eines Users ab.
+- `app/api/agent-runtime/preferences/route.ts` und
+  `app/api/agent-runtime/effective/route.ts` pruefen Workspace- und Agent-
+  Zugriff fuer den eingeloggten User. Ihre Responses kennen nur generische
+  Credential-Verfuegbarkeit, nicht Freigabe-, Reauth- oder Kontostatus.
+
+### Credential-Speicherung und Provider-Request
+
+- `app/lib/pi/oauth.ts` speichert OAuth-Credentials eines eingeloggten Users in
+  `/data/users/{userId}/settings/auth.json`, schreibt atomar mit restriktiven
+  Dateirechten und serialisiert Refreshes ueber einen Credential-Store-Lock.
+- Die OAuth-Routen unter `app/api/oauth/pi/` binden Status, Initiate, Complete,
+  Exchange und Disconnect an die authentifizierte `session.user.id`. Ein
+  user-scoped Request faellt nicht auf die alte globale OAuth-Datei zurueck.
+- `app/lib/agent-runtime-policy/installation-credentials.ts` liest fuer eine
+  User-Installation nur den User-Scope und erlaubt `process.env` nur fuer
+  System-Installationen. Das ist die richtige Runtime-Grenze.
+- `app/lib/agent-runtime-policy/provider-runtime.ts` loest Auth request-lokal
+  auf, mutiert `process.env` nicht und revalidiert Auswahl, Katalog und
+  Workspace-Policy vor und nach dem Credential-Lookup. Widerruf waehrend dieses
+  Fensters schlaegt damit grundsaetzlich fail-closed fehl.
+- `app/lib/pi/api-key-resolver.ts` ist ein paralleler Legacy-Pfad. Fuer
+  API-Key-Provider mischt er user-scoped Eintraege mit `process.env`; dadurch
+  kann eine scoped Aufloesung auf einen breiteren Systemwert fallen. Die
+  executable Agent-Runtime nutzt bereits den neueren Provider-Broker, aber
+  `app/lib/agents/storage.ts` und Tests referenzieren den Legacy-Resolver noch.
+  Vor Freigabe muss belegt sein, dass kein produktiver Modell-Request diesen
+  zweiten Pfad umgehen kann.
+
+### Sessions, Reconnect und Tool-Runs
+
+- `pi_sessions` speichert User, Agent, Workspace, Provider-Installation,
+  Katalog-/Policy-Revision und Auswahlquelle. Es speichert keinen Token.
+- `app/lib/agent-runtime-policy/session-runtime-service.ts` und
+  `provider-runtime.ts` pinnen eine Runtime-Auswahl revisionsgebunden. Ein
+  alter Snapshot ist keine alleinige Autorisierung: Bei einem neuen Provider-
+  Request wird die aktuelle Policy erneut gelesen.
+- `app/lib/pi/live-runtime.ts`, `app/lib/pi/runtime-service.ts` und
+  `app/lib/pi/session-runtime-access.ts` adressieren eine Runtime mit
+  `userId + sessionId`, verlangen Session-Ownership und bauen sie nach einem
+  Reconnect erneut aus der gespeicherten Session auf.
+- Der aktuelle `AgentExecutionContext` in
+  `app/lib/pi/agent-execution-context.ts` enthaelt nur eine `userId` und keine
+  getrennte Principal-/Credential-Subject-Semantik. Tools koennen daher zwar
+  den Workspace-Scope erben, aber der Modell-Broker kann die Herkunft eines
+  Runs nicht beweisbar klassifizieren.
+
+### Delegation und Automationen
+
+- `app/lib/pi/delegation-policy.ts`, `delegate-task-tool.ts` und
+  `delegation-dispatcher.ts` halten Source, Worker und Restart aktuell bei
+  derselben `userId`; Worker-Sessions sind dem User zugeordnet. Das verhindert
+  bereits einen offensichtlichen User-Wechsel, ist aber keine explizite
+  Freigabe fuer die Ausfuehrungsart `delegation`.
+- Ephemere und Managed Delegationen uebernehmen die Runtime-Auswahl des
+  Parent-Runs. Der Resolver kann nicht unterscheiden, ob ein User das
+  persoenliche Credential auch dem delegierten Workload erlauben wollte.
+- Die Architektur in
+  `docs/architecture/canvas-notebook/team-workspace/11-automation-execution-model.md`
+  verlangt fuer Organization Automations einen Service Actor und verbietet
+  private User-Secrets.
+- Der aktuelle Runner in `app/lib/automations/runner.ts` setzt jedoch
+  `automationUserId = responsibleUserId || ownerUserId || createdByUserId` und
+  uebergibt diese ID unveraendert an Workspace-, Session-, Tool- und Runtime-
+  Resolver. Bei aktivem Team-Flag kann eine Organization-Automation deshalb
+  die User-Installation und Preference des verantwortlichen Users erreichen.
+  Dies ist eine belegte Policy-Luecke und kein blosses UI-Problem.
+
+### UI und Status
+
+- `app/components/settings/PiOAuthButton.tsx` zeigt pro eingeloggtem User nur
+  Providername, `connected` und optional `expiresAt`. Ein sicherer Account-
+  Hinweis, `reauth_required` und die Team-Freigaben fehlen.
+- `ProviderInstallationCredentialEditor.tsx` erklaert den User-Scope korrekt.
+  Seine sichtbare Einbindung liegt aber in `AiProvidersModelsPanel.tsx`; der
+  zugehoerige Settings-Tab `ai-providers` ist in
+  `IntegrationsSettingsClient.tsx` nur fuer Instanz-Admins sichtbar. Ein
+  normales Teammitglied hat damit keinen vollstaendigen Self-Service-Flow fuer
+  Connect, Reauth, Workspace-Freigabe und Widerruf.
+- `ChatModelSelector` und `AgentRuntimePreferenceCard` zeigen Provider und
+  Credential-Scope, unterscheiden aber nicht zwischen fehlender Verbindung,
+  fehlender User-Einwilligung, Workspace-Verbot, Agent-Verbot und
+  Refresh-/Reauth-Fehler.
+
+### Vorhandene Tests, die erweitert werden koennen
+
+- `scripts/pi-oauth-user-scope-test.ts`
+- `scripts/agent-runtime-resolution-test.ts`
+- `scripts/agent-session-runtime-api-test.ts`
+- `scripts/pi-session-provider-switch-test.ts`
+- `scripts/channel-session-runtime-test.ts`
+- `scripts/chat-workspace-runtime-lifecycle-test.ts`
+- `scripts/pi-delegate-task-runtime-test.ts`
+- `scripts/pi-delegation-dispatcher-test.ts`
+- `scripts/automation-runner-tool-context-test.ts`
+- `scripts/automation-workspace-scope-test.ts`
+- `scripts/agent-runtime-provider-verification-test.ts`
+- `scripts/account-credentials-route-test.ts`
+
+Die vorhandenen Tests decken einzelne User-Scope-, Snapshot-, Race-,
+Delegation- und Automationseigenschaften ab. Es fehlt ein gemeinsamer Zwei-
+User-Matrixtest fuer `openai-codex`, ausdrueckliche Team-Freigaben,
+Principal-Arten, Refresh/Widerruf sowie negative Organization-Automationen.
+
+## Fehlerursachen und Verifikationsstatus
+
+| Befund | Status | Konsequenz fuer die Umsetzung |
+| --- | --- | --- |
+| `allowUserCredentials` plus `context.userId` ist die gesamte Team-Autorisierung | im Code belegt | Ein eigener User-Grant und ein typisierter Execution Principal sind zwingend. |
+| Organization-Automation verwendet `responsibleUserId` im Runtime-Resolver | im Code belegt | Service Actor und Credential Subject muessen getrennt werden; User-Credentials dort hart ausschliessen. |
+| OAuth-Datei und OAuth-Routen sind user-scoped | im Code belegt | Vorhandene Speicherung behalten; keine Token-Migration in DB oder Workspace. |
+| Provider-Broker revalidiert Policy und Credential pro Request | im Code belegt | Als einziger Modell-Auth-Pfad ausbauen und um Grant-/Principal-Revalidierung erweitern. |
+| Legacy-API-Key-Resolver kann scoped Werte mit `process.env` mischen | im Code belegt | Produktionsaufrufer entfernen oder denselben strikten Installations-Resolver verwenden lassen. |
+| Session-Snapshot enthaelt keine Credential-Bindung | im Code belegt | Nicht-geheime Subject-/Grant-Metadaten pinnen, aber bei jedem Request aktuell revalidieren. |
+| OAuth-UI ist fuer normale Mitglieder nicht vollstaendig erreichbar | im Code belegt | User-facing Account-/Grant-Flaeche ausserhalb des Admin-Katalogs schaffen. |
+| `openai-codex` liefert eine stabile, sichere Account-ID oder E-Mail | zu verifizieren | PI-OAuth-Typ und Provider-Response pruefen; keine JWT-Heuristik oder Token-Introspection ohne dokumentierten Vertrag. |
+| Lokales Disconnect widerruft den Token auch upstream | zu verifizieren | Provider-Revoke-Unterstuetzung pruefen; mindestens lokalen Entzug atomar und sofort wirksam machen. |
+| Alle produktiven Modellaufrufe gehen ueber `provider-runtime.ts` | zu verifizieren | Callgraph fuer Chat, Reconnect, Channels, Delegation, Automationen, Titel/Summary und Provider-Test vervollstaendigen. |
+| Eine laufende Runtime wird bei Grant-/OAuth-Widerruf aktiv invalidiert | teilweise belegt | Neue Calls scheitern bereits; Cache-/Queue-Invalidierung und klare UI-Ereignisse fehlen. |
+
+## Zielarchitektur und Least-Privilege-Nachweis
+
+### 1. Vier getrennte Autoritaeten
+
+Eine User-OAuth-Nutzung ist nur erlaubt, wenn alle vier unabhaengigen Gates
+gleichzeitig erfolgreich sind:
+
+1. **Organization/Workspace-Policy:** Provider-Installation und Modell sind
+   erlaubt; `allowUserCredentials` ist aktiv. Dieses Gate kann nur
+   einschraenken.
+2. **Agent-Policy:** Der konkrete Agent ist fuer den User und Workspace mit
+   `canUse` zugaenglich und seine Credential-Policy erlaubt die konkrete
+   Ausfuehrungsart. Organization-Agenten starten fail-closed; der eingebaute
+   Hauptagent braucht eine explizite System-Policy statt einer Sonderregel im
+   Client.
+3. **User-Grant:** Der Credential-Inhaber hat genau
+   `workspaceId + agentId + providerInstallationId + executionMode`
+   freigegeben. Nur dieser User darf den Grant erstellen oder widerrufen.
+4. **Run-Principal:** Der serverseitig abgeleitete User-Principal ist zugleich
+   Credential Subject. Bei Service Actor, fehlendem Subject oder ungleichen
+   User-IDs ist User-Scope immer verboten.
+
+Formal:
+
+```txt
+mayUseUserCredential =
+  provider.credentialScope == "user"
+  && workspacePolicy.allowUserCredentials
+  && modelAllowedByWorkspacePolicy
+  && agentAccess.canUse
+  && agentCredentialPolicy.allows(executionMode)
+  && principal.type == "user"
+  && principal.userId == credentialSubjectUserId
+  && session.userId == credentialSubjectUserId
+  && activeUserGrant.matches(
+       organizationId,
+       workspaceId,
+       agentId,
+       providerInstallationId,
+       executionMode,
+       credentialSubjectUserId
+     )
+  && oauthConnection.userId == credentialSubjectUserId
+  && oauthConnection.status == "connected"
+```
+
+Kein Gate darf ein anderes ersetzen. Insbesondere ist `responsibleUserId`
+niemals ein Credential Subject eines Service-Actor-Runs.
+
+### 2. Execution Principal statt ueberladener `userId`
+
+Der zentrale, serverseitig erzeugte Runtime-Kontext wird erweitert:
+
+```ts
+type AiExecutionMode =
+  | 'interactive'
+  | 'external_channel'
+  | 'delegation'
+  | 'personal_automation'
+  | 'organization_automation';
+
+type AiRuntimePrincipal =
+  | {
+      type: 'user';
+      userId: string;
+      credentialSubjectUserId: string;
+    }
+  | {
+      type: 'organization_service';
+      serviceActorId: string;
+      responsibleUserId: string;
+      credentialSubjectUserId: null;
+    };
+
+type AiRuntimeResolutionContext = {
+  organizationId: string;
+  workspaceId: string;
+  workspaceType: WorkspaceType;
+  agentId: string;
+  sessionId?: string | null;
+  requestedSelection?: AiRuntimeSelection | null;
+  executionMode: AiExecutionMode;
+  triggerSource: 'web' | 'mobile' | 'reconnect' | 'channel' | 'delegation' | 'automation';
+  principal: AiRuntimePrincipal;
+};
+```
+
+Die bestehende `userId` in Session-, Workspace- und Tool-APIs kann waehrend
+der Migration als Session Owner bzw. Permission Subject bestehen bleiben. Sie
+darf nach der Umstellung aber nicht mehr allein die Credential-Aufloesung
+steuern. `AgentExecutionContext` traegt denselben Principal und Mode, damit ein
+Tool weder die Ausfuehrungsart noch den Credential Subject durch Parameter
+austauschen kann.
+
+### 3. Credential-Broker als einzige Token-Grenze
+
+`provider-runtime.ts` bleibt der einzige Produktionspfad fuer Modell-Auth:
+
+- Resolver liefert nur eine nicht-geheime, authorisierte Binding-Entscheidung.
+- `installation-credentials.ts` erhaelt den bereits validierten Credential
+  Subject und die Binding-/Grant-ID, nicht eine beliebige User-ID.
+- Unmittelbar vor jedem Provider-Request werden Membership, Workspace-Policy,
+  Agent-Policy, User-Grant, OAuth-Status und Session-Bindung erneut gelesen.
+- Token/Headers/Env leben nur im lokalen Request-Scope von `streamFn` und
+  gelangen weder in Tools, Prompt, Session, DB, Audit noch Client-Response.
+- Ein fehlender User-Grant fuehrt nicht zu Organization-, System-,
+  `process.env`- oder anderem User-Fallback.
+- Ein Providerwechsel erzeugt eine neue explizite Auswahl und Binding-Pruefung;
+  ein gepinnter `openai-codex`-Run wechselt bei Fehler nicht still auf
+  `openai` oder einen Workspace-Default.
+
+Der Legacy-Resolver wird entweder auf Test-/Migrationszwecke begrenzt oder als
+Adapter auf den Installations-Resolver umgebaut. Danach verhindert ein
+statischer Test neue produktive Importe ausserhalb der erlaubten Datei.
+
+### 4. Agent-Definition ist kein Credential-Owner
+
+Die vorhandenen Agent-Felder `scopeType`, `organizationId`, `ownerUserId` und
+die Access-Pruefung bleiben die Ownership-Quelle. Eine kleine serverseitige
+Agent-Credential-Policy ergaenzt sie, beispielsweise:
+
+```ts
+type AgentPersonalCredentialPolicy =
+  | 'deny'
+  | 'interactive_user_grant'
+  | 'interactive_and_delegated_user_grant';
+```
+
+- User-eigene Agents koennen fuer den eigenen interaktiven Principal innerhalb
+  der Workspace-Obergrenze freigegeben werden.
+- Organization-Agents starten bei `deny`; ein Admin kann nur die Agent-
+  Eignung erlauben, niemals den User-Grant erzeugen.
+- Der eingebaute Hauptagent erhaelt eine explizit getestete System-Policy fuer
+  `interactive_user_grant`.
+- Delegation braucht sowohl eine passende Agent-Policy des Ziel-Agenten als
+  auch einen separaten User-Grant fuer den Mode `delegation`.
+- Weder Agent-Definition noch `agent_grants` speichern Token, OAuth-Subject
+  oder eine uebertragbare Secret-Ref.
+
+### 5. Verhalten nach Ausfuehrungsart
+
+| Actor / Ausfuehrung | Workspace | Agent | User-Credential im Team | Begruendung |
+| --- | --- | --- | --- | --- |
+| User A, direkter Web-/Mobile-Run | Personal von A | erlaubter Agent | wie bisher aus A-Scope; keine Team-Freigabe noetig | Personal Ownership und User-Principal stimmen ueberein. |
+| User A, direkter Run | Team | Agent mit passender Policy | nur mit Workspace-Gate und aktivem Grant von A fuer genau diesen Agent/Provider/`interactive` | Zielumfang des Tickets. |
+| User B im selben Team | Team | derselbe Agent | nur eigenes Credential und eigener Grant von B; A gilt wie nicht vorhanden | Keine Cross-User-Aufloesung oder Statussichtbarkeit. |
+| Reconnect von A | Team | gepinnter Agent | Reconnect selbst laedt keinen Token; naechster Turn baut A-Principal neu und revalidiert Grant/Policy | Snapshot ist Auswahl, nicht Autorisierung. |
+| Tool-Call in einem Run von A | Team | aktueller Agent | Tool erhaelt keinen Provider-Token; weitere Modellaufrufe nutzen denselben versiegelten Principal | Keine Credential-Weitergabe an Tools. |
+| Externer Channel fuer A | Team | erlaubter Agent | V1 standardmaessig aus; nur eigener Grant `external_channel` nach eindeutigem Channel-User-Mapping | Hintergrund-/Channel-Risiko getrennt vom Live-Chat. |
+| Ephemere oder Managed Delegation von A | Team | erlaubter Ziel-Agent | V1 default-deny; nur separater Grant `delegation`, gleicher User-Principal und passende Ziel-Agent-Policy | Keine implizite Vererbung aus `interactive`. |
+| Personal Automation von A | Personal von A | erlaubter Agent | A-Scope nach bestehender Personal-Automation-Policy | Kein Team-Workspace-Fall; aktuelle Semantik bleibt. |
+| Organization Automation | Team | Organization-/System-Agent | niemals User-Scope; nur Organization/System/Managed | Service Actor hat `credentialSubjectUserId = null`. |
+| System-/Background-Run ohne User-Principal | beliebig | beliebig | niemals | Kein authentifizierter Credential-Inhaber. |
+
+Fuer V1 kann die UI ausschliesslich `interactive`-Grants im Team anbieten.
+`delegation` und `external_channel` bleiben bis zu eigener UI- und Threat-
+Model-Abnahme technisch default-deny. Der Datenvertrag wird dennoch von Beginn
+an explizit, damit spaetere Aufrufer nicht wieder auf eine allgemeine `userId`
+zurueckfallen.
+
+## Datenvertraege
+
+### User-Grant
+
+Neue Tabelle `ai_user_workspace_provider_grants` in `app/lib/db/schema.ts`, den
+SQLite-/Postgres-Migrationen und den Store-Abstraktionen:
+
+```ts
+type AiUserWorkspaceProviderGrant = {
+  id: string;
+  organizationId: string;
+  userId: string;
+  workspaceId: string;
+  agentId: string;
+  providerInstallationId: string;
+  allowedExecutionModes: AiExecutionMode[];
+  status: 'active' | 'revoked';
+  revision: number;
+  grantedAt: Date;
+  revokedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+```
+
+Constraints und Indizes:
+
+- Unique-Key auf `userId + workspaceId + agentId + providerInstallationId`;
+- Foreign Keys auf User, Workspace und Provider-Installation mit sicherem
+  Revoke/Delete-Verhalten;
+- Organization-ID muss zu Workspace und Installation passen;
+- `organization_automation` ist per Schema-/Service-Validierung nie in
+  `allowedExecutionModes` zulaessig;
+- Update mit `expectedRevision`/CAS; Revoke ist idempotent;
+- Grant enthaelt keine OAuth-Daten und kann ohne Credential nicht als
+  Autorisierung genutzt werden.
+
+Der Workspace-Policy-Flag bleibt als Admin-Obergrenze bestehen. Bestehende
+Team-Workspaces erhalten keine Grants durch Migration.
+
+### Agent-Policy
+
+Die Agent-Policy wird als nicht-geheimes Feld an der zentralen Agent-Definition
+oder in einer eigenen Policy-Tabelle mit Revision gespeichert. Die konkrete
+Persistenzentscheidung wird in Phase 1 anhand der bestehenden Agent-Update-
+APIs getroffen. Pflichtfelder des logischen Vertrags sind:
+
+```ts
+type AiAgentCredentialPolicy = {
+  agentId: string;
+  personalCredentialPolicy: AgentPersonalCredentialPolicy;
+  revision: number;
+  updatedByUserId: string | null;
+  updatedAt: Date | null;
+};
+```
+
+Eine User-API darf dieses Objekt lesen, aber nur berechtigte Agent-Manager
+duerfen es aendern. Der User-Grant kann die Agent-Policy nur weiter
+einschraenken.
+
+### Session-Snapshot
+
+`AiSessionRuntimeSnapshot` und `pi_sessions` werden um ausschliesslich
+nicht-geheime Bindungsmetadaten ergaenzt:
+
+```ts
+type AiSessionRuntimeAuthorizationSnapshot = {
+  credentialScope: AiCredentialScope;
+  credentialSubjectUserId: string | null;
+  executionMode: AiExecutionMode;
+  principalType: 'user' | 'organization_service';
+  userGrantId: string | null;
+  userGrantRevision: number | null;
+};
+```
+
+Der Snapshot belegt, welche Entscheidung die Auswahl gepinnt hat. Er ist
+niemals eine dauerhafte Freigabe: aktuelle Revision, Status, OAuth-Verbindung,
+Membership und Policies werden vor jedem neuen Provider-Request revalidiert.
+Ein Aufruf mit einem anderen Principal oder Mode darf einen existierenden
+Snapshot nicht umdeuten.
+
+Fuer Organization-Automationen ist `credentialSubjectUserId = null`, auch wenn
+Session-Ownership aus Kompatibilitaetsgruenden vorerst noch auf einer
+`responsibleUserId` basiert. Dieser Widerspruch wird sichtbar und fail-closed,
+bis Session Ownership langfristig auf Service Actors erweitert wird.
+
+### Sicherer Connection-Status
+
+Token-Datei und Refresh-Credential bleiben unter
+`/data/users/{userId}/settings/auth.json`. Separat darf nur ein minimales,
+user-scoped Statusobjekt geliefert werden:
+
+```ts
+type AiUserProviderConnectionStatus = {
+  providerId: 'openai-codex';
+  state: 'disconnected' | 'connected' | 'refreshing' | 'reauth_required';
+  accountLabel: string | null;
+  expiresAt: number | null;
+  lastVerifiedAt: string | null;
+  revision: number;
+};
+```
+
+`accountLabel` darf nur aus dokumentierter, nicht-tokenbasierter
+Provider-Metadaten oder einem vom User selbst gesetzten Alias entstehen. Vor
+der Implementierung ist zu pruefen, ob PI fuer `openai-codex` eine stabile
+Account-Kennung liefert. Kein Access-/ID-Token wird im Client decodiert, kein
+vollstaendiger Token oder Refresh-Fehlertext wird persistiert. Wenn keine
+verifizierbare Kennung existiert, zeigt die UI einen expliziten User-Alias plus
+„nicht vom Provider bestaetigt“ statt eine erfundene Identitaet.
+
+## API-Vertraege
+
+### Eigene Verbindung und Freigaben
+
+Die vorhandenen `/api/oauth/pi/*`-Routen bleiben strikt auf den eingeloggten
+User begrenzt. Der Statusvertrag wird um `state`, sicheren `accountLabel` und
+`lastVerifiedAt` erweitert. Keine Admin-Route kann Status oder Accountlabel
+eines anderen Users abrufen.
+
+Neue, user-owned Route, beispielsweise
+`/api/agent-runtime/user-credential-grants`:
+
+- `GET ?workspaceId&agentId&providerInstallationId`
+  - verlangt `canRead + canRunAgent` sowie `canUse` fuer den Agent;
+  - gibt nur den eigenen Grant, den eigenen Connection-Status und redacted
+    Gate-Entscheidungen zurueck.
+- `PUT`
+  - Body:
+    `{ workspaceId, agentId, providerInstallationId, allowedExecutionModes, expectedRevision }`;
+  - setzt `userId` aus der Session;
+  - validiert Organization/Workspace, Agent-Zugriff, Agent-Policy, Provider-
+    Scope `user`, OAuth-Auth-Methode und erlaubte Modes;
+  - erlaubt niemals `organization_automation`.
+- `DELETE ?workspaceId&agentId&providerInstallationId&expectedRevision`
+  - widerruft nur den eigenen Grant idempotent;
+  - erhoeht die relevante Runtime-Autorisierungsrevision und invalidiert
+    betroffene Laufzeit-Caches.
+
+Die effektive Runtime-Response erhaelt fuer User-Installationen einen
+redacted, UI-tauglichen Status:
+
+```ts
+type AiUserCredentialEligibility = {
+  state:
+    | 'ready'
+    | 'not_connected'
+    | 'reauth_required'
+    | 'workspace_policy_blocked'
+    | 'agent_policy_blocked'
+    | 'consent_required'
+    | 'execution_mode_blocked';
+  accountLabel: string | null;
+  grantRevision: number | null;
+};
+```
+
+Diese Daten werden nur fuer den aktuellen User berechnet. Katalog- und Admin-
+APIs geben weiterhin keine user-spezifischen Connection-Metadaten aus.
+
+### Fehlercodes
+
+Resolver und Provider-Broker unterscheiden mindestens:
+
+- `USER_CREDENTIAL_NOT_CONNECTED`
+- `USER_CREDENTIAL_REAUTH_REQUIRED`
+- `USER_CREDENTIAL_CONSENT_REQUIRED`
+- `USER_CREDENTIAL_WORKSPACE_BLOCKED`
+- `USER_CREDENTIAL_AGENT_BLOCKED`
+- `USER_CREDENTIAL_EXECUTION_MODE_BLOCKED`
+- `USER_CREDENTIAL_SUBJECT_MISMATCH`
+- `USER_CREDENTIAL_GRANT_REVOKED`
+- `ORGANIZATION_AUTOMATION_USER_CREDENTIAL_FORBIDDEN`
+
+API-Meldungen duerfen einem fremden User nicht bestaetigen, dass ein Credential
+oder Grant existiert. Bei Cross-User-IDs gilt die Ressource als nicht vorhanden
+oder der serverseitig abgeleitete Subject gewinnt; die Response nennt niemals
+den fremden Account.
+
+## Strikt sequenzielle Implementierungsphasen
+
+Jede Phase beginnt erst, wenn die vorherige implementiert, mit ihren
+fokussierten Tests validiert und als eigener Commit abgeschlossen ist. Bei
+einem fehlgeschlagenen Gate wird nicht mit der naechsten Phase begonnen.
+
+### Phase 1: Verifikationsspikes und Sicherheitsvertrag fixieren
+
+1. Alle produktiven Aufrufer von `resolvePiApiKey`,
+   `resolveProviderInstallationRuntimeAuth`, `resolveExecutableAgentRuntime`
+   und `resolveAndPinSessionRuntime` fuer Chat, Summary/Title, Reconnect,
+   Channels, Delegation, Provider-Test und Automationen als Callgraph
+   dokumentieren.
+2. Den konkreten `openai-codex`-Credential-Typ der installierten PI-Version
+   pruefen: sichere Account-Metadaten, Refreshfehler und moegliche upstream
+   Revoke-Funktion. Keine Live-Credentials in Fixtures oder Logs verwenden.
+3. Agent-Policy-Persistenz sowie SQLite-/Postgres-Migrationspfad festlegen.
+4. Die oben definierte Matrix als ausfuehrbare Testtabelle anlegen; Tests sind
+   zunaechst rot fuer fehlende Principal-/Grant-Gates.
+
+Gate: Callgraph ohne unbekannten produktiven Auth-Pfad, festgeschriebener
+Accountlabel-Vertrag und reproduzierbare failing security tests.
+
+Fokussierter Commit: `test: capture team user credential security gaps`
+
+### Phase 2: Principal, Execution Mode und Organization-Automation absichern
+
+1. `AiRuntimeResolutionContext` und `AgentExecutionContext` um den
+   serverseitigen Principal, `executionMode` und `triggerSource` erweitern.
+2. Alle Entry Points typisiert migrieren; keine Default-Werte im tiefen
+   Resolver, weil ein vergessener Aufrufer compile- oder testseitig auffallen
+   soll.
+3. Automation-Policy und Runner so umbauen, dass Organization-Automationen
+   `organization_service` mit `credentialSubjectUserId = null` verwenden.
+   `responsibleUserId` bleibt nur Audit-/Permission-Verantwortlicher.
+4. User-Installationen und User Preferences fuer Service-Actor-Runs schon vor
+   jedem Credential-Lookup aus dem effektiven Katalog entfernen. Eine alte
+   user-scoped Snapshot-Auswahl fuehrt zu einem klaren, pausierbaren Fehler und
+   nicht zu einem stillen Providerwechsel.
+
+Gate: Organization-Automations koennen auch bei aktivem Workspace-Flag kein
+User-Credential aufloesen; direkte Personal-Runs bleiben unveraendert.
+
+Fokussierter Commit: `fix: separate runtime principals from automation owners`
+
+### Phase 3: User-Grants und Agent-Policy persistieren
+
+1. Schema, SQLite- und Postgres-Migrationen fuer User-Grants und Agent-
+   Credential-Policy implementieren; Startup-/Provider-Paritaet testen.
+2. Store und Domain-Service mit CAS, idempotentem Revoke und strikter
+   Organization-/Workspace-/User-Konsistenz bauen.
+3. Bestehende Team-Policies nicht automatisch in User-Grants umwandeln.
+4. Admin-Policy-Aenderungen, Agent-Policy-Aenderungen, Grant und Revoke mit
+   IDs, Scope, Revision, Actor und Status auditieren, aber ohne Accountlabel,
+   Token oder Credential-Dateipfad.
+
+Gate: Zwei User koennen nur eigene Grants lesen/aendern; Migration ist auf
+leerer und bestehender SQLite-/Postgres-Datenbank idempotent; Default bleibt
+Team-deny.
+
+Fokussierter Commit: `feat: add scoped user provider grants`
+
+### Phase 4: Einen authoritativen Resolver und Broker erzwingen
+
+1. `runtime-resolver.ts` um Workspace-, Agent-, Grant-, Principal- und Mode-
+   Gates erweitern und die genaue Eligibility statt nur
+   `credentialAvailable` zurueckgeben.
+2. `provider-runtime.ts` revalidiert die komplette Binding-Entscheidung vor
+   und nach OAuth-Refresh. `installation-credentials.ts` akzeptiert nur den
+   validierten Credential Subject.
+3. Legacy-Auth-Aufrufer auf diesen Pfad migrieren oder explizit aus dem
+   Produktionspfad entfernen; scoped Auth darf nie `process.env` beimischen.
+4. Einen Import-/Callgraph-Test hinzufuegen, der neue Modell-Auth-Bypaesse und
+   direkte OAuth-Dateizugriffe ausserhalb des Credential-Moduls ablehnt.
+5. Race-Tests fuer Policy-, Grant-, Agent-Policy- und Disconnect-Aenderung
+   waehrend Credential-Lookup ergaenzen.
+
+Gate: Jeder Modell-Request hat einen versiegelten Principal und eine aktuelle
+Grant-Entscheidung; alle breiteren und Cross-User-Fallbacks sind negativ
+getestet.
+
+Fokussierter Commit: `refactor: enforce one scoped provider auth broker`
+
+### Phase 5: Session-Snapshot, Reconnect und Laufzeit-Widerruf
+
+1. Snapshot-Typ, `pi_sessions`, Store und Session-CAS um die nicht-geheime
+   Authorization Snapshot erweitern.
+2. Neue Session, Session-PATCH, Reconnect-Prewarm, WebSocket-Subscribe,
+   Mobile-Ticket und Channel-Session gegen Session Owner, Principal und
+   Workspace revalidieren.
+3. Ein Snapshot pinnt Provider/Modell und dokumentiert Subject/Grant, darf aber
+   einen abgelaufenen Grant nicht verlaengern. Naechster Turn/Provider-Call
+   liest die aktuelle Revision.
+4. Disconnect, Grant-Revoke, Workspace-/Agent-Policy-Aenderung und
+   Membership-Entzug invalidieren betroffene Live-Runtime-Caches und queued
+   Runs. Ein bereits gestarteter externer Request wird nicht mit einem neuen
+   Token fortgesetzt; jeder Folgecall stoppt.
+5. Providerwechsel verlangt einen neuen Snapshot-CAS. Kein automatischer
+   Fallback bei Reauth oder Revoke.
+
+Gate: Reconnect verwendet nur das Credential desselben Users; Widerruf greift
+bei bestehender Session vor dem naechsten Provider-Request und Tokens fehlen in
+Snapshot, Events und Logs.
+
+Fokussierter Commit: `fix: bind session runtime to current user grants`
+
+### Phase 6: Delegation, Channels und Tool-Run-Grenzen
+
+1. Direkte Tool-Calls erben den versiegelten Execution Context und erhalten
+   nie Provider-Auth. Modell-Fortsetzungen nach Tools gehen erneut durch den
+   Broker.
+2. Delegation erbt nicht automatisch den `interactive`-Grant. Parent, Worker,
+   Ziel-Agent, Principal, Workspace und Mode `delegation` werden im Store und
+   beim Dispatcher-Restart revalidiert.
+3. V1 laesst Team-Delegation mit User-Credential default-deny, sofern die
+   Produktfreigabe fuer einen separaten Delegations-Grant nicht in derselben
+   Phase explizit umgesetzt und abgenommen wird.
+4. Externe Channels verwenden `external_channel`; fehlendes oder mehrdeutiges
+   User-Mapping sowie fehlender Mode-Grant blockieren den Run.
+5. Organization-Automationen bleiben unabhaengig von Delegations-/Channel-
+   Grants immer User-Credential-deny.
+
+Gate: Dispatcher-Restart, Managed Target, ephemerer Worker, Channel-Reconnect
+und Tool-Fortsetzung koennen Subject oder Mode nicht erweitern.
+
+Fokussierter Commit: `fix: preserve credential boundaries across agent workloads`
+
+### Phase 7: User-facing Connect-, Consent- und Reauth-UI
+
+1. Eine fuer normale Mitglieder sichtbare persoenliche Provider-Flaeche in den
+   Settings oder Agent-Preferences schaffen; der Admin-Katalog bleibt getrennt.
+2. Connect/Reauth/Disconnect fuer `openai-codex`, sicheren Account-Hinweis,
+   Ablauf-/Reauth-Status und einen Link zur eigenen Freigabeverwaltung zeigen.
+3. Beim Auswaehlen im Team-Workspace einen expliziten Consent-Dialog fuer
+   Workspace, Agent, Provider und V1-Mode `interactive` anzeigen. Kein
+   vorselektierter Delegations-/Channel-/Automation-Scope.
+4. ChatModelSelector und Runtime Preference unterscheiden die definierten
+   Statuscodes und verlinken zielgerichtet zu Connect, Reauth oder Consent.
+5. Disconnect/Revoke erklaert die Auswirkung auf bestehende Sessions; Admins
+   sehen nur aggregierte Policy-/Readiness-Informationen, niemals User-
+   Accountlabels oder Verbindungsstatus anderer Mitglieder.
+
+Gate: Ein normales Teammitglied kann den gesamten eigenen Flow ohne Admin-
+Zugriff bedienen; User B sieht in DOM, API und Fehlertext keine Metadaten von A.
+
+Fokussierter Commit: `feat: add personal ChatGPT team consent UI`
+
+### Phase 8: Abschlussregression und Betriebsfreigabe
+
+1. Alle unten genannten fokussierten Tests sowie Lint fuer betroffene Dateien
+   ausfuehren.
+2. `npm run build` ausfuehren. Kein Containerbau ist fuer dieses Ticket
+   erforderlich; falls spaeter explizit verlangt, erst nach erfolgreichem Build
+   und nie parallel zu einem anderen Test-Container.
+3. Manuelle Zwei-User-Abnahme nach der unten stehenden Checkliste. Browser-/
+   Playwright-E2E nur nach expliziter Freigabe gemaess Repository-Regeln.
+4. Security-Diff pruefen: keine Tokenwerte, keine fremden Accountlabels, keine
+   untypisierten Runtime-Aufrufer, keine stillen Fallbacks.
+5. Ticket und Index erst nach vollstaendig bestandener Produktabnahme auf
+   `erledigt` setzen.
+
+Gate: automatisierte und manuelle Abnahmekriterien vollstaendig dokumentiert;
+Rollback wurde auf einem Upgrade-Testbestand geprobt.
+
+Fokussierter Commit: `test: verify personal ChatGPT team isolation`
+
+## Automatisierte Abnahmekriterien
+
+### Runtime- und Zwei-User-Matrix
+
+- User A und B besitzen getrennte `openai-codex`-Fixtures mit Sentinel-
+  Credentials. Jeder Provider-Request erhaelt ausschliesslich den Sentinel des
+  aktiven Subjects.
+- Workspace-Flag aus, fehlender Grant, falscher Agent, falscher Mode,
+  widerrufener Grant, deaktivierter Agent, fehlendes `canRunAgent` und
+  gesperrtes Modell werden jeweils vor Credential-Lookup abgelehnt.
+- Ein Admin kann die Workspace-/Agent-Obergrenze, aber keinen Grant fuer A oder
+  B erstellen.
+- Manipulierte `userId`, Grant-ID, Session-ID, Agent-ID und
+  Provider-Installation in API-Payloads erweitern keine Rechte.
+- User B erhaelt fuer Status, Grant oder Session von A keine unterscheidbare Existenz-
+  Information.
+
+### OAuth, Refresh und Widerruf
+
+- Erfolgreicher Refresh ersetzt nur das Credential von A unter dessen Pfad und laesst B
+  unveraendert.
+- `invalid_grant`/abgelaufener Refresh setzt einen klaren
+  `reauth_required`-Status und startet keinen Provider-Request mit altem Token.
+- Zwei parallele Refreshes bleiben durch den per-User/per-Provider Lock
+  serialisiert.
+- Disconnect waehrend des Lookup-Fensters blockiert den Request in der finalen
+  Revalidierung.
+- Kein API-/Audit-/Console-Output enthaelt Sentinel Access Token, Refresh Token,
+  Auth-Header, komplette OAuth-Credential-Objekte oder Credential-Dateipfade.
+
+### Session, Reconnect und Providerwechsel
+
+- Neue Team-Session von A pinnt Scope, Subject und Grant-Revision ohne Token.
+- Reconnect als A funktioniert nach erneuter Policy-/Grant-Pruefung; Reconnect
+  als B liefert `SESSION_NOT_FOUND` bzw. den bestehenden Ownership-Fehler.
+- Grant-/Policy-Revoke nach Session-Erstellung blockiert den naechsten Turn und
+  laesst die History lesbar.
+- Providerwechsel ist CAS-gebunden; ein Race mit Policy-/Grant-Revision
+  scheitert und verlangt erneute Auswahl.
+- Reauth-Fehler verursacht keinen stillen Wechsel von `openai-codex` zu
+  `openai`, App Default oder Organization Credential.
+
+### Delegation, Tools, Channels und Automation
+
+- Tool-Parameter und Tool-Env enthalten kein Provider-Credential; ein weiterer
+  Modell-Turn nach Tool-Result revalidiert den Broker.
+- Ephemere und Managed Delegation sind ohne Mode-Grant blockiert. Falls der
+  Mode aktiviert wird, gelten gleicher User, Workspace und Ziel-Agent-Policy;
+  Dispatcher-Restart behaelt diese Grenzen.
+- Channel-Run ist ohne eindeutiges internes User-Mapping oder ohne
+  `external_channel`-Grant blockiert.
+- Personal Automation im Personal Workspace kann weiterhin das Owner-
+  Credential verwenden.
+- Organization Automation kann trotz `allowUserCredentials = true`,
+  `responsibleUserId`, User Preference und altem User-Snapshot niemals einen
+  User-Provider materialisieren; sie pausiert mit dem spezifischen Policy-
+  Fehler.
+
+### Schema/API/UI-Vertraege
+
+- SQLite und Postgres erstellen Constraints/Indizes identisch; wiederholte
+  Startup-Migration bleibt idempotent.
+- Bestehende Team-Sessions und Preferences erzeugen durch Migration keinen
+  Grant.
+- User-Grant-APIs sind session-derived, CSRF-/Rate-Limit-konform, CAS-geschuetzt
+  und auditieren nur redacted Metadaten.
+- Komponenten-/Contract-Tests pruefen jeden Eligibility-State, Reauth-Link,
+  Consent-Text, Revoke-Flow und die Admin-/Member-Sichtbarkeit.
+- Ein statischer Regressionstest verbietet direkte produktive OAuth-Dateireads
+  und neue Importe des Legacy-Key-Resolvers in Runtime-Aufrufern.
+
+## Manuelle Abnahme
+
+Die Abnahme nutzt zwei normale Testnutzer A und B sowie einen Admin. Sie darf
+erst in der Implementierungsphase und fuer Browser/Playwright nur nach
+expliziter Freigabe erfolgen.
+
+1. Admin erlaubt `openai-codex` und User-Credentials fuer genau einen Team-
+   Workspace sowie den Hauptagenten.
+2. A verbindet das eigene ChatGPT-Konto in der persoenlichen Provider-Flaeche
+   und sieht den sicheren Account-Hinweis.
+3. A kann im Personal Workspace chatten, im Team Workspace vor Consent jedoch
+   nicht.
+4. A erteilt den sichtbaren Grant fuer Team-Workspace, Hauptagent und
+   `interactive`; der eigene Team-Chat funktioniert anschliessend.
+5. B sieht weder das Konto noch den Grant von A und kann mit derselben Auswahl nicht
+   laufen. Nach eigener Verbindung/Freigabe verwendet B ausschliesslich Bs
+   Konto.
+6. Die bestehende Session von A funktioniert nach Page Reload/WebSocket-Reconnect;
+   ein Login als B kann die Session nicht abonnieren oder fortsetzen.
+7. Admin sperrt das Modell oder User-Credentials. Der naechste Turn von A stoppt mit
+   klarer Policy-Meldung; erneutes Aktivieren erzeugt keinen User-Grant.
+8. A widerruft den Workspace-Grant und spaeter die OAuth-Verbindung. Bestehende
+   History bleibt, neue Provider-Calls stoppen sofort und die UI bietet den
+   richtigen Consent- bzw. Reauth-Flow.
+9. Delegation, externer Channel und Organization-Automation werden ohne eigene
+   Freigabe bzw. grundsaetzlich fuer Organization Automation blockiert.
+10. Server-/Audit-Logs und gespeicherter Session-Snapshot werden auf Tokens,
+    Auth-Header, fremde Accountlabels und Credential-Pfade kontrolliert.
+
+## Migration, Rollout und Rollback
+
+### Migration
+
+- Additive Tabellen/Felder zuerst ausrollen; alte Runtime liest sie noch nicht.
+- Alle neuen Team-Grants starten leer. Es gibt kein Backfill aus
+  `allowUserCredentials`, User Preferences oder bestehenden Sessions.
+- Bestehende Personal-Workspace-Nutzung bleibt funktional, solange Principal-
+  und Broker-Migration keine Regression zeigt.
+- Bestehende Team-Snapshots mit User-Installation bleiben als History
+  erhalten, sind aber bis zu neuem explizitem Consent nicht ausfuehrbar.
+- Accountstatus wird lazy beim eigenen Statusabruf/Connect/Refresh aufgebaut;
+  OAuth-Tokens werden weder verschoben noch neu serialisiert.
+- SQLite-, Postgres-, Backup-/Restore- und SQLite-to-Postgres-Pfade muessen die
+  neuen nicht-geheimen Daten mitnehmen. OAuth-Dateien bleiben Bestandteil der
+  bestehenden user-scoped Backup-Policy.
+
+### Gestufter Rollout
+
+1. Principal-/Automation-Fix aktivieren; Organization-Automation sofort
+   fail-closed fuer User-Credentials.
+2. Grant- und Broker-Code hinter einem serverseitigen Feature-Gate deployen,
+   Default aus.
+3. Interne Testorganisation mit `interactive` aktivieren und Isolation/Audit
+   beobachten.
+4. Allgemein aktivieren; `delegation` und `external_channel` bleiben getrennt
+   aus, bis ihre Abnahme erfolgt ist.
+
+Das Feature-Gate darf nur die neue Team-Nutzung deaktivieren. Es darf weder
+Principal-Pruefung noch Organization-Automation-Sperre umgehen.
+
+### Rollback
+
+- Feature-Gate deaktivieren: Neue Team-User-Credential-Ausfuehrungen werden
+  blockiert; Personal-Workspace und Organization/Managed Provider bleiben
+  nutzbar.
+- Grant-Daten und additive Snapshot-Felder bleiben fuer ein spaeteres
+  Vorwaerts-Rollout erhalten, werden aber nicht ausgewertet.
+- Keine Down-Migration loescht Grants oder OAuth-State waehrend eines
+  Betriebs-Rollbacks. Eine spaetere bereinigende Migration ist separat zu
+  pruefen.
+- Wenn der neue Broker eine Regression zeigt, darf nur auf einen nachweislich
+  scope-strikten Adapter zurueckgeschaltet werden; der alte ambient-fallback-
+  faehige `resolvePiApiKey` ist kein zulaessiger Rollback-Pfad.
+- Queued Organization-Automationen mit ehemaliger User-Auswahl bleiben
+  pausiert, bis ein erlaubter Organization/System/Managed Provider explizit
+  gewaehlt wurde.
+
+## Risiken und Gegenmassnahmen
+
+| Risiko | Gegenmassnahme |
+| --- | --- |
+| Admin-Policy wird als Einwilligung missverstanden | Vier-Gate-Modell; Grant kann nur der eingeloggte Credential-Inhaber schreiben. |
+| `responsibleUserId` bleibt verdeckter Secret-Subject | Typisierter Service-Actor-Principal mit `credentialSubjectUserId = null`; negativer Automationstest. |
+| Snapshot konserviert widerrufene Rechte | Snapshot nur als Auswahl/Audit; aktuelle Grant-/Policy-Revalidierung pro Provider-Request. |
+| Organization-Agent exfiltriert persoenliches Credential | Token bleibt im Broker, Agent/Tools sehen keine Ref; Agent-Policy plus per-Agent-Grant; keine Authdaten im Prompt. |
+| OAuth-Refresh-Race nutzt altes Credential | Store-Lock plus Revalidierung nach Refresh und vor Request; Runtime-Invalidierung bei Revoke. |
+| UI leakt Accountidentitaet an Admin/B | Eigene Statusroute, keine Accountfelder im Admin-Katalog, Cross-User-Contracttests. |
+| Fehlende Provider-Accountmetadaten fuehren zu unsicherer Tokenanalyse | Verifikationsgate; nur dokumentierte Metadaten oder klar markierter User-Alias. |
+| Legacy-Key-Resolver umgeht Scope | Ein Broker, statischer Importtest, kein ambient Fallback fuer scoped Runs. |
+| Zu breite Delegations-/Channel-Freigabe | Eigene Execution Modes, V1 default-deny, keine implizite Vererbung aus `interactive`. |
+| Rollback reaktiviert unsichere Automationen | Automation-Sperre nicht feature-gaten; Jobs mit unzulaessiger Auswahl pausiert halten. |
+
+## Definition of Done
+
+Ticket 16 ist erst umgesetzt, wenn:
+
+- die belegte Organization-Automation-Luecke geschlossen ist;
+- alle produktiven Modellaufrufe denselben scope-strikten Broker verwenden;
+- User A sein Credential explizit fuer einen erlaubten eigenen Team-Run
+  freigeben und jederzeit widerrufen kann;
+- User B und jeder Service Actor das Credential weder sehen noch direkt oder
+  indirekt verwenden koennen;
+- Workspace- und Agent-Policy nur einschraenken, niemals stellvertretend
+  freigeben;
+- Session, Reconnect, Tool-Fortsetzung und die explizit definierten
+  Hintergrundarten denselben Principal-/Grant-Vertrag einhalten;
+- Snapshot, Audit, Logs, Client-Responses und Tools keine Tokens enthalten;
+- fokussierte Tests, `npm run build` und die freigegebene manuelle Abnahme
+  bestanden sind;
+- die Implementierung in den beschriebenen sequenziellen Commits vorliegt und
+  Ticket/Index erst danach auf `erledigt` gesetzt wurden.

--- a/scripts/agent-model-probe-test.ts
+++ b/scripts/agent-model-probe-test.ts
@@ -74,6 +74,14 @@ async function main() {
   assert.equal(inexact.success, false);
   assert.equal(inexact.code, 'MODEL_TEST_UNEXPECTED_RESPONSE');
 
+  const punctuated = await testAgentModelConnection({
+    agentId: 'provider-verification',
+    provider: fakeModel.provider,
+    model: fakeModel,
+    complete: async () => assistantText(fakeModel, 'OK.'),
+  });
+  assert.equal(punctuated.success, true);
+
   const successful = await testAgentModelConnection({
     agentId: 'provider-verification',
     provider: fakeModel.provider,

--- a/scripts/agent-runtime-resolution-test.ts
+++ b/scripts/agent-runtime-resolution-test.ts
@@ -886,6 +886,25 @@ async function main() {
   });
   assert.equal(resolution.source, 'user_preference');
 
+  // A personal interactive grant must not follow the same user's session into
+  // an external channel. Those runs use only non-user credentials unless a
+  // future, separately reviewed grant mode explicitly permits them.
+  const externalChannelResolution = await resolveEffectiveAgentRuntime({
+    ...organizationContext,
+    executionMode: 'external_channel',
+    principal: {
+      type: 'user',
+      userId: owner.id,
+      credentialSubjectUserId: owner.id,
+    },
+  });
+  assert.equal(externalChannelResolution.valid, true);
+  assert.equal(externalChannelResolution.source, 'workspace_default');
+  assert.equal(
+    externalChannelResolution.providers.some((provider) => provider.installationId === userProviderId),
+    false,
+  );
+
   // Organization automations retain a responsible user for audit and
   // workspace authorization, but that user must never become the credential
   // subject. Even with the workspace policy and a user preference enabled,

--- a/scripts/agent-runtime-resolution-test.ts
+++ b/scripts/agent-runtime-resolution-test.ts
@@ -218,6 +218,7 @@ async function main() {
     RuntimeStoredDataError,
     SessionRuntimeSnapshotConflictError,
     writeUserModelPreferenceStore,
+    writeUserWorkspaceProviderGrant,
     writeWorkspaceModelPolicyStore,
     writePiSessionRuntimeSnapshot,
   } = await import('../app/lib/agent-runtime-policy/runtime-store');
@@ -854,6 +855,26 @@ async function main() {
     },
   });
   assert.equal(organizationPolicy.revision, 2);
+  const ungrantedTeamResolution = await resolveEffectiveAgentRuntime({
+    ...organizationContext,
+    requestedSelection: userSelection,
+  });
+  assert.equal(ungrantedTeamResolution.valid, false);
+  assert.equal(
+    ungrantedTeamResolution.issues.some((entry) => entry.code === 'CREDENTIAL_NOT_AVAILABLE'),
+    true,
+  );
+  const userCredentialGrant = await writeUserWorkspaceProviderGrant({
+    organizationId: organization.organizationId,
+    userId: owner.id,
+    workspaceId: organizationWorkspaceId,
+    agentId: 'canvas-agent',
+    providerInstallationId: userProviderId,
+    allowedExecutionModes: ['interactive'],
+    expectedRevision: 0,
+  });
+  assert.equal(userCredentialGrant.status, 'active');
+  assert.deepEqual(userCredentialGrant.allowedExecutionModes, ['interactive']);
   resolution = await setUserRuntimePreference({
     context: organizationContext,
     update: {

--- a/scripts/agent-runtime-resolution-test.ts
+++ b/scripts/agent-runtime-resolution-test.ts
@@ -865,6 +865,37 @@ async function main() {
   });
   assert.equal(resolution.source, 'user_preference');
 
+  // Organization automations retain a responsible user for audit and
+  // workspace authorization, but that user must never become the credential
+  // subject. Even with the workspace policy and a user preference enabled,
+  // user-scoped installations are unavailable to a service principal.
+  const organizationAutomationContext = {
+    ...organizationContext,
+    executionMode: 'organization_automation' as const,
+    principal: {
+      type: 'organization_service' as const,
+      serviceActorId: `org-service:${organization.organizationId}`,
+      responsibleUserId: owner.id,
+      credentialSubjectUserId: null,
+    },
+  };
+  const organizationAutomationResolution = await resolveEffectiveAgentRuntime(organizationAutomationContext);
+  assert.equal(organizationAutomationResolution.valid, true);
+  assert.equal(organizationAutomationResolution.source, 'workspace_default');
+  assert.equal(
+    organizationAutomationResolution.providers.some((provider) => provider.installationId === userProviderId),
+    false,
+  );
+  const organizationAutomationUserSelection = await resolveEffectiveAgentRuntime({
+    ...organizationAutomationContext,
+    requestedSelection: userSelection,
+  });
+  assert.equal(organizationAutomationUserSelection.valid, false);
+  assert.equal(
+    organizationAutomationUserSelection.issues.some((entry) => entry.code === 'PROVIDER_INSTALLATION_NOT_ALLOWED'),
+    true,
+  );
+
   const memberId = 'runtime-member';
   const now = Date.now();
   sqlite.prepare(`

--- a/scripts/agent-runtime-resolution-test.ts
+++ b/scripts/agent-runtime-resolution-test.ts
@@ -38,6 +38,12 @@ let organizationCredentialReadBarrier: {
   release: Deferred;
 } | null = null;
 
+let userCredentialReadBarrier: {
+  remainingReads: number;
+  started: Deferred;
+  release: Deferred;
+} | null = null;
+
 function delayOrganizationCredentialReadAfter(readsToSkip: number): {
   started: Promise<void>;
   release: () => void;
@@ -53,6 +59,26 @@ function delayOrganizationCredentialReadAfter(readsToSkip: number): {
     started: started.promise,
     release: () => {
       organizationCredentialReadBarrier = null;
+      release.resolve();
+    },
+  };
+}
+
+function delayUserCredentialReadAfter(readsToSkip: number): {
+  started: Promise<void>;
+  release: () => void;
+} {
+  const started = deferred();
+  const release = deferred();
+  userCredentialReadBarrier = {
+    remainingReads: readsToSkip,
+    started,
+    release,
+  };
+  return {
+    started: started.promise,
+    release: () => {
+      userCredentialReadBarrier = null;
       release.resolve();
     },
   };
@@ -144,8 +170,12 @@ moduleInternals._load = (request, parent, isMain) => {
         scope: string,
         storageScope?: { secretScope?: string } | null,
       ) => {
-        const barrier = organizationCredentialReadBarrier;
-        if (barrier && storageScope?.secretScope === 'organization') {
+        const barrier = storageScope?.secretScope === 'organization'
+          ? organizationCredentialReadBarrier
+          : storageScope?.secretScope === 'user'
+            ? userCredentialReadBarrier
+            : null;
+        if (barrier) {
           if (barrier.remainingReads > 0) {
             barrier.remainingReads -= 1;
           } else {
@@ -875,6 +905,11 @@ async function main() {
   });
   assert.equal(userCredentialGrant.status, 'active');
   assert.deepEqual(userCredentialGrant.allowedExecutionModes, ['interactive']);
+  await replaceScopedEnvEntries(
+    'agents',
+    [{ key: 'OPENAI_COMPATIBLE_API_KEY', value: 'sk-user-compatible-runtime-test' }],
+    { secretScope: 'user', organizationId: organization.organizationId, userId: owner.id },
+  );
   resolution = await setUserRuntimePreference({
     context: organizationContext,
     update: {
@@ -885,6 +920,57 @@ async function main() {
     },
   });
   assert.equal(resolution.source, 'user_preference');
+
+  const personalAutomationResolution = await resolveEffectiveAgentRuntime({
+    ...personalContext,
+    requestedSelection: userSelection,
+    executionMode: 'personal_automation',
+    principal: {
+      type: 'user',
+      userId: owner.id,
+      credentialSubjectUserId: owner.id,
+    },
+  });
+  assert.equal(personalAutomationResolution.valid, true);
+  assert.equal(
+    personalAutomationResolution.effectiveSelection?.selection.providerInstallationId,
+    userProviderId,
+  );
+
+  const grantedTeamRuntime = await resolveExecutableAgentRuntime({
+    ...organizationContext,
+    requestedSelection: userSelection,
+  });
+  const streamCallsBeforeGrantRace = scopedStreamCalls.length;
+  const userCredentialRead = delayUserCredentialReadAfter(1);
+  const revokedGrantStream = grantedTeamRuntime.streamFn(
+    grantedTeamRuntime.model,
+    { messages: [] },
+    { sessionId: 'scoped-runtime-grant-race-test' },
+  );
+  try {
+    await within(userCredentialRead.started, 'User credential read barrier');
+    sqlite.prepare(`
+      UPDATE ai_user_workspace_provider_grants
+      SET status = 'revoked', revision = revision + 1, revoked_at = ?, updated_at = ?
+      WHERE organization_id = ? AND user_id = ? AND workspace_id = ?
+        AND agent_id = ? AND provider_installation_id = ?
+    `).run(
+      Date.now(),
+      Date.now(),
+      organization.organizationId,
+      owner.id,
+      organizationWorkspaceId,
+      'canvas-agent',
+      userProviderId,
+    );
+    userCredentialRead.release();
+    await within(Promise.resolve(revokedGrantStream), 'Revoked user grant stream');
+  } finally {
+    userCredentialRead.release();
+  }
+  assert.equal(scopedStreamCalls.length, streamCallsBeforeGrantRace);
+  assert.equal(grantedTeamRuntime.requiresRecreation(), true);
 
   // A personal interactive grant must not follow the same user's session into
   // an external channel. Those runs use only non-user credentials unless a


### PR DESCRIPTION
## Summary
- add user-scoped provider credential grants for interactive team-workspace use
- deny personal credentials to service, delegation, automation, and external-channel runtimes
- preserve runtime snapshots while enforcing current principal policy on reconnect
- accept the harmless `OK.` provider-probe response used by Kimi via Ollama

## Validation
- `npx tsc --noEmit --pretty false`
- `npx eslint app/lib/agents/model-test.ts scripts/agent-model-probe-test.ts`
- `npx tsx --conditions react-server scripts/agent-model-probe-test.ts`
- `npm run test:pi:delegate-task-runtime`
- local Ollama/Kimi 2.6 provider verification and authenticated WebSocket chat transport

## Security
Personal credentials resolve only for an interactive user principal with an explicit grant. Delegated, automated, service-principal, and external-channel execution fail closed.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds user-scoped provider credential grants for interactive team-workspace sessions while retaining personal credentials for owner-run personal automations and excluding service, delegated, automated team, and external-channel execution.
- Adds grant persistence, migration, API endpoints, and settings controls.
- Propagates explicit execution modes and principals through runtime callers.
- Revalidates workspace policy and credential grants immediately before provider dispatch.
- Extends runtime-resolution and provider-probe validation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/agent-runtime-policy/runtime-resolver.ts | Adds principal- and execution-mode-aware credential eligibility, including owner-scoped personal automation behavior and team grant checks. |
| app/lib/agent-runtime-policy/provider-runtime.ts | Resolves credentials for the explicit principal and revalidates team-workspace grants after credential lookup immediately before dispatch. |
| app/lib/automations/runner.ts | Labels personal and organization automation executions with distinct modes and principals so runtime credential policy can fail closed. |
| app/lib/agent-runtime-policy/runtime-store.ts | Adds revision-controlled persistence and revocation for user workspace provider grants. |
| app/api/agent-runtime/user-credential-grants/route.ts | Adds authenticated, workspace-authorized endpoints for reading, enabling, and revoking the current user's provider grants. |
| app/components/settings/AgentRuntimePreferenceCard.tsx | Adds controls for connecting and explicitly enabling personal OAuth providers in team workspaces. |
| scripts/agent-runtime-resolution-test.ts | Covers interactive team grants, personal automation credential retention, external-channel isolation, and revocation during credential lookup. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant API as Grant API
    participant DB as Runtime Store
    participant Resolver
    participant Auth as Credential Resolver
    participant Provider

    User->>API: Enable personal provider for team workspace
    API->>DB: Persist interactive grant
    User->>Resolver: Start interactive agent run
    Resolver->>DB: Read policy and active grant
    Resolver->>Auth: Resolve owner's credential
    Auth-->>Resolver: Provider authentication
    Resolver->>DB: Re-read policy and grant
    alt Grant remains active
        Resolver->>Provider: Dispatch authenticated request
    else Grant revoked or policy changed
        Resolver-->>User: Fail closed and recreate runtime
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: revalidate personal credential gran..."](https://github.com/canvascoding/canvas-notebook/commit/ed62e62541ef1389869b48a5a92700b7a72b0f52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55733129)</sub>

<!-- /greptile_comment -->