### PR TITLE
Fix vision delivery for read-tool images

### DIFF
--- a/app/lib/automations/runner.ts
+++ b/app/lib/automations/runner.ts
@@ -11,7 +11,8 @@ import {
 import { sessionRuntimeSnapshotFromResolvedSelection } from '@/app/lib/agent-runtime-policy/runtime-snapshot';
 import { SessionRuntimeContextRevisionConflictError } from '@/app/lib/agent-runtime-policy/runtime-store';
 import { createDirectory } from '@/app/lib/filesystem/workspace-files';
-import { normalizePiMessagesForLlm } from '@/app/lib/pi/message-normalization';
+import { prepareMessagesForEffectiveModel } from '@/app/lib/pi/multimodal-preparation';
+import { projectAgentEventForExternal } from '@/app/lib/pi/visual-data-projection';
 import { preparePiHistoryContext } from '@/app/lib/pi/session-summary';
 import { estimateTextTokens } from '@/app/lib/pi/history-budget';
 import { MAX_LLM_HISTORY_BYTES } from '@/app/lib/pi/llm-payload-limits';
@@ -649,12 +650,16 @@ export async function executeAutomationRun(runId: string): Promise<void> {
         const config = {
           model,
           thinkingLevel: executableRuntime.selection.selection.thinkingLevel as ThinkingLevel,
-          convertToLlm: async (messages: AgentMessage[]) => normalizePiMessagesForLlm(messages, {
-            workspaceImageRoot: automationWorkspace.rootPath,
-            allowedImageFileRoots: [automationWorkspace.rootPath],
-            uploadOwnerUserId: runtimeContext.userId,
-            uploadWorkspaceId: automationWorkspace.workspaceId,
-          }),
+          convertToLlm: async (messages: AgentMessage[]) => prepareMessagesForEffectiveModel(
+            messages,
+            model,
+            {
+              workspaceImageRoot: automationWorkspace.rootPath,
+              allowedImageFileRoots: [automationWorkspace.rootPath],
+              uploadOwnerUserId: runtimeContext.userId,
+              uploadWorkspaceId: automationWorkspace.workspaceId,
+            },
+          ),
           prepareNextTurn: async (turnContext: { context: AgentContext }) => {
             const nextWorkspaceFileTree = hasWorkspaceReadCapability
               ? await buildWorkspaceFileTreePrompt({
@@ -711,7 +716,7 @@ export async function executeAutomationRun(runId: string): Promise<void> {
           executableRuntime.streamFn,
         )) {
           if (loopEvents.length < MAX_EVENTS_LOG) {
-            const json = JSON.stringify(event);
+            const json = JSON.stringify(projectAgentEventForExternal(event));
             loopEvents.push(json.length > MAX_EVENT_JSON_LENGTH ? json.slice(0, MAX_EVENT_JSON_LENGTH) + '...[truncated]' : json);
           }
           if (event.type === 'agent_end') {

--- a/app/lib/pi/delegate-task-tool.ts
+++ b/app/lib/pi/delegate-task-tool.ts
@@ -449,9 +449,10 @@ async function runEphemeralWorker(params: {
       model,
       thinkingLevel: params.runtime.selection.selection.thinkingLevel as ThinkingLevel,
       convertToLlm: async (messages: AgentMessage[]) => {
-        const { normalizePiMessagesForLlm } = await import('@/app/lib/pi/message-normalization');
-        return normalizePiMessagesForLlm(
-          messages.filter((message) => message.role !== 'compact-break' && message.role !== 'composio_auth_required'),
+        const { prepareMessagesForEffectiveModel } = await import('@/app/lib/pi/multimodal-preparation');
+        return prepareMessagesForEffectiveModel(
+          messages,
+          model,
           {
             workspaceImageRoot: params.executionContext.workspaceRoot,
             allowedImageFileRoots: [params.executionContext.workspaceRoot],

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -27,7 +27,7 @@ import {
   type PiHistoryComposition,
   type PiSessionSummaryState,
 } from '@/app/lib/pi/history-budget';
-import { normalizePiMessagesForLlm, filterImagesForNonVisionModel } from '@/app/lib/pi/message-normalization';
+import { prepareMessagesForEffectiveModel } from '@/app/lib/pi/multimodal-preparation';
 import { MAX_LLM_HISTORY_BYTES } from '@/app/lib/pi/llm-payload-limits';
 import { createCompactBreakMessage, createRuntimeContinuationMessage, type RuntimeContinuationReason } from '@/app/lib/pi/custom-messages';
 import {
@@ -39,7 +39,6 @@ import {
 import {
   formatImageInputUnsupportedError,
   isImageInputUnsupportedError,
-  modelSupportsImageInput,
 } from '@/app/lib/pi/model-resolver';
 import { preparePiHistoryContext } from '@/app/lib/pi/session-summary';
 import { loadPiSessionWithSummary, savePiSession } from '@/app/lib/pi/session-store';
@@ -1897,9 +1896,7 @@ async function createRuntime(sessionId: string, userId: string): Promise<LivePiR
       messages: initialMessages,
     },
     convertToLlm: async (messages) => {
-      const filtered = messages.filter((m) => m.role !== 'compact-break' && m.role !== 'composio_auth_required');
-      const messagesForLlm = modelSupportsImageInput(model) ? filtered : filterImagesForNonVisionModel(filtered);
-      return normalizePiMessagesForLlm(messagesForLlm, imageNormalizationOptions);
+      return prepareMessagesForEffectiveModel(messages, model, imageNormalizationOptions);
     },
     transformContext: async (messages, signal) => {
       if (!runtimeRef.current) {

--- a/app/lib/pi/multimodal-preparation.ts
+++ b/app/lib/pi/multimodal-preparation.ts
@@ -1,0 +1,31 @@
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import type { Api, Message, Model } from '@earendil-works/pi-ai';
+
+import {
+  filterImagesForNonVisionModel,
+  normalizePiMessagesForLlm,
+  type PiMessageNormalizationOptions,
+} from './message-normalization';
+
+/**
+ * The one boundary at which Canvas turns agent messages into provider payloads.
+ * All execution modes use this helper so a model's effective input modalities
+ * govern read-tool images consistently before PI's provider adapter encodes it.
+ */
+export async function prepareMessagesForEffectiveModel(
+  messages: AgentMessage[],
+  model: Model<Api>,
+  options: PiMessageNormalizationOptions = {},
+): Promise<Message[]> {
+  const runnableMessages = messages.filter(
+    (message) => message.role !== 'compact-break' && message.role !== 'composio_auth_required',
+  );
+  // `model` is the already materialized, policy-checked provider model. Its
+  // input list is the effective capability contract for this request; do not
+  // re-infer it from a model name at the delivery boundary.
+  const capabilityScopedMessages = model.input.includes('image')
+    ? runnableMessages
+    : filterImagesForNonVisionModel(runnableMessages);
+
+  return normalizePiMessagesForLlm(capabilityScopedMessages, options);
+}

--- a/app/lib/pi/runtime-event-emitter.ts
+++ b/app/lib/pi/runtime-event-emitter.ts
@@ -6,6 +6,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { projectAgentEventForExternal } from './visual-data-projection';
 
 interface PiRuntimeEvent {
   sessionId: string;
@@ -32,7 +33,7 @@ class PiRuntimeEventEmitter extends EventEmitter {
     this.emit('agent_event', {
       sessionId,
       userId,
-      event,
+      event: projectAgentEventForExternal(event),
       timestamp: Date.now(),
     } as PiRuntimeEvent);
   }

--- a/app/lib/pi/session-store.ts
+++ b/app/lib/pi/session-store.ts
@@ -20,6 +20,7 @@ import {
   type PiSystemPromptSnapshot,
 } from './system-prompt-snapshot';
 import { parsePersistedPiMessage, type PiMessageProjectionMode } from './message-projection';
+import { projectAgentMessageForPersistence } from './visual-data-projection';
 import { ensureSessionChannelLink } from '@/app/lib/channels/channel-links';
 import { DEFAULT_AGENT_ID, normalizeChannelThreadKey, normalizeStoredChannelId, WEB_CHANNEL_ID, webChannelSessionKey } from '@/app/lib/channels/constants';
 import {
@@ -484,7 +485,7 @@ export async function savePiSession(
       newMessages.map((m, index) => ({
         piSessionDbId: sessionDbId,
         role: m.role,
-        content: JSON.stringify(m),
+        content: JSON.stringify(projectAgentMessageForPersistence(m)),
         timestamp: getAgentMessageTimestamp(m),
         sequence: startIndex + index + 1,
       }))

--- a/app/lib/pi/stream-proxy.ts
+++ b/app/lib/pi/stream-proxy.ts
@@ -1,4 +1,5 @@
 import { type AgentEvent } from '@earendil-works/pi-agent-core';
+import { projectAgentEventForExternal } from './visual-data-projection';
 
 type AgentErrorEvent = {
   type: 'error';
@@ -15,7 +16,7 @@ function getErrorMessage(error: unknown): string {
  * Encodes AgentEvent into a string for streaming.
  */
 export function encodeAgentEvent(event: StreamAgentEvent): string {
-  return JSON.stringify(event) + '\n';
+  return JSON.stringify(projectAgentEventForExternal(event)) + '\n';
 }
 
 /**

--- a/app/lib/pi/visual-data-projection.ts
+++ b/app/lib/pi/visual-data-projection.ts
@@ -1,0 +1,47 @@
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isImagePart(value: UnknownRecord): boolean {
+  return value.type === 'image' && typeof value.data === 'string';
+}
+
+function projectVisualValue(value: unknown, purpose: 'persistence' | 'external-event'): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => projectVisualValue(entry, purpose));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  if (isImagePart(value)) {
+    const mimeType = typeof value.mimeType === 'string' ? value.mimeType : 'image';
+    return {
+      type: 'text',
+      text: `[${mimeType} image omitted from ${purpose === 'persistence' ? 'persisted chat history' : 'live event'}; reopen or read the authorized source to analyze it.]`,
+    };
+  }
+
+  const projected: UnknownRecord = {};
+  for (const [key, entry] of Object.entries(value)) {
+    // Absolute real paths are only needed while the server executes a tool.
+    if (key === 'resolvedPath') continue;
+    projected[key] = projectVisualValue(entry, purpose);
+  }
+  return projected;
+}
+
+/** Removes binary image payloads and server-only resolved paths before DB writes. */
+export function projectAgentMessageForPersistence(message: AgentMessage): AgentMessage {
+  return projectVisualValue(message, 'persistence') as AgentMessage;
+}
+
+/** Removes binary image payloads and server-only resolved paths before client/log transport. */
+export function projectAgentEventForExternal<T extends Record<string, unknown>>(event: T): T {
+  return projectVisualValue(event, 'external-event') as T;
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:integration": "node scripts/integration-test.mjs",
     "test:integration:pi": "node scripts/pi-integration-test.mjs",
     "test:pi:attachments": "tsx scripts/pi-attachments-test.ts",
+    "test:pi:multimodal-delivery": "tsx scripts/pi-multimodal-delivery-test.ts",
     "test:pi:summary": "tsx scripts/pi-session-summary-test.ts",
     "test:pi:session-title": "tsx --conditions react-server scripts/pi-session-title-test.ts",
     "test:pi:usage": "tsx scripts/pi-usage-test.ts",

--- a/scripts/automation-runner-tool-context-test.ts
+++ b/scripts/automation-runner-tool-context-test.ts
@@ -414,7 +414,10 @@ moduleInternals._load = (request, parent, isMain) => {
   }
 
   if (request === '@/app/lib/pi/message-normalization' || request.endsWith('/pi/message-normalization')) {
-    return { normalizePiMessagesForLlm: async (messages: unknown[]) => messages };
+    return {
+      normalizePiMessagesForLlm: async (messages: unknown[]) => messages,
+      filterImagesForNonVisionModel: (messages: unknown[]) => messages,
+    };
   }
 
   if (request === '@/app/lib/pi/tool-registry' || request.endsWith('/pi/tool-registry')) {

--- a/scripts/pi-delegate-task-runtime-test.ts
+++ b/scripts/pi-delegate-task-runtime-test.ts
@@ -409,7 +409,10 @@ moduleInternals._load = (request, parent, isMain) => {
     };
   }
   if (matchesModule(request, 'app/lib/pi/message-normalization')) {
-    return { normalizePiMessagesForLlm: async (messages: unknown[]) => messages };
+    return {
+      normalizePiMessagesForLlm: async (messages: unknown[]) => messages,
+      filterImagesForNonVisionModel: (messages: unknown[]) => messages,
+    };
   }
   return originalLoad(request, parent, isMain);
 };

--- a/scripts/pi-message-projection-test.ts
+++ b/scripts/pi-message-projection-test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync } from 'node:fs';
+import Module from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -7,6 +8,22 @@ import type { AgentMessage } from '@earendil-works/pi-agent-core';
 
 const dataDir = mkdtempSync(path.join(tmpdir(), 'canvas-pi-message-projection-'));
 process.env.DATA = dataDir;
+
+const moduleInternals = Module as typeof Module & {
+  _load: (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+};
+const originalLoad = moduleInternals._load;
+moduleInternals._load = (request, parent, isMain) => {
+  if (request === 'server-only') return {};
+  if (request === '@earendil-works/pi-ai' || request === '@earendil-works/pi-ai/compat') {
+    return {
+      getModels: () => [],
+      getProviders: () => [],
+      registerBuiltInApiProviders: () => undefined,
+    };
+  }
+  return originalLoad(request, parent, isMain);
+};
 
 async function main() {
   const { eq } = await import('drizzle-orm');
@@ -53,6 +70,7 @@ async function main() {
     ],
     details: {
       filePath: 'case.pdf',
+      resolvedPath: '/private/runtime/workspace/case.pdf',
       type: 'image',
       mimeType: 'image/png',
       previewUrl: '/api/files/preview?path=case.pdf&w=192&preset=mini',
@@ -93,13 +111,14 @@ async function main() {
   assert.equal(rows.length, 1);
   const rawContent = rows[0].content;
   assert.ok(rawContent.includes('raw-pdf-body'));
-  assert.ok(rawContent.includes(imageData.slice(0, 200)));
+  assert.doesNotMatch(rawContent, new RegExp(imageData.slice(0, 200)));
+  assert.doesNotMatch(rawContent, /private\/runtime\/workspace/);
 
   const rawMessage = parsePersistedPiMessage(rawContent, 'raw') as unknown as Record<string, unknown>;
   assert.equal(JSON.stringify(rawMessage).length, rawContent.length);
   const rawParts = rawMessage.content as Array<Record<string, unknown>>;
   assert.equal(rawParts[0].text, hugeText);
-  assert.equal(rawParts[1].data, imageData);
+  assert.match(String(rawParts[1].text), /omitted from persisted chat history/);
 
   const loaded = await loadPiSessionWithSummary(sessionId, userId, 'canvas-agent');
   assert.ok(loaded);
@@ -117,6 +136,7 @@ async function main() {
   assert.equal(projectedToolDetails.mimeType, 'image/png');
   assert.equal(projectedToolDetails.previewUrl, '/api/files/preview?path=case.pdf&w=192&preset=mini');
   assert.equal(projectedToolDetails.mediaUrl, '/api/media/case.pdf');
+  assert.equal(projectedToolDetails.resolvedPath, undefined);
 
   const projectedUserImage = loaded.messages.find((message) => {
     const content = (message as unknown as { content?: unknown }).content;
@@ -124,7 +144,7 @@ async function main() {
   });
   assert.ok(projectedUserImage);
   const projectedUserJson = JSON.stringify(projectedUserImage);
-  assert.match(projectedUserJson, /image omitted from loaded chat context/);
+  assert.match(projectedUserJson, /image omitted from persisted chat history/);
   assert.doesNotMatch(projectedUserJson, new RegExp(imageData.slice(0, 200)));
 
   const normalizedForLlm = await normalizePiMessagesForLlm([userImageMessage, toolResultMessage]);
@@ -222,6 +242,7 @@ async function main() {
 
 main()
   .finally(() => {
+    moduleInternals._load = originalLoad;
     rmSync(dataDir, { recursive: true, force: true });
   })
   .catch((error) => {

--- a/scripts/pi-multimodal-delivery-test.ts
+++ b/scripts/pi-multimodal-delivery-test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import type { Model } from '@earendil-works/pi-ai';
+
+import { prepareMessagesForEffectiveModel } from '../app/lib/pi/multimodal-preparation';
+import {
+  projectAgentEventForExternal,
+  projectAgentMessageForPersistence,
+} from '../app/lib/pi/visual-data-projection';
+
+const visionModel = {
+  id: 'vision-test',
+  name: 'Vision test',
+  provider: 'test',
+  api: 'openai-completions',
+  baseUrl: 'https://example.test/v1',
+  reasoning: false,
+  input: ['text', 'image'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 8_192,
+  maxTokens: 1_024,
+} as unknown as Model<'openai-completions'>;
+
+const textModel = {
+  ...visionModel,
+  id: 'text-test',
+  input: ['text'],
+} as Model<'openai-completions'>;
+
+async function main() {
+  const imageData = Buffer.from('read-tool-image').toString('base64');
+  const toolResult = {
+    role: 'toolResult',
+    toolCallId: 'read-1',
+    toolName: 'read',
+    content: [
+      { type: 'text', text: 'Read image.png' },
+      { type: 'image', data: imageData, mimeType: 'image/png' },
+    ],
+    details: {
+      filePath: 'image.png',
+      resolvedPath: '/private/workspace/image.png',
+      type: 'image',
+    },
+    timestamp: Date.now(),
+  } as unknown as AgentMessage;
+
+  const visionPayload = await prepareMessagesForEffectiveModel([toolResult], visionModel);
+  const visionContent = visionPayload[0].content as Array<{ type: string; data?: string }>;
+  assert.equal(visionContent.filter((part) => part.type === 'image').length, 1);
+  assert.equal(visionContent.find((part) => part.type === 'image')?.data, imageData);
+
+  const textPayload = await prepareMessagesForEffectiveModel([toolResult], textModel);
+  const textContent = textPayload[0].content as Array<{ type: string; text?: string }>;
+  assert.equal(textContent.filter((part) => part.type === 'image').length, 0);
+  assert.match(textContent.map((part) => part.text || '').join('\n'), /does not support vision/i);
+
+  const persisted = projectAgentMessageForPersistence(toolResult);
+  const persistedJson = JSON.stringify(persisted);
+  assert.doesNotMatch(persistedJson, new RegExp(imageData));
+  assert.doesNotMatch(persistedJson, /private\/workspace/);
+  assert.match(persistedJson, /omitted from persisted chat history/);
+
+  const external = projectAgentEventForExternal({
+    type: 'tool_execution_end',
+    result: toolResult,
+  });
+  const externalJson = JSON.stringify(external);
+  assert.doesNotMatch(externalJson, new RegExp(imageData));
+  assert.doesNotMatch(externalJson, /private\/workspace/);
+  assert.match(externalJson, /omitted from live event/);
+
+  console.log('[PI Multimodal Delivery Test] Passed.');
+}
+
+void main();


### PR DESCRIPTION
## Summary
- route read-tool image results through one effective-model multimodal preparation path for live chat, automations, and delegated workers
- retain images for models whose materialized input contract includes `image`; use the existing safe text fallback for text-only models
- omit image bytes and internal resolved paths from persisted sessions, streamed events, and automation logs

## Verification
- `npm run test:pi:multimodal-delivery`
- `npm run test:pi:attachments`
- `npx tsx scripts/pi-message-projection-test.ts`
- `npm run test:pi:delegate-task-runtime`
- `npm run test:automation:runner`
- focused ESLint

## Build note
`npm run build` compiled successfully, then stopped at the pre-existing TypeScript error in `app/lib/pi/effective-tool-manifest.ts:41` (`Property operations does not exist on type {}`).

No browser/Playwright run was performed because it was not requested.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes multimodal message preparation across live chat, automations, and delegated workers, while projecting image bytes and resolved server paths out of persistence and external events.
- Uses the effective model’s declared input modalities to retain or remove images.
- Sanitizes persisted messages, streamed events, runtime events, and automation logs.
- Adds focused multimodal delivery and projection coverage.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until externally projected screenshot results retain enough safe metadata for the live chat to render their image attachment.

The generic event projection removes browser screenshot image parts before client attachment extraction, and the remaining screenshot details cannot reconstruct the preview.

**Files Needing Attention:** app/lib/pi/visual-data-projection.ts, app/lib/pi/runtime-event-emitter.ts, app/lib/pi/stream-proxy.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/pi/multimodal-preparation.ts | Centralizes custom-role filtering, effective-model image capability checks, and provider-message normalization. |
| app/lib/pi/visual-data-projection.ts | Removes image bytes and resolved paths recursively, but its generic image replacement also removes browser screenshot attachments from live events. |
| app/lib/pi/runtime-event-emitter.ts | Sanitizes all runtime events before broadcast, exposing the generic projection’s screenshot regression. |
| app/lib/pi/stream-proxy.ts | Applies the same projection to streamed events and therefore reproduces the screenshot attachment loss. |
| app/lib/pi/session-store.ts | Projects newly persisted messages to avoid storing image bytes and internal resolved paths. |
| app/lib/automations/runner.ts | Adopts centralized model-aware preparation and sanitizes serialized automation event logs. |
| app/lib/pi/delegate-task-tool.ts | Routes delegated-worker messages through the shared effective-model multimodal preparation path. |
| app/lib/pi/live-runtime.ts | Replaces inline filtering and normalization with the shared preparation helper. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Tool result with image content] --> B[Effective-model preparation]
  B --> C[Provider payload]
  A --> D[External or persistence projection]
  D --> E[Image replaced with omission text]
  E --> F[Stream / runtime event / database]
  F --> G[Client attachment extraction]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix vision read tool delivery"](https://github.com/canvascoding/canvas-notebook/commit/837d5333d53a1a1ec022f97881afded43fd279a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55821302)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->