### PR TITLE
Fix ChatGPT team credential consent

### DIFF
--- a/app/lib/agent-runtime-policy/installation-credentials.ts
+++ b/app/lib/agent-runtime-policy/installation-credentials.ts
@@ -6,11 +6,12 @@ import path from 'node:path';
 import type { ProviderEnv, ProviderHeaders } from '@earendil-works/pi-ai';
 
 import type { AiProviderInstallation } from '@/app/lib/agent-runtime-policy/types';
+import { providerUsesOAuth } from '@/app/lib/agent-runtime-policy/provider-auth-policy';
 import { isManagedControlPlaneAvailable } from '@/app/lib/agents/storage';
 import { readScopedEnvState, type EnvStorageScope } from '@/app/lib/integrations/env-config';
 import { CANVAS_CONTROL_PLANE_PROVIDER_ID } from '@/app/lib/managed/control-plane-models';
 import { getProviderRequestAuth, isOAuthProvider, type OAuthProviderId } from '@/app/lib/pi/oauth';
-import { getAuthMethodForProvider, getProviderEnvVars } from '@/app/lib/pi/provider-help';
+import { getProviderEnvVars } from '@/app/lib/pi/provider-help';
 
 const PROVIDER_API_KEY_NAMES: Record<string, readonly string[]> = {
   'ant-ling': ['ANT_LING_API_KEY'],
@@ -232,10 +233,7 @@ export async function resolveProviderInstallationRuntimeAuth(input: {
     };
   }
 
-  const authMethod = getAuthMethodForProvider(providerId);
-  const wantsOAuth = input.provider.config.authMethod === 'oauth'
-    || (authMethod === 'oauth' && input.provider.config.authMethod !== 'api-key');
-  if (wantsOAuth) {
+  if (providerUsesOAuth(input.provider)) {
     if (input.provider.credentialScope !== 'user' || !isOAuthProvider(providerId)) {
       return { configured: false, env: {} };
     }

--- a/app/lib/agent-runtime-policy/provider-auth-policy.ts
+++ b/app/lib/agent-runtime-policy/provider-auth-policy.ts
@@ -11,6 +11,31 @@ export type AiProviderAuthPolicyIssue =
   | 'OAUTH_REQUIRES_USER_SCOPE';
 
 /**
+ * Return the effective authentication method for catalog consumers.
+ *
+ * OAuth-only providers predate the optional catalog `authMethod` field, so
+ * migrated installations may correctly store an empty config. Consumers must
+ * derive OAuth from the provider contract instead of treating that optional
+ * persisted field as the authority.
+ */
+export function resolveProviderAuthMethod(
+  providerId: string,
+  configuredAuthMethod?: AiProviderSafeConfig['authMethod'],
+): AiProviderSafeConfig['authMethod'] | undefined {
+  const providerAuthMethod = getAuthMethodForProvider(providerId.trim().toLowerCase());
+  if (providerAuthMethod === 'oauth') return 'oauth';
+  if (providerAuthMethod === 'both') return configuredAuthMethod === 'oauth' ? 'oauth' : 'api-key';
+  return configuredAuthMethod;
+}
+
+export function providerUsesOAuth(input: {
+  providerId: string;
+  config: Pick<AiProviderSafeConfig, 'authMethod'>;
+}): boolean {
+  return resolveProviderAuthMethod(input.providerId, input.config.authMethod) === 'oauth';
+}
+
+/**
  * Credential scopes that can safely host one provider installation. OAuth
  * tokens belong to an individual account, while managed credentials are
  * exclusively supplied by the Control Plane.
@@ -21,11 +46,7 @@ export function getAllowedCredentialScopesForProvider(
 ): readonly AiCredentialScope[] {
   const normalizedProviderId = providerId.trim().toLowerCase();
   if (normalizedProviderId === CANVAS_CONTROL_PLANE_PROVIDER_ID) return MANAGED_CREDENTIAL_SCOPE;
-  const providerAuthMethod = getAuthMethodForProvider(normalizedProviderId);
-  if (
-    providerAuthMethod === 'oauth'
-    || (providerAuthMethod === 'both' && configuredAuthMethod === 'oauth')
-  ) return USER_CREDENTIAL_SCOPE;
+  if (resolveProviderAuthMethod(normalizedProviderId, configuredAuthMethod) === 'oauth') return USER_CREDENTIAL_SCOPE;
   return STANDARD_CREDENTIAL_SCOPES;
 }
 

--- a/app/lib/agent-runtime-policy/runtime-resolver.ts
+++ b/app/lib/agent-runtime-policy/runtime-resolver.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { ensureAgentRuntimeCatalogInitialized } from '@/app/lib/agent-runtime-policy/bootstrap-service';
 import { readAppRuntimeCatalog } from '@/app/lib/agent-runtime-policy/catalog-store';
 import { isProviderInstallationCredentialAvailable } from '@/app/lib/agent-runtime-policy/installation-credentials';
+import { resolveProviderAuthMethod } from '@/app/lib/agent-runtime-policy/provider-auth-policy';
 import {
   readPiSessionRuntimeSnapshot,
   readUserWorkspaceProviderGrant,
@@ -84,7 +85,7 @@ export function buildEffectiveCatalogProviders(input: {
       name: provider.name,
       source: provider.source,
       credentialScope: provider.credentialScope,
-      authMethod: provider.config.authMethod,
+      authMethod: resolveProviderAuthMethod(provider.providerId, provider.config.authMethod),
       credentialAvailable,
       selectable: provider.status === 'ready' && credentialAvailable,
       status: provider.status,

--- a/app/lib/agent-runtime-policy/runtime-service.ts
+++ b/app/lib/agent-runtime-policy/runtime-service.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { readAppRuntimeCatalog } from '@/app/lib/agent-runtime-policy/catalog-store';
+import { providerUsesOAuth } from '@/app/lib/agent-runtime-policy/provider-auth-policy';
 import {
   deleteWorkspaceModelPolicyStore,
   deleteUserModelPreferenceStore,
@@ -181,7 +182,7 @@ async function assertUserProviderGrantTarget(input: {
     readWorkspaceModelPolicy(input.context.organizationId, input.context.workspaceId),
   ]);
   const provider = catalog.providers.find((candidate) => candidate.installationId === input.providerInstallationId);
-  if (!provider || !provider.enabled || provider.credentialScope !== 'user' || provider.config.authMethod !== 'oauth') {
+  if (!provider || !provider.enabled || provider.credentialScope !== 'user' || !providerUsesOAuth(provider)) {
     throw new AiRuntimePolicyError(
       'PROVIDER_INSTALLATION_NOT_ALLOWED',
       'The selected provider installation is not an enabled personal OAuth provider.',

--- a/scripts/agent-runtime-catalog-test.ts
+++ b/scripts/agent-runtime-catalog-test.ts
@@ -39,6 +39,8 @@ async function main() {
   } = await import('../app/lib/agent-runtime-policy/catalog-store');
   const {
     getAllowedCredentialScopesForProvider,
+    providerUsesOAuth,
+    resolveProviderAuthMethod,
     validateProviderCatalogAuth,
   } = await import('../app/lib/agent-runtime-policy/provider-auth-policy');
 
@@ -49,6 +51,13 @@ async function main() {
     credentialScope: 'user',
     config: { authMethod: 'oauth' },
   }), null);
+  assert.equal(validateProviderCatalogAuth({
+    providerId: 'openai-codex',
+    credentialScope: 'user',
+    config: {},
+  }), null);
+  assert.equal(resolveProviderAuthMethod('openai-codex'), 'oauth');
+  assert.equal(providerUsesOAuth({ providerId: 'openai-codex', config: {} }), true);
   assert.equal(validateProviderCatalogAuth({
     providerId: 'openai-codex',
     credentialScope: 'organization',

--- a/scripts/agent-runtime-resolution-test.ts
+++ b/scripts/agent-runtime-resolution-test.ts
@@ -239,6 +239,7 @@ async function main() {
     parseUserPreferenceUpdate,
     replaceWorkspaceRuntimePolicy,
     resetUserRuntimePreference,
+    setUserProviderGrant,
     setUserRuntimePreference,
   } = await import('../app/lib/agent-runtime-policy/runtime-service');
   const {
@@ -413,8 +414,10 @@ async function main() {
 
   const organizationProviderId = installationId(organization.organizationId, 'openai-compatible', 'organization');
   const userProviderId = installationId(organization.organizationId, 'openai-compatible', 'user');
+  const codexProviderId = installationId(organization.organizationId, 'openai-codex', 'user');
   const missingCredentialProviderId = installationId(organization.organizationId, 'openai', 'user');
   const sharedModel = 'shared-model';
+  const codexModel = 'codex-model';
   const catalogUpdate = parseAiCatalogUpdate({
     expectedRevision: 0,
     providers: [
@@ -443,6 +446,17 @@ async function main() {
         },
         modelIds: [sharedModel],
         defaultModelId: sharedModel,
+      },
+      {
+        providerInstallationId: codexProviderId,
+        providerId: 'openai-codex',
+        enabled: true,
+        credentialScope: 'user',
+        // Legacy OAuth-only installations legitimately omit authMethod. The
+        // team consent path must derive OAuth from the provider contract.
+        config: {},
+        modelIds: [codexModel],
+        defaultModelId: codexModel,
       },
       {
         providerInstallationId: missingCredentialProviderId,
@@ -484,6 +498,17 @@ async function main() {
         models: [{
           id: 'key-model',
           name: 'Key Model',
+          reasoning: true,
+          supportsVision: true,
+        }],
+      },
+      'openai-codex': {
+        id: 'openai-codex',
+        name: 'OpenAI Codex',
+        source: 'built-in',
+        models: [{
+          id: codexModel,
+          name: 'Codex Model',
           reasoning: true,
           supportsVision: true,
         }],
@@ -879,12 +904,52 @@ async function main() {
       allowedModels: [
         { providerInstallationId: organizationProviderId, modelId: sharedModel },
         { providerInstallationId: userProviderId, modelId: sharedModel },
+        { providerInstallationId: codexProviderId, modelId: codexModel },
       ],
       defaultSelection: organizationPolicy.defaultSelection,
       allowUserCredentials: true,
     },
   });
   assert.equal(organizationPolicy.revision, 2);
+  const codexSelection = {
+    providerInstallationId: codexProviderId,
+    providerId: 'openai-codex',
+    modelId: codexModel,
+    thinkingLevel: 'off' as const,
+  };
+  const ungrantedCodexResolution = await resolveEffectiveAgentRuntime({
+    ...organizationContext,
+    requestedSelection: codexSelection,
+  });
+  const ungrantedCodexProvider = ungrantedCodexResolution.providers.find((provider) => (
+    provider.installationId === codexProviderId
+  ));
+  assert.equal(ungrantedCodexProvider?.authMethod, 'oauth');
+  assert.equal(ungrantedCodexProvider?.selectable, false);
+  assert.equal(ungrantedCodexResolution.valid, false);
+
+  const codexGrant = await setUserProviderGrant({
+    context: organizationContext,
+    update: {
+      providerInstallationId: codexProviderId,
+      allowedExecutionModes: ['interactive'],
+      expectedRevision: 0,
+    },
+  });
+  assert.equal(codexGrant.status, 'active');
+  const grantedCodexResolution = await resolveEffectiveAgentRuntime({
+    ...organizationContext,
+    requestedSelection: codexSelection,
+  });
+  assert.equal(grantedCodexResolution.valid, false);
+  assert.equal(
+    grantedCodexResolution.issues.some((entry) => entry.code === 'CREDENTIAL_NOT_AVAILABLE'),
+    true,
+  );
+  assert.equal(
+    grantedCodexResolution.providers.find((provider) => provider.installationId === codexProviderId)?.selectable,
+    false,
+  );
   const ungrantedTeamResolution = await resolveEffectiveAgentRuntime({
     ...organizationContext,
     requestedSelection: userSelection,
@@ -1045,6 +1110,16 @@ async function main() {
   assert.equal(memberResolution.preference, null);
   assert.equal(memberResolution.source, 'workspace_default');
   assert.equal(memberResolution.effectiveSelection?.selection.providerInstallationId, organizationProviderId);
+  const memberCodexResolution = await resolveEffectiveAgentRuntime({
+    ...organizationContext,
+    userId: memberId,
+    requestedSelection: codexSelection,
+  });
+  assert.equal(memberCodexResolution.valid, false);
+  assert.equal(
+    memberCodexResolution.providers.find((provider) => provider.installationId === codexProviderId)?.credentialAvailable,
+    false,
+  );
 
   const { auth } = await import('../app/lib/auth');
   type RouteSession = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>;
@@ -1126,6 +1201,7 @@ async function main() {
         defaultProvider: 'openai-compatible',
         defaultModel: sharedModel,
         defaultThinking: 'off',
+        expectedRevision: 1,
         expectedCatalogRevision: 1,
       }),
     },
@@ -1159,7 +1235,12 @@ async function main() {
       }),
     },
   ));
-  assert.equal(memberPreferenceUpdateResponse.status, 200);
+  const memberPreferenceUpdatePayload = await memberPreferenceUpdateResponse.json();
+  // A team member cannot save a preference for an unconfigured personal
+  // credential. This prevents the owner’s user-scoped credential from being
+  // treated as shared workspace state.
+  assert.equal(memberPreferenceUpdateResponse.status, 409, JSON.stringify(memberPreferenceUpdatePayload));
+  assert.equal(memberPreferenceUpdatePayload.code, 'CREDENTIAL_NOT_AVAILABLE');
 
   routeSession = {
     ...routeSession,
@@ -1199,17 +1280,35 @@ async function main() {
   ));
   assert.equal(ownerPolicyResponse.status, 200);
 
+  const ownerDefaultAgentResponse = await agentsRoute.POST(new NextRequest(
+    'http://localhost:3000/api/agents',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Owner Default Agent',
+        defaultProviderInstallationId: null,
+        defaultProvider: null,
+        defaultModel: null,
+        defaultThinking: null,
+      }),
+    },
+  ));
+  assert.equal(ownerDefaultAgentResponse.status, 200);
+  const ownerDefaultAgentId = (await ownerDefaultAgentResponse.json()).data.agent.agentId as string;
+
   const outsideCatalogAgentDefault = await agentsRoute.PATCH(new NextRequest(
     'http://localhost:3000/api/agents',
     {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        agentId: memberInheritedAgentId,
+        agentId: ownerDefaultAgentId,
         defaultProviderInstallationId: `aip_${'f'.repeat(24)}`,
         defaultProvider: 'openai-compatible',
         defaultModel: sharedModel,
         defaultThinking: 'off',
+        expectedRevision: 1,
         expectedCatalogRevision: 1,
       }),
     },
@@ -1223,11 +1322,12 @@ async function main() {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        agentId: memberInheritedAgentId,
+        agentId: ownerDefaultAgentId,
         defaultProviderInstallationId: userProviderId,
         defaultProvider: 'openai-compatible',
         defaultModel: sharedModel,
         defaultThinking: 'off',
+        expectedRevision: 1,
         expectedCatalogRevision: 0,
       }),
     },
@@ -1241,7 +1341,7 @@ async function main() {
            default_provider AS provider, default_model AS model, default_thinking AS thinking
     FROM agents
     WHERE agent_id = ?
-  `).get(memberInheritedAgentId) as {
+  `).get(ownerDefaultAgentId) as {
     providerInstallationId: string | null;
     provider: string | null;
     model: string | null;
@@ -1260,11 +1360,12 @@ async function main() {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        agentId: memberInheritedAgentId,
+        agentId: ownerDefaultAgentId,
         defaultProviderInstallationId: userProviderId,
         defaultProvider: 'openai-compatible',
         defaultModel: sharedModel,
         defaultThinking: 'off',
+        expectedRevision: 1,
         expectedCatalogRevision: 1,
       }),
     },
@@ -1291,12 +1392,13 @@ async function main() {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        agentId: memberInheritedAgentId,
+        agentId: ownerDefaultAgentId,
         name: '',
         defaultProviderInstallationId: organizationProviderId,
         defaultProvider: 'openai-compatible',
         defaultModel: sharedModel,
         defaultThinking: 'off',
+        expectedRevision: 2,
         expectedCatalogRevision: 1,
       }),
     },
@@ -1307,7 +1409,7 @@ async function main() {
            default_provider AS provider, default_model AS model, default_thinking AS thinking
     FROM agents
     WHERE agent_id = ?
-  `).get(memberInheritedAgentId);
+  `).get(ownerDefaultAgentId);
   assert.deepEqual(defaultAfterInvalidCombinedPatch, {
     providerInstallationId: userProviderId,
     provider: 'openai-compatible',


### PR DESCRIPTION
## Summary
- derive OAuth eligibility for OAuth-only providers from the provider contract, including legacy installations without `authMethod`
- expose the resolved OAuth method to the existing team credential-consent UI
- preserve server-side workspace policy, grant, credential-owner, and runtime isolation checks

## Verification
- `npx eslint app/lib/agent-runtime-policy/provider-auth-policy.ts app/lib/agent-runtime-policy/runtime-service.ts app/lib/agent-runtime-policy/runtime-resolver.ts app/lib/agent-runtime-policy/installation-credentials.ts scripts/agent-runtime-catalog-test.ts scripts/agent-runtime-resolution-test.ts`
- `npx tsc --noEmit --pretty false`
- `npx tsx --conditions react-server scripts/agent-runtime-catalog-test.ts`
- `npx tsx --conditions react-server scripts/agent-runtime-resolution-test.ts`
- `npx tsx scripts/pi-oauth-user-scope-test.ts`
- `npx tsx --conditions react-server scripts/agent-runtime-provider-coverage-test.ts`

`npm run build` is currently blocked before application compilation by an existing third-party-license workflow assertion about release publication order. Browser/Playwright tests were not run per task constraint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR derives the effective authentication method from each provider’s contract so legacy OAuth-only installations can enter the existing team credential-consent flow without persisting `authMethod`.
- Centralizes effective authentication resolution in `provider-auth-policy.ts`.
- Uses the resolved method for runtime credentials, user grants, and effective catalog responses.
- Adds coverage for legacy OpenAI Codex installations while preserving credential ownership and availability checks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete regressions identified.

The centralized resolver preserves the prior credential-routing and scope behavior while aligning grant eligibility and the effective catalog payload for legacy OAuth-only installations.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/agent-runtime-policy/provider-auth-policy.ts | Adds a centralized effective-auth resolver whose behavior is consistent with the existing provider contracts, validation, and credential-scope rules. |
| app/lib/agent-runtime-policy/installation-credentials.ts | Replaces the inline OAuth predicate with an equivalent shared policy helper, preserving runtime credential isolation. |
| app/lib/agent-runtime-policy/runtime-resolver.ts | Exposes the derived authentication method so legacy OAuth-only providers reach the existing consent UI. |
| app/lib/agent-runtime-policy/runtime-service.ts | Allows user grants for OAuth-only providers whose legacy installation config omits the redundant authentication field. |
| scripts/agent-runtime-catalog-test.ts | Adds focused assertions for contract-derived OAuth behavior and legacy empty configuration. |
| scripts/agent-runtime-resolution-test.ts | Extends runtime and route coverage for consent, credential ownership, revision handling, and unavailable personal credentials. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Provider installation] --> B[Resolve provider auth contract]
    B -->|OAuth-only| C[Effective method: OAuth]
    B -->|Dual-auth and configured OAuth| C
    B -->|Dual-auth without OAuth selection| D[Effective method: API key]
    C --> E{User-scoped credential and grant available?}
    E -->|Yes| F[Provider selectable]
    E -->|No| G[Show consent or credential-unavailable state]
    D --> H[Resolve API-key credentials]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix ChatGPT team credential consent"](https://github.com/canvascoding/canvas-notebook/commit/f70702b81bf3facfbc26c868bc031b6f9bdcb76d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56044136)</sub>

<!-- /greptile_comment -->