### PR TITLE
Fix optimistic vision provider fallback

### DIFF
--- a/app/lib/agent-runtime-policy/provider-runtime.ts
+++ b/app/lib/agent-runtime-policy/provider-runtime.ts
@@ -51,6 +51,7 @@ import {
   modelSupportsImageInput,
   resolvePiModel,
 } from '@/app/lib/pi/model-resolver';
+import { createVisionFallbackStreamFn } from '@/app/lib/pi/vision-fallback-stream';
 
 export class AiRuntimeExecutionError extends Error {
   readonly status = 409;
@@ -588,6 +589,32 @@ async function materializeResolution(
     return auth;
   };
 
+  const authenticatedStreamFn: ExecutableAgentRuntime['streamFn'] = async (requestedModel, requestContext, options) => {
+    try {
+      if (requestedModel.id !== model.id || requestedModel.provider !== model.provider) {
+        throw new AiRuntimeExecutionError(
+          'RUNTIME_PROVIDER_CHANGED',
+          'The active runtime model changed before the provider request started. Try again.',
+        );
+      }
+      const auth = await resolveRequestAuth();
+      const authenticatedModel = auth.baseUrl
+        ? { ...requestedModel, baseUrl: auth.baseUrl }
+        : requestedModel;
+      return streamSimple(authenticatedModel, requestContext, {
+        ...omitUnsupportedTemperature(authenticatedModel, options),
+        ...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
+        ...((auth.headers || options?.headers)
+          ? { headers: { ...auth.headers, ...options?.headers } }
+          : {}),
+        env: { ...options?.env, ...auth.env },
+      });
+    } catch (error) {
+      recreationRequired ||= isRuntimeRecreationRequiredError(error);
+      return runtimeErrorStream(requestedModel, error);
+    }
+  };
+
   return {
     resolution,
     selection,
@@ -609,31 +636,7 @@ async function materializeResolution(
         return undefined;
       }
     },
-    streamFn: async (requestedModel, requestContext, options) => {
-      try {
-        if (requestedModel.id !== model.id || requestedModel.provider !== model.provider) {
-          throw new AiRuntimeExecutionError(
-            'RUNTIME_PROVIDER_CHANGED',
-            'The active runtime model changed before the provider request started. Try again.',
-          );
-        }
-        const auth = await resolveRequestAuth();
-        const authenticatedModel = auth.baseUrl
-          ? { ...requestedModel, baseUrl: auth.baseUrl }
-          : requestedModel;
-        return streamSimple(authenticatedModel, requestContext, {
-          ...omitUnsupportedTemperature(authenticatedModel, options),
-          ...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
-          ...((auth.headers || options?.headers)
-            ? { headers: { ...auth.headers, ...options?.headers } }
-            : {}),
-          env: { ...options?.env, ...auth.env },
-        });
-      } catch (error) {
-        recreationRequired ||= isRuntimeRecreationRequiredError(error);
-        return runtimeErrorStream(requestedModel, error);
-      }
-    },
+    streamFn: createVisionFallbackStreamFn(authenticatedStreamFn, createAssistantMessageEventStream),
     requiresRecreation: () => recreationRequired,
   };
 }

