### PR TITLE
Fix MCP OAuth dynamic registration compatibility

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -4,7 +4,7 @@ This file is generated from `package-lock.json`, installed package license files
 versioned overrides, and the bundled non-npm component inventory.
 
 - Canvas Notebook version: 2026.8.24.2
-- Lockfile SHA-256: `e495bc8527be422921a944ad861026c8eee98ec2feba8d0c657909c8e2d1ecd5`
+- Lockfile SHA-256: `c7ba174eaaf46e4bb15b6034f379a11597210df6c8a376aa4436464ddc384295`
 - Distributed components: 1510
 - Release gate: **approved**
 
@@ -89,15 +89,15 @@ Third-party trademarks and branding are not granted by the software licenses bel
 | @babel/template | 7.29.7 | runtime | MIT | allowed |
 | @babel/traverse | 7.29.7 | runtime | MIT | allowed |
 | @babel/types | 7.29.7 | runtime | MIT | allowed |
-| @better-auth/core | 1.7.0-rc.6 | runtime | MIT | allowed |
-| @better-auth/drizzle-adapter | 1.7.0-rc.6 | runtime | MIT | allowed |
-| @better-auth/expo | 1.7.0-rc.6 | runtime | MIT | allowed |
-| @better-auth/kysely-adapter | 1.7.0-rc.6 | runtime | MIT | allowed |
-| @better-auth/memory-adapter | 1.7.0-rc.6 | runtime | MIT | allowed |
-| @better-auth/mongo-adapter | 1.7.0-rc.6 | runtime | MIT | allowed |
-| @better-auth/oauth-provider | 1.7.0-rc.6 | runtime | MIT | allowed |
-| @better-auth/prisma-adapter | 1.7.0-rc.6 | runtime | MIT | allowed |
-| @better-auth/telemetry | 1.7.0-rc.6 | runtime | MIT | allowed |
+| @better-auth/core | 1.7.1 | runtime | MIT | allowed |
+| @better-auth/drizzle-adapter | 1.7.1 | runtime | MIT | allowed |
+| @better-auth/expo | 1.7.1 | runtime | MIT | allowed |
+| @better-auth/kysely-adapter | 1.7.1 | runtime | MIT | allowed |
+| @better-auth/memory-adapter | 1.7.1 | runtime | MIT | allowed |
+| @better-auth/mongo-adapter | 1.7.1 | runtime | MIT | allowed |
+| @better-auth/oauth-provider | 1.7.1 | runtime | MIT | allowed |
+| @better-auth/prisma-adapter | 1.7.1 | runtime | MIT | allowed |
+| @better-auth/telemetry | 1.7.1 | runtime | MIT | allowed |
 | @better-auth/utils | 0.4.2 | runtime | MIT | allowed |
 | @better-auth/utils | 0.5.0 | runtime | MIT | allowed |
 | @better-fetch/fetch | 1.3.1 | runtime | MIT | allowed |
@@ -669,7 +669,7 @@ Third-party trademarks and branding are not granted by the software licenses bel
 | basic-ftp | 5.3.1 | runtime | MIT | allowed |
 | batch | 0.6.1 | runtime | MIT | allowed |
 | bcryptjs | 3.0.3 | runtime | BSD-3-Clause | allowed |
-| better-auth | 1.7.0-rc.6 | runtime | MIT | allowed |
+| better-auth | 1.7.1 | runtime | MIT | allowed |
 | better-call | 1.4.0 | runtime | MIT | allowed |
 | better-sqlite3 | 12.11.1 | runtime | MIT | allowed |
 | bidi-js | 1.0.3 | runtime | MIT | allowed |
@@ -14102,7 +14102,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ### License text 7a07f7d9085c
 
-Applies to @better-auth/core@1.7.0-rc.6, @better-auth/drizzle-adapter@1.7.0-rc.6, @better-auth/expo@1.7.0-rc.6, @better-auth/kysely-adapter@1.7.0-rc.6, @better-auth/memory-adapter@1.7.0-rc.6, @better-auth/mongo-adapter@1.7.0-rc.6, @better-auth/oauth-provider@1.7.0-rc.6, @better-auth/prisma-adapter@1.7.0-rc.6, @better-auth/telemetry@1.7.0-rc.6, better-auth@1.7.0-rc.6.
+Applies to @better-auth/core@1.7.1, @better-auth/drizzle-adapter@1.7.1, @better-auth/expo@1.7.1, @better-auth/kysely-adapter@1.7.1, @better-auth/memory-adapter@1.7.1, @better-auth/mongo-adapter@1.7.1, @better-auth/oauth-provider@1.7.1, @better-auth/prisma-adapter@1.7.1, @better-auth/telemetry@1.7.1, better-auth@1.7.1.
 
 Copyright notices:
 

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -125,6 +125,27 @@ function directMcpOAuthUnavailableResponse(): Response {
   );
 }
 
