### PR TITLE
Fix live collaboration representation routing

### DIFF
--- a/app/api/files/collaboration/session/route.ts
+++ b/app/api/files/collaboration/session/route.ts
@@ -21,7 +21,7 @@ import {
   COLLABORATION_SCHEMA_VERSION,
   RICH_MARKDOWN_SCHEMA_VERSION,
   type CollaborationProvider,
-  type CollaborationRepresentation,
+  type CollaborationSessionRepresentation,
   type CollaborationSessionResponse,
 } from '@/app/lib/collaboration/types';
 
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
 
   const body = await readJsonBody<{
     path?: string;
-    representation?: CollaborationRepresentation;
+    representation?: CollaborationSessionRepresentation;
     provider?: CollaborationProvider;
   }>(request);
   const requested = parseCollaborationSessionRequest(body);

--- a/app/api/mobile/v1/notebook/collaboration/session/route.ts
+++ b/app/api/mobile/v1/notebook/collaboration/session/route.ts
@@ -21,8 +21,6 @@ import {
   requireTeamRuntimeLicense,
 } from '@/app/lib/license/entitlements';
 import { issueMobileCollaborationTicket } from '@/app/lib/mobile/collaboration-ticket';
-import { readFile } from '@/app/lib/filesystem/workspace-files';
-import { analyzeMarkdownRichMode } from '@/app/lib/markdown/rich-markdown-codec';
 import { requireRequestWorkspace, workspaceFileOptions } from '@/app/lib/workspaces/request';
 
 export const dynamic = 'force-dynamic';
@@ -58,28 +56,11 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await readJsonBody<{ path?: unknown }>(request);
-  const requestedPath = typeof body.path === 'string' ? body.path.trim().toLowerCase() : '';
-  const preliminaryRequest = parseCollaborationSessionRequest({
-    path: body.path,
-    provider: 'yjs',
-    representation: requestedPath.endsWith('.txt') ? 'plain_text' : 'tiptap_xml',
-  });
-  if (!preliminaryRequest) {
-    return NextResponse.json(
-      { success: false, error: 'A supported Markdown or plain-text path is required.' },
-      { status: 400 },
-    );
-  }
   const fileOptions = workspaceFileOptions(workspaceResult.workspace);
