### PR TITLE
Fix streamed MCP dynamic registration requests

### DIFF
--- a/app/lib/mcp/server/oauth-request-policy.ts
+++ b/app/lib/mcp/server/oauth-request-policy.ts
@@ -206,7 +206,13 @@ async function normalizeDynamicClientRegistrationRequest(
   headers.set('content-type', 'application/json');
   headers.delete('content-length');
   return {
-    request: new Request(request, {
+    // Do not use the incoming Request as the constructor input here. In the
+    // production Next.js request pipeline it can carry a one-shot body stream;
+    // deriving from it while replacing the body can throw before Better Auth
+    // receives the normalized registration. All OAuth-relevant request data is
+    // explicitly preserved instead.
+    request: new Request(request.url, {
+      method: request.method,
       headers,
       body: JSON.stringify({
         ...metadata,

--- a/scripts/mcp-server-oauth-provider-test.ts
+++ b/scripts/mcp-server-oauth-provider-test.ts
@@ -162,6 +162,54 @@ async function assertRouteRegistration(
   assert.equal((await readJson(rejectedMethod)).error, 'invalid_client_metadata');
 }
 
+async function assertRegistrationRebuildDoesNotReuseIncomingRequest(
+  prepareRequest: (request: Request) => Promise<{
+    request: Request;
+    response: Response | null;
+  }>,
+  NextRequest: typeof import('next/server').NextRequest,
+): Promise<void> {
+  const incomingRequest = new NextRequest(`${ISSUER}/oauth2/register`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: ORIGIN,
+    },
+    body: JSON.stringify({
+      client_name: 'Stream-backed public client',
+      redirect_uris: [REDIRECT_URI],
+    }),
+  });
+  const nativeRequest = globalThis.Request;
+  const requestDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'Request');
+  assert.ok(requestDescriptor);
+
+  class RequestRejectingRequestInput extends nativeRequest {
+    constructor(input: RequestInfo | URL, init?: RequestInit) {
+      if (input instanceof nativeRequest) {
+        throw new Error('The normalized request must not reuse the incoming Request body stream.');
+      }
+      super(input, init);
+    }
+  }
+
+  Object.defineProperty(globalThis, 'Request', {
+    ...requestDescriptor,
+    value: RequestRejectingRequestInput,
+  });
+  try {
+    const prepared = await prepareRequest(incomingRequest);
+    assert.equal(prepared.response, null);
+    assert.equal(prepared.request.url, incomingRequest.url);
+    assert.equal(prepared.request.method, 'POST');
+    assert.equal(prepared.request.headers.get('origin'), ORIGIN);
+    const metadata = await prepared.request.json() as Record<string, unknown>;
+    assert.equal(metadata.token_endpoint_auth_method, 'none');
+  } finally {
+    Object.defineProperty(globalThis, 'Request', requestDescriptor);
+  }
+}
+
 async function assertMetadata(
   getMetadata: (request: Request) => Promise<Response>,
 ): Promise<void> {
@@ -424,6 +472,10 @@ async function main(): Promise<void> {
     }));
     assert.equal(disabledResponse?.status, 404);
     process.env.CANVAS_MCP_DIRECT_ENABLED = previousFeatureFlag;
+    await assertRegistrationRebuildDoesNotReuseIncomingRequest(
+      prepareDirectMcpOAuthRequest,
+      NextRequest,
+    );
     await assertRouteRegistration(postOAuthRoute, NextRequest);
     const clientId = await assertRegistrationPolicy(
       auth,


### PR DESCRIPTION
## Summary
- rebuild normalized dynamic-registration requests from explicit URL, method, headers, and JSON body
- avoid reusing the incoming one-shot request stream in the Next.js route pipeline
- add a regression test that rejects Request-as-input reconstruction

## Verification
- `npm run test:mcp:server-provider`
- `npm run test:mcp:server-postgres-provider`
- `npm run test:mcp:server-diagnostics`
- `npm run test:mcp:server-oauth-client`
- `npm run lint`
- `npm run build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR rebuilds normalized dynamic-registration requests from explicit request fields to avoid reusing a one-shot Next.js body stream.
- Preserves the registration URL, method, headers, and normalized JSON body.
- Adds a regression test that rejects Request-as-input reconstruction and verifies public-client normalization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changed request construction preserves the URL, POST method, headers, and normalized body required by the registration handler, while the regression test safely restores its temporary global constructor override.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/mcp/server/oauth-request-policy.ts | Reconstructs validated registration requests from explicit fields while preserving the OAuth-relevant request data. |
| scripts/mcp-server-oauth-provider-test.ts | Adds an isolated regression assertion proving normalization does not derive the replacement request from the incoming Request object. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix streamed MCP registration requests"](https://github.com/canvascoding/canvas-notebook/commit/c8c3aa9413cdbba279cbfea654116981155ed88f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57564188)</sub>

<!-- /greptile_comment -->