### PR TITLE
Expose tool call IDs to mobile chat

### DIFF
--- a/app/lib/mobile/chat.ts
+++ b/app/lib/mobile/chat.ts
@@ -28,6 +28,7 @@ import {
   isToolCallPart,
   stripAttachmentBlocks,
 } from '@/app/lib/chat/message-content';
+import { mobileToolCallId } from '@/app/lib/mobile/tool-call-id';
 import { formatMobileToolInput } from '@/app/lib/mobile/tool-input';
 import {
   getActiveRuntimeStatusSummaries,
@@ -198,12 +199,6 @@ function parsedMobileMessage(row: MobileChatMessageRow): Record<string, unknown>
   return parsePersistedPiMessage(row.content, 'display') as unknown as Record<string, unknown>;
 }
 
-function messageToolCallId(message: Record<string, unknown>): string | null {
-  return typeof message.toolCallId === 'string' && message.toolCallId.trim()
-    ? message.toolCallId.trim().slice(0, 200)
-    : null;
-}
-
 function mobileToolInputsById(rows: MobileChatMessageRow[]): Map<string, string> {
   const inputs = new Map<string, string>();
   for (const row of rows) {
@@ -223,7 +218,7 @@ function missingToolInputIds(rows: MobileChatMessageRow[], knownInputs: Map<stri
   for (const row of rows) {
     const message = parsedMobileMessage(row);
     if (message.role !== 'toolResult') continue;
-    const toolCallId = messageToolCallId(message);
+    const toolCallId = mobileToolCallId(message);
     if (toolCallId && !knownInputs.has(toolCallId)) missing.add(toolCallId);
   }
   return Array.from(missing);
@@ -251,7 +246,7 @@ export function serializeMobileChatMessage(input: {
   )) === index);
   const visibleText = extractPiMessageText(piMessage, { hideAttachmentMetadata: true })
     || stripAttachmentBlocks(contentToString(parsed.content));
-  const toolCallId = messageToolCallId(parsed);
+  const toolCallId = mobileToolCallId(parsed);
   const clientMessageId = typeof parsed.clientMessageId === 'string'
     && parsed.clientMessageId.trim().length <= 256
     ? parsed.clientMessageId.trim()

--- a/app/lib/mobile/chat.ts
+++ b/app/lib/mobile/chat.ts
@@ -82,6 +82,7 @@ export type MobileChatMessage = {
   kind: 'message' | 'tool' | 'error';
   text: string;
   clientMessageId?: string;
+  toolCallId: string | null;
   toolName: string | null;
   toolInput: string | null;
   attachments: MobileChatAttachment[];
@@ -262,6 +263,7 @@ export function serializeMobileChatMessage(input: {
     kind: isError ? 'error' : role === 'tool' ? 'tool' : 'message',
     text: visibleText,
     ...(clientMessageId ? { clientMessageId } : {}),
+    toolCallId,
     toolName: messageToolName(parsed),
     toolInput: toolCallId ? toolInputsById.get(toolCallId) || null : null,
     attachments: attachments.map(serializeMessageAttachment),

--- a/app/lib/mobile/tool-call-id.ts
+++ b/app/lib/mobile/tool-call-id.ts
@@ -1,0 +1,5 @@
+export function mobileToolCallId(message: Record<string, unknown>): string | null {
+  return typeof message.toolCallId === 'string' && message.toolCallId.trim()
+    ? message.toolCallId.trim().slice(0, 200)
+    : null;
+}

--- a/scripts/mobile-chat-contract-test.ts
+++ b/scripts/mobile-chat-contract-test.ts
@@ -65,6 +65,7 @@ assert.match(service, /pi_session_runtime\.override/u);
 assert.match(service, /extractMessageAttachments/u);
 assert.match(service, /extractPiMessageText\(piMessage, \{ hideAttachmentMetadata: true \}\)/u);
 assert.match(service, /mobileToolInputsById/u);
+assert.match(service, /toolCallId,/u);
 assert.match(service, /toolInput:/u);
 assert.match(service, /safeRelativeUrl/u);
 assert.match(websocketServer, /SESSION_DATA_CONFLICT/u);

--- a/scripts/mobile-chat-contract-test.ts
+++ b/scripts/mobile-chat-contract-test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 
 import { runMigrations } from '../app/lib/db/migrate';
+import { mobileToolCallId } from '../app/lib/mobile/tool-call-id';
 import { formatMobileToolInput } from '../app/lib/mobile/tool-input';
 
 const sqlite = new Database(':memory:');
@@ -81,5 +82,9 @@ assert.match(formattedToolInput || '', /printf \\"hello\\"/u);
 assert.match(formattedToolInput || '', /Research\/brief\.md/u);
 assert.doesNotMatch(formattedToolInput || '', /top-secret-token|example-secret/u);
 assert.match(formattedToolInput || '', /\[REDACTED\]/u);
+
+assert.equal(mobileToolCallId({ role: 'toolResult', toolCallId: ' tool-call-qa ' }), 'tool-call-qa');
+assert.equal(mobileToolCallId({ role: 'toolResult', toolCallId: '   ' }), null);
+assert.equal(mobileToolCallId({ role: 'assistant' }), null);
 
 console.log('mobile-chat-contract-test: ok');


### PR DESCRIPTION
## Summary

- include the persisted `toolCallId` in mobile chat message serialization
- cover the contract field in the mobile chat regression test

This lets the mobile client reconcile live and persisted tool rows without duplicate or ambiguous entries.

## Verification

- `npm run test:mobile:chat`
- `npm run build`
- native iOS integration test through the versioned mobile API and chat WebSocket contract

## Mobile dependency

Companion mobile PR: https://github.com/canvascoding/canvas-notebook-mobile/pull/26




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR exposes persisted tool-call identifiers in serialized mobile chat messages and extracts identifier normalization into a reusable helper.
- Adds nullable `toolCallId` to `MobileChatMessage`.
- Uses the shared identifier helper for serialization and tool-input lookup.
- Extends the mobile chat contract script with identifier normalization checks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/mobile/chat.ts | Adds the normalized persisted tool-call identifier to the mobile chat message contract and serializer. |
| app/lib/mobile/tool-call-id.ts | Extracts bounded, trimmed tool-call identifier normalization into a shared helper. |
| scripts/mobile-chat-contract-test.ts | Adds direct coverage for valid, blank, and absent tool-call identifier normalization. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Test mobile tool call ID serialization"](https://github.com/canvascoding/canvas-notebook/commit/9bcf66ce0951fd02d41f5af5e0dbab77d2a582bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56172137)</sub>

<!-- /greptile_comment -->