-  const representation = requestedPath.endsWith('.txt')
-    ? 'plain_text'
-    : analyzeMarkdownRichMode((await readFile(preliminaryRequest.path, fileOptions)).toString('utf8')).mode === 'source'
-      ? 'plain_text'
-      : 'tiptap_xml';
   const collaborationRequest = parseCollaborationSessionRequest({
     path: body.path,
     provider: 'yjs',
-    representation,
+    representation: 'auto',
   });
   if (!collaborationRequest) {
     return NextResponse.json(

--- a/app/components/editor/CodeEditor.tsx
+++ b/app/components/editor/CodeEditor.tsx
@@ -41,6 +41,7 @@ import type { WorkspaceMarkdownLocation } from '@/app/lib/markdown/workspace-mar
 import { useTranslations } from 'next-intl';
 import { yCollab } from 'y-codemirror.next';
 import { useCollaborationDocument } from '@/app/lib/collaboration/client';
+import type { CollaborationSessionResponse } from '@/app/lib/collaboration/types';
 
 export interface CodeEditorProps {
   value: string;
@@ -49,6 +50,7 @@ export interface CodeEditorProps {
   path?: string;
   markdownNavigationTarget?: WorkspaceMarkdownLocation | null;
   collaborationEnabled?: boolean;
+  collaborationSession?: CollaborationSessionResponse | null;
 }
 
 const CODE_MIRROR_BASIC_SETUP = {
@@ -292,6 +294,7 @@ export function CodeEditor({
   path,
   markdownNavigationTarget,
   collaborationEnabled,
+  collaborationSession,
 }: CodeEditorProps) {
   const t = useTranslations('notebook');
   const { currentFile } = useFileStore();
@@ -306,6 +309,7 @@ export function CodeEditor({
     workspaceId: activeWorkspaceId,
     path: languagePath,
     representation: 'plain_text',
+    session: collaborationSession,
   });
   const collaborationReadOnly = shouldCollaborate && (
     !collaboration?.session

--- a/app/components/editor/MarkdownEditor.tsx
+++ b/app/components/editor/MarkdownEditor.tsx
@@ -207,7 +207,12 @@ import {
 import { ObsidianInlineFootnoteExtension } from './ObsidianInlineFootnoteExtension';
 import Collaboration, { isChangeOrigin } from '@tiptap/extension-collaboration';
 import CollaborationCaret from '@tiptap/extension-collaboration-caret';
-import { useCollaborationDocument, type CollaborationDocument } from '@/app/lib/collaboration/client';
+import {
+  useCollaborationDocument,
+  useTextCollaborationSession,
+  type CollaborationDocument,
+} from '@/app/lib/collaboration/client';
+import type { CollaborationSessionResponse } from '@/app/lib/collaboration/types';
 
 export interface MarkdownEditorProps {
   value: string;
@@ -216,6 +221,7 @@ export interface MarkdownEditorProps {
   filePath?: string;
   externalValueSync?: 'always' | 'when-blurred';
   collaborationEnabled?: boolean;
+  collaborationSession?: CollaborationSessionResponse | null;
   showNotebookMetadata?: boolean;
 }
 
@@ -4824,6 +4830,7 @@ function RichMarkdownEditor({
   onSourceMode,
   markdownNavigationTarget,
   collaborationEnabled = false,
+  collaborationSession,
   showNotebookMetadata = false,
 }: MarkdownEditorProps & {
   isMobileKeyboardActive: boolean;
@@ -4854,6 +4861,7 @@ function RichMarkdownEditor({
     workspaceId: activeWorkspaceId,
     path: filePath,
     representation: 'tiptap_xml',
+    session: collaborationSession,
   });
   const collaborationReadOnly = collaborationEnabled && (
     !collaboration?.session
@@ -5633,6 +5641,7 @@ function SourceMarkdownEditor({
   onRichMode,
   markdownNavigationTarget,
   collaborationEnabled = false,
+  collaborationSession,
   sourceModeReason,
 }: MarkdownEditorProps & {
   initiallyShowMobileToolbar?: boolean;
@@ -5721,6 +5730,7 @@ function SourceMarkdownEditor({
           path={filePath ?? 'document.md'}
           markdownNavigationTarget={markdownNavigationTarget}
           collaborationEnabled={collaborationEnabled}
+          collaborationSession={collaborationSession}
         />
       </div>
       <MarkdownDocumentStatus value={value} />
@@ -5739,6 +5749,13 @@ export function MarkdownEditor({
 }: MarkdownEditorProps) {
   useVisualViewportBottomOffset();
 
+  const t = useTranslations('notebook');
+  const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
+  const collaborationSession = useTextCollaborationSession({
+    enabled: collaborationEnabled,
+    workspaceId: activeWorkspaceId,
+    path: filePath,
+  });
   const isMobileKeyboardActive = useMobileKeyboardActive();
   const parsedDocument = useMemo(() => parseCanvasMarkdownDocument(value), [value]);
   const richModeAnalysis = useMemo(() => analyzeMarkdownRichMode(value), [value]);
@@ -5750,7 +5767,10 @@ export function MarkdownEditor({
   const [markdownNavigationTarget, setMarkdownNavigationTarget] = useState<WorkspaceMarkdownLocation | null>(() => (
     filePath ? consumeWorkspaceMarkdownLocation(filePath) : null
   ));
-  const effectiveMode: EditorMode = sourceModeRequired ? 'source' : mode;
+  const authoritativeRepresentation = collaborationSession.session?.representation;
+  const effectiveMode: EditorMode = collaborationEnabled && authoritativeRepresentation
+    ? authoritativeRepresentation === 'plain_text' ? 'source' : 'rich'
+    : sourceModeRequired ? 'source' : mode;
 
   useEffect(() => {
     if (!filePath) return;
@@ -5783,6 +5803,21 @@ export function MarkdownEditor({
     setSourceModeRequested(false);
     setMode('rich');
   }, [collaborationEnabled, sourceModeRequired]);
+
+  if (collaborationEnabled && !collaborationSession.session) {
+    return (
+      <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-background p-6 text-center">
+        <p className="text-sm text-muted-foreground" role="status">
+          {collaborationSession.error || t('collaboration.connecting')}
+        </p>
+        {collaborationSession.error ? (
+          <Button size="sm" variant="outline" onClick={collaborationSession.retry}>
+            {t('externalChangeReload')}
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
 
   if (readOnly && effectiveMode === 'source') {
     return (
@@ -5817,6 +5852,7 @@ export function MarkdownEditor({
         onRichMode={switchToRichMode}
         markdownNavigationTarget={markdownNavigationTarget}
         collaborationEnabled={collaborationEnabled}
+        collaborationSession={collaborationSession.session}
         sourceModeReason={richModeAnalysis.mode === 'source' ? richModeAnalysis.reason : undefined}
       />
     );
@@ -5833,6 +5869,7 @@ export function MarkdownEditor({
       onSourceMode={switchToSourceMode}
       markdownNavigationTarget={markdownNavigationTarget}
       collaborationEnabled={collaborationEnabled}
+      collaborationSession={collaborationSession.session}
       showNotebookMetadata={showNotebookMetadata}
     />
   );

--- a/app/lib/collaboration/client.ts
+++ b/app/lib/collaboration/client.ts
@@ -13,6 +13,8 @@ import type {
   CollaborationSessionResponse,
 } from './types';
 
+type RequestedTextCollaborationRepresentation = TextCollaborationRepresentation | 'auto';
+
 type RegistryEntry = {
   key: string;
   refs: number;
@@ -43,7 +45,10 @@ function emit(entry: RegistryEntry): void {
   for (const listener of entry.listeners) listener();
 }
 
-async function requestSession(path: string, representation: TextCollaborationRepresentation): Promise<CollaborationSessionResponse> {
+async function requestSession(
+  path: string,
+  representation: RequestedTextCollaborationRepresentation,
+): Promise<CollaborationSessionResponse> {
   const response = await fetch('/api/files/collaboration/session', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...workspaceHeaders() },
@@ -54,13 +59,32 @@ async function requestSession(path: string, representation: TextCollaborationRep
   return payload as CollaborationSessionResponse;
 }
 
+function requireTextSession(
+  session: CollaborationSessionResponse,
+  representation?: TextCollaborationRepresentation,
+): CollaborationSessionResponse {
+  if (
+    session.provider !== 'yjs'
+    || (session.representation !== 'plain_text' && session.representation !== 'tiptap_xml')
+    || (representation && session.representation !== representation)
+  ) {
+    throw new Error('The collaboration representation does not match this editor. Reload to use the current document representation.');
+  }
+  return session;
+}
+
 function websocketUrl(relative: string): string {
   const url = new URL(relative, window.location.href);
   url.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   return url.toString();
 }
 
-function createEntry(key: string, path: string, representation: TextCollaborationRepresentation): RegistryEntry {
+function createEntry(
+  key: string,
+  path: string,
+  representation: TextCollaborationRepresentation,
+  initialSession?: CollaborationSessionResponse | null,
+): RegistryEntry {
   const entry: RegistryEntry = {
     key,
     refs: 0,
@@ -82,7 +106,10 @@ function createEntry(key: string, path: string, representation: TextCollaboratio
       ]);
       if (entry.refs === 0 && !registry.has(key)) return;
       entry.doc = new Y.Doc({ gc: true });
-      let session = await requestSession(path, representation);
+      let session = requireTextSession(
+        initialSession || await requestSession(path, representation),
+        representation,
+      );
       entry.session = session;
       const persistence = new IndexeddbPersistence(
         `canvas:${session.documentId}:${session.lifecycleGeneration}:${representation}`,
@@ -96,7 +123,14 @@ function createEntry(key: string, path: string, representation: TextCollaboratio
         document: entry.doc,
         token: async () => {
           if (Date.parse(session.expiresAt) - Date.now() < 30_000) {
-            session = await requestSession(path, representation);
+            const refreshed = requireTextSession(await requestSession(path, 'auto'), representation);
+            if (
+              refreshed.documentId !== session.documentId
+              || refreshed.lifecycleGeneration !== session.lifecycleGeneration
+            ) {
+              throw new Error('The collaboration document generation changed. Reload to use the current document state.');
+            }
+            session = refreshed;
             entry.session = session;
           }
           return session.token;
@@ -184,9 +218,12 @@ export function useCollaborationDocument(input: {
   workspaceId: string | null;
   path: string | undefined;
   representation: TextCollaborationRepresentation;
+  session?: CollaborationSessionResponse | null;
 }): CollaborationDocument | null {
   const key = input.enabled && input.workspaceId && input.path
-    ? `${input.workspaceId}\0${input.path}\0${input.representation}`
+    ? input.session
+      ? `${input.workspaceId}\0${input.path}\0${input.session.documentId}\0${input.session.lifecycleGeneration}\0${input.representation}`
+      : `${input.workspaceId}\0${input.path}\0${input.representation}`
     : null;
   const [state, setState] = useState<CollaborationDocument | null>(null);
   useEffect(() => {
@@ -195,7 +232,7 @@ export function useCollaborationDocument(input: {
     }
     let entry = registry.get(key);
     if (!entry) {
-      entry = createEntry(key, input.path, input.representation);
+      entry = createEntry(key, input.path, input.representation, input.session);
       registry.set(key, entry);
     }
     if (entry.cleanupTimer) clearTimeout(entry.cleanupTimer);
@@ -216,6 +253,68 @@ export function useCollaborationDocument(input: {
         }, 1_000);
       }
     };
-  }, [input.path, input.representation, key]);
+  }, [input.path, input.representation, input.session, key]);
   return key && state?.registryKey === key ? state : null;
+}
+
+export type TextCollaborationSessionResolution = {
+  session: CollaborationSessionResponse | null;
+  loading: boolean;
+  error: string | null;
+  retry: () => void;
+};
+
+/**
+ * Resolves the durable Yjs representation before an editor selects its root
+ * type. This is intentionally separate from the WebSocket registry so the
+ * UI can choose CodeMirror or Tiptap without making an unsafe first guess.
+ */
+export function useTextCollaborationSession(input: {
+  enabled: boolean;
+  workspaceId: string | null;
+  path: string | undefined;
+}): TextCollaborationSessionResolution {
+  const key = input.enabled && input.workspaceId && input.path
+    ? `${input.workspaceId}\0${input.path}`
+    : null;
+  const [attempt, setAttempt] = useState(0);
+  const [state, setState] = useState<{
+    key: string | null;
+    session: CollaborationSessionResponse | null;
+    error: string | null;
+  }>({ key: null, session: null, error: null });
+
+  useEffect(() => {
+    if (!key || !input.path) {
+      setState({ key: null, session: null, error: null });
+      return;
+    }
+    let cancelled = false;
+    setState({ key, session: null, error: null });
+    void requestSession(input.path, 'auto')
+      .then((session) => requireTextSession(session))
+      .then((session) => {
+        if (!cancelled) setState({ key, session, error: null });
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setState({
+            key,
+            session: null,
+            error: error instanceof Error ? error.message : 'Collaboration could not be started.',
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [input.path, key, attempt]);
+
+  const current = state.key === key ? state : { session: null, error: null };
+  return {
+    session: current.session,
+    loading: Boolean(key) && !current.session && !current.error,
+    error: current.error,
+    retry: () => setAttempt((currentAttempt) => currentAttempt + 1),
+  };
 }

--- a/app/lib/collaboration/session-service.ts
+++ b/app/lib/collaboration/session-service.ts
@@ -3,7 +3,6 @@ import 'server-only';
 import { readFile, type WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 import { getFileCollaborationState } from '@/app/lib/files/collaboration-policy';
 import { importPortableExcalidrawAssets } from '@/app/lib/excalidraw-collaboration/assets';
-import { analyzeMarkdownRichMode } from '@/app/lib/markdown/rich-markdown-codec';
 import {
   ensureExcalidrawScene,
   loadExcalidrawScene,
@@ -12,16 +11,19 @@ import type { WorkspaceContext } from '@/app/lib/workspaces/types';
 import {
   CollaborationDocumentStateError,
   resolveTextCollaborationState,
+  selectInitialTextCollaborationRepresentation,
 } from './document-state-service';
+import { loadCollaborationStateIncludingArchived } from './persistence';
 import type {
   CollaborationPermission,
   CollaborationProvider,
   CollaborationRepresentation,
+  TextCollaborationRepresentation,
 } from './types';
 
 export class CollaborationSessionError extends Error {
   readonly status: 400 | 404 | 409 | 413;
-  readonly code?: 'source_representation_required';
+  readonly code?: 'source_representation_required' | 'representation_mismatch';
 
   constructor(
     message: string,
@@ -37,11 +39,18 @@ export class CollaborationSessionError extends Error {
 
 export type CollaborationSessionRequest = {
   path: string;
-  representation: CollaborationRepresentation;
-  provider: CollaborationProvider;
+  representation: 'excalidraw_scene';
+  provider: 'excalidraw';
+} | {
+  path: string;
+  representation: TextCollaborationRepresentation | 'auto';
+  provider: 'yjs';
 };
 
-export type CollaborationSessionGrant = CollaborationSessionRequest & {
+export type CollaborationSessionGrant = {
+  path: string;
+  provider: CollaborationProvider;
+  representation: CollaborationRepresentation;
   documentId: string;
   documentName: string;
   lifecycleGeneration: number;
@@ -68,12 +77,16 @@ export function parseCollaborationSessionRequest(input: {
       : null;
   }
   if (input.provider !== undefined && input.provider !== 'yjs') return null;
-  if (ext === 'txt' && input.representation === 'plain_text') {
-    return { path, representation: 'plain_text', provider: 'yjs' };
+  if (ext === 'txt' && (input.representation === 'plain_text' || input.representation === 'auto')) {
+    return { path, representation: input.representation, provider: 'yjs' };
   }
   if (
     (ext === 'md' || ext === 'markdown')
-    && (input.representation === 'plain_text' || input.representation === 'tiptap_xml')
+    && (
+      input.representation === 'auto'
+      || input.representation === 'plain_text'
+      || input.representation === 'tiptap_xml'
+    )
   ) {
     return { path, representation: input.representation, provider: 'yjs' };
   }
@@ -132,23 +145,31 @@ export async function createCollaborationSessionGrant(input: {
     lifecycleGeneration = state.lifecycleGeneration;
   } else {
     const initialContent = (await readFile(request.path, fileOptions)).toString('utf8');
-    if (request.representation === 'tiptap_xml' && analyzeMarkdownRichMode(initialContent).mode === 'source') {
+    const selectedInitialRepresentation = selectInitialTextCollaborationRepresentation(request.path, initialContent);
+    const existingState = await loadCollaborationStateIncludingArchived(collaboration.document.id);
+    if (
+      !existingState
+      && request.representation === 'tiptap_xml'
+      && selectedInitialRepresentation !== 'tiptap_xml'
+    ) {
       throw new CollaborationSessionError(
         'This Markdown document can only collaborate in source mode so its representation is preserved.',
         409,
         'source_representation_required',
       );
     }
-    let state;
+    const initialRepresentation: TextCollaborationRepresentation = request.representation === 'auto'
+      ? selectedInitialRepresentation
+      : request.representation;
+    let resolved;
     try {
-      ({ state } = await resolveTextCollaborationState({
+      resolved = await resolveTextCollaborationState({
         document: collaboration.document,
         workspace,
         path: collaboration.document.path,
-        initialRepresentation: request.representation as 'plain_text' | 'tiptap_xml',
+        initialRepresentation,
         initialContent,
-        requireRepresentationMatch: true,
-      }));
+      });
     } catch (error) {
       if (error instanceof CollaborationDocumentStateError) {
         throw new CollaborationSessionError(
@@ -158,7 +179,27 @@ export async function createCollaborationSessionGrant(input: {
       }
       throw error;
     }
+    const { state } = resolved;
+    // Existing documents own their Yjs representation. A checkpoint can be
+    // source-only according to the conservative UI codec after a live agent
+    // edit while its validated Y.Doc remains rich text.
+    if (!resolved.initialized && request.representation !== 'auto' && state.representation !== request.representation) {
+      throw new CollaborationSessionError(
+        'The collaboration representation does not match this editor. Reload to use the current document representation.',
+        409,
+        'representation_mismatch',
+      );
+    }
     lifecycleGeneration = state.lifecycleGeneration;
+    return {
+      path: request.path,
+      provider: request.provider,
+      representation: state.representation,
+      documentId: collaboration.document.id,
+      documentName: collaboration.document.id,
+      lifecycleGeneration,
+      permission: workspace.permissions.canWrite ? 'write' : 'read',
+    };
   }
 
   return {

--- a/app/lib/collaboration/types.ts
+++ b/app/lib/collaboration/types.ts
@@ -5,6 +5,13 @@ export const COLLABORATION_TICKET_TTL_MS = 90_000;
 export type CollaborationProvider = 'yjs' | 'excalidraw';
 export type TextCollaborationRepresentation = 'plain_text' | 'tiptap_xml';
 export type CollaborationRepresentation = TextCollaborationRepresentation | 'excalidraw_scene';
+/**
+ * `auto` is accepted only while establishing a text-collaboration session.
+ * The server resolves it to the durable representation before issuing a
+ * ticket, so a client never guesses the Yjs top-level type from a file
+ * checkpoint.
+ */
+export type CollaborationSessionRepresentation = CollaborationRepresentation | 'auto';
 export type CollaborationPermission = 'read' | 'write';
 export type CollaborationActorType = 'user' | 'agent';
 export type CollaborationActivity = 'viewing' | 'editing' | 'agent_editing';

--- a/scripts/file-agent-operation-integration-test.ts
+++ b/scripts/file-agent-operation-integration-test.ts
@@ -43,6 +43,10 @@ import {
 } from '../app/lib/collaboration/persistence';
 import { createRichMarkdownYDoc, richMarkdownFromYDoc } from '../app/lib/collaboration/markdown-state';
 import { removeDocumentPresenceEntry, upsertDocumentPresenceEntry } from '../app/lib/collaboration/presence';
+import {
+  CollaborationSessionError,
+  createCollaborationSessionGrant,
+} from '../app/lib/collaboration/session-service';
 import { openDb } from '../app/lib/db';
 import {
   ensureFileRevisionForCurrentContent,
@@ -68,6 +72,7 @@ const workspaceId = `agent-operation-workspace-${suffix}`;
 const userId = `agent-operation-user-${suffix}`;
 let toolDocumentId: string | null = null;
 let uninitializedToolDocumentId: string | null = null;
+let representationRoutingDocumentId: string | null = null;
 const workspace: WorkspaceContext = {
   workspaceId,
   workspaceType: 'organization',
@@ -935,6 +940,62 @@ try {
   assert.equal(initializedEditDetails.collaboration?.durability, 'checkpointed_file');
   assert.equal(await persistedText(uninitializedToolDocumentId), '# Existing note\n\nParagraph updated by agent');
 
+  // The durable Yjs representation must win over a source-only checkpoint.
+  // This is the regression path for a document that an agent has changed
+  // before a browser opens it again.
+  const representationRoutingPath = `agent-representation-routing-${suffix}.md`;
+  const routingRichInitialContent = '# Strategy update\n\nInitial paragraph\n';
+  const sourceOnlyCheckpoint = '# Strategy update\n\nInitial paragraph\n\n%% agent-generated note %%\n';
+  await fs.writeFile(path.join(workspace.rootPath, representationRoutingPath), routingRichInitialContent, 'utf8');
+  ensureFileRevisionForCurrentContent({
+    workspace,
+    path: representationRoutingPath,
+    contentHash: createHash('sha256').update(routingRichInitialContent, 'utf8').digest('hex'),
+    sizeBytes: Buffer.byteLength(routingRichInitialContent, 'utf8'),
+    actorUserId: userId,
+    actorType: 'user',
+  });
+  const representationRoutingProjection = getFileCollaborationState({
+    workspace,
+    path: representationRoutingPath,
+    ensureDocument: true,
+  });
+  assert(representationRoutingProjection.document);
+  representationRoutingDocumentId = representationRoutingProjection.document.id;
+  await ensureCollaborationState({
+    documentId: representationRoutingDocumentId,
+    workspaceId,
+    organizationId: workspace.organizationId || null,
+    path: representationRoutingPath,
+    representation: 'tiptap_xml',
+    initialContent: routingRichInitialContent,
+  });
+  const sourceOnlyDoc = createRichMarkdownYDoc(sourceOnlyCheckpoint);
+  await persistCollaborationYDoc(representationRoutingDocumentId, sourceOnlyDoc);
+  sourceOnlyDoc.destroy();
+  await fs.writeFile(path.join(workspace.rootPath, representationRoutingPath), sourceOnlyCheckpoint, 'utf8');
+
+  const resolvedGrant = await createCollaborationSessionGrant({
+    workspace,
+    fileOptions: { workspace },
+    request: { path: representationRoutingPath, provider: 'yjs', representation: 'auto' },
+  });
+  assert.equal(resolvedGrant.representation, 'tiptap_xml');
+  const explicitRichGrant = await createCollaborationSessionGrant({
+    workspace,
+    fileOptions: { workspace },
+    request: { path: representationRoutingPath, provider: 'yjs', representation: 'tiptap_xml' },
+  });
+  assert.equal(explicitRichGrant.representation, 'tiptap_xml');
+  await assert.rejects(
+    () => createCollaborationSessionGrant({
+      workspace,
+      fileOptions: { workspace },
+      request: { path: representationRoutingPath, provider: 'yjs', representation: 'plain_text' },
+    }),
+    (error: unknown) => error instanceof CollaborationSessionError && error.code === 'representation_mismatch',
+  );
+
   // Cross-node Markdown edits are persisted as real review operations. Accept
   // reapplies the exact patch to the then-current Yjs document, preserving an
   // unrelated human edit outside the reviewed target.
@@ -1264,6 +1325,7 @@ try {
       archivedDocumentId,
       ...(toolDocumentId ? [toolDocumentId] : []),
       ...(uninitializedToolDocumentId ? [uninitializedToolDocumentId] : []),
+      ...(representationRoutingDocumentId ? [representationRoutingDocumentId] : []),
     ]) {
       await database.run('DELETE FROM collaboration_agent_operations WHERE document_id = ?', [cleanupDocumentId]);
       await database.run('DELETE FROM collaboration_yjs_state_backups WHERE document_id = ?', [cleanupDocumentId]);

--- a/scripts/mobile-collaboration-ticket-test.ts
+++ b/scripts/mobile-collaboration-ticket-test.ts
@@ -78,6 +78,24 @@ assert.deepEqual(parseCollaborationSessionRequest({
   provider: 'yjs',
   representation: 'plain_text',
 });
+assert.deepEqual(parseCollaborationSessionRequest({
+  path: 'Notes/Shared.md',
+  provider: 'yjs',
+  representation: 'auto',
+}), {
+  path: 'Notes/Shared.md',
+  provider: 'yjs',
+  representation: 'auto',
+});
+assert.deepEqual(parseCollaborationSessionRequest({
+  path: 'Notes/Shared.txt',
+  provider: 'yjs',
+  representation: 'auto',
+}), {
+  path: 'Notes/Shared.txt',
+  provider: 'yjs',
+  representation: 'auto',
+});
 assert.equal(parseCollaborationSessionRequest({
   path: 'Notes/Shared.pdf',
   provider: 'yjs',
@@ -91,8 +109,8 @@ const routeSource = readFileSync(
 );
 const serverSource = readFileSync(path.join(root, 'server/collaboration-server.ts'), 'utf8');
 assert.match(routeSource, /issueMobileCollaborationTicket/u);
-assert.match(routeSource, /analyzeMarkdownRichMode/u);
-assert.match(routeSource, /representation,/u);
+assert.match(routeSource, /representation:\s*'auto'/u);
+assert.doesNotMatch(routeSource, /analyzeMarkdownRichMode/u);
 assert.match(routeSource, /error instanceof CollaborationSessionError && error\.code/u);
 assert.match(routeSource, /richTextSchemaVersion: RICH_MARKDOWN_SCHEMA_VERSION/u);
 assert.equal(RICH_MARKDOWN_SCHEMA_VERSION, 3);

--- a/tests/file-live-collaboration.spec.ts
+++ b/tests/file-live-collaboration.spec.ts
@@ -521,6 +521,52 @@ test.describe('Markdown live collaboration', () => {
       await expect.poll(() => collaborativeEditorText(editor)).not.toContain('Combined paragraph');
       await expect(reviewRegion.getByRole('button', { name: /Reject|Ablehnen/i }))
         .toHaveCount(0, { timeout: 20_000 });
+
+      // A rich Y.Doc can validly retain Markdown that the conservative source
+      // codec classifies as source-only. This models an agent review that adds
+      // an Obsidian comment after the document already has a rich Yjs identity.
+      const sourceOnlyRead = await runAgentTool({
+        toolName: 'read',
+        toolCallId: `read-source-only-${suffix}`,
+        params: { path: filePath },
+        context: agentContext,
+      });
+      const sourceOnlySha256 = String((sourceOnlyRead.details as { sha256?: string } | undefined)?.sha256 || '');
+      const sourceOnlyPatch = await runAgentTool({
+        toolName: 'apply_patch',
+        toolCallId: `patch-source-only-${suffix}`,
+        params: {
+          files: [{
+            path: filePath,
+            expectedSha256: sourceOnlySha256,
+            edits: [{
+              oldText: 'Keep this paragraph edited by user\n\nFinal paragraph',
+              newText: 'Keep this paragraph edited by user\n\nFinal paragraph\n\n%% agent-generated note %%',
+            }],
+          }],
+        },
+        context: agentContext,
+      });
+      const sourceOnlyDetails = sourceOnlyPatch.details as {
+        results?: Array<{ collaboration?: { operationStatus?: string } }>;
+      };
+      expect(sourceOnlyDetails.results?.[0]?.collaboration?.operationStatus).toBe('needs_review');
+      const sourceOnlyAccept = page.waitForResponse((response) => (
+        response.request().method() === 'POST'
+        && /\/api\/files\/collaboration\/operations\/[^/]+\/accept$/u.test(response.url())
+      ));
+      await reviewRegion.getByRole('button', { name: /Accept|Annehmen/i }).click();
+      expect((await sourceOnlyAccept).ok()).toBeTruthy();
+      await expect.poll(() => collaborativeEditorText(editor), { timeout: 20_000 })
+        .toContain('agent-generated note');
+
+      // Opening a new editor is the regression boundary: it must resolve the
+      // existing rich Yjs representation instead of selecting CodeMirror from
+      // the source-only checkpoint text.
+      await openCollaborativeMarkdown(page, filePath);
+      const reopenedEditor = page.locator('.tiptap-editor-shell .ProseMirror');
+      await expect.poll(() => collaborativeEditorText(reopenedEditor), { timeout: 20_000 })
+        .toContain('agent-generated note');
       expect(browserErrors, 'Agent review UI must not emit browser errors.').toEqual([]);
     } finally {
       await page.close().catch(() => undefined);


### PR DESCRIPTION
## Summary
- resolve Markdown editor representation from the durable Yjs collaboration state via an `auto` session handshake
- keep existing rich Yjs documents on the Tiptap path even when agent edits add source-only Markdown syntax
- reject legacy explicit representation mismatches safely and keep document/generation checks on provider refresh
- cover the regression in collaboration service and multi-client browser tests

## Validation
- `npx tsc --noEmit`
- `npm run lint`
- `npm run test:mobile:notebook`
- `npm run test:editor:rich-blocks`
- `npm run test:collaboration:live`
- `npm run test:collaboration:hardening`
- `npm run test:collaboration:operations` (isolated PostgreSQL)
- production Next build
- `npm run test:e2e:collaboration` (2/2; real two-client/agent scenario)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves Markdown collaboration representation selection to an `auto` session handshake so existing Yjs state remains authoritative.
- Resolves text editor mode from the durable collaboration representation before mounting CodeMirror or Tiptap.
- Preserves document and lifecycle-generation checks when refreshing collaboration tickets.
- Updates browser, mobile-session, and agent-operation regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect remaining after checking browser, service, lifecycle, and mobile-consumer paths.

The session handshake consistently resolves `auto` to a durable representation, validates representation and generation on reuse, and the checked consumers accept the resulting durable response contract.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/collaboration/session-service.ts | Resolves `auto` requests against durable Yjs state, rejects incompatible explicit requests, and returns the authoritative representation. |
| app/lib/collaboration/client.ts | Adds the representation-resolution handshake, validates initial and refreshed sessions, and keys registry entries by document generation. |
| app/components/editor/MarkdownEditor.tsx | Delays editor mounting until session resolution and selects source or rich mode from the authoritative representation. |
| app/api/mobile/v1/notebook/collaboration/session/route.ts | Replaces checkpoint-content representation inference with server-side automatic resolution. |
| tests/file-live-collaboration.spec.ts | Covers reopening a rich collaborative document after an agent adds source-only Markdown syntax. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Editor
  participant SessionAPI
  participant StateService
  participant YjsState
  Editor->>SessionAPI: Request session(path, auto)
  SessionAPI->>StateService: Resolve collaboration state
  StateService->>YjsState: Load durable representation
  YjsState-->>StateService: plain_text or tiptap_xml
  StateService-->>SessionAPI: Grant with resolved representation
  SessionAPI-->>Editor: Session response
  alt plain_text
    Editor->>Editor: Mount CodeMirror
  else tiptap_xml
    Editor->>Editor: Mount Tiptap
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Resolve live editor representation from ..."](https://github.com/canvascoding/canvas-notebook/commit/51c4e2e7e2ed2b80fcfe72335fe593e00f212716) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56311490)</sub>

<!-- /greptile_comment -->