### PR TITLE
Keep completed To-dos out of mobile attention

### DIFF
--- a/app/lib/mobile/inbox.ts
+++ b/app/lib/mobile/inbox.ts
@@ -153,7 +153,7 @@ function todoWorkspaceOptions(workspace: WorkspaceContext) {
 async function listInboxTodos(input: { userId: string; workspace: WorkspaceContext }) {
   const workspaceTodos = await listTodos(input.userId, {
     ...todoWorkspaceOptions(input.workspace),
-    status: 'active',
+    status: 'open',
     limit: MAX_SOURCE_ITEMS,
   });
   // User-scoped personal To-dos have no concrete workspace. Attach them
@@ -167,7 +167,7 @@ async function listInboxTodos(input: { userId: string; workspace: WorkspaceConte
   const personalTodos = await listTodos(input.userId, {
     workspaceType: 'personal',
     scopeKind: 'user',
-    status: 'active',
+    status: 'open',
     limit: MAX_SOURCE_ITEMS,
   });
   return Array.from(new Map([...workspaceTodos, ...personalTodos].map((todo) => [todo.id, todo])).values());

--- a/scripts/mobile-inbox-todos-test.ts
+++ b/scripts/mobile-inbox-todos-test.ts
@@ -202,6 +202,7 @@ async function main() {
       filter: 'todos',
       limit: 20,
     });
+    assert.equal(todoAttentionInbox.items.some((item) => item.id === `todo:${firstTodo.id}`), true);
     assert.equal(todoAttentionInbox.items.every((item) => item.todoStatus === 'open'), true);
     assert.equal(todoAttentionInbox.items.some((item) => item.id === `todo:${completedTodo.id}`), false);
     assert.equal(
@@ -522,6 +523,7 @@ async function main() {
       status: 'open',
       limit: 20,
     });
+    assert.equal(openTodoPage.todos.some((todo) => todo.id === firstTodo.id), true);
     assert.equal(openTodoPage.todos.every((todo) => todo.status === 'open'), true);
     const completedTodoPage = await listMobileTodos({
       userId: 'mobile-attention-user',

--- a/scripts/mobile-inbox-todos-test.ts
+++ b/scripts/mobile-inbox-todos-test.ts
@@ -174,8 +174,7 @@ async function main() {
     assert.equal(inbox.items.some((item) => item.id === 'chat:attention-session'), true);
     assert.equal(inbox.items.some((item) => item.id === 'chat:historic-unread-session'), true);
     assert.equal(inbox.items.some((item) => item.id === `todo:${firstTodo.id}`), true);
-    assert.equal(inbox.items.some((item) => item.id === `todo:${completedTodo.id}`), true);
-    assert.equal(inbox.items.find((item) => item.id === `todo:${completedTodo.id}`)?.unread, false);
+    assert.equal(inbox.items.some((item) => item.id === `todo:${completedTodo.id}`), false);
     await assert.rejects(
       () => markMobileInboxRead({
         userId: 'mobile-attention-user',
@@ -197,6 +196,14 @@ async function main() {
     assert.equal(inbox.counts.emails, 3);
     const unreadInbox = await listMobileInbox({ userId: 'mobile-attention-user', workspace, filter: 'unread', limit: 20 });
     assert.equal(unreadInbox.items.some((item) => item.id === `todo:${completedTodo.id}`), false);
+    const todoAttentionInbox = await listMobileInbox({
+      userId: 'mobile-attention-user',
+      workspace,
+      filter: 'todos',
+      limit: 20,
+    });
+    assert.equal(todoAttentionInbox.items.every((item) => item.todoStatus === 'open'), true);
+    assert.equal(todoAttentionInbox.items.some((item) => item.id === `todo:${completedTodo.id}`), false);
     assert.equal(
       inbox.items.find((item) => item.id === 'studio:generation-ready')?.previewUrl,
       '/api/mobile/v1/studio/outputs/generation-preview-output/preview',
@@ -509,6 +516,20 @@ async function main() {
       limit: 20,
     });
     assert.equal(unreadTodoPage.todos.some((todo) => todo.id === completedTodo.id), false);
+    const openTodoPage = await listMobileTodos({
+      userId: 'mobile-attention-user',
+      workspace,
+      status: 'open',
+      limit: 20,
+    });
+    assert.equal(openTodoPage.todos.every((todo) => todo.status === 'open'), true);
+    const completedTodoPage = await listMobileTodos({
+      userId: 'mobile-attention-user',
+      workspace,
+      status: 'done',
+      limit: 20,
+    });
+    assert.equal(completedTodoPage.todos.some((todo) => todo.id === completedTodo.id), true);
 
     const loadedTodo = await getMobileTodo({ userId: 'mobile-attention-user', workspace, todoId: firstTodo.id });
     assert.equal(loadedTodo.title, 'Approve launch copy');


### PR DESCRIPTION
## Summary
- query only open workspace and personal To-dos for the mobile Inbox attention feed
- prevent completed To-dos from resurfacing as actionable Inbox items
- retain completed To-dos in the full mobile To-do API for retrieval and management
- add regression coverage for open, completed, and filtered Inbox behavior

## Verification
- npm run test:mobile:inbox
- npx tsc --noEmit --pretty false
- focused ESLint checks
- git diff --check

## Mobile dependency
Pair with canvascoding/canvas-notebook-mobile#22, which separates Attention from full To-do management.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR keeps completed To-dos out of the mobile attention feed while retaining them in the full To-do API.
- Restricts workspace and personal attention queries to open To-dos.
- Adds regression coverage for open, completed, and filtered Inbox behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/mobile/inbox.ts | Narrows mobile Inbox attention queries to open To-dos without changing full To-do retrieval. |
| scripts/mobile-inbox-todos-test.ts | Covers open and completed To-do behavior, with non-vacuous assertions requiring the expected open fixture in filtered results. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review feedback"](https://github.com/canvascoding/canvas-notebook/commit/91debeaf8e18f1ab9b26eacbdc37f14208c7140f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56154226)</sub>

<!-- /greptile_comment -->