+class DirectMcpOAuthStageError extends Error {
+  constructor(readonly code: string) {
+    super(code);
+    this.name = 'DirectMcpOAuthStageError';
+  }
+}
+
+async function runDirectMcpOAuthStage<T>(
+  code: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch {
+    // Preserve a stable, non-sensitive failure stage for production
+    // correlation. Do not attach the upstream error: it can contain OAuth
+    // client metadata, tokens, or database details.
+    throw new DirectMcpOAuthStageError(code);
+  }
+}
+
 async function handleDirectMcpOAuthRequest(
   request: NextRequest,
   handler: () => Promise<Response>,
@@ -163,9 +184,11 @@ async function handleDirectMcpOAuthRequest(
       startedAt,
     });
     return response;
-  } catch {
+  } catch (error) {
     failDirectMcpDiagnostic(diagnostics, {
-      code: 'OAUTH_INTERNAL_ERROR',
+      code: error instanceof DirectMcpOAuthStageError
+        ? error.code
+        : 'OAUTH_INTERNAL_ERROR',
       startedAt,
       statusCode: 503,
     });
@@ -178,7 +201,10 @@ async function handleDirectMcpOAuthRequest(
 
 export async function GET(request: NextRequest) {
   return handleDirectMcpOAuthRequest(request, async () => {
-    const prepared = await prepareDirectMcpOAuthRequest(request);
+    const prepared = await runDirectMcpOAuthStage(
+      'OAUTH_REQUEST_POLICY_ERROR',
+      () => prepareDirectMcpOAuthRequest(request),
+    );
     if (prepared.response) return prepared.response;
 
     if (isTeamUserManagementPath(request.nextUrl.pathname)) {
@@ -192,10 +218,21 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   return handleDirectMcpOAuthRequest(request, async () => {
     const pathname = request.nextUrl.pathname;
-    const prepared = await prepareDirectMcpOAuthRequest(request);
+    const isRegistration = pathname === '/api/auth/oauth2/register';
+    const prepared = await runDirectMcpOAuthStage(
+      isRegistration
+        ? 'OAUTH_REGISTRATION_NORMALIZATION_ERROR'
+        : 'OAUTH_REQUEST_POLICY_ERROR',
+      () => prepareDirectMcpOAuthRequest(request),
+    );
     if (prepared.response) return prepared.response;
     const authRequest = prepared.request;
-    const revocationCandidate = await prepareDirectMcpRevocation(authRequest);
+    const revocationCandidate = await runDirectMcpOAuthStage(
+      isRegistration
+        ? 'OAUTH_REGISTRATION_PRE_PROVIDER_ERROR'
+        : 'OAUTH_REQUEST_PRE_PROVIDER_ERROR',
+      () => prepareDirectMcpRevocation(authRequest),
+    );
 
     if (revocationCandidate) {
       try {
@@ -227,7 +264,12 @@ export async function POST(request: NextRequest) {
       if (licenseResponse) return licenseResponse;
     }
 
-    const response = await auth.handler(authRequest);
+    const response = await runDirectMcpOAuthStage(
+      isRegistration
+        ? 'OAUTH_REGISTRATION_PROVIDER_THROWN'
+        : 'OAUTH_REQUEST_PROVIDER_THROWN',
+      () => auth.handler(authRequest),
+    );
     try {
       await initializeCreatedUserOnboarding(pathname, response);
     } catch (error) {

--- a/app/lib/mcp/server/oauth-request-policy.ts
+++ b/app/lib/mcp/server/oauth-request-policy.ts
@@ -6,6 +6,13 @@ import { directMcpRefreshGrantIsActive } from '@/app/lib/mcp/server/oauth-grant-
 import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
 
 const MAX_DYNAMIC_CLIENT_REGISTRATION_BYTES = 16 * 1024;
+const PUBLIC_DYNAMIC_CLIENT_AUTH_METHODS = new Set([
+  'none',
+  // Several MCP clients still send this RFC 7591 value even though an open
+  // registration endpoint can only issue a public client. Normalize it below
+  // and advertise the resulting `none` method in the registration response.
+  'client_secret_post',
+]);
 
 export type PreparedDirectMcpOAuthRequest = {
   request: Request;
@@ -87,11 +94,14 @@ function validateRegistrationBody(body: unknown): Response | null {
   }
   if (
     metadata.token_endpoint_auth_method !== undefined
-    && metadata.token_endpoint_auth_method !== 'none'
+    && (
+      typeof metadata.token_endpoint_auth_method !== 'string'
+      || !PUBLIC_DYNAMIC_CLIENT_AUTH_METHODS.has(metadata.token_endpoint_auth_method)
+    )
   ) {
     return oauthError(
       'invalid_client_metadata',
-      'Unauthenticated registration is limited to public clients.',
+      'Unauthenticated registration only supports public MCP clients.',
     );
   }
   if (Array.isArray(metadata.grant_types)) {
@@ -186,9 +196,11 @@ async function normalizeDynamicClientRegistrationRequest(
   const validationError = validateRegistrationBody(body);
   if (validationError) return { request, response: validationError };
 
-  // Better Auth defaults an omitted method to client_secret_basic. ChatGPT
-  // registers a public client and may omit this optional RFC 7591 field, so
-  // make the public-client contract explicit before handing it to the provider.
+  // Better Auth versions before the stable 1.7 line default an omitted method
+  // to client_secret_basic. MCP clients may also optimistically request
+  // client_secret_post during open registration. Both cases must result in a
+  // public client: a secret cannot safely be issued to an unauthenticated
+  // registrant.
   const metadata = body as Record<string, unknown>;
   const headers = new Headers(request.headers);
   headers.set('content-type', 'application/json');

--- a/docs/compliance/third-party-components.json
+++ b/docs/compliance/third-party-components.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": "scripts/generate-third-party-notices.ts",
   "packageVersion": "2026.8.24.2",
-  "lockfileSha256": "e495bc8527be422921a944ad861026c8eee98ec2feba8d0c657909c8e2d1ecd5",
+  "lockfileSha256": "c7ba174eaaf46e4bb15b6034f379a11597210df6c8a376aa4436464ddc384295",
   "summary": {
     "totalComponents": 2034,
     "npmComponents": 2011,
@@ -11862,7 +11862,7 @@
     },
     {
       "name": "@better-auth/core",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/@better-auth/core",
       "usage": "runtime",
@@ -11884,7 +11884,7 @@
     },
     {
       "name": "@better-auth/drizzle-adapter",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/@better-auth/drizzle-adapter",
       "usage": "runtime",
@@ -11906,7 +11906,7 @@
     },
     {
       "name": "@better-auth/expo",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/@better-auth/expo",
       "usage": "runtime",
@@ -11928,7 +11928,7 @@
     },
     {
       "name": "@better-auth/kysely-adapter",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/@better-auth/kysely-adapter",
       "usage": "runtime",
@@ -11950,7 +11950,7 @@
     },
     {
       "name": "@better-auth/memory-adapter",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/@better-auth/memory-adapter",
       "usage": "runtime",
@@ -11972,7 +11972,7 @@
     },
     {
       "name": "@better-auth/mongo-adapter",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/@better-auth/mongo-adapter",
       "usage": "runtime",
@@ -11994,7 +11994,7 @@
     },
     {
       "name": "@better-auth/oauth-provider",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/@better-auth/oauth-provider",
       "usage": "runtime",
@@ -12016,7 +12016,7 @@
     },
     {
       "name": "@better-auth/prisma-adapter",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/@better-auth/prisma-adapter",
       "usage": "runtime",
@@ -12038,7 +12038,7 @@
     },
     {
       "name": "@better-auth/telemetry",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/@better-auth/telemetry",
       "usage": "runtime",
@@ -25470,7 +25470,7 @@
     },
     {
       "name": "better-auth",
-      "versionOrCommit": "1.7.0-rc.6",
+      "versionOrCommit": "1.7.1",
       "sourceUrl": "https://github.com/better-auth/better-auth",
       "packagePathOrArtifact": "node_modules/better-auth",
       "usage": "runtime",

--- a/docs/compliance/third-party-license-cache.json
+++ b/docs/compliance/third-party-license-cache.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 6,
-  "lockfileSha256": "e495bc8527be422921a944ad861026c8eee98ec2feba8d0c657909c8e2d1ecd5",
+  "lockfileSha256": "c7ba174eaaf46e4bb15b6034f379a11597210df6c8a376aa4436464ddc384295",
   "entries": {
     "node_modules/@aws-sdk/credential-provider-http@3.972.70": {
       "packagePath": "node_modules/@aws-sdk/credential-provider-http",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@better-auth/expo": "1.7.0-rc.6",
-        "@better-auth/oauth-provider": "1.7.0-rc.6",
+        "@better-auth/expo": "1.7.1",
+        "@better-auth/oauth-provider": "1.7.1",
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",
@@ -84,7 +84,7 @@
         "@xterm/xterm": "^6.0.0",
         "archiver": "^8.0.0",
         "bcryptjs": "^3.0.3",
-        "better-auth": "1.7.0-rc.6",
+        "better-auth": "1.7.1",
         "better-sqlite3": "^12.6.2",
         "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
@@ -1010,9 +1010,9 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.7.0-rc.6.tgz",
-      "integrity": "sha512-P8PzMgkDdIsF4t3v3QovJ4NnkA/609mSsTPaPrNSN37fQUeLmQmfIUCyf6ZLJRGaMyd9wCnJ8mVMTCxgfA7OHw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.41.1",
@@ -1039,12 +1039,12 @@
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.7.0-rc.6.tgz",
-      "integrity": "sha512-RpyoXLX2ZOuISNnyS8or9qaVbTS5BtkiUA/mfO4ZWxK13WuhpdfrBMAXQTYK2ITiVKOsnREFkCaJ/5g8AKGYqQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.7.1.tgz",
+      "integrity": "sha512-qlqNyg5V9bXHSP68/vtlsiZayhR4hgvEGiS/E3SIj8bCpWWFGmyQkxJbQCqpBmC7vT30wE/kNtJMHIgnV3rkiw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.0-rc.6",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0"
       },
@@ -1055,9 +1055,9 @@
       }
     },
     "node_modules/@better-auth/expo": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/expo/-/expo-1.7.0-rc.6.tgz",
-      "integrity": "sha512-2e/lG0HMhBC/HP1x7FMa4p5lfQSv86UNVo3NYaxycBONxJiD2eZKViNuE8DCFhX32F3avKxCS/UCNEqzGvF8Cw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/expo/-/expo-1.7.1.tgz",
+      "integrity": "sha512-Cnq6Zx58p3c9wGslQMv7Q1gkLxRqs3WMxQ0YamNdxp0430fzY/bsYwchT+5SXotm+yw088krkiiBqrVAU4tymw==",
       "license": "MIT",
       "dependencies": {
         "@better-fetch/fetch": "1.3.1",
@@ -1065,8 +1065,8 @@
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/core": "^1.7.0-rc.6",
-        "better-auth": "^1.7.0-rc.6",
+        "@better-auth/core": "^1.7.1",
+        "better-auth": "^1.7.1",
         "expo-constants": ">=17.0.0",
         "expo-linking": ">=7.0.0",
         "expo-network": ">=8.0.7",
@@ -1092,12 +1092,12 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.7.0-rc.6.tgz",
-      "integrity": "sha512-5W/TesEgJk3uiSeSTYU5/tYG3QbYkqU7QUxtD/TwJPPsVI0QODMKtP6pPVcOzlDmFvUgXw8/BxluLaQxemEn5A==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.7.1.tgz",
+      "integrity": "sha512-yWCpE1cZpMUj37nD6JFDK+GDR8zS37L5WI73il3qbU9TXtWsxUQKc/5c3IHsHizWQsmcQI8uv2pAFKxsRDa+AQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.0-rc.6",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "kysely": "^0.28.17 || ^0.29.0"
       },
@@ -1108,22 +1108,22 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.7.0-rc.6.tgz",
-      "integrity": "sha512-+5lYYZwbWtMiudEPVfUKNsmiGk/BzwgvfcQCXiKEdzhlFEl3Z22Z9PBG4aILjFK4KEZ6SYA5hJoF0MDIrIaixw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.7.1.tgz",
+      "integrity": "sha512-6NX1yv88DeqdoG7owYFqKwlrDGaIPhsC52JUGrUgeGVKyOq8a/6hHlHsqG1C2FwT23SHQiKVYCEAG9N6aH5OvQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.0-rc.6",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.7.0-rc.6.tgz",
-      "integrity": "sha512-LRhRafLDEpuuvFB5jCXWMZFg1kOB/zgyv+Qz6c+O5zyAoyofsATtHc8YbZH+f/G8qAWznknNYzpuTc/V6uw1og==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.7.1.tgz",
+      "integrity": "sha512-9ILTcNqhG37QK//qR4UhYLyKzNqq6w6zVTf5KX6xkiTjNcV7Oh1yS31lkIJEVTqRNcy9AoV6FZMW6Bbsm8IMDA==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.0-rc.6",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
@@ -1134,29 +1134,29 @@
       }
     },
     "node_modules/@better-auth/oauth-provider": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/oauth-provider/-/oauth-provider-1.7.0-rc.6.tgz",
-      "integrity": "sha512-Q2wxJqhfUG7gpNNAFwfPOjGu0y0RNuzGufv80PMVWW6JJmA9wU2IBWjI79kdNx5XVy8SjbqV1ET6eUxcWqpihQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/oauth-provider/-/oauth-provider-1.7.1.tgz",
+      "integrity": "sha512-VWIw7ti6rodlbbdSbn0mts/TZcBWUj6YaoIpREmv70eoGmWTa6MPWEbGuUdADQe3Vy4YqysIbmQA6qgRqfLTaw==",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.2.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/core": "^1.7.0-rc.6",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1",
-        "better-auth": "^1.7.0-rc.6",
+        "better-auth": "^1.7.1",
         "better-call": "1.4.0"
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.7.0-rc.6.tgz",
-      "integrity": "sha512-mqH1qqh1Gzz2jvPU7YvmFLczA8ybhFX6GC5jjqJOI/S9JiGmJByIZN7MY6mvqVL/+ozSr0uPzsl3FAtuqeh83g==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.7.1.tgz",
+      "integrity": "sha512-ZiUcafQ85InAofcUjyGgCPjKLfQjXr9SvDmMjuFUW8oEbreA6C6GaFAEA77VuV2doZUQlzvQQ4gCoTmS28W92A==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.0-rc.6",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
@@ -1171,12 +1171,12 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.7.0-rc.6.tgz",
-      "integrity": "sha512-z1kjZlk+/By3HhWw5EflvvlHWLIJe0KZccLQhwljt4P8G1Uy/OmFquCeoxdJ7RzS7/ro/TxveXwXt5d0CrYJ/Q==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.7.1.tgz",
+      "integrity": "sha512-kLKjMfFlTbyt49DGeI9okHAsn0MtBZcMoQYKaEdgR0H3BHzqqyzePcQz/hxAmRgjB4p/6inise3zJwhX0sgXrQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.7.0-rc.6",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1"
       }
@@ -12620,18 +12620,18 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.7.0-rc.6",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.7.0-rc.6.tgz",
-      "integrity": "sha512-31NEEHwuOWd6UZ8MusPjI5aCPpwWwLJh6Xo3qMkvoKdzmHLr1QrEOwYnXqO5jwNu/AER9GeDJouMzEhQ24anZw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.7.1.tgz",
+      "integrity": "sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.7.0-rc.6",
-        "@better-auth/drizzle-adapter": "1.7.0-rc.6",
-        "@better-auth/kysely-adapter": "1.7.0-rc.6",
-        "@better-auth/memory-adapter": "1.7.0-rc.6",
-        "@better-auth/mongo-adapter": "1.7.0-rc.6",
-        "@better-auth/prisma-adapter": "1.7.0-rc.6",
-        "@better-auth/telemetry": "1.7.0-rc.6",
+        "@better-auth/core": "1.7.1",
+        "@better-auth/drizzle-adapter": "1.7.1",
+        "@better-auth/kysely-adapter": "1.7.1",
+        "@better-auth/memory-adapter": "1.7.1",
+        "@better-auth/mongo-adapter": "1.7.1",
+        "@better-auth/prisma-adapter": "1.7.1",
+        "@better-auth/telemetry": "1.7.1",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1",
         "@noble/ciphers": "^2.2.0",
@@ -18560,7 +18560,7 @@
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -19223,7 +19223,7 @@
         "node": ">=16"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -28339,7 +28339,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -28361,7 +28361,7 @@
         "npm": ">=8.0.0"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -28381,7 +28381,7 @@
         "npm": ">=8.0.0"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -28405,7 +28405,7 @@
         "npm": ">=8.0.0"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -28501,7 +28501,7 @@
         "npm": ">=8.0.0"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },

--- a/package.json
+++ b/package.json
@@ -321,8 +321,8 @@
     "container:rebuild": "node scripts/setup.mjs"
   },
   "dependencies": {
-    "@better-auth/expo": "1.7.0-rc.6",
-    "@better-auth/oauth-provider": "1.7.0-rc.6",
+    "@better-auth/expo": "1.7.1",
+    "@better-auth/oauth-provider": "1.7.1",
     "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/lang-cpp": "^6.0.3",
     "@codemirror/lang-css": "^6.3.1",
@@ -395,7 +395,7 @@
     "@xterm/xterm": "^6.0.0",
     "archiver": "^8.0.0",
     "bcryptjs": "^3.0.3",
-    "better-auth": "1.7.0-rc.6",
+    "better-auth": "1.7.1",
     "better-sqlite3": "^12.6.2",
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",

--- a/scripts/mcp-server-oauth-provider-test.ts
+++ b/scripts/mcp-server-oauth-provider-test.ts
@@ -117,6 +117,51 @@ async function registerClient(
   return prepared.response ?? auth.handler(prepared.request);
 }
 
+async function assertRouteRegistration(
+  post: (request: import('next/server').NextRequest) => Promise<Response>,
+  NextRequest: typeof import('next/server').NextRequest,
+): Promise<void> {
+  for (const tokenEndpointAuthMethod of [undefined, 'client_secret_post']) {
+    const response = await post(new NextRequest(`${ISSUER}/oauth2/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: ORIGIN,
+      },
+      body: JSON.stringify({
+        client_name: tokenEndpointAuthMethod
+          ? 'ChatGPT-compatible public client'
+          : 'Implicit public client',
+        redirect_uris: [REDIRECT_URI],
+        ...(tokenEndpointAuthMethod ? { token_endpoint_auth_method: tokenEndpointAuthMethod } : {}),
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        scope: DIRECT_MCP_OAUTH_SCOPES.join(' '),
+      }),
+    }));
+    assert.equal([200, 201].includes(response.status), true);
+    assert.match(response.headers.get('x-request-id') || '', /^[0-9a-f-]{36}$/iu);
+    const registered = await readJson(response);
+    assert.equal(registered.token_endpoint_auth_method, 'none');
+    assert.equal('client_secret' in registered, false);
+  }
+
+  const rejectedMethod = await post(new NextRequest(`${ISSUER}/oauth2/register`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: ORIGIN,
+    },
+    body: JSON.stringify({
+      client_name: 'Confidential client is not allowed',
+      redirect_uris: [REDIRECT_URI],
+      token_endpoint_auth_method: 'client_secret_basic',
+    }),
+  }));
+  assert.equal(rejectedMethod.status, 400);
+  assert.equal((await readJson(rejectedMethod)).error, 'invalid_client_metadata');
+}
+
 async function assertMetadata(
   getMetadata: (request: Request) => Promise<Response>,
 ): Promise<void> {
@@ -173,18 +218,6 @@ async function assertRegistrationPolicy(
   assert.equal('client_secret' in registered, false);
   assert.deepEqual(registered.grant_types, ['authorization_code', 'refresh_token']);
   assert.equal(registered.scope, DIRECT_MCP_OAUTH_SCOPES.join(' '));
-
-  const implicitPublicClient = await registerClient(auth, {
-    client_name: 'ChatGPT Public Client Without Auth Method',
-    redirect_uris: [REDIRECT_URI],
-    grant_types: ['authorization_code', 'refresh_token'],
-    response_types: ['code'],
-    scope: DIRECT_MCP_OAUTH_SCOPES.join(' '),
-  }, prepareRequest);
-  assert.equal([200, 201].includes(implicitPublicClient.status), true);
-  const implicitPublicRegistered = await readJson(implicitPublicClient);
-  assert.equal(implicitPublicRegistered.token_endpoint_auth_method, 'none');
-  assert.equal('client_secret' in implicitPublicRegistered, false);
 
   const invalidScope = await registerClient(auth, {
     client_name: 'Invalid Scope',
@@ -375,10 +408,12 @@ async function main(): Promise<void> {
     const [{ auth }, { getAuthorizationServerMetadata }, {
       enforceDirectMcpOAuthRequestPolicy,
       prepareDirectMcpOAuthRequest,
-    }] = await Promise.all([
+    }, { POST: postOAuthRoute }, { NextRequest }] = await Promise.all([
       import('../app/lib/auth'),
       import('../app/lib/mcp/server/authorization-server-metadata'),
       import('../app/lib/mcp/server/oauth-request-policy'),
+      import('../app/api/auth/[...all]/route'),
+      import('next/server'),
     ]);
 
     await assertMetadata(getAuthorizationServerMetadata);
@@ -389,6 +424,7 @@ async function main(): Promise<void> {
     }));
     assert.equal(disabledResponse?.status, 404);
     process.env.CANVAS_MCP_DIRECT_ENABLED = previousFeatureFlag;
+    await assertRouteRegistration(postOAuthRoute, NextRequest);
     const clientId = await assertRegistrationPolicy(
       auth,
       enforceDirectMcpOAuthRequestPolicy,


### PR DESCRIPTION
## Summary
- accept MCP clients that request `client_secret_post` during open dynamic registration and normalize them to public `none` clients
- upgrade Better Auth OAuth provider packages from release candidate `1.7.0-rc.6` to stable `1.7.1`
- record redacted registration failure stages for safe production diagnosis

## Verification
- `npm run test:mcp:server-provider`
- `npm run test:mcp:server-postgres-provider`
- `npm run test:mcp:server-schema`
- `npm run test:mcp:server-diagnostics`
- `npm run test:mcp:server-oauth-client`
- `npm run test:mcp:server-resource`
- `npm run test:mcp:server-settings`
- `npm run test:mcp:server-auth-probe`
- `npx tsc --noEmit --pretty false --incremental false --project tsconfig.json`
- `npm run lint`
- `npm run build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR broadens MCP dynamic-registration compatibility while retaining public-client semantics, upgrades Better Auth packages to stable 1.7.1, and adds redacted stage-specific diagnostics.
- Accepts omitted or `client_secret_post` authentication metadata and normalizes registrations to `none` without issuing a client secret.
- Adds stage-specific diagnostic codes while preserving the existing OAuth error responses.
- Updates provider tests and regenerated dependency-compliance artifacts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The registration policy preserves the public-client boundary by withholding secrets and advertising `none`, while the diagnostic wrappers retain existing response semantics and the dependency family is upgraded consistently.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/mcp/server/oauth-request-policy.ts | Expands the registration allowlist to `client_secret_post` but rewrites every accepted open registration to a public `none` client. |
| app/api/auth/[...all]/route.ts | Adds redacted stage-specific exception classification without changing the direct OAuth client-facing fallback response. |
| scripts/mcp-server-oauth-provider-test.ts | Extends route-level registration coverage for omitted, normalized, and rejected authentication methods. |
| package.json | Pins Better Auth, its OAuth provider, and Expo integration to stable version 1.7.1. |
| package-lock.json | Resolves the Better Auth package family consistently at 1.7.1 and updates generated lockfile metadata. |
| THIRD_PARTY_NOTICES.md | Regenerates distributed-component notices for the Better Auth upgrade. |
| docs/compliance/third-party-components.json | Regenerates the third-party component inventory and lockfile digest. |
| docs/compliance/third-party-license-cache.json | Refreshes cached Better Auth license metadata for version 1.7.1. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Route as OAuth Route
    participant Policy as Request Policy
    participant Provider as Better Auth Provider
    Client->>Route: POST /oauth2/register
    Route->>Policy: Prepare registration
    Policy->>Policy: Validate metadata and size
    Policy->>Policy: Normalize auth method to none
    Policy->>Provider: Forward public-client metadata
    Provider-->>Route: Registration response without secret
    Route-->>Client: client_id and auth method none
    Note over Route,Provider: Unexpected failures become redacted stage diagnostics and HTTP 503
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix MCP OAuth dynamic registration compa..."](https://github.com/canvascoding/canvas-notebook/commit/7fd7b8873db7a19a1c17209e9c311f02314f3eaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56297654)</sub>

<!-- /greptile_comment -->