--- a/app/lib/automations/runner.ts
+++ b/app/lib/automations/runner.ts
@@ -11,7 +11,8 @@ import {
 import { sessionRuntimeSnapshotFromResolvedSelection } from '@/app/lib/agent-runtime-policy/runtime-snapshot';
 import { SessionRuntimeContextRevisionConflictError } from '@/app/lib/agent-runtime-policy/runtime-store';
 import { createDirectory } from '@/app/lib/filesystem/workspace-files';
-import { normalizePiMessagesForLlm } from '@/app/lib/pi/message-normalization';
+import { prepareMessagesForEffectiveModel } from '@/app/lib/pi/multimodal-preparation';
+import { projectAgentEventForExternal } from '@/app/lib/pi/visual-data-projection';
 import { preparePiHistoryContext } from '@/app/lib/pi/session-summary';
 import { estimateTextTokens } from '@/app/lib/pi/history-budget';
 import { MAX_LLM_HISTORY_BYTES } from '@/app/lib/pi/llm-payload-limits';
@@ -649,12 +650,16 @@ export async function executeAutomationRun(runId: string): Promise<void> {
         const config = {
           model,
           thinkingLevel: executableRuntime.selection.selection.thinkingLevel as ThinkingLevel,
-          convertToLlm: async (messages: AgentMessage[]) => normalizePiMessagesForLlm(messages, {
-            workspaceImageRoot: automationWorkspace.rootPath,
-            allowedImageFileRoots: [automationWorkspace.rootPath],
-            uploadOwnerUserId: runtimeContext.userId,
-            uploadWorkspaceId: automationWorkspace.workspaceId,
-          }),
+          convertToLlm: async (messages: AgentMessage[]) => prepareMessagesForEffectiveModel(
+            messages,
+            model,
+            {
+              workspaceImageRoot: automationWorkspace.rootPath,
+              allowedImageFileRoots: [automationWorkspace.rootPath],
+              uploadOwnerUserId: runtimeContext.userId,
+              uploadWorkspaceId: automationWorkspace.workspaceId,
+            },
+          ),
           prepareNextTurn: async (turnContext: { context: AgentContext }) => {
             const nextWorkspaceFileTree = hasWorkspaceReadCapability
               ? await buildWorkspaceFileTreePrompt({
@@ -711,7 +716,7 @@ export async function executeAutomationRun(runId: string): Promise<void> {
           executableRuntime.streamFn,
         )) {
           if (loopEvents.length < MAX_EVENTS_LOG) {
-            const json = JSON.stringify(event);
+            const json = JSON.stringify(projectAgentEventForExternal(event));
             loopEvents.push(json.length > MAX_EVENT_JSON_LENGTH ? json.slice(0, MAX_EVENT_JSON_LENGTH) + '...[truncated]' : json);
           }
           if (event.type === 'agent_end') {

--- a/app/lib/pi/delegate-task-tool.ts
+++ b/app/lib/pi/delegate-task-tool.ts
@@ -449,9 +449,10 @@ async function runEphemeralWorker(params: {
       model,
       thinkingLevel: params.runtime.selection.selection.thinkingLevel as ThinkingLevel,
       convertToLlm: async (messages: AgentMessage[]) => {
-        const { normalizePiMessagesForLlm } = await import('@/app/lib/pi/message-normalization');
-        return normalizePiMessagesForLlm(
-          messages.filter((message) => message.role !== 'compact-break' && message.role !== 'composio_auth_required'),
+        const { prepareMessagesForEffectiveModel } = await import('@/app/lib/pi/multimodal-preparation');
+        return prepareMessagesForEffectiveModel(
+          messages,
+          model,
           {
             workspaceImageRoot: params.executionContext.workspaceRoot,
             allowedImageFileRoots: [params.executionContext.workspaceRoot],

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -27,7 +27,7 @@ import {
   type PiHistoryComposition,
   type PiSessionSummaryState,
 } from '@/app/lib/pi/history-budget';
-import { normalizePiMessagesForLlm, filterImagesForNonVisionModel } from '@/app/lib/pi/message-normalization';
+import { prepareMessagesForEffectiveModel } from '@/app/lib/pi/multimodal-preparation';
 import { MAX_LLM_HISTORY_BYTES } from '@/app/lib/pi/llm-payload-limits';
 import { createCompactBreakMessage, createRuntimeContinuationMessage, type RuntimeContinuationReason } from '@/app/lib/pi/custom-messages';
 import {
@@ -39,7 +39,6 @@ import {
 import {
   formatImageInputUnsupportedError,
   isImageInputUnsupportedError,
-  modelSupportsImageInput,
 } from '@/app/lib/pi/model-resolver';
 import { preparePiHistoryContext } from '@/app/lib/pi/session-summary';
 import { loadPiSessionWithSummary, savePiSession } from '@/app/lib/pi/session-store';
@@ -1897,9 +1896,7 @@ async function createRuntime(sessionId: string, userId: string): Promise<LivePiR
       messages: initialMessages,
     },
     convertToLlm: async (messages) => {
-      const filtered = messages.filter((m) => m.role !== 'compact-break' && m.role !== 'composio_auth_required');
-      const messagesForLlm = modelSupportsImageInput(model) ? filtered : filterImagesForNonVisionModel(filtered);
-      return normalizePiMessagesForLlm(messagesForLlm, imageNormalizationOptions);
+      return prepareMessagesForEffectiveModel(messages, model, imageNormalizationOptions);
     },
     transformContext: async (messages, signal) => {
       if (!runtimeRef.current) {

--- a/app/lib/pi/model-resolver.ts
+++ b/app/lib/pi/model-resolver.ts
@@ -3,6 +3,10 @@ import type { BuiltinProvider } from '@earendil-works/pi-ai/providers/all';
 import type { Api, Model } from '@earendil-works/pi-ai';
 import { isManagedControlPlaneAvailable, readPiRuntimeConfig } from '../agents/storage';
 import { getManagedControlPlaneBaseUrl } from '../managed/control-plane-url';
+export {
+  formatImageInputUnsupportedError,
+  isImageInputUnsupportedError,
+} from './vision-input-rejection';
 import {
   CANVAS_CONTROL_PLANE_PROVIDER_ID,
   FALLBACK_CANVAS_CONTROL_PLANE_MODELS,
@@ -190,30 +194,6 @@ export function modelSupportsImageInput(model: ModelCapabilityProbe | null | und
 
 function inferModelInput(modelId: string): OpenAICompletionsModelInput {
   return modelSupportsVision(modelId) ? ['text', 'image'] : ['text'];
-}
-
-const IMAGE_INPUT_UNSUPPORTED_PATTERNS = [
-  /image inputs? (?:are|is) not supported/i,
-  /images? (?:are|is) not supported (?:by|for) (?:this )?model/i,
-  /(?:this|the current) model does not support images?/i,
-  /model does not support images?/i,
-  /unsupported (?:input )?modality[^.:\n]*image/i,
-  /invalid request content[\s\S]{0,240}image/i,
-  /image_url[\s\S]{0,240}(?:not supported|unsupported)/i,
-];
-
-export function isImageInputUnsupportedError(message: string): boolean {
-  return IMAGE_INPUT_UNSUPPORTED_PATTERNS.some((pattern) => pattern.test(message));
-}
-
-export function formatImageInputUnsupportedError(params: { modelId: string; provider: string; message: string }): string {
-  return [
-    `The selected model (${params.provider}/${params.modelId}) rejected the attached image input.`,
-    'Canvas did not crash; the provider refused the multimodal request after the image was sent.',
-    'Choose a model that supports image input, or switch this model/provider to text-only behavior before using image attachments.',
-    '',
-    `Provider error: ${params.message}`,
-  ].join('\n');
 }
 
 export const OLLAMA_MODELS: Model<'openai-completions'>[] = [

--- a/app/lib/pi/multimodal-preparation.ts
+++ b/app/lib/pi/multimodal-preparation.ts
@@ -2,30 +2,24 @@ import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import type { Api, Message, Model } from '@earendil-works/pi-ai';
 
 import {
-  filterImagesForNonVisionModel,
   normalizePiMessagesForLlm,
   type PiMessageNormalizationOptions,
 } from './message-normalization';
 
 /**
  * The one boundary at which Canvas turns agent messages into provider payloads.
- * All execution modes use this helper so a model's effective input modalities
- * govern read-tool images consistently before PI's provider adapter encodes it.
+ * All execution modes use this helper so read-tool images reach the provider
+ * boundary consistently. Provider capability metadata is advisory: the runtime
+ * makes one optimistic multimodal attempt and performs a safe text fallback if
+ * the provider explicitly rejects image input.
  */
 export async function prepareMessagesForEffectiveModel(
   messages: AgentMessage[],
-  model: Model<Api>,
+  _model: Model<Api>,
   options: PiMessageNormalizationOptions = {},
 ): Promise<Message[]> {
   const runnableMessages = messages.filter(
     (message) => message.role !== 'compact-break' && message.role !== 'composio_auth_required',
   );
-  // `model` is the already materialized, policy-checked provider model. Its
-  // input list is the effective capability contract for this request; do not
-  // re-infer it from a model name at the delivery boundary.
-  const capabilityScopedMessages = model.input.includes('image')
-    ? runnableMessages
-    : filterImagesForNonVisionModel(runnableMessages);
-
-  return normalizePiMessagesForLlm(capabilityScopedMessages, options);
+  return normalizePiMessagesForLlm(runnableMessages, options);
 }

--- a/app/lib/pi/multimodal-preparation.ts
+++ b/app/lib/pi/multimodal-preparation.ts
@@ -1,0 +1,31 @@
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import type { Api, Message, Model } from '@earendil-works/pi-ai';
+
+import {
+  filterImagesForNonVisionModel,
+  normalizePiMessagesForLlm,
+  type PiMessageNormalizationOptions,
+} from './message-normalization';
+
+/**
+ * The one boundary at which Canvas turns agent messages into provider payloads.
+ * All execution modes use this helper so a model's effective input modalities
+ * govern read-tool images consistently before PI's provider adapter encodes it.
+ */
+export async function prepareMessagesForEffectiveModel(
+  messages: AgentMessage[],
+  model: Model<Api>,
+  options: PiMessageNormalizationOptions = {},
+): Promise<Message[]> {
+  const runnableMessages = messages.filter(
+    (message) => message.role !== 'compact-break' && message.role !== 'composio_auth_required',
+  );
+  // `model` is the already materialized, policy-checked provider model. Its
+  // input list is the effective capability contract for this request; do not
+  // re-infer it from a model name at the delivery boundary.
+  const capabilityScopedMessages = model.input.includes('image')
+    ? runnableMessages
+    : filterImagesForNonVisionModel(runnableMessages);
+
+  return normalizePiMessagesForLlm(capabilityScopedMessages, options);
+}

--- a/app/lib/pi/runtime-event-emitter.ts
+++ b/app/lib/pi/runtime-event-emitter.ts
@@ -6,6 +6,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { projectAgentEventForExternal } from './visual-data-projection';
 
 interface PiRuntimeEvent {
   sessionId: string;
@@ -32,7 +33,7 @@ class PiRuntimeEventEmitter extends EventEmitter {
     this.emit('agent_event', {
       sessionId,
       userId,
-      event,
+      event: projectAgentEventForExternal(event),
       timestamp: Date.now(),
     } as PiRuntimeEvent);
   }

--- a/app/lib/pi/session-store.ts
+++ b/app/lib/pi/session-store.ts
@@ -20,6 +20,7 @@ import {
   type PiSystemPromptSnapshot,
 } from './system-prompt-snapshot';
 import { parsePersistedPiMessage, type PiMessageProjectionMode } from './message-projection';
+import { projectAgentMessageForPersistence } from './visual-data-projection';
 import { ensureSessionChannelLink } from '@/app/lib/channels/channel-links';
 import { DEFAULT_AGENT_ID, normalizeChannelThreadKey, normalizeStoredChannelId, WEB_CHANNEL_ID, webChannelSessionKey } from '@/app/lib/channels/constants';
 import {
@@ -484,7 +485,7 @@ export async function savePiSession(
       newMessages.map((m, index) => ({
         piSessionDbId: sessionDbId,
         role: m.role,
-        content: JSON.stringify(m),
+        content: JSON.stringify(projectAgentMessageForPersistence(m)),
         timestamp: getAgentMessageTimestamp(m),
         sequence: startIndex + index + 1,
       }))

--- a/app/lib/pi/stream-proxy.ts
+++ b/app/lib/pi/stream-proxy.ts
@@ -1,4 +1,5 @@
 import { type AgentEvent } from '@earendil-works/pi-agent-core';
+import { projectAgentEventForExternal } from './visual-data-projection';
 
 type AgentErrorEvent = {
   type: 'error';
@@ -15,7 +16,7 @@ function getErrorMessage(error: unknown): string {
  * Encodes AgentEvent into a string for streaming.
  */
 export function encodeAgentEvent(event: StreamAgentEvent): string {
-  return JSON.stringify(event) + '\n';
+  return JSON.stringify(projectAgentEventForExternal(event)) + '\n';
 }
 
 /**

--- a/app/lib/pi/vision-fallback-stream.ts
+++ b/app/lib/pi/vision-fallback-stream.ts
@@ -1,0 +1,185 @@
+import type {
+  Api,
+  AssistantMessage,
+  AssistantMessageEventStream,
+  Context,
+  Message,
+  Model,
+  SimpleStreamOptions,
+} from '@earendil-works/pi-ai';
+import type { StreamFn } from '@earendil-works/pi-agent-core';
+
+import { isImageInputUnsupportedError } from './vision-input-rejection';
+
+type ImagePart = { type: 'image' };
+type MessageWithContent = Message & { content: unknown[] };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isImagePart(value: unknown): value is ImagePart {
+  return isRecord(value) && value.type === 'image';
+}
+
+function isMessageWithContent(message: Message): message is MessageWithContent {
+  return isRecord(message) && Array.isArray(message.content);
+}
+
+function contextContainsImages(context: Context): boolean {
+  return context.messages.some((message) => (
+    isMessageWithContent(message) && message.content.some(isImagePart)
+  ));
+}
+
+function modelWithImageInput(model: Model<Api>): Model<Api> {
+  return model.input.includes('image')
+    ? model
+    : { ...model, input: Array.from(new Set([...model.input, 'image'])) } as Model<Api>;
+}
+
+function modelWithTextOnlyInput(model: Model<Api>): Model<Api> {
+  const input = model.input.filter((item) => item !== 'image');
+  return model.input.includes('image')
+    ? { ...model, input: input.length > 0 ? input : ['text'] } as Model<Api>
+    : model;
+}
+
+/**
+ * Creates a provider payload that is safe after the provider has explicitly
+ * refused image input. It preserves surrounding text and tool results so the
+ * same agent turn can continue rather than failing the tool chain.
+ */
+export function removeImagesAfterProviderRejection(context: Context): Context {
+  return {
+    ...context,
+    messages: context.messages.map((message) => {
+      if (!isMessageWithContent(message)) return message;
+
+      const imageCount = message.content.filter(isImagePart).length;
+      if (imageCount === 0) return message;
+
+      return {
+        ...message,
+        content: [
+          ...message.content.filter((part) => !isImagePart(part)),
+          {
+            type: 'text',
+            text: `[${imageCount} image${imageCount === 1 ? '' : 's'} omitted after the provider rejected image input for this model.]`,
+          },
+        ],
+      } as Message;
+    }),
+  };
+}
+
+async function pipeStream(
+  source: AssistantMessageEventStream,
+  destination: AssistantMessageEventStream,
+): Promise<void> {
+  for await (const event of source) {
+    destination.push(event);
+  }
+}
+
+function unexpectedRelayError(model: Model<Api>, error: unknown): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'error',
+    errorMessage: error instanceof Error
+      ? `The provider stream could not be relayed: ${error.message}`
+      : 'The provider stream could not be relayed.',
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Optimistically sends image context even when local model metadata is stale or
+ * incomplete. Only an unambiguous provider rejection before streaming starts
+ * triggers one text-only retry. The rejection is remembered for this executable
+ * runtime only; it is deliberately not persisted as permanent catalog metadata.
+ */
+export function createVisionFallbackStreamFn(
+  streamFn: StreamFn,
+  createStream: () => AssistantMessageEventStream,
+): StreamFn {
+  let imageInputRejected = false;
+
+  return async (
+    model: Model<Api>,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ): Promise<AssistantMessageEventStream> => {
+    if (!contextContainsImages(context)) {
+      return streamFn(model, context, options);
+    }
+
+    if (imageInputRejected) {
+      return streamFn(
+        modelWithTextOnlyInput(model),
+        removeImagesAfterProviderRejection(context),
+        options,
+      );
+    }
+
+    const initial = await streamFn(modelWithImageInput(model), context, options);
+    const output = createStream();
+
+    void (async () => {
+      const iterator = initial[Symbol.asyncIterator]();
+      const buffered = [];
+      for (let eventIndex = 0; eventIndex < 2; eventIndex += 1) {
+        const next = await iterator.next();
+        if (next.done) {
+          output.end();
+          return;
+        }
+        buffered.push(next.value);
+        // A provider can emit `start` before a request-level image rejection.
+        // Hold that protocol-only event until the next event so the fallback can
+        // still replace the failed attempt without exposing a partial response.
+        if (next.value.type !== 'start') break;
+      }
+
+      const last = buffered.at(-1);
+      if (
+        last?.type === 'error'
+        && isImageInputUnsupportedError(last.error.errorMessage ?? '')
+      ) {
+        imageInputRejected = true;
+        const fallback = await streamFn(
+          modelWithTextOnlyInput(model),
+          removeImagesAfterProviderRejection(context),
+          options,
+        );
+        await pipeStream(fallback, output);
+        return;
+      }
+
+      for (const event of buffered) output.push(event);
+      for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
+        output.push(event);
+      }
+    })().catch((error) => {
+      // The wrapped executable runtime already converts request failures into an
+      // error stream. Keep this guard only for an unexpected stream-protocol
+      // violation so consumers cannot hang waiting for completion.
+      output.push({ type: 'error', reason: 'error', error: unexpectedRelayError(model, error) });
+      console.error('[Vision Fallback] Failed to relay provider stream:', error);
+    });
+
+    return output;
+  };
+}

--- a/app/lib/pi/vision-input-rejection.ts
+++ b/app/lib/pi/vision-input-rejection.ts
@@ -1,0 +1,23 @@
+const IMAGE_INPUT_UNSUPPORTED_PATTERNS = [
+  /image inputs? (?:are|is) not supported/i,
+  /images? (?:are|is) not supported (?:by|for) (?:this )?model/i,
+  /(?:this|the current) model does not support images?/i,
+  /model does not support images?/i,
+  /unsupported (?:input )?modality[^.:\n]*image/i,
+  /invalid request content[\s\S]{0,240}image/i,
+  /image_url[\s\S]{0,240}(?:not supported|unsupported)/i,
+];
+
+export function isImageInputUnsupportedError(message: string): boolean {
+  return IMAGE_INPUT_UNSUPPORTED_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function formatImageInputUnsupportedError(params: { modelId: string; provider: string; message: string }): string {
+  return [
+    `The selected model (${params.provider}/${params.modelId}) rejected the attached image input.`,
+    'Canvas did not crash; the provider refused the multimodal request after the image was sent.',
+    'Choose a model that supports image input, or switch this model/provider to text-only behavior before using image attachments.',
+    '',
+    `Provider error: ${params.message}`,
+  ].join('\n');
+}

--- a/app/lib/pi/visual-data-projection.ts
+++ b/app/lib/pi/visual-data-projection.ts
@@ -1,0 +1,47 @@
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isImagePart(value: UnknownRecord): boolean {
+  return value.type === 'image' && typeof value.data === 'string';
+}
+
+function projectVisualValue(value: unknown, purpose: 'persistence' | 'external-event'): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => projectVisualValue(entry, purpose));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  if (isImagePart(value)) {
+    const mimeType = typeof value.mimeType === 'string' ? value.mimeType : 'image';
+    return {
+      type: 'text',
+      text: `[${mimeType} image omitted from ${purpose === 'persistence' ? 'persisted chat history' : 'live event'}; reopen or read the authorized source to analyze it.]`,
+    };
+  }
+
+  const projected: UnknownRecord = {};
+  for (const [key, entry] of Object.entries(value)) {
+    // Absolute real paths are only needed while the server executes a tool.
+    if (key === 'resolvedPath') continue;
+    projected[key] = projectVisualValue(entry, purpose);
+  }
+  return projected;
+}
+
+/** Removes binary image payloads and server-only resolved paths before DB writes. */
+export function projectAgentMessageForPersistence(message: AgentMessage): AgentMessage {
+  return projectVisualValue(message, 'persistence') as AgentMessage;
+}
+
+/** Removes binary image payloads and server-only resolved paths before client/log transport. */
+export function projectAgentEventForExternal<T extends Record<string, unknown>>(event: T): T {
+  return projectVisualValue(event, 'external-event') as T;
+}

--- a/app/lib/pi/visual-data-projection.ts
+++ b/app/lib/pi/visual-data-projection.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
 
 type UnknownRecord = Record<string, unknown>;
@@ -8,6 +9,14 @@ function isRecord(value: unknown): value is UnknownRecord {
 
 function isImagePart(value: UnknownRecord): boolean {
   return value.type === 'image' && typeof value.data === 'string';
+}
+
+function isAbsoluteFilesystemPath(value: string): boolean {
+  return path.isAbsolute(value) || /^[a-z]:[\\/]/i.test(value) || value.startsWith('\\\\');
+}
+
+function isServerPathField(key: string): boolean {
+  return key === 'path' || key.endsWith('Path');
 }
 
 function projectVisualValue(value: unknown, purpose: 'persistence' | 'external-event'): unknown {
@@ -31,6 +40,7 @@ function projectVisualValue(value: unknown, purpose: 'persistence' | 'external-e
   for (const [key, entry] of Object.entries(value)) {
     // Absolute real paths are only needed while the server executes a tool.
     if (key === 'resolvedPath') continue;
+    if (isServerPathField(key) && typeof entry === 'string' && isAbsoluteFilesystemPath(entry)) continue;
     projected[key] = projectVisualValue(entry, purpose);
   }
   return projected;

--- a/app/lib/pi/visual-data-projection.ts
+++ b/app/lib/pi/visual-data-projection.ts
@@ -19,9 +19,22 @@ function isServerPathField(key: string): boolean {
   return key === 'path' || key.endsWith('Path');
 }
 
+const ABSOLUTE_PATH_TOKEN = /(?:^|(?<=[\s"'`(]))(?:\/(?:[^\s"'`<>()\[\]{}]+\/)+[^\s"'`<>()\[\]{}]+|[a-z]:[\\/](?:[^\s"'`<>()\[\]{}]+[\\/])+[^\s"'`<>()\[\]{}]+|\\\\(?:[^\s"'`<>()\[\]{}]+[\\/])+[^\s"'`<>()\[\]{}]+)/gi;
+
+function redactAbsoluteFilesystemPaths(value: string, purpose: 'persistence' | 'external-event'): string {
+  return value.replace(
+    ABSOLUTE_PATH_TOKEN,
+    `[absolute server path omitted from ${purpose === 'persistence' ? 'persisted chat history' : 'live event'}]`,
+  );
+}
+
 function projectVisualValue(value: unknown, purpose: 'persistence' | 'external-event'): unknown {
   if (Array.isArray(value)) {
     return value.map((entry) => projectVisualValue(entry, purpose));
+  }
+
+  if (typeof value === 'string') {
+    return redactAbsoluteFilesystemPaths(value, purpose);
   }
 
   if (!isRecord(value)) {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:integration:pi": "node scripts/pi-integration-test.mjs",
     "test:pi:attachments": "tsx scripts/pi-attachments-test.ts",
     "test:pi:multimodal-delivery": "tsx scripts/pi-multimodal-delivery-test.ts",
+    "test:pi:vision-fallback": "tsx scripts/pi-vision-fallback-stream-test.ts",
     "test:pi:summary": "tsx scripts/pi-session-summary-test.ts",
     "test:pi:session-title": "tsx --conditions react-server scripts/pi-session-title-test.ts",
     "test:pi:usage": "tsx scripts/pi-usage-test.ts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:integration": "node scripts/integration-test.mjs",
     "test:integration:pi": "node scripts/pi-integration-test.mjs",
     "test:pi:attachments": "tsx scripts/pi-attachments-test.ts",
+    "test:pi:multimodal-delivery": "tsx scripts/pi-multimodal-delivery-test.ts",
     "test:pi:summary": "tsx scripts/pi-session-summary-test.ts",
     "test:pi:session-title": "tsx --conditions react-server scripts/pi-session-title-test.ts",
     "test:pi:usage": "tsx scripts/pi-usage-test.ts",

--- a/scripts/automation-runner-tool-context-test.ts
+++ b/scripts/automation-runner-tool-context-test.ts
@@ -414,7 +414,10 @@ moduleInternals._load = (request, parent, isMain) => {
   }
 
   if (request === '@/app/lib/pi/message-normalization' || request.endsWith('/pi/message-normalization')) {
-    return { normalizePiMessagesForLlm: async (messages: unknown[]) => messages };
+    return {
+      normalizePiMessagesForLlm: async (messages: unknown[]) => messages,
+      filterImagesForNonVisionModel: (messages: unknown[]) => messages,
+    };
   }
 
   if (request === '@/app/lib/pi/tool-registry' || request.endsWith('/pi/tool-registry')) {

--- a/scripts/pi-delegate-task-runtime-test.ts
+++ b/scripts/pi-delegate-task-runtime-test.ts
@@ -409,7 +409,10 @@ moduleInternals._load = (request, parent, isMain) => {
     };
   }
   if (matchesModule(request, 'app/lib/pi/message-normalization')) {
-    return { normalizePiMessagesForLlm: async (messages: unknown[]) => messages };
+    return {
+      normalizePiMessagesForLlm: async (messages: unknown[]) => messages,
+      filterImagesForNonVisionModel: (messages: unknown[]) => messages,
+    };
   }
   return originalLoad(request, parent, isMain);
 };

--- a/scripts/pi-message-projection-test.ts
+++ b/scripts/pi-message-projection-test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync } from 'node:fs';
+import Module from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -7,6 +8,22 @@ import type { AgentMessage } from '@earendil-works/pi-agent-core';
 
 const dataDir = mkdtempSync(path.join(tmpdir(), 'canvas-pi-message-projection-'));
 process.env.DATA = dataDir;
+
+const moduleInternals = Module as typeof Module & {
+  _load: (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+};
+const originalLoad = moduleInternals._load;
+moduleInternals._load = (request, parent, isMain) => {
+  if (request === 'server-only') return {};
+  if (request === '@earendil-works/pi-ai' || request === '@earendil-works/pi-ai/compat') {
+    return {
+      getModels: () => [],
+      getProviders: () => [],
+      registerBuiltInApiProviders: () => undefined,
+    };
+  }
+  return originalLoad(request, parent, isMain);
+};
 
 async function main() {
   const { eq } = await import('drizzle-orm');
@@ -53,6 +70,7 @@ async function main() {
     ],
     details: {
       filePath: 'case.pdf',
+      resolvedPath: '/private/runtime/workspace/case.pdf',
       type: 'image',
       mimeType: 'image/png',
       previewUrl: '/api/files/preview?path=case.pdf&w=192&preset=mini',
@@ -93,13 +111,14 @@ async function main() {
   assert.equal(rows.length, 1);
   const rawContent = rows[0].content;
   assert.ok(rawContent.includes('raw-pdf-body'));
-  assert.ok(rawContent.includes(imageData.slice(0, 200)));
+  assert.doesNotMatch(rawContent, new RegExp(imageData.slice(0, 200)));
+  assert.doesNotMatch(rawContent, /private\/runtime\/workspace/);
 
   const rawMessage = parsePersistedPiMessage(rawContent, 'raw') as unknown as Record<string, unknown>;
   assert.equal(JSON.stringify(rawMessage).length, rawContent.length);
   const rawParts = rawMessage.content as Array<Record<string, unknown>>;
   assert.equal(rawParts[0].text, hugeText);
-  assert.equal(rawParts[1].data, imageData);
+  assert.match(String(rawParts[1].text), /omitted from persisted chat history/);
 
   const loaded = await loadPiSessionWithSummary(sessionId, userId, 'canvas-agent');
   assert.ok(loaded);
@@ -117,6 +136,7 @@ async function main() {
   assert.equal(projectedToolDetails.mimeType, 'image/png');
   assert.equal(projectedToolDetails.previewUrl, '/api/files/preview?path=case.pdf&w=192&preset=mini');
   assert.equal(projectedToolDetails.mediaUrl, '/api/media/case.pdf');
+  assert.equal(projectedToolDetails.resolvedPath, undefined);
 
   const projectedUserImage = loaded.messages.find((message) => {
     const content = (message as unknown as { content?: unknown }).content;
@@ -124,7 +144,7 @@ async function main() {
   });
   assert.ok(projectedUserImage);
   const projectedUserJson = JSON.stringify(projectedUserImage);
-  assert.match(projectedUserJson, /image omitted from loaded chat context/);
+  assert.match(projectedUserJson, /image omitted from persisted chat history/);
   assert.doesNotMatch(projectedUserJson, new RegExp(imageData.slice(0, 200)));
 
   const normalizedForLlm = await normalizePiMessagesForLlm([userImageMessage, toolResultMessage]);
@@ -222,6 +242,7 @@ async function main() {
 
 main()
   .finally(() => {
+    moduleInternals._load = originalLoad;
     rmSync(dataDir, { recursive: true, force: true });
   })
   .catch((error) => {

--- a/scripts/pi-multimodal-delivery-test.ts
+++ b/scripts/pi-multimodal-delivery-test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import type { Model } from '@earendil-works/pi-ai';
+
+import { prepareMessagesForEffectiveModel } from '../app/lib/pi/multimodal-preparation';
+import {
+  projectAgentEventForExternal,
+  projectAgentMessageForPersistence,
+} from '../app/lib/pi/visual-data-projection';
+
+const visionModel = {
+  id: 'vision-test',
+  name: 'Vision test',
+  provider: 'test',
+  api: 'openai-completions',
+  baseUrl: 'https://example.test/v1',
+  reasoning: false,
+  input: ['text', 'image'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 8_192,
+  maxTokens: 1_024,
+} as unknown as Model<'openai-completions'>;
+
+const textModel = {
+  ...visionModel,
+  id: 'text-test',
+  input: ['text'],
+} as Model<'openai-completions'>;
+
+async function main() {
+  const imageData = Buffer.from('read-tool-image').toString('base64');
+  const toolResult = {
+    role: 'toolResult',
+    toolCallId: 'read-1',
+    toolName: 'read',
+    content: [
+      { type: 'text', text: 'Read image.png' },
+      { type: 'image', data: imageData, mimeType: 'image/png' },
+    ],
+    details: {
+      filePath: 'image.png',
+      resolvedPath: '/private/workspace/image.png',
+      type: 'image',
+    },
+    timestamp: Date.now(),
+  } as unknown as AgentMessage;
+
+  const visionPayload = await prepareMessagesForEffectiveModel([toolResult], visionModel);
+  const visionContent = visionPayload[0].content as Array<{ type: string; data?: string }>;
+  assert.equal(visionContent.filter((part) => part.type === 'image').length, 1);
+  assert.equal(visionContent.find((part) => part.type === 'image')?.data, imageData);
+
+  const textPayload = await prepareMessagesForEffectiveModel([toolResult], textModel);
+  const textContent = textPayload[0].content as Array<{ type: string; text?: string }>;
+  assert.equal(textContent.filter((part) => part.type === 'image').length, 0);
+  assert.match(textContent.map((part) => part.text || '').join('\n'), /does not support vision/i);
+
+  const persisted = projectAgentMessageForPersistence(toolResult);
+  const persistedJson = JSON.stringify(persisted);
+  assert.doesNotMatch(persistedJson, new RegExp(imageData));
+  assert.doesNotMatch(persistedJson, /private\/workspace/);
+  assert.match(persistedJson, /omitted from persisted chat history/);
+
+  const external = projectAgentEventForExternal({
+    type: 'tool_execution_end',
+    result: toolResult,
+  });
+  const externalJson = JSON.stringify(external);
+  assert.doesNotMatch(externalJson, new RegExp(imageData));
+  assert.doesNotMatch(externalJson, /private\/workspace/);
+  assert.match(externalJson, /omitted from live event/);
+
+  console.log('[PI Multimodal Delivery Test] Passed.');
+}
+
+void main();

--- a/scripts/pi-multimodal-delivery-test.ts
+++ b/scripts/pi-multimodal-delivery-test.ts
@@ -53,8 +53,7 @@ async function main() {
 
   const textPayload = await prepareMessagesForEffectiveModel([toolResult], textModel);
   const textContent = textPayload[0].content as Array<{ type: string; text?: string }>;
-  assert.equal(textContent.filter((part) => part.type === 'image').length, 0);
-  assert.match(textContent.map((part) => part.text || '').join('\n'), /does not support vision/i);
+  assert.equal(textContent.filter((part) => part.type === 'image').length, 1);
 
   const persisted = projectAgentMessageForPersistence(toolResult);
   const persistedJson = JSON.stringify(persisted);

--- a/scripts/pi-multimodal-delivery-test.ts
+++ b/scripts/pi-multimodal-delivery-test.ts
@@ -71,21 +71,30 @@ async function main() {
   assert.match(externalJson, /omitted from live event/);
 
   const absolutePath = '/private/agent-runtime/image.png';
-  const absoluteRead = projectAgentMessageForPersistence({
+  const absoluteReadInput = {
     ...toolResult,
+    content: [
+      { type: 'text', text: `Read ${absolutePath}` },
+      { type: 'image', data: imageData, mimeType: 'image/png' },
+    ],
     details: {
       filePath: absolutePath,
       requestedPath: absolutePath,
       resolvedPath: absolutePath,
       nested: { sourcePath: absolutePath },
     },
-  });
-  assert.doesNotMatch(JSON.stringify(absoluteRead), new RegExp(absolutePath));
+  };
+  const absoluteRead = projectAgentMessageForPersistence(absoluteReadInput);
+  const absoluteReadJson = JSON.stringify(absoluteRead);
+  assert.doesNotMatch(absoluteReadJson, new RegExp(absolutePath));
+  assert.match(absoluteReadJson, /absolute server path omitted from persisted chat history/);
   const absoluteEvent = projectAgentEventForExternal({
     type: 'tool_execution_end',
-    result: absoluteRead,
+    result: absoluteReadInput,
   });
-  assert.doesNotMatch(JSON.stringify(absoluteEvent), new RegExp(absolutePath));
+  const absoluteEventJson = JSON.stringify(absoluteEvent);
+  assert.doesNotMatch(absoluteEventJson, new RegExp(absolutePath));
+  assert.match(absoluteEventJson, /absolute server path omitted from live event/);
 
   console.log('[PI Multimodal Delivery Test] Passed.');
 }

--- a/scripts/pi-multimodal-delivery-test.ts
+++ b/scripts/pi-multimodal-delivery-test.ts
@@ -70,6 +70,23 @@ async function main() {
   assert.doesNotMatch(externalJson, /private\/workspace/);
   assert.match(externalJson, /omitted from live event/);
 
+  const absolutePath = '/private/agent-runtime/image.png';
+  const absoluteRead = projectAgentMessageForPersistence({
+    ...toolResult,
+    details: {
+      filePath: absolutePath,
+      requestedPath: absolutePath,
+      resolvedPath: absolutePath,
+      nested: { sourcePath: absolutePath },
+    },
+  });
+  assert.doesNotMatch(JSON.stringify(absoluteRead), new RegExp(absolutePath));
+  const absoluteEvent = projectAgentEventForExternal({
+    type: 'tool_execution_end',
+    result: absoluteRead,
+  });
+  assert.doesNotMatch(JSON.stringify(absoluteEvent), new RegExp(absolutePath));
+
   console.log('[PI Multimodal Delivery Test] Passed.');
 }
 

--- a/scripts/pi-vision-fallback-stream-test.ts
+++ b/scripts/pi-vision-fallback-stream-test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+
+import type { StreamFn } from '@earendil-works/pi-agent-core';
+import type { Api, AssistantMessage, AssistantMessageEventStream, Context, Model } from '@earendil-works/pi-ai';
+
+type TestStreamEvent = {
+  type: string;
+  reason?: string;
+  message?: AssistantMessage;
+  error?: AssistantMessage;
+};
+
+class TestAssistantMessageEventStream {
+  private readonly events: unknown[] = [];
+  private readonly waiters: Array<(value: IteratorResult<unknown>) => void> = [];
+  private done = false;
+  private resolveResult!: (message: AssistantMessage) => void;
+  private readonly finalResult = new Promise<AssistantMessage>((resolve) => {
+    this.resolveResult = resolve;
+  });
+
+  push(event: TestStreamEvent) {
+    if (this.done) return;
+    if (event.type === 'done' || event.type === 'error') {
+      this.done = true;
+      this.resolveResult(event.message ?? event.error!);
+    }
+    const waiter = this.waiters.shift();
+    if (waiter) waiter({ value: event, done: false });
+    else this.events.push(event);
+  }
+
+  end() {
+    this.done = true;
+    while (this.waiters.length > 0) this.waiters.shift()!({ value: undefined, done: true });
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<unknown> {
+    while (true) {
+      if (this.events.length > 0) yield this.events.shift()!;
+      else if (this.done) return;
+      else {
+        const event = await new Promise<IteratorResult<unknown>>((resolve) => this.waiters.push(resolve));
+        if (event.done) return;
+        yield event.value;
+      }
+    }
+  }
+
+  result() {
+    return this.finalResult;
+  }
+}
+
+const createTestStream = () => new TestAssistantMessageEventStream() as unknown as AssistantMessageEventStream;
+
+const model = {
+  id: 'new-model-without-vision-in-its-name',
+  name: 'New model',
+  provider: 'test',
+  api: 'openai-completions',
+  baseUrl: 'https://example.test/v1',
+  reasoning: false,
+  input: ['text'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 8_192,
+  maxTokens: 1_024,
+} as unknown as Model<'openai-completions'>;
+
+const imageContext: Context = {
+  messages: [{
+    role: 'toolResult',
+    toolCallId: 'read-1',
+    toolName: 'read',
+    content: [
+      { type: 'text', text: 'Read image.png' },
+      { type: 'image', data: Buffer.from('image').toString('base64'), mimeType: 'image/png' },
+    ],
+    isError: false,
+    timestamp: Date.now(),
+  }],
+};
+
+function message(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text', text: 'fallback succeeded' }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function doneStream() {
+  const stream = new TestAssistantMessageEventStream();
+  queueMicrotask(() => stream.push({ type: 'done', reason: 'stop', message: message() }));
+  return stream;
+}
+
+function rejectedImageStream() {
+  const stream = new TestAssistantMessageEventStream();
+  queueMicrotask(() => {
+    stream.push({ type: 'start', reason: 'start' });
+    stream.push({
+      type: 'error',
+      reason: 'error',
+      error: message({
+        content: [],
+        stopReason: 'error',
+        errorMessage: 'This model does not support images.',
+      }),
+    });
+  });
+  return stream;
+}
+
+async function main() {
+  const { createVisionFallbackStreamFn } = await import('../app/lib/pi/vision-fallback-stream');
+  const calls: Array<{ model: Model<Api>; context: Context }> = [];
+  const baseFallbackStreamFn: StreamFn = async (requestedModel, context) => {
+    calls.push({ model: requestedModel as Model<Api>, context });
+    return (calls.length === 1 ? rejectedImageStream() : doneStream()) as unknown as AssistantMessageEventStream;
+  };
+  const fallbackStreamFn = createVisionFallbackStreamFn(baseFallbackStreamFn, createTestStream);
+
+  const fallback = await fallbackStreamFn(model, imageContext);
+  const fallbackEvents = [];
+  for await (const event of fallback) fallbackEvents.push(event);
+  assert.equal(fallbackEvents.length, 1);
+  assert.equal(fallbackEvents[0]?.type, 'done');
+  assert.equal(calls.length, 2);
+  assert.ok(calls[0]?.model.input.includes('image'));
+  assert.equal(
+    (calls[0]?.context.messages[0]?.content as Array<{ type: string }>).some((part) => part.type === 'image'),
+    true,
+  );
+  assert.equal(calls[1]?.model.input.includes('image'), false);
+  const fallbackContent = calls[1]?.context.messages[0]?.content as Array<{ type: string; text?: string }>;
+  assert.equal(fallbackContent.some((part) => part.type === 'image'), false);
+  assert.match(fallbackContent.map((part) => part.text ?? '').join('\n'), /provider rejected image input/i);
+
+  // The first rejection changes only this executable runtime. Further image
+  // turns go straight to text and cannot create a retry loop.
+  const cachedFallback = await fallbackStreamFn(model, imageContext);
+  await cachedFallback.result();
+  assert.equal(calls.length, 3);
+  assert.equal(calls[2]?.model.input.includes('image'), false);
+
+  const successfulCalls: Array<Model<Api>> = [];
+  const baseOptimisticStreamFn: StreamFn = async (requestedModel) => {
+    successfulCalls.push(requestedModel as Model<Api>);
+    return doneStream() as unknown as AssistantMessageEventStream;
+  };
+  const optimisticStreamFn = createVisionFallbackStreamFn(baseOptimisticStreamFn, createTestStream);
+  const success = await optimisticStreamFn(model, imageContext);
+  await success.result();
+  assert.equal(successfulCalls.length, 1);
+  assert.ok(successfulCalls[0]?.input.includes('image'));
+
+  console.log('[PI Vision Fallback Stream Test] Passed.');
+}
+
+void main();


### PR DESCRIPTION
## Summary
- Supersedes the delivery behavior from #76 with a complete, main-targeted fix.
- Optimistically forwards read-tool and other image context even when catalog metadata labels a model as text-only.
- On an unambiguous pre-output provider rejection, retries exactly once without image payloads and remembers the result only for the executable runtime.
- Keeps the failed multimodal attempt out of the agent event stream, so tool chains can continue on the text-only retry.

## Verification
- `npm run test:pi:vision-fallback`
- `npm run test:pi:multimodal-delivery`
- `npm run test:pi:attachments`
- `npm run test:pi:delegate-task-runtime`
- `npm run test:automation:runner`
- `npm run test:agents:provider-coverage`
- `npm run test:agent:provider-verification`
- Targeted ESLint

`npm run build` compiled successfully, then stopped at pre-existing TypeScript errors in `scripts/todo-store-test.ts` (unrelated status/priority literal narrowing).

No live provider credentials or external model calls were used.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR optimistically forwards image context despite stale text-only model metadata and retries once without images after an unambiguous pre-output provider rejection.
- Centralizes multimodal message preparation across interactive, automation, and delegated runtimes.
- Adds executable-runtime-scoped vision fallback without exposing the rejected attempt to agent consumers.
- Removes binary image data and absolute server paths before message persistence, event transport, and automation logging.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/pi/vision-fallback-stream.ts | Adds a runtime-scoped optimistic image request and a single text-only retry for explicit pre-output image rejections. |
| app/lib/pi/multimodal-preparation.ts | Centralizes conversion of runnable agent messages into provider payloads while retaining image context. |
| app/lib/pi/visual-data-projection.ts | Recursively removes image payloads and absolute server-path representations before persistence or external transport. |
| app/lib/agent-runtime-policy/provider-runtime.ts | Wraps authenticated provider streaming with the vision fallback while retaining runtime recreation tracking. |
| app/lib/pi/session-store.ts | Projects agent messages before database serialization to prevent binary image and server-path persistence. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant Fallback as Vision fallback stream
    participant Provider
    Agent->>Fallback: Request with image context
    Fallback->>Provider: Optimistic multimodal request
    alt Provider accepts images
        Provider-->>Fallback: Assistant stream
        Fallback-->>Agent: Relay stream
    else Unambiguous pre-output image rejection
        Provider-->>Fallback: Image-input rejection
        Fallback->>Provider: Retry once without images
        Provider-->>Fallback: Text-only assistant stream
        Fallback-->>Agent: Relay retry stream only
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/canvascoding/canvas-notebook/commit/2913637442e40a9f2cfaeb559de5ffbe3a414371) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55825606)</sub>

<!-- /greptile_comment -->