### PR TITLE
Fix MCP OAuth dynamic client registration

### DIFF
--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -6,8 +6,8 @@ import { requireTeamRuntimeRoute } from '@/app/lib/license/team-route-guard';
 import { initializeUserOnboarding } from '@/app/lib/user-preferences';
 import { isOnboardingComplete, isOnboardingEnabled } from '@/app/lib/onboarding/status';
 import {
-  enforceDirectMcpOAuthRequestPolicy,
   isDirectMcpOAuthPath,
+  prepareDirectMcpOAuthRequest,
 } from '@/app/lib/mcp/server/oauth-request-policy';
 import {
   applyDirectMcpRevocation,
@@ -17,6 +17,7 @@ import {
   beginDirectMcpDiagnostic,
   completeDirectMcpDiagnostic,
   failDirectMcpDiagnostic,
+  runWithDirectMcpDiagnostic,
   withDirectMcpRequestId,
 } from '@/app/lib/mcp/server/diagnostics';
 
@@ -131,12 +132,34 @@ async function handleDirectMcpOAuthRequest(
   if (!isDirectMcpOAuthPath(request.nextUrl.pathname)) return handler();
 
   const startedAt = Date.now();
-  const diagnostics = beginDirectMcpDiagnostic(request, 'oauth.request');
+  const diagnostics = beginDirectMcpDiagnostic(
+    request,
+    request.nextUrl.pathname === '/api/auth/oauth2/register'
+      ? 'oauth.registration'
+      : 'oauth.request',
+  );
   try {
-    const response = withDirectMcpRequestId(await handler(), diagnostics.requestId);
+    const response = withDirectMcpRequestId(
+      await runWithDirectMcpDiagnostic(
+        diagnostics,
+        handler,
+      ),
+      diagnostics.requestId,
+    );
+    if (response.status >= 500) {
+      completeDirectMcpDiagnostic(diagnostics, {
+        statusCode: 503,
+        code: 'OAUTH_PROVIDER_ERROR',
+        startedAt,
+      });
+      return withDirectMcpRequestId(
+        directMcpOAuthUnavailableResponse(),
+        diagnostics.requestId,
+      );
+    }
     completeDirectMcpDiagnostic(diagnostics, {
       statusCode: response.status,
-      code: response.status >= 500 ? 'OAUTH_PROVIDER_ERROR' : 'OAUTH_REQUEST_COMPLETED',
+      code: 'OAUTH_REQUEST_COMPLETED',
       startedAt,
     });
     return response;
@@ -155,23 +178,24 @@ async function handleDirectMcpOAuthRequest(
 
 export async function GET(request: NextRequest) {
   return handleDirectMcpOAuthRequest(request, async () => {
-    const policyResponse = await enforceDirectMcpOAuthRequestPolicy(request);
-    if (policyResponse) return policyResponse;
+    const prepared = await prepareDirectMcpOAuthRequest(request);
+    if (prepared.response) return prepared.response;
 
     if (isTeamUserManagementPath(request.nextUrl.pathname)) {
       const licenseResponse = await requireTeamRuntimeRoute();
       if (licenseResponse) return licenseResponse;
     }
-    return auth.handler(request);
+    return auth.handler(prepared.request);
   });
 }
 
 export async function POST(request: NextRequest) {
   return handleDirectMcpOAuthRequest(request, async () => {
     const pathname = request.nextUrl.pathname;
-    const policyResponse = await enforceDirectMcpOAuthRequestPolicy(request);
-    if (policyResponse) return policyResponse;
-    const revocationCandidate = await prepareDirectMcpRevocation(request);
+    const prepared = await prepareDirectMcpOAuthRequest(request);
+    if (prepared.response) return prepared.response;
+    const authRequest = prepared.request;
+    const revocationCandidate = await prepareDirectMcpRevocation(authRequest);
 
     if (revocationCandidate) {
       try {
@@ -203,7 +227,7 @@ export async function POST(request: NextRequest) {
       if (licenseResponse) return licenseResponse;
     }
 
-    const response = await auth.handler(request);
+    const response = await auth.handler(authRequest);
     try {
       await initializeCreatedUserOnboarding(pathname, response);
     } catch (error) {

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -16,6 +16,7 @@ import {
   DIRECT_MCP_OAUTH_SCOPES,
   resolveDirectMcpOAuthConfig,
 } from '@/app/lib/mcp/server/config';
+import { recordDirectMcpOAuthProviderError } from '@/app/lib/mcp/server/diagnostics';
 import {
   assertUserSeatAccess,
   SeatLimitGuardError,
@@ -164,7 +165,18 @@ export const auth = betterAuth({
       enabled: false,
     }
   },
+  onAPIError: {
+    onError(error) {
+      if (recordDirectMcpOAuthProviderError(error)) return;
+      // Do not expose an upstream error body in shared logs. Direct MCP errors
+      // are correlated above; other Better Auth errors retain a safe signal.
+      console.error('[auth] Better Auth API request failed.');
+    },
+  },
   advanced: {
+    // The public origin is configured explicitly. Never let a client-supplied
+    // forwarded host/proto alter OAuth issuer or endpoint URLs.
+    trustedProxyHeaders: false,
     defaultCookieAttributes: {
       secure: useSecureCookies,
       sameSite: "lax",

--- a/app/lib/db/postgres.ts
+++ b/app/lib/db/postgres.ts
@@ -176,6 +176,42 @@ function createColumnAddSql(table: PostgresSchemaTable, column: SchemaColumn): s
   return `ALTER TABLE ${quotePostgresIdentifier(tableName)} ADD COLUMN IF NOT EXISTS ${renderColumnDefinition(column, false)}`;
 }
 
+const POSTGRES_OAUTH_JSON_ARRAY_COLUMNS = [
+  ['oauth_client', 'scopes'],
+  ['oauth_client', 'client_credentials_scopes'],
+  ['oauth_client', 'contacts'],
+  ['oauth_client', 'redirect_uris'],
+  ['oauth_client', 'post_logout_redirect_uris'],
+  ['oauth_client', 'grant_types'],
+  ['oauth_client', 'response_types'],
+  ['oauth_refresh_token', 'resources'],
+  ['oauth_refresh_token', 'requested_user_info_claims'],
+  ['oauth_refresh_token', 'scopes'],
+  ['oauth_access_token', 'resources'],
+  ['oauth_access_token', 'requested_user_info_claims'],
+  ['oauth_access_token', 'scopes'],
+  ['oauth_consent', 'resources'],
+  ['oauth_consent', 'requested_user_info_claims'],
+  ['oauth_consent', 'scopes'],
+  ['oauth_resource', 'allowed_scopes'],
+] as const;
+
+async function migratePostgresOauthArrayLiterals(pool: PgQueryable): Promise<void> {
+  for (const [table, column] of POSTGRES_OAUTH_JSON_ARRAY_COLUMNS) {
+    const quotedTable = quotePostgresIdentifier(table);
+    const quotedColumn = quotePostgresIdentifier(column);
+    // Versions before the JSON column mapper let node-postgres serialize arrays
+    // as `{...}` text. Convert only those legacy values; canonical JSON arrays
+    // already start with `[`, and NULL remains untouched.
+    await pool.query(`
+      UPDATE ${quotedTable}
+      SET ${quotedColumn} = to_json(${quotedColumn}::text[])::text
+      WHERE ${quotedColumn} IS NOT NULL
+        AND ${quotedColumn} LIKE '{%}'
+    `);
+  }
+}
+
 function uniqueColumnIndexSql(table: PostgresSchemaTable, column: SchemaColumn): string | null {
   if (!column.isUnique) return null;
   const tableName = String(table[TABLE_NAME_SYMBOL]);
@@ -654,6 +690,7 @@ export async function runPostgresMigrations(pool: PgQueryable): Promise<void> {
   for (const table of tables) {
     await pool.query(createTableSql(table));
   }
+  await migratePostgresOauthArrayLiterals(pool);
 
   await pool.query('ALTER TABLE studio_generations ADD COLUMN IF NOT EXISTS idempotency_key text');
   await pool.query('CREATE UNIQUE INDEX IF NOT EXISTS idx_studio_generations_idempotency ON studio_generations (user_id, workspace_id, idempotency_key)');

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -1,5 +1,18 @@
 import { desc, sql } from "drizzle-orm";
-import { sqliteTable, text, integer, real, index, uniqueIndex, primaryKey, check } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, index, uniqueIndex, primaryKey, check, customType } from "drizzle-orm/sqlite-core";
+
+// OAuth metadata is stored in text columns on both SQLite and PostgreSQL. A
+// plain `$type<T>()` only affects TypeScript; PostgreSQL otherwise persists
+// arrays as PostgreSQL array literals and returns strings to Better Auth.
+// Canonical JSON keeps the runtime type identical for both database providers.
+const jsonText = <T>(name: string) => customType<{
+  data: T;
+  driverData: string;
+}>({
+  dataType: () => 'text',
+  toDriver: (value) => JSON.stringify(value),
+  fromDriver: (value) => JSON.parse(value),
+})(name);
 
 export const user = sqliteTable("user", {
   id: text("id").primaryKey(),
@@ -286,30 +299,30 @@ export const oauthClient = sqliteTable("oauth_client", {
   skipConsent: integer("skip_consent", { mode: "boolean" }),
   enableEndSession: integer("enable_end_session", { mode: "boolean" }),
   subjectType: text("subject_type"),
-  scopes: text("scopes").$type<string[]>(),
-  clientCredentialsScopes: text("client_credentials_scopes").$type<string[]>(),
+  scopes: jsonText<string[]>("scopes"),
+  clientCredentialsScopes: jsonText<string[]>("client_credentials_scopes"),
   userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
   createdAt: integer("created_at", { mode: "timestamp_ms" }),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }),
   name: text("name"),
   uri: text("uri"),
   icon: text("icon"),
-  contacts: text("contacts").$type<string[]>(),
+  contacts: jsonText<string[]>("contacts"),
   tos: text("tos"),
   policy: text("policy"),
   softwareId: text("software_id"),
   softwareVersion: text("software_version"),
   softwareStatement: text("software_statement"),
-  redirectUris: text("redirect_uris").$type<string[]>().notNull(),
-  postLogoutRedirectUris: text("post_logout_redirect_uris").$type<string[]>(),
+  redirectUris: jsonText<string[]>("redirect_uris").notNull(),
+  postLogoutRedirectUris: jsonText<string[]>("post_logout_redirect_uris"),
   backchannelLogoutUri: text("backchannel_logout_uri"),
   backchannelLogoutSessionRequired: integer("backchannel_logout_session_required", { mode: "boolean" }),
   tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
   applicationType: text("application_type"),
   jwks: text("jwks"),
   jwksUri: text("jwks_uri"),
-  grantTypes: text("grant_types").$type<string[]>(),
-  responseTypes: text("response_types").$type<string[]>(),
+  grantTypes: jsonText<string[]>("grant_types"),
+  responseTypes: jsonText<string[]>("response_types"),
   public: integer("public", { mode: "boolean" }),
   type: text("type"),
   requirePKCE: integer("require_pkce", { mode: "boolean" }),
@@ -328,8 +341,8 @@ export const oauthRefreshToken = sqliteTable("oauth_refresh_token", {
   userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
   referenceId: text("reference_id"),
   authorizationCodeId: text("authorization_code_id"),
-  resources: text("resources").$type<string[]>(),
-  requestedUserInfoClaims: text("requested_user_info_claims").$type<string[]>(),
+  resources: jsonText<string[]>("resources"),
+  requestedUserInfoClaims: jsonText<string[]>("requested_user_info_claims"),
   expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   revoked: integer("revoked", { mode: "timestamp_ms" }),
@@ -338,7 +351,7 @@ export const oauthRefreshToken = sqliteTable("oauth_refresh_token", {
   rotationReplayExpiresAt: integer("rotation_replay_expires_at", { mode: "timestamp_ms" }),
   authTime: integer("auth_time", { mode: "timestamp_ms" }),
   confirmation: text("confirmation").$type<Record<string, unknown>>(),
-  scopes: text("scopes").$type<string[]>().notNull(),
+  scopes: jsonText<string[]>("scopes").notNull(),
 }, (table) => ({
   clientIdx: index("idx_oauth_refresh_token_client").on(table.clientId),
   sessionIdx: index("idx_oauth_refresh_token_session").on(table.sessionId),
@@ -353,13 +366,13 @@ export const oauthAccessToken = sqliteTable("oauth_access_token", {
   userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
   referenceId: text("reference_id"),
   authorizationCodeId: text("authorization_code_id"),
-  resources: text("resources").$type<string[]>(),
-  requestedUserInfoClaims: text("requested_user_info_claims").$type<string[]>(),
+  resources: jsonText<string[]>("resources"),
+  requestedUserInfoClaims: jsonText<string[]>("requested_user_info_claims"),
   refreshId: text("refresh_id").references(() => oauthRefreshToken.id, { onDelete: "cascade" }),
   expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   confirmation: text("confirmation").$type<Record<string, unknown>>(),
-  scopes: text("scopes").$type<string[]>().notNull(),
+  scopes: jsonText<string[]>("scopes").notNull(),
 }, (table) => ({
   clientIdx: index("idx_oauth_access_token_client").on(table.clientId),
   sessionIdx: index("idx_oauth_access_token_session").on(table.sessionId),
@@ -383,9 +396,9 @@ export const oauthConsent = sqliteTable("oauth_consent", {
   clientId: text("client_id").notNull().references(() => oauthClient.clientId, { onDelete: "cascade" }),
   userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
   referenceId: text("reference_id"),
-  resources: text("resources").$type<string[]>(),
-  requestedUserInfoClaims: text("requested_user_info_claims").$type<string[]>(),
-  scopes: text("scopes").$type<string[]>().notNull(),
+  resources: jsonText<string[]>("resources"),
+  requestedUserInfoClaims: jsonText<string[]>("requested_user_info_claims"),
+  scopes: jsonText<string[]>("scopes").notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
 }, (table) => ({
@@ -401,7 +414,7 @@ export const oauthResource = sqliteTable("oauth_resource", {
   refreshTokenTtl: integer("refresh_token_ttl"),
   signingAlgorithm: text("signing_algorithm"),
   signingKeyId: text("signing_key_id"),
-  allowedScopes: text("allowed_scopes").$type<string[]>(),
+  allowedScopes: jsonText<string[]>("allowed_scopes"),
   customClaims: text("custom_claims").$type<Record<string, unknown>>(),
   dpopBoundAccessTokensRequired: integer("dpop_bound_access_tokens_required", { mode: "boolean" }),
   disabled: integer("disabled", { mode: "boolean" }).default(false),

--- a/app/lib/mcp/server/diagnostics.ts
+++ b/app/lib/mcp/server/diagnostics.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHmac, randomUUID } from 'node:crypto';
 
 import { resolveAuthSecret } from '@/app/lib/security/auth-secret';
@@ -8,7 +9,10 @@ export type DirectMcpDiagnosticPhase =
   | 'discovery.authorization_server'
   | 'discovery.protected_resource'
   | 'mcp.http'
+  | 'oauth.registration'
   | 'oauth.request';
+
+const directMcpDiagnosticStorage = new AsyncLocalStorage<DirectMcpDiagnosticContext>();
 
 export type DirectMcpDiagnosticContext = {
   requestId: string;
@@ -132,4 +136,56 @@ export function withDirectMcpRequestId(
     statusText: response.statusText,
     headers,
   });
+}
+
+export async function runWithDirectMcpDiagnostic<T>(
+  context: DirectMcpDiagnosticContext,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return directMcpDiagnosticStorage.run(context, operation);
+}
+
+function errorMessage(error: unknown): string {
+  if (!error || typeof error !== 'object' || !('message' in error)) return '';
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' ? message.toLowerCase() : '';
+}
+
+function isServerFailure(error: unknown): boolean {
+  if (!error || typeof error !== 'object' || !('status' in error)) return true;
+  const status = (error as { status?: unknown }).status;
+  return status === 'INTERNAL_SERVER_ERROR'
+    || (typeof status === 'number' && status >= 500);
+}
+
+function classifyProviderError(error: unknown): string {
+  const message = errorMessage(error);
+  if (/relation|table|column|does not exist|schema/u.test(message)) {
+    return 'OAUTH_PERSISTENCE_SCHEMA_ERROR';
+  }
+  if (/constraint|duplicate|database|transaction|query/u.test(message)) {
+    return 'OAUTH_PERSISTENCE_ERROR';
+  }
+  return 'OAUTH_PROVIDER_INTERNAL_ERROR';
+}
+
+export function recordDirectMcpOAuthProviderError(
+  error: unknown,
+): boolean {
+  if (!isServerFailure(error)) return false;
+  const context = directMcpDiagnosticStorage.getStore();
+  if (!context) return false;
+
+  // Keep production diagnostics correlatable without recording client metadata,
+  // credentials, authorization codes, tokens, or provider error text.
+  emitDiagnostic({
+    event: 'direct_mcp_diagnostic',
+    requestId: context.requestId,
+    ...(context.flowRef ? { flowRef: context.flowRef } : {}),
+    phase: context.phase,
+    outcome: 'failed',
+    method: context.method,
+    code: classifyProviderError(error),
+  });
+  return true;
 }

--- a/app/lib/mcp/server/oauth-request-policy.ts
+++ b/app/lib/mcp/server/oauth-request-policy.ts
@@ -5,6 +5,13 @@ import {
 import { directMcpRefreshGrantIsActive } from '@/app/lib/mcp/server/oauth-grant-revocation';
 import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
 
+const MAX_DYNAMIC_CLIENT_REGISTRATION_BYTES = 16 * 1024;
+
+export type PreparedDirectMcpOAuthRequest = {
+  request: Request;
+  response: Response | null;
+};
+
 function oauthError(error: string, description: string): Response {
   return Response.json(
     {
@@ -111,40 +118,121 @@ function validateRegistrationBody(body: unknown): Response | null {
   return null;
 }
 
-export async function enforceDirectMcpOAuthRequestPolicy(
+function hasJsonContentType(request: Request): boolean {
+  const contentType = request.headers.get('content-type') || '';
+  return contentType.split(';', 1)[0]?.trim().toLowerCase() === 'application/json';
+}
+
+function bodyIsTooLarge(request: Request, body: string): boolean {
+  const contentLength = request.headers.get('content-length');
+  if (contentLength) {
+    const declaredLength = Number(contentLength);
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_DYNAMIC_CLIENT_REGISTRATION_BYTES) {
+      return true;
+    }
+  }
+  return new TextEncoder().encode(body).byteLength > MAX_DYNAMIC_CLIENT_REGISTRATION_BYTES;
+}
+
+async function normalizeDynamicClientRegistrationRequest(
   request: Request,
-): Promise<Response | null> {
+): Promise<PreparedDirectMcpOAuthRequest> {
+  if (!hasJsonContentType(request)) {
+    return {
+      request,
+      response: oauthError(
+        'invalid_client_metadata',
+        'Dynamic client registration requires an application/json body.',
+      ),
+    };
+  }
+
+  let serializedBody: string;
+  try {
+    serializedBody = await request.clone().text();
+  } catch {
+    return {
+      request,
+      response: oauthError(
+        'invalid_client_metadata',
+        'Dynamic client registration requires a JSON body.',
+      ),
+    };
+  }
+
+  if (bodyIsTooLarge(request, serializedBody)) {
+    return {
+      request,
+      response: oauthError(
+        'invalid_client_metadata',
+        'Dynamic client registration metadata is too large.',
+      ),
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(serializedBody);
+  } catch {
+    return {
+      request,
+      response: oauthError(
+        'invalid_client_metadata',
+        'Dynamic client registration requires a JSON body.',
+      ),
+    };
+  }
+
+  const validationError = validateRegistrationBody(body);
+  if (validationError) return { request, response: validationError };
+
+  // Better Auth defaults an omitted method to client_secret_basic. ChatGPT
+  // registers a public client and may omit this optional RFC 7591 field, so
+  // make the public-client contract explicit before handing it to the provider.
+  const metadata = body as Record<string, unknown>;
+  const headers = new Headers(request.headers);
+  headers.set('content-type', 'application/json');
+  headers.delete('content-length');
+  return {
+    request: new Request(request, {
+      headers,
+      body: JSON.stringify({
+        ...metadata,
+        token_endpoint_auth_method: 'none',
+      }),
+    }),
+    response: null,
+  };
+}
+
+export async function prepareDirectMcpOAuthRequest(
+  request: Request,
+): Promise<PreparedDirectMcpOAuthRequest> {
   const url = new URL(request.url);
   const runtimeSettings = await getDirectMcpRuntimeSettings();
   if (isDirectMcpOAuthPath(url.pathname) && !runtimeSettings.enabled) {
-    return disabledResponse();
+    return { request, response: disabledResponse() };
   }
-  if (!runtimeSettings.enabled) return null;
+  if (!runtimeSettings.enabled) return { request, response: null };
 
   if (
     request.method === 'POST'
     && url.pathname === '/api/auth/oauth2/register'
   ) {
-    let body: unknown;
-    try {
-      body = await request.clone().json();
-    } catch {
-      return oauthError(
-        'invalid_client_metadata',
-        'Dynamic client registration requires a JSON body.',
-      );
-    }
-    return validateRegistrationBody(body);
+    return normalizeDynamicClientRegistrationRequest(request);
   }
 
   if (
     request.method === 'GET'
     && url.pathname === '/api/auth/oauth2/authorize'
   ) {
-    return (
-      validateResourceValues(url.searchParams.getAll('resource'))
-      ?? validateAuthorizationPkce(url)
-    );
+    return {
+      request,
+      response: (
+        validateResourceValues(url.searchParams.getAll('resource'))
+        ?? validateAuthorizationPkce(url)
+      ),
+    };
   }
 
   if (
@@ -155,31 +243,43 @@ export async function enforceDirectMcpOAuthRequestPolicy(
     try {
       form = await request.clone().formData();
     } catch {
-      return oauthError(
-        'invalid_request',
-        'The OAuth token request must use a form-encoded body.',
-      );
+      return {
+        request,
+        response: oauthError(
+          'invalid_request',
+          'The OAuth token request must use a form-encoded body.',
+        ),
+      };
     }
     const grantType = form.get('grant_type');
     if (grantType === 'authorization_code' || grantType === 'refresh_token') {
       const resourceValues = form.getAll('resource')
         .filter((value): value is string => typeof value === 'string');
       const resourceError = validateResourceValues(resourceValues);
-      if (resourceError) return resourceError;
+      if (resourceError) return { request, response: resourceError };
       if (grantType === 'refresh_token') {
         const refreshGrantActive = await directMcpRefreshGrantIsActive(
           form,
           request.headers,
         );
         if (refreshGrantActive === false) {
-          return oauthError(
-            'invalid_grant',
-            'The refresh grant is inactive.',
-          );
+          return {
+            request,
+            response: oauthError(
+              'invalid_grant',
+              'The refresh grant is inactive.',
+            ),
+          };
         }
       }
     }
   }
 
-  return null;
+  return { request, response: null };
+}
+
+export async function enforceDirectMcpOAuthRequestPolicy(
+  request: Request,
+): Promise<Response | null> {
+  return (await prepareDirectMcpOAuthRequest(request)).response;
 }

--- a/app/lib/mcp/server/readiness.ts
+++ b/app/lib/mcp/server/readiness.ts
@@ -31,11 +31,32 @@ const REQUIRED_OAUTH_TABLES = [
   'oauth_resource',
 ] as const;
 
+const REQUIRED_OAUTH_COLUMNS: Record<string, readonly string[]> = {
+  oauth_client: [
+    'client_id',
+    'client_secret',
+    'scopes',
+    'redirect_uris',
+    'token_endpoint_auth_method',
+    'grant_types',
+    'response_types',
+  ],
+  oauth_client_resource: ['client_id', 'resource_id'],
+  oauth_resource: ['identifier', 'allowed_scopes'],
+  oauth_access_token: ['client_id', 'resources', 'scopes'],
+  oauth_refresh_token: ['client_id', 'resources', 'scopes'],
+  oauth_consent: ['client_id', 'resources', 'scopes'],
+};
+
 async function assertDirectMcpSchemaReady(): Promise<void> {
   const database = await openDb();
   try {
     for (const table of REQUIRED_OAUTH_TABLES) {
       await database.get(`SELECT 1 FROM ${table} LIMIT 1`);
+    }
+    for (const [table, columns] of Object.entries(REQUIRED_OAUTH_COLUMNS)) {
+      // Identifiers are fixed application constants, never request data.
+      await database.get(`SELECT ${columns.join(', ')} FROM ${table} LIMIT 0`);
     }
   } finally {
     await database.close();

--- a/app/lib/mcp/server/streamable-http.ts
+++ b/app/lib/mcp/server/streamable-http.ts
@@ -19,7 +19,6 @@ import {
   beginDirectMcpDiagnostic,
   completeDirectMcpDiagnostic,
   failDirectMcpDiagnostic,
-  withDirectMcpRequestId,
   type DirectMcpDiagnosticContext,
 } from '@/app/lib/mcp/server/diagnostics';
 import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "test:mcp:icons": "tsx scripts/mcp-icons-test.ts",
     "test:mcp:server-schema": "tsx scripts/mcp-server-oauth-schema-test.ts",
     "test:mcp:server-provider": "tsx --conditions react-server scripts/mcp-server-oauth-provider-test.ts",
+    "test:mcp:server-postgres-provider": "tsx scripts/mcp-server-oauth-postgres-provider-test.ts",
     "test:mcp:server-login-consent": "tsx --conditions react-server scripts/mcp-server-oauth-login-consent-test.ts",
     "test:mcp:server-resource": "tsx --conditions react-server scripts/mcp-server-protected-resource-test.ts",
     "test:mcp:server-oauth-client": "tsx --conditions react-server scripts/mcp-server-oauth-client-test.ts",

--- a/scripts/mcp-server-diagnostics-test.ts
+++ b/scripts/mcp-server-diagnostics-test.ts
@@ -4,6 +4,8 @@ import {
   beginDirectMcpDiagnostic,
   completeDirectMcpDiagnostic,
   failDirectMcpDiagnostic,
+  recordDirectMcpOAuthProviderError,
+  runWithDirectMcpDiagnostic,
   withDirectMcpRequestId,
 } from '../app/lib/mcp/server/diagnostics';
 
@@ -17,7 +19,7 @@ function serialize(args: unknown[]): string {
   }).join(' ');
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const originalInfo = console.info;
   const originalError = console.error;
   const captured: string[] = [];
@@ -49,11 +51,20 @@ function main(): void {
     );
     assert.equal(response.headers.get('x-request-id'), diagnostics.requestId);
 
+    const providerSecret = 'provider-error-must-never-appear-in-diagnostics';
+    await runWithDirectMcpDiagnostic(diagnostics, async () => {
+      recordDirectMcpOAuthProviderError(
+        new Error(`relation oauth_client does not exist: ${providerSecret}`),
+      );
+    });
+
     const output = captured.join('\n');
     assert.equal(output.includes(STATE), false);
     assert.equal(output.includes(CLIENT_ID), false);
     assert.equal(output.includes(diagnostics.flowRef || ''), true);
     assert.equal(output.includes('OAUTH_INTERNAL_ERROR'), true);
+    assert.equal(output.includes('OAUTH_PERSISTENCE_SCHEMA_ERROR'), true);
+    assert.equal(output.includes(providerSecret), false);
   } finally {
     console.info = originalInfo;
     console.error = originalError;
@@ -62,4 +73,7 @@ function main(): void {
   console.log('mcp-server-diagnostics-test: ok');
 }
 
-main();
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/mcp-server-oauth-client-test.ts
+++ b/scripts/mcp-server-oauth-client-test.ts
@@ -133,26 +133,77 @@ async function registerPublicClient(
   dispatch: RouteDispatcher,
   issuer: string,
   name: string,
+  tokenEndpointAuthMethod: 'none' | null = 'none',
 ): Promise<string> {
+  const metadata: JsonRecord = {
+    client_name: name,
+    redirect_uris: [REDIRECT_URI],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    scope: DIRECT_MCP_OAUTH_SCOPES.join(' '),
+  };
+  if (tokenEndpointAuthMethod !== null) {
+    metadata.token_endpoint_auth_method = tokenEndpointAuthMethod;
+  }
   const response = await dispatch(new Request(`${issuer}/oauth2/register`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
       origin: ORIGIN,
     },
-    body: JSON.stringify({
-      client_name: name,
-      redirect_uris: [REDIRECT_URI],
-      token_endpoint_auth_method: 'none',
-      grant_types: ['authorization_code', 'refresh_token'],
-      response_types: ['code'],
-      scope: DIRECT_MCP_OAUTH_SCOPES.join(' '),
-    }),
+    body: JSON.stringify(metadata),
   }));
   assert.equal([200, 201].includes(response.status), true);
-  const clientId = String((await readJson(response)).client_id);
+  const registered = await readJson(response);
+  assert.equal(registered.token_endpoint_auth_method, 'none');
+  assert.equal('client_secret' in registered, false);
+  const clientId = String(registered.client_id);
   assert.ok(clientId);
   return clientId;
+}
+
+async function assertDynamicRegistrationBoundary(
+  dispatch: RouteDispatcher,
+  issuer: string,
+): Promise<void> {
+  const implicitPublicClientId = await registerPublicClient(
+    dispatch,
+    issuer,
+    'ChatGPT Public Client With Omitted Auth Method',
+    null,
+  );
+  assert.ok(implicitPublicClientId);
+
+  const invalidAuthMethod = await dispatch(new Request(`${issuer}/oauth2/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: ORIGIN },
+    body: JSON.stringify({
+      client_name: 'Confidential Client Is Not Allowed',
+      redirect_uris: [REDIRECT_URI],
+      token_endpoint_auth_method: 'client_secret_basic',
+    }),
+  }));
+  assert.equal(invalidAuthMethod.status, 400);
+  assert.equal((await readJson(invalidAuthMethod)).error, 'invalid_client_metadata');
+
+  const invalidContentType = await dispatch(new Request(`${issuer}/oauth2/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'text/plain', origin: ORIGIN },
+    body: JSON.stringify({ redirect_uris: [REDIRECT_URI] }),
+  }));
+  assert.equal(invalidContentType.status, 400);
+  assert.equal((await readJson(invalidContentType)).error, 'invalid_client_metadata');
+
+  const oversizedMetadata = await dispatch(new Request(`${issuer}/oauth2/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: ORIGIN },
+    body: JSON.stringify({
+      redirect_uris: [REDIRECT_URI],
+      client_name: 'x'.repeat(16 * 1024),
+    }),
+  }));
+  assert.equal(oversizedMetadata.status, 400);
+  assert.equal((await readJson(oversizedMetadata)).error, 'invalid_client_metadata');
 }
 
 async function authorizeCode(input: {
@@ -308,6 +359,7 @@ async function main(): Promise<void> {
       issuer,
       'Other Public OAuth Client',
     );
+    await assertDynamicRegistrationBoundary(dispatch, issuer);
 
     const loginResponse = await dispatch(new Request(`${issuer}/sign-in/email`, {
       method: 'POST',
@@ -747,6 +799,29 @@ async function main(): Promise<void> {
     assert.equal(refreshAfterRevocation.status, 400);
     assert.equal((await readJson(refreshAfterRevocation)).error, 'invalid_grant');
 
+    const failingRegistrationDatabase = await openDb();
+    try {
+      await failingRegistrationDatabase.run(
+        'ALTER TABLE oauth_client RENAME TO oauth_client_unavailable',
+      );
+    } finally {
+      await failingRegistrationDatabase.close();
+    }
+    const providerFailure = await dispatch(new Request(`${issuer}/oauth2/register`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: ORIGIN },
+      body: JSON.stringify({
+        client_name: 'Provider Failure Diagnostic Client',
+        redirect_uris: [REDIRECT_URI],
+        token_endpoint_auth_method: 'none',
+      }),
+    }));
+    assert.equal(providerFailure.status, 503);
+    assert.match(providerFailure.headers.get('x-request-id') || '', /^[0-9a-f-]{36}$/iu);
+    const providerFailureBody = await readJson(providerFailure);
+    assert.equal(providerFailureBody.error, 'temporarily_unavailable');
+    assert.equal(JSON.stringify(providerFailureBody).includes('oauth_client'), false);
+
     captureLogs = false;
     const auditDatabase = await openDb();
     let auditText: string;
@@ -785,6 +860,8 @@ async function main(): Promise<void> {
         `Audit records must not contain the ${label}.`,
       );
     }
+    assert.equal(capturedText.includes('OAUTH_PERSISTENCE_SCHEMA_ERROR'), true);
+    assert.equal(capturedText.includes('oauth_client'), false);
 
     originalConsole.log('mcp-server-oauth-client-test: ok');
   } finally {

--- a/scripts/mcp-server-oauth-postgres-provider-test.ts
+++ b/scripts/mcp-server-oauth-postgres-provider-test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+
+import { PGlite } from '@electric-sql/pglite';
+import { oauthProvider } from '@better-auth/oauth-provider';
+import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { betterAuth } from 'better-auth';
+import { jwt } from 'better-auth/plugins';
+import { drizzle } from 'drizzle-orm/pglite';
+
+import { runPostgresMigrations } from '../app/lib/db/postgres';
+import * as schema from '../app/lib/db/schema';
+import { DIRECT_MCP_OAUTH_SCOPES } from '../app/lib/mcp/server/config';
+
+const ORIGIN = 'https://notebook.example.test';
+const ISSUER = `${ORIGIN}/api/auth`;
+const RESOURCE = `${ORIGIN}/mcp`;
+const REDIRECT_URI = 'https://chatgpt.com/connector/oauth/callback';
+
+async function main(): Promise<void> {
+  const postgres = new PGlite();
+  try {
+    await runPostgresMigrations(
+      postgres as unknown as Parameters<typeof runPostgresMigrations>[0],
+    );
+    const database = drizzle(postgres, { schema });
+    const auth = betterAuth({
+      secret: 'mcp-oauth-postgres-provider-test-secret-at-least-32-characters',
+      baseURL: ORIGIN,
+      database: drizzleAdapter(database, { provider: 'pg' }),
+      plugins: [
+        jwt({ jwt: { issuer: ISSUER } }),
+        oauthProvider({
+          loginPage: '/login',
+          consentPage: '/oauth/consent',
+          allowDynamicClientRegistration: true,
+          allowUnauthenticatedClientRegistration: true,
+          allowPublicClientPrelogin: false,
+          grantTypes: ['authorization_code', 'refresh_token'],
+          scopes: [...DIRECT_MCP_OAUTH_SCOPES],
+          clientRegistrationDefaultScopes: ['openid'],
+          clientRegistrationAllowedScopes: [...DIRECT_MCP_OAUTH_SCOPES],
+          resources: [{
+            identifier: RESOURCE,
+            name: 'Canvas Notebook MCP',
+            allowedScopes: [...DIRECT_MCP_OAUTH_SCOPES],
+          }],
+          clientRegistrationDefaultResources: [RESOURCE],
+          clientRegistrationAllowedResources: [RESOURCE],
+          storeClientSecret: 'hashed',
+          storeTokens: 'hashed',
+          clientPrivileges: () => false,
+        }),
+      ],
+    });
+
+    const response = await auth.handler(new Request(`${ISSUER}/oauth2/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: ORIGIN,
+      },
+      body: JSON.stringify({
+        client_name: 'ChatGPT PostgreSQL Dynamic Client',
+        redirect_uris: [REDIRECT_URI],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        scope: DIRECT_MCP_OAUTH_SCOPES.join(' '),
+      }),
+    }));
+    assert.equal(response.status, 201);
+    const registered = await response.json() as Record<string, unknown>;
+    assert.equal(registered.token_endpoint_auth_method, 'none');
+    assert.equal('client_secret' in registered, false);
+    assert.equal(typeof registered.client_id, 'string');
+
+    const clientId = String(registered.client_id);
+    const storedClient = await postgres.query<{
+      client_secret: string | null;
+      token_endpoint_auth_method: string | null;
+    }>(`
+      SELECT client_secret, token_endpoint_auth_method
+      FROM oauth_client
+      WHERE client_id = $1
+    `, [clientId]);
+    assert.equal(storedClient.rows.length, 1);
+    assert.equal(storedClient.rows[0]?.client_secret, null);
+    assert.equal(storedClient.rows[0]?.token_endpoint_auth_method, 'none');
+
+    const clientResources = await postgres.query<{ resource_id: string }>(`
+      SELECT client_id AS resource_id
+      FROM oauth_client_resource
+      WHERE client_id = $1
+    `, [clientId]);
+    assert.equal(clientResources.rows.length, 1);
+  } finally {
+    await postgres.close();
+  }
+}
+
+main().then(() => {
+  console.log('mcp-server-oauth-postgres-provider-test: ok');
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/mcp-server-oauth-provider-test.ts
+++ b/scripts/mcp-server-oauth-provider-test.ts
@@ -100,7 +100,10 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
 async function registerClient(
   auth: { handler: (request: Request) => Promise<Response> },
   body: Record<string, unknown>,
-  enforcePolicy: (request: Request) => Promise<Response | null>,
+  prepareRequest: (request: Request) => Promise<{
+    request: Request;
+    response: Response | null;
+  }>,
 ): Promise<Response> {
   const request = new Request(`${ISSUER}/oauth2/register`, {
     method: 'POST',
@@ -110,7 +113,8 @@ async function registerClient(
     },
     body: JSON.stringify(body),
   });
-  return (await enforcePolicy(request)) ?? auth.handler(request);
+  const prepared = await prepareRequest(request);
+  return prepared.response ?? auth.handler(prepared.request);
 }
 
 async function assertMetadata(
@@ -120,7 +124,12 @@ async function assertMetadata(
     `${ORIGIN}/.well-known/oauth-authorization-server/api/auth`,
     `${ISSUER}/.well-known/oauth-authorization-server`,
   ]) {
-    const response = await getMetadata(new Request(url));
+    const response = await getMetadata(new Request(url, {
+      headers: {
+        'x-forwarded-host': 'attacker.example.test',
+        'x-forwarded-proto': 'http',
+      },
+    }));
     assert.equal(response.status, 200);
     assert.match(response.headers.get('content-type') || '', /application\/json/u);
     assert.match(response.headers.get('cache-control') || '', /max-age=300/u);
@@ -144,6 +153,10 @@ async function assertMetadata(
 async function assertRegistrationPolicy(
   auth: { handler: (request: Request) => Promise<Response> },
   enforcePolicy: (request: Request) => Promise<Response | null>,
+  prepareRequest: (request: Request) => Promise<{
+    request: Request;
+    response: Response | null;
+  }>,
 ): Promise<string> {
   const validRegistration = await registerClient(auth, {
     client_name: 'ChatGPT Direct MCP Test',
@@ -152,7 +165,7 @@ async function assertRegistrationPolicy(
     grant_types: ['authorization_code', 'refresh_token'],
     response_types: ['code'],
     scope: DIRECT_MCP_OAUTH_SCOPES.join(' '),
-  }, enforcePolicy);
+  }, prepareRequest);
   assert.equal([200, 201].includes(validRegistration.status), true);
   const registered = await readJson(validRegistration);
   assert.equal(typeof registered.client_id, 'string');
@@ -161,6 +174,18 @@ async function assertRegistrationPolicy(
   assert.deepEqual(registered.grant_types, ['authorization_code', 'refresh_token']);
   assert.equal(registered.scope, DIRECT_MCP_OAUTH_SCOPES.join(' '));
 
+  const implicitPublicClient = await registerClient(auth, {
+    client_name: 'ChatGPT Public Client Without Auth Method',
+    redirect_uris: [REDIRECT_URI],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    scope: DIRECT_MCP_OAUTH_SCOPES.join(' '),
+  }, prepareRequest);
+  assert.equal([200, 201].includes(implicitPublicClient.status), true);
+  const implicitPublicRegistered = await readJson(implicitPublicClient);
+  assert.equal(implicitPublicRegistered.token_endpoint_auth_method, 'none');
+  assert.equal('client_secret' in implicitPublicRegistered, false);
+
   const invalidScope = await registerClient(auth, {
     client_name: 'Invalid Scope',
     redirect_uris: [REDIRECT_URI],
@@ -168,7 +193,7 @@ async function assertRegistrationPolicy(
     grant_types: ['authorization_code'],
     response_types: ['code'],
     scope: 'openid knowledge:write',
-  }, enforcePolicy);
+  }, prepareRequest);
   assert.equal(invalidScope.status, 400);
   assert.equal((await readJson(invalidScope)).error, 'invalid_scope');
 
@@ -177,7 +202,7 @@ async function assertRegistrationPolicy(
     redirect_uris: [REDIRECT_URI],
     token_endpoint_auth_method: 'none',
     grant_types: ['client_credentials'],
-  }, enforcePolicy);
+  }, prepareRequest);
   assert.equal(clientCredentials.status, 400);
   assert.equal((await readJson(clientCredentials)).error, 'invalid_client_metadata');
 
@@ -187,7 +212,7 @@ async function assertRegistrationPolicy(
     token_endpoint_auth_method: 'none',
     grant_types: ['authorization_code'],
     response_types: ['code'],
-  }, enforcePolicy);
+  }, prepareRequest);
   assert.equal(invalidRedirect.status, 400);
 
   const disabledPkce = await registerClient(auth, {
@@ -197,7 +222,7 @@ async function assertRegistrationPolicy(
     grant_types: ['authorization_code'],
     response_types: ['code'],
     require_pkce: false,
-  }, enforcePolicy);
+  }, prepareRequest);
   assert.equal(disabledPkce.status, 400);
   assert.equal((await readJson(disabledPkce)).error, 'invalid_client_metadata');
 
@@ -347,7 +372,10 @@ async function main(): Promise<void> {
   configureRuntime(dataDir);
 
   try {
-    const [{ auth }, { getAuthorizationServerMetadata }, { enforceDirectMcpOAuthRequestPolicy }] = await Promise.all([
+    const [{ auth }, { getAuthorizationServerMetadata }, {
+      enforceDirectMcpOAuthRequestPolicy,
+      prepareDirectMcpOAuthRequest,
+    }] = await Promise.all([
       import('../app/lib/auth'),
       import('../app/lib/mcp/server/authorization-server-metadata'),
       import('../app/lib/mcp/server/oauth-request-policy'),
@@ -364,6 +392,7 @@ async function main(): Promise<void> {
     const clientId = await assertRegistrationPolicy(
       auth,
       enforceDirectMcpOAuthRequestPolicy,
+      prepareDirectMcpOAuthRequest,
     );
     await assertAuthorizePolicy(auth, clientId, enforceDirectMcpOAuthRequestPolicy);
     await assertTokenPolicy(auth, clientId, enforceDirectMcpOAuthRequestPolicy);

--- a/scripts/mcp-server-oauth-schema-test.ts
+++ b/scripts/mcp-server-oauth-schema-test.ts
@@ -278,16 +278,16 @@ function assertSqliteFreshIdempotentAndUpgrade(): void {
     'post_logout_redirect_uris',
     'grant_types',
     'response_types',
-    'metadata',
   ]) {
     const column = oauthClientConfig.columns.find(
       (candidate) => candidate.name === columnName,
     );
     assert.equal(
       column?.columnType,
-      'SQLiteText',
-      `${columnName} must remain plain text because Better Auth owns serialization.`,
+      'SQLiteCustomColumn',
+      `${columnName} must serialize canonical JSON while remaining a text column.`,
     );
+    assert.equal(column?.getSQLType(), 'text');
   }
 
   const sqlite = new Database(':memory:');
@@ -545,8 +545,24 @@ async function assertPostgresFreshIdempotentAndUpgrade(): Promise<void> {
     await assertPostgresSchema(postgres);
     const firstSnapshot = await postgresOAuthSchemaSnapshot(postgres);
 
+    await postgres.query(`
+      INSERT INTO oauth_client (id, client_id, redirect_uris, scopes)
+      VALUES ('legacy-oauth-client', 'legacy-oauth-client', '{https://chatgpt.com/callback}', '{openid,workspace:list}')
+    `);
     await runPostgresMigrations(migrationTarget);
     assert.equal(await postgresOAuthSchemaSnapshot(postgres), firstSnapshot);
+    const migratedLegacyClient = await postgres.query<{
+      redirect_uris: string;
+      scopes: string;
+    }>(`
+      SELECT redirect_uris, scopes
+      FROM oauth_client
+      WHERE client_id = 'legacy-oauth-client'
+    `);
+    assert.deepEqual(migratedLegacyClient.rows, [{
+      redirect_uris: '["https://chatgpt.com/callback"]',
+      scopes: '["openid","workspace:list"]',
+    }]);
 
     await seedPostgresAuthData(postgres);
     await postgres.exec(`


### PR DESCRIPTION
## Summary
- store OAuth list fields as canonical JSON across SQLite and PostgreSQL
- normalize public dynamic-client registration and return redacted, correlated provider failures
- add PostgreSQL DCR regression coverage and explicit 4xx boundary tests

## Verification
- `npm run test:mcp:server-provider`
- `npm run test:mcp:server-postgres-provider`
- `npm run test:mcp:server-schema`
- `npm run test:mcp:server-diagnostics`
- `npm run test:mcp:server-resource`
- `npm run test:mcp:server-settings`
- `npm run test:mcp:server-oauth-client`
- `npm run lint` (one existing unrelated warning)

`npm run build` is currently blocked in the prebuild license-compliance assertion for the native release workflow; this change does not touch that workflow.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes MCP OAuth dynamic client registration by normalizing public-client metadata, storing OAuth list fields consistently as JSON, and returning correlated redacted provider failures.
- Adds canonical JSON mapping and legacy PostgreSQL conversion for OAuth array fields.
- Normalizes registration requests before passing them to Better Auth.
- Adds request-scoped diagnostics, schema-readiness checks, and SQLite/PostgreSQL regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/auth/[...all]/route.ts | Routes normalized OAuth requests through Better Auth and converts provider failures into correlated, redacted 503 responses. |
| app/lib/auth.ts | Adds request-scoped provider-error recording and disables proxy-derived OAuth endpoint URLs. |
| app/lib/db/postgres.ts | Converts legacy PostgreSQL OAuth array literals to canonical JSON during startup migration. |
| app/lib/db/schema.ts | Introduces a JSON text mapper for OAuth list fields across SQLite and PostgreSQL. |
| app/lib/mcp/server/oauth-request-policy.ts | Validates and normalizes unauthenticated dynamic-client registration requests for public clients. |
| app/lib/mcp/server/diagnostics.ts | Adds async request correlation and redacted classification of OAuth provider errors. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix MCP OAuth dynamic registration"](https://github.com/canvascoding/canvas-notebook/commit/c2923090caeb4d3318683c7c88b3272ebbca642f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56047958)</sub>

<!-- /greptile_comment -->