### PR TITLE
Add Direct MCP workspace access controls

### DIFF
--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -20,6 +20,11 @@ import {
   runWithDirectMcpDiagnostic,
   withDirectMcpRequestId,
 } from '@/app/lib/mcp/server/diagnostics';
+import { pruneUnusedDirectMcpDynamicClients } from '@/app/lib/mcp/server/oauth-client-maintenance';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+const DIRECT_MCP_DYNAMIC_CLIENT_REGISTRATION_RATE_LIMIT = 10;
+const DIRECT_MCP_DYNAMIC_CLIENT_REGISTRATION_RATE_WINDOW_MS = 60_000;
 
 function hasAuthPathSegment(pathname: string, segment: string): boolean {
   return new RegExp(`/${segment}(?:/|$)`).test(pathname);
@@ -125,6 +130,46 @@ function directMcpOAuthUnavailableResponse(): Response {
   );
 }
 
+function directMcpOAuthRegistrationRateLimitedResponse(response: Response): Response {
+  const retryAfter = response.headers.get('retry-after') || '60';
+  return NextResponse.json(
+    {
+      error: 'temporarily_unavailable',
+      error_description: 'Direct MCP client registration is temporarily rate limited. Try again later.',
+    },
+    {
+      status: 429,
+      headers: {
+        'cache-control': 'no-store',
+        pragma: 'no-cache',
+        'retry-after': retryAfter,
+      },
+    },
+  );
+}
+
+function directMcpRegistrationAuditStatus(status: number): 'success' | 'failure' | 'error' | 'blocked' {
+  if (status === 429) return 'blocked';
+  if (status >= 500) return 'error';
+  return status < 400 ? 'success' : 'failure';
+}
+
+async function recordDirectMcpRegistrationAudit(response: Response): Promise<void> {
+  await recordAuditEvent({
+    source: 'direct_mcp',
+    eventType: 'oauth_client_registration',
+    entityType: 'oauth_client',
+    action: 'direct_mcp.dynamic_client_registration',
+    status: directMcpRegistrationAuditStatus(response.status),
+    summary: `Direct MCP OAuth client registration returned HTTP ${response.status}.`,
+    metadata: {
+      endpoint: '/api/auth/oauth2/register',
+      statusCode: response.status,
+      rateLimited: response.status === 429,
+    },
+  });
+}
+
 class DirectMcpOAuthStageError extends Error {
   constructor(readonly code: string) {
     super(code);
@@ -159,6 +204,7 @@ async function handleDirectMcpOAuthRequest(
       ? 'oauth.registration'
       : 'oauth.request',
   );
+  const isRegistration = request.nextUrl.pathname === '/api/auth/oauth2/register';
   try {
     const response = withDirectMcpRequestId(
       await runWithDirectMcpDiagnostic(
@@ -168,23 +214,33 @@ async function handleDirectMcpOAuthRequest(
       diagnostics.requestId,
     );
     if (response.status >= 500) {
+      const unavailableResponse = withDirectMcpRequestId(
+        directMcpOAuthUnavailableResponse(),
+        diagnostics.requestId,
+      );
+      if (isRegistration) await recordDirectMcpRegistrationAudit(unavailableResponse);
       await completeDirectMcpDiagnostic(diagnostics, {
         statusCode: 503,
         code: 'OAUTH_PROVIDER_ERROR',
         startedAt,
       });
-      return withDirectMcpRequestId(
-        directMcpOAuthUnavailableResponse(),
-        diagnostics.requestId,
-      );
+      return unavailableResponse;
     }
+    if (isRegistration) await recordDirectMcpRegistrationAudit(response);
     await completeDirectMcpDiagnostic(diagnostics, {
       statusCode: response.status,
-      code: 'OAUTH_REQUEST_COMPLETED',
+      code: isRegistration && response.status === 429
+        ? 'OAUTH_REGISTRATION_RATE_LIMITED'
+        : 'OAUTH_REQUEST_COMPLETED',
       startedAt,
     });
     return response;
   } catch (error) {
+    const unavailableResponse = withDirectMcpRequestId(
+      directMcpOAuthUnavailableResponse(),
+      diagnostics.requestId,
+    );
+    if (isRegistration) await recordDirectMcpRegistrationAudit(unavailableResponse);
     await failDirectMcpDiagnostic(diagnostics, {
       code: error instanceof DirectMcpOAuthStageError
         ? error.code
@@ -192,10 +248,7 @@ async function handleDirectMcpOAuthRequest(
       startedAt,
       statusCode: 503,
     });
-    return withDirectMcpRequestId(
-      directMcpOAuthUnavailableResponse(),
-      diagnostics.requestId,
-    );
+    return unavailableResponse;
   }
 }
 
@@ -226,6 +279,22 @@ export async function POST(request: NextRequest) {
       () => prepareDirectMcpOAuthRequest(request),
     );
     if (prepared.response) return prepared.response;
+    if (isRegistration) {
+      const limited = rateLimit(request, {
+        limit: DIRECT_MCP_DYNAMIC_CLIENT_REGISTRATION_RATE_LIMIT,
+        windowMs: DIRECT_MCP_DYNAMIC_CLIENT_REGISTRATION_RATE_WINDOW_MS,
+        keyPrefix: 'direct-mcp-oauth-client-registration',
+      });
+      if (!limited.ok) return directMcpOAuthRegistrationRateLimitedResponse(limited.response);
+
+      try {
+        await pruneUnusedDirectMcpDynamicClients();
+      } catch {
+        // Maintenance must never make a legitimate public client registration
+        // fail. The OAuth provider still owns the authoritative registration.
+        console.warn('[direct-mcp] Unable to prune unused OAuth clients.');
+      }
+    }
     const authRequest = prepared.request;
     const revocationCandidate = await runDirectMcpOAuthStage(
       isRegistration

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -168,7 +168,7 @@ async function handleDirectMcpOAuthRequest(
       diagnostics.requestId,
     );
     if (response.status >= 500) {
-      completeDirectMcpDiagnostic(diagnostics, {
+      await completeDirectMcpDiagnostic(diagnostics, {
         statusCode: 503,
         code: 'OAUTH_PROVIDER_ERROR',
         startedAt,
@@ -178,14 +178,14 @@ async function handleDirectMcpOAuthRequest(
         diagnostics.requestId,
       );
     }
-    completeDirectMcpDiagnostic(diagnostics, {
+    await completeDirectMcpDiagnostic(diagnostics, {
       statusCode: response.status,
       code: 'OAUTH_REQUEST_COMPLETED',
       startedAt,
     });
     return response;
   } catch (error) {
-    failDirectMcpDiagnostic(diagnostics, {
+    await failDirectMcpDiagnostic(diagnostics, {
       code: error instanceof DirectMcpOAuthStageError
         ? error.code
         : 'OAUTH_INTERNAL_ERROR',

--- a/app/api/integrations/mcp-server/connections/route.ts
+++ b/app/api/integrations/mcp-server/connections/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
+import { auth } from '@/app/lib/auth';
+import {
+  disconnectDirectMcpConnection,
+  listDirectMcpConnections,
+} from '@/app/lib/mcp/server/connection-management';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'cache-control': 'no-store' };
+
+function unavailableResponse(): NextResponse {
+  return NextResponse.json(
+    { success: false, code: 'MCP_CONNECTIONS_UNAVAILABLE', error: 'MCP connections are temporarily unavailable.' },
+    { status: 503, headers: NO_STORE_HEADERS },
+  );
+}
+
+async function requireUser(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user?.id) {
+    return {
+      ok: false as const,
+      response: NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS },
+      ),
+    };
+  }
+  return { ok: true as const, userId: session.user.id };
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const user = await requireUser(request);
+  if (!user.ok) return user.response;
+
+  const limited = rateLimit(request, {
+    limit: 60,
+    windowMs: 60_000,
+    keyPrefix: 'integrations-mcp-server-connections-list',
+  });
+  if (!limited.ok) return limited.response;
+
+  try {
+    const connections = await listDirectMcpConnections(user.userId);
+    return NextResponse.json({ success: true, data: { connections } }, { headers: NO_STORE_HEADERS });
+  } catch {
+    return unavailableResponse();
+  }
+}
+
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  const user = await requireUser(request);
+  if (!user.ok) return user.response;
+
+  const limited = rateLimit(request, {
+    limit: 20,
+    windowMs: 60_000,
+    keyPrefix: 'integrations-mcp-server-connections-disconnect',
+  });
+  if (!limited.ok) return limited.response;
+
+  let connectionId: string | null = null;
+  try {
+    const payload = await request.json() as { connectionId?: unknown };
+    connectionId = typeof payload.connectionId === 'string' ? payload.connectionId : null;
+  } catch {
+    // A malformed body is not a service outage and can be reported precisely.
+  }
+  if (!connectionId || connectionId.length > 2048) {
+    return NextResponse.json(
+      { success: false, error: 'A valid MCP connection is required.' },
+      { status: 400, headers: NO_STORE_HEADERS },
+    );
+  }
+
+  try {
+    const result = await disconnectDirectMcpConnection(user.userId, connectionId);
+    if (result.status === 'not_found') {
+      return NextResponse.json(
+        { success: false, error: 'MCP connection not found.' },
+        { status: 404, headers: NO_STORE_HEADERS },
+      );
+    }
+
+    await recordAuditEvent({
+      userId: user.userId,
+      source: 'direct_mcp',
+      eventType: 'oauth_grant',
+      entityType: 'mcp_connection',
+      entityId: 'direct',
+      action: 'direct_mcp.connection.disconnect',
+      status: 'success',
+      summary: 'Direct MCP connection disconnected by the signed-in user.',
+      metadata: { origin: 'user_settings' },
+    });
+    return NextResponse.json({ success: true }, { headers: NO_STORE_HEADERS });
+  } catch {
+    return unavailableResponse();
+  }
+}

--- a/app/api/integrations/mcp-server/connections/workspaces/route.ts
+++ b/app/api/integrations/mcp-server/connections/workspaces/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
+import { auth } from '@/app/lib/auth';
+import { resolveOwnedDirectMcpConnectionClientId } from '@/app/lib/mcp/server/connection-management';
+import {
+  listDirectMcpAllowedWorkspaceIds,
+  listDirectMcpSelectableWorkspaces,
+  replaceDirectMcpAllowedWorkspaces,
+} from '@/app/lib/mcp/server/workspace-access-policy';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'cache-control': 'no-store' };
+const MAX_CONNECTION_REFERENCE_LENGTH = 2048;
+const MAX_ALLOWED_WORKSPACES = 200;
+const MAX_WORKSPACE_ID_LENGTH = 200;
+
+function unavailableResponse(): NextResponse {
+  return NextResponse.json(
+    { success: false, code: 'MCP_WORKSPACE_ACCESS_UNAVAILABLE', error: 'MCP workspace access is temporarily unavailable.' },
+    { status: 503, headers: NO_STORE_HEADERS },
+  );
+}
+
+async function requireUser(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user?.id) {
+    return {
+      ok: false as const,
+      response: NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS },
+      ),
+    };
+  }
+  return { ok: true as const, userId: session.user.id };
+}
+
+async function resolveConnection(userId: string, connectionId: string) {
+  if (!connectionId || connectionId.length > MAX_CONNECTION_REFERENCE_LENGTH) return null;
+  return resolveOwnedDirectMcpConnectionClientId(userId, connectionId);
+}
+
+function parseWorkspaceIds(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length > MAX_ALLOWED_WORKSPACES) return null;
+  const workspaceIds = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== 'string') return null;
+    const workspaceId = item.trim();
+    if (!workspaceId || workspaceId.length > MAX_WORKSPACE_ID_LENGTH) return null;
+    workspaceIds.add(workspaceId);
+  }
+  return [...workspaceIds];
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const user = await requireUser(request);
+  if (!user.ok) return user.response;
+
+  const limited = rateLimit(request, {
+    limit: 60,
+    windowMs: 60_000,
+    keyPrefix: 'integrations-mcp-server-workspace-access-list',
+  });
+  if (!limited.ok) return limited.response;
+
+  const connectionId = request.nextUrl.searchParams.get('connection_id') || '';
+  try {
+    const clientId = await resolveConnection(user.userId, connectionId);
+    if (!clientId) {
+      return NextResponse.json(
+        { success: false, error: 'MCP connection not found.' },
+        { status: 404, headers: NO_STORE_HEADERS },
+      );
+    }
+    const [workspaces, allowedWorkspaceIds] = await Promise.all([
+      listDirectMcpSelectableWorkspaces(user.userId),
+      listDirectMcpAllowedWorkspaceIds({ clientId, userId: user.userId }),
+    ]);
+    const currentWorkspaceIds = new Set(workspaces.map((workspace) => workspace.workspaceId));
+    return NextResponse.json({
+      success: true,
+      data: {
+        connectionId,
+        workspaces,
+        allowedWorkspaceIds: [...allowedWorkspaceIds].filter((workspaceId) => currentWorkspaceIds.has(workspaceId)),
+      },
+    }, { headers: NO_STORE_HEADERS });
+  } catch {
+    return unavailableResponse();
+  }
+}
+
+export async function PUT(request: NextRequest): Promise<NextResponse> {
+  const user = await requireUser(request);
+  if (!user.ok) return user.response;
+
+  const limited = rateLimit(request, {
+    limit: 20,
+    windowMs: 60_000,
+    keyPrefix: 'integrations-mcp-server-workspace-access-update',
+  });
+  if (!limited.ok) return limited.response;
+
+  let connectionId = '';
+  let workspaceIds: string[] | null = null;
+  try {
+    const payload = await request.json() as { connectionId?: unknown; workspaceIds?: unknown };
+    connectionId = typeof payload.connectionId === 'string' ? payload.connectionId : '';
+    workspaceIds = parseWorkspaceIds(payload.workspaceIds);
+  } catch {
+    // A malformed request is a validation error, not a service outage.
+  }
+  if (!connectionId || connectionId.length > MAX_CONNECTION_REFERENCE_LENGTH || !workspaceIds) {
+    return NextResponse.json(
+      { success: false, error: 'A valid MCP connection and workspace selection are required.' },
+      { status: 400, headers: NO_STORE_HEADERS },
+    );
+  }
+
+  try {
+    const clientId = await resolveConnection(user.userId, connectionId);
+    if (!clientId) {
+      return NextResponse.json(
+        { success: false, error: 'MCP connection not found.' },
+        { status: 404, headers: NO_STORE_HEADERS },
+      );
+    }
+    const result = await replaceDirectMcpAllowedWorkspaces({
+      clientId,
+      userId: user.userId,
+      workspaceIds,
+    });
+    if (result.status === 'invalid_workspace') {
+      return NextResponse.json(
+        { success: false, error: 'One or more selected workspaces are no longer available to you.' },
+        { status: 422, headers: NO_STORE_HEADERS },
+      );
+    }
+
+    await recordAuditEvent({
+      userId: user.userId,
+      source: 'direct_mcp',
+      eventType: 'workspace_access',
+      entityType: 'mcp_connection',
+      entityId: 'direct',
+      action: 'direct_mcp.connection.workspace_access.update',
+      status: 'success',
+      summary: 'Direct MCP workspace access updated by the signed-in user.',
+      metadata: { allowedWorkspaceCount: result.allowedWorkspaceCount },
+    });
+    return NextResponse.json({
+      success: true,
+      data: { allowedWorkspaceCount: result.allowedWorkspaceCount },
+    }, { headers: NO_STORE_HEADERS });
+  } catch {
+    return unavailableResponse();
+  }
+}

--- a/app/api/integrations/mcp-server/requests/route.ts
+++ b/app/api/integrations/mcp-server/requests/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { requireInstanceAdmin } from '@/app/lib/admin-auth';
+import {
+  DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES,
+  DIRECT_MCP_REQUEST_HISTORY_RETENTION_HOURS,
+  listRecentDirectMcpRequestHistory,
+} from '@/app/lib/mcp/server/request-history';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const admin = await requireInstanceAdmin(request);
+  if (!admin.ok) return admin.response;
+
+  const limited = rateLimit(request, {
+    limit: 60,
+    windowMs: 60_000,
+    keyPrefix: 'integrations-mcp-server-requests',
+  });
+  if (!limited.ok) return limited.response;
+
+  try {
+    const entries = await listRecentDirectMcpRequestHistory();
+    return NextResponse.json({
+      success: true,
+      data: {
+        retentionHours: DIRECT_MCP_REQUEST_HISTORY_RETENTION_HOURS,
+        maxEntries: DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES,
+        entries: entries.map((entry) => ({
+          requestId: entry.requestId,
+          phase: entry.phase,
+          httpMethod: entry.httpMethod,
+          operation: entry.operation,
+          toolName: entry.toolName,
+          outcome: entry.outcome,
+          statusCode: entry.statusCode,
+          code: entry.code,
+          durationMs: entry.durationMs,
+          createdAt: entry.createdAt.toISOString(),
+        })),
+      },
+    }, {
+      headers: { 'cache-control': 'no-store' },
+    });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Direct MCP request history is unavailable.' },
+      { status: 500, headers: { 'cache-control': 'no-store' } },
+    );
+  }
+}

--- a/app/api/integrations/mcp-server/requests/route.ts
+++ b/app/api/integrations/mcp-server/requests/route.ts
@@ -30,6 +30,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         maxEntries: DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES,
         entries: entries.map((entry) => ({
           requestId: entry.requestId,
+          serverVersion: entry.serverVersion,
           phase: entry.phase,
           httpMethod: entry.httpMethod,
           operation: entry.operation,

--- a/app/api/integrations/mcp-server/workspaces/route.ts
+++ b/app/api/integrations/mcp-server/workspaces/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { recordAuditEvent } from '@/app/lib/audit/audit-service';
+import { auth } from '@/app/lib/auth';
+import {
+  listDirectMcpWorkspaceConfigurations,
+  setDirectMcpWorkspaceEnabled,
+} from '@/app/lib/mcp/server/workspace-access-policy';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'cache-control': 'no-store' };
+const MAX_WORKSPACE_ID_LENGTH = 200;
+
+function unavailableResponse(): NextResponse {
+  return NextResponse.json(
+    { success: false, code: 'MCP_WORKSPACE_SETTINGS_UNAVAILABLE', error: 'MCP workspace settings are temporarily unavailable.' },
+    { status: 503, headers: NO_STORE_HEADERS },
+  );
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { success: false, error: 'Unauthorized' },
+      { status: 401, headers: NO_STORE_HEADERS },
+    );
+  }
+
+  const limited = rateLimit(request, {
+    limit: 60,
+    windowMs: 60_000,
+    keyPrefix: 'integrations-mcp-server-workspace-settings-list',
+  });
+  if (!limited.ok) return limited.response;
+
+  const rawWorkspaceId = request.nextUrl.searchParams.get('workspace_id');
+  const workspaceId = rawWorkspaceId === null ? null : rawWorkspaceId.trim();
+  if (workspaceId !== null && (!workspaceId || workspaceId.length > MAX_WORKSPACE_ID_LENGTH)) {
+    return NextResponse.json(
+      { success: false, error: 'A valid workspace is required.' },
+      { status: 400, headers: NO_STORE_HEADERS },
+    );
+  }
+
+  try {
+    const workspaces = await listDirectMcpWorkspaceConfigurations(session.user.id);
+    if (workspaceId === null) {
+      return NextResponse.json({ success: true, data: { workspaces } }, { headers: NO_STORE_HEADERS });
+    }
+    const workspace = workspaces.find((candidate) => candidate.workspaceId === workspaceId);
+    if (!workspace) {
+      return NextResponse.json(
+        { success: false, error: 'Workspace not found.' },
+        { status: 404, headers: NO_STORE_HEADERS },
+      );
+    }
+    return NextResponse.json({ success: true, data: { workspace } }, { headers: NO_STORE_HEADERS });
+  } catch {
+    return unavailableResponse();
+  }
+}
+
+export async function PUT(request: NextRequest): Promise<NextResponse> {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { success: false, error: 'Unauthorized' },
+      { status: 401, headers: NO_STORE_HEADERS },
+    );
+  }
+
+  const limited = rateLimit(request, {
+    limit: 20,
+    windowMs: 60_000,
+    keyPrefix: 'integrations-mcp-server-workspace-settings-update',
+  });
+  if (!limited.ok) return limited.response;
+
+  let workspaceId = '';
+  let enabled: boolean | null = null;
+  try {
+    const payload = await request.json() as { workspaceId?: unknown; enabled?: unknown };
+    workspaceId = typeof payload.workspaceId === 'string' ? payload.workspaceId.trim() : '';
+    enabled = typeof payload.enabled === 'boolean' ? payload.enabled : null;
+  } catch {
+    // A malformed request is a validation error, not a service outage.
+  }
+  if (!workspaceId || workspaceId.length > MAX_WORKSPACE_ID_LENGTH || enabled === null) {
+    return NextResponse.json(
+      { success: false, error: 'A workspace and enabled value are required.' },
+      { status: 400, headers: NO_STORE_HEADERS },
+    );
+  }
+
+  try {
+    const result = await setDirectMcpWorkspaceEnabled({
+      userId: session.user.id,
+      workspaceId,
+      enabled,
+    });
+    if (result.status === 'not_found') {
+      return NextResponse.json(
+        { success: false, error: 'Workspace not found.' },
+        { status: 404, headers: NO_STORE_HEADERS },
+      );
+    }
+    if (result.status === 'forbidden') {
+      return NextResponse.json(
+        { success: false, error: 'You do not have permission to configure MCP access for this workspace.' },
+        { status: 403, headers: NO_STORE_HEADERS },
+      );
+    }
+
+    await recordAuditEvent({
+      workspaceId,
+      userId: session.user.id,
+      source: 'direct_mcp',
+      eventType: 'workspace_access',
+      entityType: 'workspace',
+      entityId: workspaceId,
+      action: 'direct_mcp.workspace_access.update',
+      status: 'success',
+      summary: 'Direct MCP workspace access updated by a workspace manager.',
+      metadata: { enabled: result.enabled },
+    });
+    return NextResponse.json({
+      success: true,
+      data: { enabled: result.enabled },
+    }, { headers: NO_STORE_HEADERS });
+  } catch {
+    return unavailableResponse();
+  }
+}

--- a/app/components/settings/DirectMcpWorkspaceAccessSwitch.tsx
+++ b/app/components/settings/DirectMcpWorkspaceAccessSwitch.tsx
@@ -19,24 +19,31 @@ export function DirectMcpWorkspaceAccessSwitch({
   canManage,
   onUpdated,
 }: DirectMcpWorkspaceAccessSwitchProps) {
+  if (enabled !== undefined) {
+    return (
+      <WorkspaceAccessSwitchControl
+        key={`${workspaceId}:${enabled}:${Boolean(canManage)}`}
+        workspaceId={workspaceId}
+        initialEnabled={enabled}
+        initialManager={Boolean(canManage)}
+        onUpdated={onUpdated}
+      />
+    );
+  }
+
+  return <WorkspaceAccessSwitchLoader workspaceId={workspaceId} onUpdated={onUpdated} />;
+}
+
+function WorkspaceAccessSwitchLoader({
+  workspaceId,
+  onUpdated,
+}: Pick<DirectMcpWorkspaceAccessSwitchProps, 'workspaceId' | 'onUpdated'>) {
   const t = useTranslations('settings.workspacePanel.management.mcp');
-  const [isEnabled, setIsEnabled] = useState(enabled ?? false);
-  const [isManager, setIsManager] = useState(canManage ?? false);
-  const [isLoading, setIsLoading] = useState(enabled === undefined);
-  const [isSaving, setIsSaving] = useState(false);
+  const [configuration, setConfiguration] = useState<{ enabled: boolean; canManage: boolean } | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (enabled !== undefined) {
-      setIsEnabled(enabled);
-      setIsManager(Boolean(canManage));
-      setIsLoading(false);
-      return;
-    }
-
     let active = true;
-    setIsLoading(true);
-    setError(null);
     void fetch(`/api/integrations/mcp-server/workspaces?${new URLSearchParams({ workspace_id: workspaceId })}`, {
       credentials: 'include',
       cache: 'no-store',
@@ -46,20 +53,61 @@ export function DirectMcpWorkspaceAccessSwitch({
         throw new Error(payload.error || t('errors.load'));
       }
       if (!active) return;
-      setIsEnabled(payload.data.workspace.enabled);
-      setIsManager(payload.data.workspace.canManage === true);
+      setConfiguration({
+        enabled: payload.data.workspace.enabled,
+        canManage: payload.data.workspace.canManage === true,
+      });
     }).catch((loadError: unknown) => {
       if (active) setError(loadError instanceof Error ? loadError.message : t('errors.load'));
-    }).finally(() => {
-      if (active) setIsLoading(false);
     });
     return () => {
       active = false;
     };
-  }, [canManage, enabled, t, workspaceId]);
+  }, [t, workspaceId]);
+
+  if (!configuration) {
+    return (
+      <div className="shrink-0">
+        <div className="flex items-center justify-end gap-2">
+          {error ? null : <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden="true" />}
+          <Switch checked={false} disabled aria-label={t('switchLabel')} />
+        </div>
+        {error ? <p role="alert" className="mt-2 max-w-64 text-right text-xs text-destructive">{error}</p> : null}
+      </div>
+    );
+  }
+
+  return (
+    <WorkspaceAccessSwitchControl
+      key={`${workspaceId}:${configuration.enabled}:${configuration.canManage}`}
+      workspaceId={workspaceId}
+      initialEnabled={configuration.enabled}
+      initialManager={configuration.canManage}
+      onUpdated={onUpdated}
+    />
+  );
+}
+
+type WorkspaceAccessSwitchControlProps = {
+  workspaceId: string;
+  initialEnabled: boolean;
+  initialManager: boolean;
+  onUpdated?: (enabled: boolean) => void | Promise<void>;
+};
+
+function WorkspaceAccessSwitchControl({
+  workspaceId,
+  initialEnabled,
+  initialManager,
+  onUpdated,
+}: WorkspaceAccessSwitchControlProps) {
+  const t = useTranslations('settings.workspacePanel.management.mcp');
+  const [isEnabled, setIsEnabled] = useState(initialEnabled);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const update = async (nextEnabled: boolean) => {
-    if (!isManager || isSaving || isLoading) return;
+    if (!initialManager || isSaving) return;
     setIsSaving(true);
     setError(null);
     try {
@@ -91,11 +139,11 @@ export function DirectMcpWorkspaceAccessSwitch({
   return (
     <div className="shrink-0">
       <div className="flex items-center justify-end gap-2">
-        {isSaving || isLoading ? <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden="true" /> : null}
+        {isSaving ? <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden="true" /> : null}
         <Switch
           checked={isEnabled}
           onCheckedChange={(nextEnabled) => void update(nextEnabled)}
-          disabled={!isManager || isSaving || isLoading}
+          disabled={!initialManager || isSaving}
           aria-label={t('switchLabel')}
         />
       </div>

--- a/app/components/settings/DirectMcpWorkspaceAccessSwitch.tsx
+++ b/app/components/settings/DirectMcpWorkspaceAccessSwitch.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { Switch } from '@/components/ui/switch';
+
+type DirectMcpWorkspaceAccessSwitchProps = {
+  workspaceId: string;
+  enabled?: boolean;
+  canManage?: boolean;
+  onUpdated?: (enabled: boolean) => void | Promise<void>;
+};
+
+export function DirectMcpWorkspaceAccessSwitch({
+  workspaceId,
+  enabled,
+  canManage,
+  onUpdated,
+}: DirectMcpWorkspaceAccessSwitchProps) {
+  const t = useTranslations('settings.workspacePanel.management.mcp');
+  const [isEnabled, setIsEnabled] = useState(enabled ?? false);
+  const [isManager, setIsManager] = useState(canManage ?? false);
+  const [isLoading, setIsLoading] = useState(enabled === undefined);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (enabled !== undefined) {
+      setIsEnabled(enabled);
+      setIsManager(Boolean(canManage));
+      setIsLoading(false);
+      return;
+    }
+
+    let active = true;
+    setIsLoading(true);
+    setError(null);
+    void fetch(`/api/integrations/mcp-server/workspaces?${new URLSearchParams({ workspace_id: workspaceId })}`, {
+      credentials: 'include',
+      cache: 'no-store',
+    }).then(async (response) => {
+      const payload = await response.json();
+      if (!response.ok || !payload.success || typeof payload.data?.workspace?.enabled !== 'boolean') {
+        throw new Error(payload.error || t('errors.load'));
+      }
+      if (!active) return;
+      setIsEnabled(payload.data.workspace.enabled);
+      setIsManager(payload.data.workspace.canManage === true);
+    }).catch((loadError: unknown) => {
+      if (active) setError(loadError instanceof Error ? loadError.message : t('errors.load'));
+    }).finally(() => {
+      if (active) setIsLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, [canManage, enabled, t, workspaceId]);
+
+  const update = async (nextEnabled: boolean) => {
+    if (!isManager || isSaving || isLoading) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/integrations/mcp-server/workspaces', {
+        method: 'PUT',
+        credentials: 'include',
+        cache: 'no-store',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ workspaceId, enabled: nextEnabled }),
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success || typeof payload.data?.enabled !== 'boolean') {
+        throw new Error(payload.error || t('errors.update'));
+      }
+      setIsEnabled(payload.data.enabled);
+      try {
+        await onUpdated?.(payload.data.enabled);
+      } catch {
+        // The server update succeeded. Keep the local switch state even if a
+        // background refresh of surrounding UI state cannot complete.
+      }
+    } catch (updateError) {
+      setError(updateError instanceof Error ? updateError.message : t('errors.update'));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="shrink-0">
+      <div className="flex items-center justify-end gap-2">
+        {isSaving || isLoading ? <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden="true" /> : null}
+        <Switch
+          checked={isEnabled}
+          onCheckedChange={(nextEnabled) => void update(nextEnabled)}
+          disabled={!isManager || isSaving || isLoading}
+          aria-label={t('switchLabel')}
+        />
+      </div>
+      {error ? <p role="alert" className="mt-2 max-w-64 text-right text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/app/components/settings/EditWorkspaceDialog.tsx
+++ b/app/components/settings/EditWorkspaceDialog.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { DirectMcpWorkspaceAccessSwitch } from '@/app/components/settings/DirectMcpWorkspaceAccessSwitch';
 import { WorkspaceMembersEditor } from '@/app/components/settings/WorkspaceMembersEditor';
 import { WorkspaceIconPicker } from '@/app/components/workspaces/WorkspaceIconPicker';
 import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
@@ -163,6 +164,27 @@ function EditWorkspaceDialogContent({
               </div>
 
               <WorkspaceIconPicker value={icon} onChange={setIcon} disabled={isSubmitting} />
+
+              {workspace ? (
+                <section className="rounded-lg border bg-muted/20 p-4" aria-labelledby="workspace-mcp-access-title">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <h3 id="workspace-mcp-access-title" className="text-sm font-semibold">
+                        {t('mcp.title')}
+                      </h3>
+                      <p className="mt-1 text-sm leading-5 text-muted-foreground">
+                        {t('mcp.description')}
+                      </p>
+                    </div>
+                    <DirectMcpWorkspaceAccessSwitch
+                      workspaceId={workspace.id}
+                      canManage={workspace.permissions.canManageWorkspace}
+                      onUpdated={() => onChanged()}
+                    />
+                  </div>
+                  <p className="mt-3 text-xs text-muted-foreground">{t('mcp.immediate')}</p>
+                </section>
+              ) : null}
 
               {error ? (
                 <p className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">

--- a/app/components/settings/McpServerSettingsPanel.tsx
+++ b/app/components/settings/McpServerSettingsPanel.tsx
@@ -275,11 +275,17 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
   }, [applyStatus, t]);
 
   useEffect(() => {
-    void loadConnections();
+    const timer = window.setTimeout(() => {
+      void loadConnections();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [loadConnections]);
 
   useEffect(() => {
-    void loadMcpWorkspaceConfigurations();
+    const timer = window.setTimeout(() => {
+      void loadMcpWorkspaceConfigurations();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [loadMcpWorkspaceConfigurations]);
 
   const disconnectConnection = useCallback(async (connection: DirectMcpConnection) => {

--- a/app/components/settings/McpServerSettingsPanel.tsx
+++ b/app/components/settings/McpServerSettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
   RefreshCw,
   Save,
   Server,
+  ShieldCheck,
   Unplug,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -82,6 +83,20 @@ type DirectMcpConnection = {
   scopes: string[];
   connectedAt: string | null;
   updatedAt: string | null;
+  allowedWorkspaceCount: number;
+};
+
+type DirectMcpWorkspaceOption = {
+  workspaceId: string;
+  name: string;
+  description: string | null;
+  type: string;
+};
+
+type DirectMcpWorkspaceAccess = {
+  connectionId: string;
+  workspaces: DirectMcpWorkspaceOption[];
+  allowedWorkspaceIds: string[];
 };
 
 function enabledTools(status: McpServerStatus): string[] {
@@ -122,6 +137,11 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
   const [isConnectionsLoading, setIsConnectionsLoading] = useState(false);
   const [connectionsError, setConnectionsError] = useState<string | null>(null);
   const [disconnectingConnectionId, setDisconnectingConnectionId] = useState<string | null>(null);
+  const [expandedWorkspaceAccessConnectionId, setExpandedWorkspaceAccessConnectionId] = useState<string | null>(null);
+  const [workspaceAccess, setWorkspaceAccess] = useState<DirectMcpWorkspaceAccess | null>(null);
+  const [isWorkspaceAccessLoading, setIsWorkspaceAccessLoading] = useState(false);
+  const [workspaceAccessError, setWorkspaceAccessError] = useState<string | null>(null);
+  const [isWorkspaceAccessSaving, setIsWorkspaceAccessSaving] = useState(false);
 
   const applyStatus = useCallback((nextStatus: McpServerStatus) => {
     setStatus(nextStatus);
@@ -251,6 +271,91 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
       setDisconnectingConnectionId(null);
     }
   }, [disconnectingConnectionId, t]);
+
+  const loadWorkspaceAccess = useCallback(async (connection: DirectMcpConnection) => {
+    setIsWorkspaceAccessLoading(true);
+    setWorkspaceAccessError(null);
+    try {
+      const query = new URLSearchParams({ connection_id: connection.connectionId });
+      const response = await fetch(`/api/integrations/mcp-server/connections/workspaces?${query}`, {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success || payload.data?.connectionId !== connection.connectionId) {
+        throw new Error(payload.error || t('connections.workspaceAccess.errors.load'));
+      }
+      setWorkspaceAccess({
+        connectionId: connection.connectionId,
+        workspaces: Array.isArray(payload.data?.workspaces) ? payload.data.workspaces : [],
+        allowedWorkspaceIds: Array.isArray(payload.data?.allowedWorkspaceIds)
+          ? payload.data.allowedWorkspaceIds.filter((workspaceId: unknown): workspaceId is string => typeof workspaceId === 'string')
+          : [],
+      });
+    } catch (loadError) {
+      setWorkspaceAccessError(loadError instanceof Error
+        ? loadError.message
+        : t('connections.workspaceAccess.errors.load'));
+    } finally {
+      setIsWorkspaceAccessLoading(false);
+    }
+  }, [t]);
+
+  const toggleWorkspaceAccess = useCallback((connection: DirectMcpConnection) => {
+    setExpandedWorkspaceAccessConnectionId((current) => {
+      const next = current === connection.connectionId ? null : connection.connectionId;
+      if (next) void loadWorkspaceAccess(connection);
+      return next;
+    });
+  }, [loadWorkspaceAccess]);
+
+  const setWorkspaceAllowed = useCallback((workspaceId: string, allowed: boolean) => {
+    setWorkspaceAccess((current) => {
+      if (!current) return current;
+      const selected = new Set(current.allowedWorkspaceIds);
+      if (allowed) selected.add(workspaceId);
+      else selected.delete(workspaceId);
+      return { ...current, allowedWorkspaceIds: [...selected].sort() };
+    });
+  }, []);
+
+  const saveWorkspaceAccess = useCallback(async () => {
+    if (!workspaceAccess || isWorkspaceAccessSaving) return;
+    setIsWorkspaceAccessSaving(true);
+    setWorkspaceAccessError(null);
+    setSuccess(null);
+    try {
+      const response = await fetch('/api/integrations/mcp-server/connections/workspaces', {
+        method: 'PUT',
+        credentials: 'include',
+        cache: 'no-store',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          connectionId: workspaceAccess.connectionId,
+          workspaceIds: workspaceAccess.allowedWorkspaceIds,
+        }),
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || t('connections.workspaceAccess.errors.save'));
+      }
+      const allowedWorkspaceCount = typeof payload.data?.allowedWorkspaceCount === 'number'
+        ? payload.data.allowedWorkspaceCount
+        : workspaceAccess.allowedWorkspaceIds.length;
+      setConnections((current) => current?.map((connection) => (
+        connection.connectionId === workspaceAccess.connectionId
+          ? { ...connection, allowedWorkspaceCount }
+          : connection
+      )) ?? []);
+      setSuccess(t('connections.workspaceAccess.saved'));
+    } catch (saveError) {
+      setWorkspaceAccessError(saveError instanceof Error
+        ? saveError.message
+        : t('connections.workspaceAccess.errors.save'));
+    } finally {
+      setIsWorkspaceAccessSaving(false);
+    }
+  }, [isWorkspaceAccessSaving, t, workspaceAccess]);
 
   const savedDraft: DraftSettings | null = status ? ({
     enabled: status.desiredEnabled,
@@ -471,34 +576,137 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
             <div className="divide-y overflow-hidden rounded-lg border">
               {connections.map((connection) => {
                 const authorizedAt = connection.updatedAt || connection.connectedAt;
+                const isWorkspaceAccessExpanded = expandedWorkspaceAccessConnectionId === connection.connectionId;
+                const accessForConnection = workspaceAccess?.connectionId === connection.connectionId
+                  ? workspaceAccess
+                  : null;
+                const selectedWorkspaceIds = new Set(accessForConnection?.allowedWorkspaceIds ?? []);
                 return (
-                  <div key={connection.connectionId} className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="min-w-0">
-                      <p className="font-medium">{connection.clientName}</p>
-                      <div className="mt-2 flex flex-wrap gap-1.5">
-                        {connection.scopes.map((scope) => (
-                          <Badge key={scope} variant="outline" className="font-mono font-normal">{scope}</Badge>
-                        ))}
-                      </div>
-                      {authorizedAt ? (
+                  <div key={connection.connectionId}>
+                    <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0">
+                        <p className="font-medium">{connection.clientName}</p>
+                        <div className="mt-2 flex flex-wrap gap-1.5">
+                          {connection.scopes.map((scope) => (
+                            <Badge key={scope} variant="outline" className="font-mono font-normal">{scope}</Badge>
+                          ))}
+                        </div>
                         <p className="mt-2 text-xs text-muted-foreground">
-                          {t('connections.authorizedAt', { time: formatRequestTime(authorizedAt) })}
+                          {t('connections.workspaceAccess.selectedCount', { count: connection.allowedWorkspaceCount })}
                         </p>
-                      ) : null}
+                        {authorizedAt ? (
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {t('connections.authorizedAt', { time: formatRequestTime(authorizedAt) })}
+                          </p>
+                        ) : null}
+                      </div>
+                      <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+                        <Button
+                          type="button"
+                          variant={isWorkspaceAccessExpanded ? 'secondary' : 'outline'}
+                          size="sm"
+                          disabled={disconnectingConnectionId !== null || isWorkspaceAccessLoading || isWorkspaceAccessSaving}
+                          onClick={() => toggleWorkspaceAccess(connection)}
+                        >
+                          {isWorkspaceAccessLoading && isWorkspaceAccessExpanded
+                            ? <Loader2 className="animate-spin" />
+                            : <ShieldCheck />}
+                          {t('connections.workspaceAccess.manage')}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="text-destructive hover:text-destructive"
+                          disabled={disconnectingConnectionId !== null || isWorkspaceAccessLoading || isWorkspaceAccessSaving}
+                          onClick={() => void disconnectConnection(connection)}
+                        >
+                          {disconnectingConnectionId === connection.connectionId
+                            ? <Loader2 className="animate-spin" />
+                            : <Unplug />}
+                          {t('connections.disconnect')}
+                        </Button>
+                      </div>
                     </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="self-start text-destructive hover:text-destructive"
-                      disabled={disconnectingConnectionId !== null}
-                      onClick={() => void disconnectConnection(connection)}
-                    >
-                      {disconnectingConnectionId === connection.connectionId
-                        ? <Loader2 className="animate-spin" />
-                        : <Unplug />}
-                      {t('connections.disconnect')}
-                    </Button>
+                    {isWorkspaceAccessExpanded ? (
+                      <div className="border-t bg-muted/20 p-4">
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div>
+                            <p className="font-medium">{t('connections.workspaceAccess.title')}</p>
+                            <p className="mt-1 max-w-2xl text-sm leading-5 text-muted-foreground">
+                              {t('connections.workspaceAccess.description')}
+                            </p>
+                          </div>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => void loadWorkspaceAccess(connection)}
+                            disabled={isWorkspaceAccessLoading || isWorkspaceAccessSaving}
+                          >
+                            {isWorkspaceAccessLoading ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+                            {t('connections.workspaceAccess.refresh')}
+                          </Button>
+                        </div>
+
+                        {isWorkspaceAccessLoading && !accessForConnection ? (
+                          <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            {t('connections.workspaceAccess.loading')}
+                          </div>
+                        ) : workspaceAccessError ? (
+                          <p role="alert" className="mt-3 text-sm text-destructive">{workspaceAccessError}</p>
+                        ) : accessForConnection?.workspaces.length ? (
+                          <>
+                            <div className="mt-4 max-h-72 divide-y overflow-y-auto rounded-md border bg-background">
+                              {accessForConnection.workspaces.map((workspace) => {
+                                const checkboxId = `mcp-workspace-${connection.connectionId}-${workspace.workspaceId}`;
+                                return (
+                                  <label key={workspace.workspaceId} htmlFor={checkboxId} className="flex cursor-pointer items-start gap-3 p-3 hover:bg-muted/40">
+                                    <input
+                                      id={checkboxId}
+                                      type="checkbox"
+                                      className="mt-0.5 h-4 w-4 rounded border-input accent-primary"
+                                      checked={selectedWorkspaceIds.has(workspace.workspaceId)}
+                                      disabled={isWorkspaceAccessSaving}
+                                      onChange={(event) => setWorkspaceAllowed(workspace.workspaceId, event.target.checked)}
+                                    />
+                                    <span className="min-w-0 flex-1">
+                                      <span className="block truncate text-sm font-medium">{workspace.name}</span>
+                                      <span className="mt-0.5 block text-xs text-muted-foreground">
+                                        {workspace.description || t('connections.workspaceAccess.type', { type: workspace.type })}
+                                      </span>
+                                    </span>
+                                  </label>
+                                );
+                              })}
+                            </div>
+                            {selectedWorkspaceIds.size === 0 ? (
+                              <p className="mt-3 rounded-md border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm text-foreground">
+                                {t('connections.workspaceAccess.noneSelected')}
+                              </p>
+                            ) : null}
+                            <div className="mt-4 flex justify-end">
+                              <Button
+                                type="button"
+                                size="sm"
+                                onClick={() => void saveWorkspaceAccess()}
+                                disabled={isWorkspaceAccessSaving}
+                              >
+                                {isWorkspaceAccessSaving ? <Loader2 className="animate-spin" /> : <Save />}
+                                {isWorkspaceAccessSaving
+                                  ? t('connections.workspaceAccess.saving')
+                                  : t('connections.workspaceAccess.save')}
+                              </Button>
+                            </div>
+                          </>
+                        ) : accessForConnection ? (
+                          <p className="mt-3 rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+                            {t('connections.workspaceAccess.noWorkspaces')}
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </div>
                 );
               })}

--- a/app/components/settings/McpServerSettingsPanel.tsx
+++ b/app/components/settings/McpServerSettingsPanel.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
+import { DirectMcpWorkspaceAccessSwitch } from '@/app/components/settings/DirectMcpWorkspaceAccessSwitch';
 
 type McpCapabilityStatus = {
   id: string;
@@ -99,6 +100,15 @@ type DirectMcpWorkspaceAccess = {
   allowedWorkspaceIds: string[];
 };
 
+type DirectMcpWorkspaceConfiguration = {
+  workspaceId: string;
+  name: string;
+  description: string | null;
+  type: string;
+  enabled: boolean;
+  canManage: boolean;
+};
+
 function enabledTools(status: McpServerStatus): string[] {
   return status.capabilities
     .filter((capability) => capability.available && capability.enabled)
@@ -142,6 +152,9 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
   const [isWorkspaceAccessLoading, setIsWorkspaceAccessLoading] = useState(false);
   const [workspaceAccessError, setWorkspaceAccessError] = useState<string | null>(null);
   const [isWorkspaceAccessSaving, setIsWorkspaceAccessSaving] = useState(false);
+  const [mcpWorkspaceConfigurations, setMcpWorkspaceConfigurations] = useState<DirectMcpWorkspaceConfiguration[] | null>(null);
+  const [isMcpWorkspaceConfigurationsLoading, setIsMcpWorkspaceConfigurationsLoading] = useState(false);
+  const [mcpWorkspaceConfigurationsError, setMcpWorkspaceConfigurationsError] = useState<string | null>(null);
 
   const applyStatus = useCallback((nextStatus: McpServerStatus) => {
     setStatus(nextStatus);
@@ -216,6 +229,30 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
     }
   }, [t]);
 
+  const loadMcpWorkspaceConfigurations = useCallback(async () => {
+    setIsMcpWorkspaceConfigurationsLoading(true);
+    setMcpWorkspaceConfigurationsError(null);
+    try {
+      const response = await fetch('/api/integrations/mcp-server/workspaces', {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || t('workspaceCatalog.errors.load'));
+      }
+      setMcpWorkspaceConfigurations(Array.isArray(payload.data?.workspaces)
+        ? payload.data.workspaces as DirectMcpWorkspaceConfiguration[]
+        : []);
+    } catch (loadError) {
+      setMcpWorkspaceConfigurationsError(loadError instanceof Error
+        ? loadError.message
+        : t('workspaceCatalog.errors.load'));
+    } finally {
+      setIsMcpWorkspaceConfigurationsLoading(false);
+    }
+  }, [t]);
+
   useEffect(() => {
     let active = true;
     void fetch('/api/integrations/mcp-server', {
@@ -240,6 +277,10 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
   useEffect(() => {
     void loadConnections();
   }, [loadConnections]);
+
+  useEffect(() => {
+    void loadMcpWorkspaceConfigurations();
+  }, [loadMcpWorkspaceConfigurations]);
 
   const disconnectConnection = useCallback(async (connection: DirectMcpConnection) => {
     if (disconnectingConnectionId || !window.confirm(
@@ -357,6 +398,13 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
     }
   }, [isWorkspaceAccessSaving, t, workspaceAccess]);
 
+  const refreshMcpWorkspaceConfiguration = useCallback(async () => {
+    setWorkspaceAccess(null);
+    setWorkspaceAccessError(null);
+    setExpandedWorkspaceAccessConnectionId(null);
+    await Promise.all([loadMcpWorkspaceConfigurations(), loadConnections()]);
+  }, [loadConnections, loadMcpWorkspaceConfigurations]);
+
   const savedDraft: DraftSettings | null = status ? ({
     enabled: status.desiredEnabled,
     tools: enabledTools(status),
@@ -366,6 +414,8 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
   const enabledCapabilityCount = draft?.tools.length ?? 0;
   const serverIsEnabled = draft?.enabled ?? status?.desiredEnabled ?? false;
   const serverIsActive = Boolean(status?.runtimeEnabled && !status.configurationError);
+  const configuredMcpWorkspaces = mcpWorkspaceConfigurations ?? [];
+  const enabledMcpWorkspaceCount = configuredMcpWorkspaces.filter((workspace) => workspace.enabled).length;
   const connectionConfig = serverIsActive && status?.endpoint
     ? JSON.stringify({
       mcpServers: {
@@ -544,6 +594,59 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
             </div>
           </section>
         ) : null}
+
+        <section aria-labelledby="mcp-server-workspaces-title" className="space-y-3 border-t pt-6">
+          <div>
+            <h3 id="mcp-server-workspaces-title" className="font-semibold">{t('workspaceCatalog.title')}</h3>
+            <p className="mt-1 max-w-3xl text-sm leading-5 text-muted-foreground">
+              {t('workspaceCatalog.description')}
+            </p>
+          </div>
+
+          {serverIsActive && !isMcpWorkspaceConfigurationsLoading && enabledMcpWorkspaceCount === 0 ? (
+            <div className="rounded-lg border border-amber-500/35 bg-amber-500/10 px-4 py-3 text-sm">
+              <p className="font-medium text-foreground">{t('workspaceCatalog.noneEnabled.title')}</p>
+              <p className="mt-1 leading-5 text-muted-foreground">{t('workspaceCatalog.noneEnabled.description')}</p>
+            </div>
+          ) : null}
+
+          {isMcpWorkspaceConfigurationsLoading && !mcpWorkspaceConfigurations ? (
+            <div className="flex items-center gap-2 py-3 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t('workspaceCatalog.loading')}
+            </div>
+          ) : mcpWorkspaceConfigurationsError ? (
+            <p role="alert" className="text-sm text-destructive">{mcpWorkspaceConfigurationsError}</p>
+          ) : configuredMcpWorkspaces.length ? (
+            <div className="divide-y overflow-hidden rounded-lg border">
+              {configuredMcpWorkspaces.map((workspace) => (
+                <div key={workspace.workspaceId} className="flex items-start justify-between gap-4 p-4">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">{workspace.name}</p>
+                    <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                      {workspace.description || t('workspaceCatalog.type', { type: workspace.type })}
+                    </p>
+                    {!workspace.canManage ? (
+                      <p className="mt-2 text-xs text-muted-foreground">{t('workspaceCatalog.notManager')}</p>
+                    ) : null}
+                  </div>
+                  <DirectMcpWorkspaceAccessSwitch
+                    workspaceId={workspace.workspaceId}
+                    enabled={workspace.enabled}
+                    canManage={workspace.canManage}
+                    onUpdated={refreshMcpWorkspaceConfiguration}
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+              {t('workspaceCatalog.empty')}
+            </p>
+          )}
+
+          <p className="text-xs leading-5 text-muted-foreground">{t('workspaceCatalog.connectionHint')}</p>
+        </section>
 
         <section aria-labelledby="mcp-server-connections-title" className="space-y-3 border-t pt-6">
           <div className="flex flex-wrap items-end justify-between gap-2">

--- a/app/components/settings/McpServerSettingsPanel.tsx
+++ b/app/components/settings/McpServerSettingsPanel.tsx
@@ -43,6 +43,7 @@ type McpServerStatus = {
   endpoint: string | null;
   issuer: string | null;
   protocolVersion: string;
+  serverVersion: string;
   transport: 'streamable-http';
   authentication: 'oauth-2.1-pkce';
   configurationError: string | null;
@@ -57,6 +58,7 @@ type DraftSettings = {
 
 type DirectMcpRequestHistoryEntry = {
   requestId: string;
+  serverVersion: string | null;
   phase: string;
   httpMethod: string;
   operation: string | null;
@@ -430,6 +432,11 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
                             <p className="mt-1 break-all font-mono text-xs text-muted-foreground">
                               {t('requestHistory.requestId')}: {entry.requestId}
                             </p>
+                            {entry.serverVersion ? (
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {t('requestHistory.serverVersion')}: {entry.serverVersion}
+                              </p>
+                            ) : null}
                           </div>
                           <div className="text-xs text-muted-foreground sm:text-right">
                             <p>{formatRequestTime(entry.createdAt)}</p>
@@ -541,6 +548,10 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
                   <div>
                     <dt className="text-muted-foreground">{t('developer.protocol')}</dt>
                     <dd className="mt-1 font-mono text-xs">MCP {status?.protocolVersion}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">{t('developer.serverVersion')}</dt>
+                    <dd className="mt-1 font-mono text-xs">{status?.serverVersion}</dd>
                   </div>
                   <div>
                     <dt className="text-muted-foreground">{t('developer.authentication')}</dt>

--- a/app/components/settings/McpServerSettingsPanel.tsx
+++ b/app/components/settings/McpServerSettingsPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   ArrowRight,
   Check,
+  Clock3,
   Copy,
   KeyRound,
   Link2,
@@ -54,6 +55,24 @@ type DraftSettings = {
   tools: string[];
 };
 
+type DirectMcpRequestHistoryEntry = {
+  requestId: string;
+  phase: string;
+  httpMethod: string;
+  operation: string | null;
+  toolName: string | null;
+  outcome: 'succeeded' | 'failed' | 'rejected';
+  statusCode: number | null;
+  code: string;
+  durationMs: number;
+  createdAt: string;
+};
+
+type DirectMcpRequestHistoryState = {
+  retentionHours: number;
+  entries: DirectMcpRequestHistoryEntry[];
+};
+
 function enabledTools(status: McpServerStatus): string[] {
   return status.capabilities
     .filter((capability) => capability.available && capability.enabled)
@@ -67,6 +86,15 @@ function draftsEqual(left: DraftSettings, right: DraftSettings): boolean {
     && left.tools.every((tool, index) => tool === right.tools[index]);
 }
 
+function formatRequestTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'short',
+    timeStyle: 'medium',
+  }).format(date);
+}
+
 export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
   const t = useTranslations('settings.mcpServer');
   const [status, setStatus] = useState<McpServerStatus | null>(null);
@@ -76,6 +104,9 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [copied, setCopied] = useState<'endpoint' | 'config' | null>(null);
+  const [requestHistory, setRequestHistory] = useState<DirectMcpRequestHistoryState | null>(null);
+  const [isRequestHistoryLoading, setIsRequestHistoryLoading] = useState(false);
+  const [requestHistoryError, setRequestHistoryError] = useState<string | null>(null);
 
   const applyStatus = useCallback((nextStatus: McpServerStatus) => {
     setStatus(nextStatus);
@@ -104,6 +135,29 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
       setIsLoading(false);
     }
   }, [applyStatus, t]);
+
+  const loadRequestHistory = useCallback(async () => {
+    setIsRequestHistoryLoading(true);
+    setRequestHistoryError(null);
+    try {
+      const response = await fetch('/api/integrations/mcp-server/requests', {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || t('requestHistory.errors.load'));
+      }
+      setRequestHistory({
+        retentionHours: typeof payload.data?.retentionHours === 'number' ? payload.data.retentionHours : 24,
+        entries: Array.isArray(payload.data?.entries) ? payload.data.entries : [],
+      });
+    } catch (loadError) {
+      setRequestHistoryError(loadError instanceof Error ? loadError.message : t('requestHistory.errors.load'));
+    } finally {
+      setIsRequestHistoryLoading(false);
+    }
+  }, [t]);
 
   useEffect(() => {
     let active = true;
@@ -311,6 +365,87 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
                 {copied === 'endpoint' ? t('copied') : t('copy')}
               </Button>
             </div>
+          </section>
+        ) : null}
+
+        {isAdmin ? (
+          <section aria-labelledby="mcp-server-request-history-title" className="border-t pt-6">
+            <details
+              className="group overflow-hidden rounded-lg border"
+              onToggle={(event) => {
+                if (event.currentTarget.open) void loadRequestHistory();
+              }}
+            >
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 font-medium marker:hidden [&::-webkit-details-marker]:hidden">
+                <span className="flex items-center gap-2">
+                  <Clock3 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                  <span id="mcp-server-request-history-title">{t('requestHistory.title')}</span>
+                </span>
+                <ArrowRight className="h-4 w-4 text-muted-foreground transition-transform group-open:rotate-90" aria-hidden="true" />
+              </summary>
+              <div className="space-y-3 border-t bg-muted/20 p-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <p className="max-w-2xl text-sm leading-5 text-muted-foreground">
+                    {t('requestHistory.description', { hours: requestHistory?.retentionHours ?? 24 })}
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void loadRequestHistory()}
+                    disabled={isRequestHistoryLoading}
+                  >
+                    {isRequestHistoryLoading ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+                    {t('requestHistory.refresh')}
+                  </Button>
+                </div>
+
+                {isRequestHistoryLoading && !requestHistory ? (
+                  <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {t('requestHistory.loading')}
+                  </div>
+                ) : requestHistoryError ? (
+                  <p role="alert" className="text-sm text-destructive">{requestHistoryError}</p>
+                ) : requestHistory?.entries.length ? (
+                  <div className="max-h-[28rem] divide-y overflow-y-auto rounded-md border bg-background">
+                    {requestHistory.entries.map((entry) => {
+                      const requestLabel = entry.toolName
+                        ? `${entry.operation || entry.httpMethod} · ${entry.toolName}`
+                        : entry.operation || entry.httpMethod;
+                      const outcomeVariant = entry.outcome === 'failed'
+                        ? 'destructive' as const
+                        : entry.outcome === 'rejected'
+                          ? 'secondary' as const
+                          : 'default' as const;
+                      return (
+                        <div key={entry.requestId} className="grid gap-2 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="font-medium">{requestLabel}</span>
+                              <Badge variant={outcomeVariant}>{t(`requestHistory.outcomes.${entry.outcome}`)}</Badge>
+                              {entry.statusCode ? <Badge variant="outline">HTTP {entry.statusCode}</Badge> : null}
+                            </div>
+                            <p className="mt-1 break-words font-mono text-xs text-muted-foreground">{entry.code}</p>
+                            <p className="mt-1 break-all font-mono text-xs text-muted-foreground">
+                              {t('requestHistory.requestId')}: {entry.requestId}
+                            </p>
+                          </div>
+                          <div className="text-xs text-muted-foreground sm:text-right">
+                            <p>{formatRequestTime(entry.createdAt)}</p>
+                            <p className="mt-1">{t('requestHistory.duration', { duration: entry.durationMs })}</p>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                    {t('requestHistory.empty', { hours: requestHistory?.retentionHours ?? 24 })}
+                  </p>
+                )}
+              </div>
+            </details>
           </section>
         ) : null}
 

--- a/app/components/settings/McpServerSettingsPanel.tsx
+++ b/app/components/settings/McpServerSettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
   RefreshCw,
   Save,
   Server,
+  Unplug,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
@@ -75,6 +76,14 @@ type DirectMcpRequestHistoryState = {
   entries: DirectMcpRequestHistoryEntry[];
 };
 
+type DirectMcpConnection = {
+  connectionId: string;
+  clientName: string;
+  scopes: string[];
+  connectedAt: string | null;
+  updatedAt: string | null;
+};
+
 function enabledTools(status: McpServerStatus): string[] {
   return status.capabilities
     .filter((capability) => capability.available && capability.enabled)
@@ -109,6 +118,10 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
   const [requestHistory, setRequestHistory] = useState<DirectMcpRequestHistoryState | null>(null);
   const [isRequestHistoryLoading, setIsRequestHistoryLoading] = useState(false);
   const [requestHistoryError, setRequestHistoryError] = useState<string | null>(null);
+  const [connections, setConnections] = useState<DirectMcpConnection[] | null>(null);
+  const [isConnectionsLoading, setIsConnectionsLoading] = useState(false);
+  const [connectionsError, setConnectionsError] = useState<string | null>(null);
+  const [disconnectingConnectionId, setDisconnectingConnectionId] = useState<string | null>(null);
 
   const applyStatus = useCallback((nextStatus: McpServerStatus) => {
     setStatus(nextStatus);
@@ -161,6 +174,28 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
     }
   }, [t]);
 
+  const loadConnections = useCallback(async () => {
+    setIsConnectionsLoading(true);
+    setConnectionsError(null);
+    try {
+      const response = await fetch('/api/integrations/mcp-server/connections', {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || t('connections.errors.load'));
+      }
+      setConnections(Array.isArray(payload.data?.connections)
+        ? payload.data.connections as DirectMcpConnection[]
+        : []);
+    } catch (loadError) {
+      setConnectionsError(loadError instanceof Error ? loadError.message : t('connections.errors.load'));
+    } finally {
+      setIsConnectionsLoading(false);
+    }
+  }, [t]);
+
   useEffect(() => {
     let active = true;
     void fetch('/api/integrations/mcp-server', {
@@ -181,6 +216,41 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
       active = false;
     };
   }, [applyStatus, t]);
+
+  useEffect(() => {
+    void loadConnections();
+  }, [loadConnections]);
+
+  const disconnectConnection = useCallback(async (connection: DirectMcpConnection) => {
+    if (disconnectingConnectionId || !window.confirm(
+      t('connections.disconnectConfirm', { client: connection.clientName }),
+    )) return;
+
+    setDisconnectingConnectionId(connection.connectionId);
+    setConnectionsError(null);
+    setSuccess(null);
+    try {
+      const response = await fetch('/api/integrations/mcp-server/connections', {
+        method: 'DELETE',
+        credentials: 'include',
+        cache: 'no-store',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ connectionId: connection.connectionId }),
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || t('connections.errors.disconnect'));
+      }
+      setConnections((current) => current?.filter((item) => item.connectionId !== connection.connectionId) ?? []);
+      setSuccess(t('connections.disconnected'));
+    } catch (disconnectError) {
+      setConnectionsError(disconnectError instanceof Error
+        ? disconnectError.message
+        : t('connections.errors.disconnect'));
+    } finally {
+      setDisconnectingConnectionId(null);
+    }
+  }, [disconnectingConnectionId, t]);
 
   const savedDraft: DraftSettings | null = status ? ({
     enabled: status.desiredEnabled,
@@ -369,6 +439,76 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
             </div>
           </section>
         ) : null}
+
+        <section aria-labelledby="mcp-server-connections-title" className="space-y-3 border-t pt-6">
+          <div className="flex flex-wrap items-end justify-between gap-2">
+            <div>
+              <h3 id="mcp-server-connections-title" className="font-semibold">{t('connections.title')}</h3>
+              <p className="mt-1 max-w-3xl text-sm leading-5 text-muted-foreground">
+                {t('connections.description')}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void loadConnections()}
+              disabled={isConnectionsLoading}
+            >
+              {isConnectionsLoading ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+              {t('connections.refresh')}
+            </Button>
+          </div>
+
+          {isConnectionsLoading && !connections ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t('connections.loading')}
+            </div>
+          ) : connectionsError ? (
+            <p role="alert" className="text-sm text-destructive">{connectionsError}</p>
+          ) : connections?.length ? (
+            <div className="divide-y overflow-hidden rounded-lg border">
+              {connections.map((connection) => {
+                const authorizedAt = connection.updatedAt || connection.connectedAt;
+                return (
+                  <div key={connection.connectionId} className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <p className="font-medium">{connection.clientName}</p>
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        {connection.scopes.map((scope) => (
+                          <Badge key={scope} variant="outline" className="font-mono font-normal">{scope}</Badge>
+                        ))}
+                      </div>
+                      {authorizedAt ? (
+                        <p className="mt-2 text-xs text-muted-foreground">
+                          {t('connections.authorizedAt', { time: formatRequestTime(authorizedAt) })}
+                        </p>
+                      ) : null}
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="self-start text-destructive hover:text-destructive"
+                      disabled={disconnectingConnectionId !== null}
+                      onClick={() => void disconnectConnection(connection)}
+                    >
+                      {disconnectingConnectionId === connection.connectionId
+                        ? <Loader2 className="animate-spin" />
+                        : <Unplug />}
+                      {t('connections.disconnect')}
+                    </Button>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+              {t('connections.empty')}
+            </p>
+          )}
+        </section>
 
         {isAdmin ? (
           <section aria-labelledby="mcp-server-request-history-title" className="border-t pt-6">

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -386,6 +386,23 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_mcp_direct_grant_revocation_user_client
       ON mcp_direct_grant_revocation (user_id, client_id);
 
+    -- A Direct MCP connection starts with no workspace data access. Rows here
+    -- are an explicit user-selected allowlist and are checked in addition to
+    -- Canvas's current workspace ACL for every tool invocation.
+    CREATE TABLE IF NOT EXISTS mcp_direct_workspace_grant (
+      client_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      workspace_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (client_id, user_id, workspace_id),
+      FOREIGN KEY (client_id) REFERENCES oauth_client(client_id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_mcp_direct_workspace_grant_user_client
+      ON mcp_direct_workspace_grant (user_id, client_id);
+
     CREATE TABLE IF NOT EXISTS oauth_consent (
       id TEXT PRIMARY KEY NOT NULL,
       client_id TEXT NOT NULL,

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -369,6 +369,23 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_mcp_revoked_access_token_expiry
       ON mcp_revoked_access_token (expires_at);
 
+    -- Revokes one user's Direct MCP grant while preserving the public OAuth
+    -- client for other users. A timestamp lets a subsequent reauthorization
+    -- issue a new bearer token for the same browser session.
+    CREATE TABLE IF NOT EXISTS mcp_direct_grant_revocation (
+      client_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      revoked_at INTEGER NOT NULL,
+      PRIMARY KEY (client_id, session_id, user_id),
+      FOREIGN KEY (client_id) REFERENCES oauth_client(client_id) ON DELETE CASCADE,
+      FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_mcp_direct_grant_revocation_user_client
+      ON mcp_direct_grant_revocation (user_id, client_id);
+
     CREATE TABLE IF NOT EXISTS oauth_consent (
       id TEXT PRIMARY KEY NOT NULL,
       client_id TEXT NOT NULL,

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -403,6 +403,17 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_mcp_direct_workspace_grant_user_client
       ON mcp_direct_workspace_grant (user_id, client_id);
 
+    -- Workspace managers opt workspaces into Direct MCP before users can add
+    -- them to an individual OAuth client connection. Absence means disabled.
+    CREATE TABLE IF NOT EXISTS mcp_direct_workspace_setting (
+      workspace_id TEXT PRIMARY KEY NOT NULL,
+      enabled_by_user_id TEXT NOT NULL,
+      enabled_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (workspace_id) REFERENCES canvas_workspaces(id) ON DELETE CASCADE,
+      FOREIGN KEY (enabled_by_user_id) REFERENCES user(id) ON DELETE CASCADE
+    );
+
     CREATE TABLE IF NOT EXISTS oauth_consent (
       id TEXT PRIMARY KEY NOT NULL,
       client_id TEXT NOT NULL,

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -1503,6 +1503,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS direct_mcp_request_history (
       id TEXT PRIMARY KEY NOT NULL,
       request_id TEXT NOT NULL,
+      server_version TEXT,
       flow_ref TEXT,
       phase TEXT NOT NULL,
       http_method TEXT NOT NULL,
@@ -2523,6 +2524,10 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
   // ── Column additions for existing volumes ────────────────────────────────────
   // Each block adds columns that were missing from older schema versions.
   // ALTER TABLE ADD COLUMN is idempotent here because we check PRAGMA table_info first.
+
+  addColumns(sqlite, 'direct_mcp_request_history', {
+    server_version: 'TEXT',
+  });
 
   addColumns(sqlite, 'agents', {
     scope_type: "TEXT NOT NULL DEFAULT 'user'",

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -1500,6 +1500,22 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       created_at INTEGER NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS direct_mcp_request_history (
+      id TEXT PRIMARY KEY NOT NULL,
+      request_id TEXT NOT NULL,
+      flow_ref TEXT,
+      phase TEXT NOT NULL,
+      http_method TEXT NOT NULL,
+      operation TEXT,
+      tool_name TEXT,
+      outcome TEXT NOT NULL,
+      status_code INTEGER,
+      code TEXT NOT NULL,
+      duration_ms INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS automation_jobs (
       id TEXT PRIMARY KEY NOT NULL,
       name TEXT NOT NULL,
@@ -2492,6 +2508,8 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_audit_events_user_created ON audit_events (user_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_audit_events_entity_created ON audit_events (entity_type, entity_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_audit_events_source_action_created ON audit_events (source, action, created_at);
+    CREATE INDEX IF NOT EXISTS idx_direct_mcp_request_history_created ON direct_mcp_request_history (created_at);
+    CREATE INDEX IF NOT EXISTS idx_direct_mcp_request_history_expires ON direct_mcp_request_history (expires_at);
   `);
 
   if (tableExists(sqlite, 'ai_sessions') && tableExists(sqlite, 'ai_messages')) {

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -391,6 +391,20 @@ export const mcpRevokedAccessToken = sqliteTable("mcp_revoked_access_token", {
   expiryIdx: index("idx_mcp_revoked_access_token_expiry").on(table.expiresAt),
 }));
 
+// A user can disconnect their own Direct MCP grant without disabling the
+// dynamically registered public client for other users. The timestamp keeps
+// bearer JWTs issued before the disconnect invalid while permitting a later,
+// explicit reauthorization for the same browser session.
+export const mcpDirectGrantRevocation = sqliteTable("mcp_direct_grant_revocation", {
+  clientId: text("client_id").notNull().references(() => oauthClient.clientId, { onDelete: "cascade" }),
+  sessionId: text("session_id").notNull().references(() => session.id, { onDelete: "cascade" }),
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  revokedAt: integer("revoked_at", { mode: "timestamp_ms" }).notNull(),
+}, (table) => ({
+  grantPk: primaryKey({ columns: [table.clientId, table.sessionId, table.userId] }),
+  userClientIdx: index("idx_mcp_direct_grant_revocation_user_client").on(table.userId, table.clientId),
+}));
+
 export const oauthConsent = sqliteTable("oauth_consent", {
   id: text("id").primaryKey(),
   clientId: text("client_id").notNull().references(() => oauthClient.clientId, { onDelete: "cascade" }),

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -2256,6 +2256,28 @@ export const auditEvents = sqliteTable("audit_events", {
   sourceActionCreatedIdx: index("idx_audit_events_source_action_created").on(table.source, table.action, table.createdAt),
 }));
 
+// Short-lived, metadata-only diagnostics for the public Canvas MCP server.
+// This is intentionally separate from audit_events: it is automatically
+// pruned and must never contain request bodies, OAuth material, or user data.
+export const directMcpRequestHistory = sqliteTable("direct_mcp_request_history", {
+  id: text("id").primaryKey(),
+  requestId: text("request_id").notNull(),
+  flowRef: text("flow_ref"),
+  phase: text("phase").notNull(),
+  httpMethod: text("http_method").notNull(),
+  operation: text("operation"),
+  toolName: text("tool_name"),
+  outcome: text("outcome").notNull(),
+  statusCode: integer("status_code"),
+  code: text("code").notNull(),
+  durationMs: integer("duration_ms").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  createdIdx: index("idx_direct_mcp_request_history_created").on(table.createdAt),
+  expiresIdx: index("idx_direct_mcp_request_history_expires").on(table.expiresAt),
+}));
+
 export const telegramActiveSession = sqliteTable("telegram_active_session", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   userId: text("user_id").notNull().references(() => user.id),

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -419,6 +419,15 @@ export const mcpDirectWorkspaceGrant = sqliteTable("mcp_direct_workspace_grant",
   userClientIdx: index("idx_mcp_direct_workspace_grant_user_client").on(table.userId, table.clientId),
 }));
 
+// A workspace manager must opt a workspace into Direct MCP before an
+// individual user can grant it to one of their OAuth clients.
+export const mcpDirectWorkspaceSetting = sqliteTable("mcp_direct_workspace_setting", {
+  workspaceId: text("workspace_id").primaryKey().references(() => canvasWorkspaces.id, { onDelete: "cascade" }),
+  enabledByUserId: text("enabled_by_user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  enabledAt: integer("enabled_at", { mode: "timestamp_ms" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+});
+
 export const oauthConsent = sqliteTable("oauth_consent", {
   id: text("id").primaryKey(),
   clientId: text("client_id").notNull().references(() => oauthClient.clientId, { onDelete: "cascade" }),

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -405,6 +405,20 @@ export const mcpDirectGrantRevocation = sqliteTable("mcp_direct_grant_revocation
   userClientIdx: index("idx_mcp_direct_grant_revocation_user_client").on(table.userId, table.clientId),
 }));
 
+// Direct MCP only exposes workspace data after the signed-in person explicitly
+// selects it for that public OAuth client. Current Canvas ACL checks remain in
+// effect at every tool call, so an outdated row never grants access by itself.
+export const mcpDirectWorkspaceGrant = sqliteTable("mcp_direct_workspace_grant", {
+  clientId: text("client_id").notNull().references(() => oauthClient.clientId, { onDelete: "cascade" }),
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  workspaceId: text("workspace_id").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+}, (table) => ({
+  grantPk: primaryKey({ columns: [table.clientId, table.userId, table.workspaceId] }),
+  userClientIdx: index("idx_mcp_direct_workspace_grant_user_client").on(table.userId, table.clientId),
+}));
+
 export const oauthConsent = sqliteTable("oauth_consent", {
   id: text("id").primaryKey(),
   clientId: text("client_id").notNull().references(() => oauthClient.clientId, { onDelete: "cascade" }),

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -2262,6 +2262,7 @@ export const auditEvents = sqliteTable("audit_events", {
 export const directMcpRequestHistory = sqliteTable("direct_mcp_request_history", {
   id: text("id").primaryKey(),
   requestId: text("request_id").notNull(),
+  serverVersion: text("server_version"),
   flowRef: text("flow_ref"),
   phase: text("phase").notNull(),
   httpMethod: text("http_method").notNull(),

--- a/app/lib/mcp/server/access-token-verifier.ts
+++ b/app/lib/mcp/server/access-token-verifier.ts
@@ -27,6 +27,7 @@ type DirectMcpGrantStateRow = {
   client_id: string;
   client_disabled: unknown;
   revoked_token_hash: string | null;
+  grant_revoked_at: unknown;
 };
 
 export type DirectMcpJwtClaims = {
@@ -252,7 +253,8 @@ export async function loadDirectMcpGrantState(
         local_user.banned AS user_banned,
         oauth_client.client_id AS client_id,
         oauth_client.disabled AS client_disabled,
-        revoked_access_token.token_hash AS revoked_token_hash
+        revoked_access_token.token_hash AS revoked_token_hash,
+        grant_revocation.revoked_at AS grant_revoked_at
       FROM "session" auth_session
       INNER JOIN "user" local_user
         ON local_user.id = auth_session.user_id
@@ -263,6 +265,10 @@ export async function loadDirectMcpGrantState(
        AND revoked_access_token.client_id = oauth_client.client_id
        AND revoked_access_token.session_id = auth_session.id
        AND revoked_access_token.user_id = local_user.id
+      LEFT JOIN mcp_direct_grant_revocation grant_revocation
+        ON grant_revocation.client_id = oauth_client.client_id
+       AND grant_revocation.session_id = auth_session.id
+       AND grant_revocation.user_id = local_user.id
       WHERE auth_session.id = ?
         AND auth_session.user_id = ?
       LIMIT 1
@@ -283,6 +289,8 @@ function assertGrantStateActive(
   claims: DirectMcpJwtClaims,
 ): void {
   const sessionExpiresAt = timestampToMilliseconds(state?.session_expires_at);
+  const grantRevokedAt = timestampToMilliseconds(state?.grant_revoked_at);
+  const tokenIssuedAt = claims.issuedAt * 1000;
   if (
     !state
     || state.session_id !== claims.sessionId
@@ -293,6 +301,7 @@ function assertGrantStateActive(
     || sessionExpiresAt === null
     || sessionExpiresAt <= Date.now()
     || state.revoked_token_hash !== null
+    || (grantRevokedAt !== null && tokenIssuedAt <= grantRevokedAt)
   ) {
     throw invalidToken();
   }

--- a/app/lib/mcp/server/auth-probe.ts
+++ b/app/lib/mcp/server/auth-probe.ts
@@ -13,6 +13,7 @@ import {
   DirectMcpAuthorizationError,
   verifyDirectMcpAccessToken,
 } from '@/app/lib/mcp/server/access-token-verifier';
+import { DIRECT_MCP_RESOURCE_SCOPES } from '@/app/lib/mcp/server/config';
 import { directMcpToolAuthorizationError } from '@/app/lib/mcp/server/tool-auth';
 import type { DirectMcpToolDescriptor } from '@/app/lib/mcp/server/tool-descriptor';
 
@@ -95,7 +96,7 @@ export async function runDirectMcpAuthProbe(
       [DIRECT_MCP_AUTH_PROBE_SCOPE],
     );
     const scopes = principal.scopes
-      .filter((scope) => scope === DIRECT_MCP_AUTH_PROBE_SCOPE)
+      .filter((scope) => (DIRECT_MCP_RESOURCE_SCOPES as readonly string[]).includes(scope))
       .sort();
     const structuredContent = {
       authenticated: true,

--- a/app/lib/mcp/server/auth-probe.ts
+++ b/app/lib/mcp/server/auth-probe.ts
@@ -16,6 +16,7 @@ import {
 import { DIRECT_MCP_RESOURCE_SCOPES } from '@/app/lib/mcp/server/config';
 import { directMcpToolAuthorizationError } from '@/app/lib/mcp/server/tool-auth';
 import type { DirectMcpToolDescriptor } from '@/app/lib/mcp/server/tool-descriptor';
+import { listDirectMcpAllowedWorkspaceIds } from '@/app/lib/mcp/server/workspace-access-policy';
 
 export const DIRECT_MCP_AUTH_PROBE_TOOL = 'auth_probe';
 export const DIRECT_MCP_AUTH_PROBE_SCOPE = 'workspace:list';
@@ -49,8 +50,9 @@ export function getDirectMcpAuthProbeToolDescriptor(): DirectMcpToolDescriptor {
           type: 'array',
           items: { type: 'string' },
         },
+        allowed_workspace_count: { type: 'integer' },
       },
-      required: ['authenticated', 'user_ref', 'scopes'],
+      required: ['authenticated', 'user_ref', 'scopes', 'allowed_workspace_count'],
       additionalProperties: false,
     },
     annotations: {
@@ -98,10 +100,12 @@ export async function runDirectMcpAuthProbe(
     const scopes = principal.scopes
       .filter((scope) => (DIRECT_MCP_RESOURCE_SCOPES as readonly string[]).includes(scope))
       .sort();
+    const allowedWorkspaceIds = await listDirectMcpAllowedWorkspaceIds(principal);
     const structuredContent = {
       authenticated: true,
       user_ref: redactedUserReference(principal.userId),
       scopes,
+      allowed_workspace_count: allowedWorkspaceIds.size,
     };
     return {
       content: [{

--- a/app/lib/mcp/server/authorization-server-metadata.ts
+++ b/app/lib/mcp/server/authorization-server-metadata.ts
@@ -41,14 +41,14 @@ export async function getAuthorizationServerMetadata(request: Request): Promise<
         : await metadataHandler(request),
       diagnostics.requestId,
     );
-    completeDirectMcpDiagnostic(diagnostics, {
+    await completeDirectMcpDiagnostic(diagnostics, {
       statusCode: response.status,
       code: response.status === 404 ? 'MCP_DISABLED' : 'MCP_DISCOVERY_COMPLETED',
       startedAt,
     });
     return response;
   } catch {
-    failDirectMcpDiagnostic(diagnostics, {
+    await failDirectMcpDiagnostic(diagnostics, {
       code: 'MCP_DISCOVERY_ERROR',
       startedAt,
       statusCode: 500,

--- a/app/lib/mcp/server/connection-management.ts
+++ b/app/lib/mcp/server/connection-management.ts
@@ -20,6 +20,7 @@ type DirectMcpConnectionRow = {
   scopes: unknown;
   connected_at: unknown;
   updated_at: unknown;
+  allowed_workspace_count: unknown;
 };
 
 type DirectMcpConnectionReference = {
@@ -34,6 +35,7 @@ export type DirectMcpConnection = {
   scopes: DirectMcpOAuthScope[];
   connectedAt: string | null;
   updatedAt: string | null;
+  allowedWorkspaceCount: number;
 };
 
 export type DisconnectDirectMcpConnectionResult =
@@ -63,6 +65,14 @@ function timestampToIso(value: unknown): string | null {
     return Number.isNaN(date.getTime()) ? null : date.toISOString();
   }
   return null;
+}
+
+function toSafeCount(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.min(200, Math.trunc(value)));
+  }
+  if (typeof value === 'string') return toSafeCount(Number(value));
+  return 0;
 }
 
 function parseScopes(value: unknown): DirectMcpOAuthScope[] {
@@ -134,6 +144,44 @@ function directMcpResource(): string {
   return resolveDirectMcpOAuthConfig().resource;
 }
 
+async function findOwnedDirectMcpConnectionClientId(input: {
+  database: Awaited<ReturnType<typeof openDb>>;
+  userId: string;
+  connectionId: string;
+}): Promise<string | null> {
+  const reference = decodeConnectionReference(input.connectionId);
+  if (!reference || reference.userId !== input.userId) return null;
+
+  const connection = await input.database.get(`
+    SELECT oauth_consent.client_id AS client_id
+    FROM oauth_consent
+    INNER JOIN oauth_client
+      ON oauth_client.client_id = oauth_consent.client_id
+    INNER JOIN oauth_client_resource
+      ON oauth_client_resource.client_id = oauth_client.client_id
+    WHERE oauth_consent.id = ?
+      AND oauth_consent.user_id = ?
+      AND oauth_client_resource.resource_id = ?
+      AND oauth_client.token_endpoint_auth_method = 'none'
+    LIMIT 1
+  `, [reference.consentId, input.userId, directMcpResource()]) as { client_id: unknown } | undefined;
+  return typeof connection?.client_id === 'string' && connection.client_id
+    ? connection.client_id
+    : null;
+}
+
+export async function resolveOwnedDirectMcpConnectionClientId(
+  userId: string,
+  connectionId: string,
+): Promise<string | null> {
+  const database = await openDb();
+  try {
+    return await findOwnedDirectMcpConnectionClientId({ database, userId, connectionId });
+  } finally {
+    await database.close();
+  }
+}
+
 export async function listDirectMcpConnections(
   userId: string,
 ): Promise<DirectMcpConnection[]> {
@@ -146,7 +194,13 @@ export async function listDirectMcpConnections(
         oauth_client.name AS client_name,
         oauth_consent.scopes AS scopes,
         oauth_consent.created_at AS connected_at,
-        oauth_consent.updated_at AS updated_at
+        oauth_consent.updated_at AS updated_at,
+        (
+          SELECT COUNT(*)
+          FROM mcp_direct_workspace_grant workspace_grant
+          WHERE workspace_grant.client_id = oauth_consent.client_id
+            AND workspace_grant.user_id = oauth_consent.user_id
+        ) AS allowed_workspace_count
       FROM oauth_consent
       INNER JOIN oauth_client
         ON oauth_client.client_id = oauth_consent.client_id
@@ -168,6 +222,7 @@ export async function listDirectMcpConnections(
         scopes: parseScopes(row.scopes),
         connectedAt: timestampToIso(row.connected_at),
         updatedAt: timestampToIso(row.updated_at),
+        allowedWorkspaceCount: toSafeCount(row.allowed_workspace_count),
       });
     }
     return [...connections.values()];
@@ -180,28 +235,16 @@ export async function disconnectDirectMcpConnection(
   userId: string,
   connectionId: string,
 ): Promise<DisconnectDirectMcpConnectionResult> {
-  const reference = decodeConnectionReference(connectionId);
-  if (!reference || reference.userId !== userId) return { status: 'not_found' };
-
   const database = await openDb();
   const revokedAt = Date.now();
   try {
     await database.run('BEGIN');
-    const connection = await database.get(`
-      SELECT oauth_consent.client_id AS client_id
-      FROM oauth_consent
-      INNER JOIN oauth_client
-        ON oauth_client.client_id = oauth_consent.client_id
-      INNER JOIN oauth_client_resource
-        ON oauth_client_resource.client_id = oauth_client.client_id
-      WHERE oauth_consent.id = ?
-        AND oauth_consent.user_id = ?
-        AND oauth_client_resource.resource_id = ?
-        AND oauth_client.token_endpoint_auth_method = 'none'
-      LIMIT 1
-    `, [reference.consentId, userId, directMcpResource()]) as { client_id: string } | undefined;
-
-    if (!connection) {
+    const clientId = await findOwnedDirectMcpConnectionClientId({
+      database,
+      userId,
+      connectionId,
+    });
+    if (!clientId) {
       await database.run('ROLLBACK');
       return { status: 'not_found' };
     }
@@ -214,7 +257,7 @@ export async function disconnectDirectMcpConnection(
       SELECT DISTINCT session_id
       FROM oauth_access_token
       WHERE client_id = ? AND user_id = ? AND session_id IS NOT NULL
-    `, [connection.client_id, userId, connection.client_id, userId]) as Array<{ session_id: string }>;
+    `, [clientId, userId, clientId, userId]) as Array<{ session_id: string }>;
 
     for (const sessionRow of sessionRows) {
       if (!sessionRow.session_id) continue;
@@ -224,23 +267,27 @@ export async function disconnectDirectMcpConnection(
         ) VALUES (?, ?, ?, ?)
         ON CONFLICT(client_id, session_id, user_id)
         DO UPDATE SET revoked_at = excluded.revoked_at
-      `, [connection.client_id, sessionRow.session_id, userId, revokedAt]);
+      `, [clientId, sessionRow.session_id, userId, revokedAt]);
     }
 
     await database.run(`
       UPDATE oauth_refresh_token
       SET revoked = COALESCE(revoked, ?)
       WHERE client_id = ? AND user_id = ?
-    `, [revokedAt, connection.client_id, userId]);
+    `, [revokedAt, clientId, userId]);
     await database.run(`
       UPDATE oauth_access_token
       SET expires_at = CASE WHEN expires_at > ? THEN ? ELSE expires_at END
       WHERE client_id = ? AND user_id = ?
-    `, [revokedAt, revokedAt, connection.client_id, userId]);
+    `, [revokedAt, revokedAt, clientId, userId]);
+    await database.run(`
+      DELETE FROM mcp_direct_workspace_grant
+      WHERE client_id = ? AND user_id = ?
+    `, [clientId, userId]);
     await database.run(`
       DELETE FROM oauth_consent
       WHERE client_id = ? AND user_id = ?
-    `, [connection.client_id, userId]);
+    `, [clientId, userId]);
     await database.run('COMMIT');
     return { status: 'disconnected' };
   } catch (error) {

--- a/app/lib/mcp/server/connection-management.ts
+++ b/app/lib/mcp/server/connection-management.ts
@@ -1,0 +1,256 @@
+import 'server-only';
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+import { openDb } from '@/app/lib/db';
+import {
+  DIRECT_MCP_OAUTH_SCOPES,
+  type DirectMcpOAuthScope,
+  resolveDirectMcpOAuthConfig,
+} from '@/app/lib/mcp/server/config';
+import { resolveAuthSecret } from '@/app/lib/security/auth-secret';
+
+const MAX_CONNECTIONS = 50;
+const MAX_CONNECTION_REFERENCE_LENGTH = 2048;
+
+type DirectMcpConnectionRow = {
+  consent_id: string;
+  client_id: string;
+  client_name: string | null;
+  scopes: unknown;
+  connected_at: unknown;
+  updated_at: unknown;
+};
+
+type DirectMcpConnectionReference = {
+  version: 1;
+  userId: string;
+  consentId: string;
+};
+
+export type DirectMcpConnection = {
+  connectionId: string;
+  clientName: string;
+  scopes: DirectMcpOAuthScope[];
+  connectedAt: string | null;
+  updatedAt: string | null;
+};
+
+export type DisconnectDirectMcpConnectionResult =
+  | { status: 'disconnected' }
+  | { status: 'not_found' };
+
+function safeClientName(value: string | null): string {
+  const normalized = value
+    ?.replace(/[\u0000-\u001f\u007f]/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim()
+    .slice(0, 120);
+  return normalized || 'MCP client';
+}
+
+function timestampToIso(value: unknown): string | null {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const milliseconds = value < 1_000_000_000_000 ? value * 1000 : value;
+    const date = new Date(milliseconds);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return timestampToIso(numeric);
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  return null;
+}
+
+function parseScopes(value: unknown): DirectMcpOAuthScope[] {
+  let parsed: unknown = value;
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      parsed = [];
+    }
+  }
+  if (!Array.isArray(parsed)) return [];
+  const allowed = new Set<string>(DIRECT_MCP_OAUTH_SCOPES);
+  return DIRECT_MCP_OAUTH_SCOPES.filter((scope) => (
+    allowed.has(scope) && parsed.includes(scope)
+  ));
+}
+
+function connectionSignature(encodedPayload: string): string {
+  return createHmac(
+    'sha256',
+    resolveAuthSecret(process.env, { allowProductionBuildFallback: true }),
+  ).update(encodedPayload).digest('base64url');
+}
+
+function encodeConnectionReference(userId: string, consentId: string): string {
+  const payload = Buffer.from(JSON.stringify({ version: 1, userId, consentId }), 'utf8')
+    .toString('base64url');
+  return `${payload}.${connectionSignature(payload)}`;
+}
+
+function decodeConnectionReference(value: string): DirectMcpConnectionReference | null {
+  if (!value || value.length > MAX_CONNECTION_REFERENCE_LENGTH) return null;
+  const [encodedPayload, signature, ...extra] = value.split('.');
+  if (!encodedPayload || !signature || extra.length > 0) return null;
+
+  const expectedSignature = connectionSignature(encodedPayload);
+  const actualBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expectedSignature);
+  if (
+    actualBuffer.length !== expectedBuffer.length
+    || !timingSafeEqual(actualBuffer, expectedBuffer)
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as Partial<DirectMcpConnectionReference>;
+    if (
+      parsed.version !== 1
+      || typeof parsed.userId !== 'string'
+      || !parsed.userId
+      || typeof parsed.consentId !== 'string'
+      || !parsed.consentId
+    ) {
+      return null;
+    }
+    return {
+      version: 1,
+      userId: parsed.userId,
+      consentId: parsed.consentId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function directMcpResource(): string {
+  return resolveDirectMcpOAuthConfig().resource;
+}
+
+export async function listDirectMcpConnections(
+  userId: string,
+): Promise<DirectMcpConnection[]> {
+  const database = await openDb();
+  try {
+    const rows = await database.all(`
+      SELECT
+        oauth_consent.id AS consent_id,
+        oauth_consent.client_id AS client_id,
+        oauth_client.name AS client_name,
+        oauth_consent.scopes AS scopes,
+        oauth_consent.created_at AS connected_at,
+        oauth_consent.updated_at AS updated_at
+      FROM oauth_consent
+      INNER JOIN oauth_client
+        ON oauth_client.client_id = oauth_consent.client_id
+      INNER JOIN oauth_client_resource
+        ON oauth_client_resource.client_id = oauth_client.client_id
+      WHERE oauth_consent.user_id = ?
+        AND oauth_client_resource.resource_id = ?
+        AND oauth_client.token_endpoint_auth_method = 'none'
+      ORDER BY oauth_consent.updated_at DESC, oauth_consent.created_at DESC
+      LIMIT ?
+    `, [userId, directMcpResource(), MAX_CONNECTIONS]) as DirectMcpConnectionRow[];
+
+    const connections = new Map<string, DirectMcpConnection>();
+    for (const row of rows) {
+      if (connections.has(row.client_id)) continue;
+      connections.set(row.client_id, {
+        connectionId: encodeConnectionReference(userId, row.consent_id),
+        clientName: safeClientName(row.client_name),
+        scopes: parseScopes(row.scopes),
+        connectedAt: timestampToIso(row.connected_at),
+        updatedAt: timestampToIso(row.updated_at),
+      });
+    }
+    return [...connections.values()];
+  } finally {
+    await database.close();
+  }
+}
+
+export async function disconnectDirectMcpConnection(
+  userId: string,
+  connectionId: string,
+): Promise<DisconnectDirectMcpConnectionResult> {
+  const reference = decodeConnectionReference(connectionId);
+  if (!reference || reference.userId !== userId) return { status: 'not_found' };
+
+  const database = await openDb();
+  const revokedAt = Date.now();
+  try {
+    await database.run('BEGIN');
+    const connection = await database.get(`
+      SELECT oauth_consent.client_id AS client_id
+      FROM oauth_consent
+      INNER JOIN oauth_client
+        ON oauth_client.client_id = oauth_consent.client_id
+      INNER JOIN oauth_client_resource
+        ON oauth_client_resource.client_id = oauth_client.client_id
+      WHERE oauth_consent.id = ?
+        AND oauth_consent.user_id = ?
+        AND oauth_client_resource.resource_id = ?
+        AND oauth_client.token_endpoint_auth_method = 'none'
+      LIMIT 1
+    `, [reference.consentId, userId, directMcpResource()]) as { client_id: string } | undefined;
+
+    if (!connection) {
+      await database.run('ROLLBACK');
+      return { status: 'not_found' };
+    }
+
+    const sessionRows = await database.all(`
+      SELECT DISTINCT session_id
+      FROM oauth_refresh_token
+      WHERE client_id = ? AND user_id = ? AND session_id IS NOT NULL
+      UNION
+      SELECT DISTINCT session_id
+      FROM oauth_access_token
+      WHERE client_id = ? AND user_id = ? AND session_id IS NOT NULL
+    `, [connection.client_id, userId, connection.client_id, userId]) as Array<{ session_id: string }>;
+
+    for (const sessionRow of sessionRows) {
+      if (!sessionRow.session_id) continue;
+      await database.run(`
+        INSERT INTO mcp_direct_grant_revocation (
+          client_id, session_id, user_id, revoked_at
+        ) VALUES (?, ?, ?, ?)
+        ON CONFLICT(client_id, session_id, user_id)
+        DO UPDATE SET revoked_at = excluded.revoked_at
+      `, [connection.client_id, sessionRow.session_id, userId, revokedAt]);
+    }
+
+    await database.run(`
+      UPDATE oauth_refresh_token
+      SET revoked = COALESCE(revoked, ?)
+      WHERE client_id = ? AND user_id = ?
+    `, [revokedAt, connection.client_id, userId]);
+    await database.run(`
+      UPDATE oauth_access_token
+      SET expires_at = CASE WHEN expires_at > ? THEN ? ELSE expires_at END
+      WHERE client_id = ? AND user_id = ?
+    `, [revokedAt, revokedAt, connection.client_id, userId]);
+    await database.run(`
+      DELETE FROM oauth_consent
+      WHERE client_id = ? AND user_id = ?
+    `, [connection.client_id, userId]);
+    await database.run('COMMIT');
+    return { status: 'disconnected' };
+  } catch (error) {
+    try {
+      await database.run('ROLLBACK');
+    } catch {
+      // The transaction may already have been rolled back by the database.
+    }
+    throw error;
+  } finally {
+    await database.close();
+  }
+}

--- a/app/lib/mcp/server/diagnostics.ts
+++ b/app/lib/mcp/server/diagnostics.ts
@@ -3,6 +3,10 @@ import 'server-only';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHmac, randomUUID } from 'node:crypto';
 
+import {
+  recordDirectMcpRequestHistory,
+  type DirectMcpRequestHistoryEntry,
+} from '@/app/lib/mcp/server/request-history';
 import { resolveAuthSecret } from '@/app/lib/security/auth-secret';
 
 export type DirectMcpDiagnosticPhase =
@@ -19,6 +23,10 @@ export type DirectMcpDiagnosticContext = {
   flowRef: string | null;
   phase: DirectMcpDiagnosticPhase;
   method: string;
+  operation?: 'tools/list' | 'tools/call';
+  toolName?: string;
+  historyCode?: string;
+  historyRecorded?: boolean;
 };
 
 type DirectMcpDiagnosticOutcome = 'started' | 'succeeded' | 'failed';
@@ -83,14 +91,51 @@ export function beginDirectMcpDiagnostic(
   return context;
 }
 
-export function completeDirectMcpDiagnostic(
+function historyOutcome(
+  statusCode: number,
+  historyCode: string,
+): DirectMcpRequestHistoryEntry['outcome'] {
+  if (statusCode >= 500 || historyCode === 'MCP_TOOL_ERROR' || historyCode.startsWith('OAUTH_PERSISTENCE_')) {
+    return 'failed';
+  }
+  if (statusCode >= 400) return 'rejected';
+  return 'succeeded';
+}
+
+async function recordRequestHistory(
+  context: DirectMcpDiagnosticContext,
+  input: {
+    statusCode?: number;
+    code: string;
+    startedAt: number;
+    outcome: DirectMcpRequestHistoryEntry['outcome'];
+  },
+): Promise<void> {
+  if (context.historyRecorded) return;
+  context.historyRecorded = true;
+  await recordDirectMcpRequestHistory({
+    requestId: context.requestId,
+    flowRef: context.flowRef,
+    phase: context.phase,
+    httpMethod: context.method,
+    operation: context.operation,
+    toolName: context.toolName,
+    outcome: input.outcome,
+    statusCode: input.statusCode,
+    code: input.code,
+    durationMs: Math.max(0, Date.now() - input.startedAt),
+  });
+}
+
+export async function completeDirectMcpDiagnostic(
   context: DirectMcpDiagnosticContext,
   input: {
     statusCode: number;
     code: string;
     startedAt: number;
   },
-): void {
+): Promise<void> {
+  const historyCode = context.historyCode ?? input.code;
   emitDiagnostic({
     event: 'direct_mcp_diagnostic',
     requestId: context.requestId,
@@ -102,16 +147,22 @@ export function completeDirectMcpDiagnostic(
     code: input.code,
     durationMs: Math.max(0, Date.now() - input.startedAt),
   });
+  await recordRequestHistory(context, {
+    statusCode: input.statusCode,
+    code: historyCode,
+    startedAt: input.startedAt,
+    outcome: historyOutcome(input.statusCode, historyCode),
+  });
 }
 
-export function failDirectMcpDiagnostic(
+export async function failDirectMcpDiagnostic(
   context: DirectMcpDiagnosticContext,
   input: {
     code: string;
     startedAt: number;
     statusCode?: number;
   },
-): void {
+): Promise<void> {
   emitDiagnostic({
     event: 'direct_mcp_diagnostic',
     requestId: context.requestId,
@@ -123,6 +174,28 @@ export function failDirectMcpDiagnostic(
     code: input.code,
     durationMs: Math.max(0, Date.now() - input.startedAt),
   });
+  await recordRequestHistory(context, {
+    statusCode: input.statusCode,
+    code: input.code,
+    startedAt: input.startedAt,
+    outcome: 'failed',
+  });
+}
+
+export function recordDirectMcpRequestOperation(
+  operation: 'tools/list' | 'tools/call',
+  toolName?: string,
+): void {
+  const context = directMcpDiagnosticStorage.getStore();
+  if (!context) return;
+  context.operation = operation;
+  if (toolName) context.toolName = toolName;
+}
+
+export function recordDirectMcpToolFailure(): void {
+  const context = directMcpDiagnosticStorage.getStore();
+  if (!context) return;
+  context.historyCode = 'MCP_TOOL_ERROR';
 }
 
 export function withDirectMcpRequestId(
@@ -178,6 +251,7 @@ export function recordDirectMcpOAuthProviderError(
 
   // Keep production diagnostics correlatable without recording client metadata,
   // credentials, authorization codes, tokens, or provider error text.
+  const code = classifyProviderError(error);
   emitDiagnostic({
     event: 'direct_mcp_diagnostic',
     requestId: context.requestId,
@@ -185,7 +259,8 @@ export function recordDirectMcpOAuthProviderError(
     phase: context.phase,
     outcome: 'failed',
     method: context.method,
-    code: classifyProviderError(error),
+    code,
   });
+  context.historyCode = code;
   return true;
 }

--- a/app/lib/mcp/server/direct-server.ts
+++ b/app/lib/mcp/server/direct-server.ts
@@ -8,7 +8,6 @@ import {
   type CallToolResult,
 } from '@modelcontextprotocol/server';
 
-import packageJson from '@/package.json';
 import {
   DIRECT_MCP_AUTH_PROBE_TOOL,
   getDirectMcpAuthProbeToolDescriptor,
@@ -23,6 +22,7 @@ import {
   getDirectMcpWorkspaceToolDefinitions,
 } from '@/app/lib/mcp/server/workspace-tools';
 import type { DirectMcpToolDescriptor } from '@/app/lib/mcp/server/tool-descriptor';
+import { DIRECT_MCP_SERVER_VERSION } from '@/app/lib/mcp/server/version';
 
 type DirectMcpToolHandler = {
   id: DirectMcpToolId;
@@ -58,7 +58,7 @@ export function createDirectMcpServer(
   const server = new Server(
     {
       name: 'canvas-notebook-direct-mcp',
-      version: packageJson.version,
+      version: DIRECT_MCP_SERVER_VERSION,
     },
     {
       capabilities: { tools: {} },

--- a/app/lib/mcp/server/direct-server.ts
+++ b/app/lib/mcp/server/direct-server.ts
@@ -53,7 +53,7 @@ export function createDirectMcpServer(
   const toolsById = new Map(tools.map((tool) => [tool.id, tool]));
   const instructions = tools.length === 0
     ? 'No MCP tools are currently enabled for this Canvas Notebook instance.'
-    : 'Canvas Notebook provides read-only access to the signed-in user’s workspaces and workspace files.';
+    : 'Canvas Notebook provides read-only access only to workspaces the signed-in user explicitly allows for this MCP connection.';
 
   const server = new Server(
     {

--- a/app/lib/mcp/server/direct-server.ts
+++ b/app/lib/mcp/server/direct-server.ts
@@ -16,6 +16,10 @@ import {
 } from '@/app/lib/mcp/server/auth-probe';
 import { getDirectMcpEnabledTools, type DirectMcpToolId } from '@/app/lib/mcp/server/config';
 import {
+  recordDirectMcpRequestOperation,
+  recordDirectMcpToolFailure,
+} from '@/app/lib/mcp/server/diagnostics';
+import {
   getDirectMcpWorkspaceToolDefinitions,
 } from '@/app/lib/mcp/server/workspace-tools';
 import type { DirectMcpToolDescriptor } from '@/app/lib/mcp/server/tool-descriptor';
@@ -62,19 +66,30 @@ export function createDirectMcpServer(
     },
   );
 
-  server.setRequestHandler('tools/list', async () => ({
-    tools: tools.map((tool) => tool.descriptor),
-  }));
+  server.setRequestHandler('tools/list', async () => {
+    recordDirectMcpRequestOperation('tools/list');
+    return { tools: tools.map((tool) => tool.descriptor) };
+  });
 
   server.setRequestHandler('tools/call', async (request, context) => {
+    recordDirectMcpRequestOperation('tools/call');
     const tool = toolsById.get(request.params.name as DirectMcpToolId);
     if (!tool) {
+      recordDirectMcpToolFailure();
       throw new ProtocolError(
         ProtocolErrorCode.MethodNotFound,
         'The requested tool is not available.',
       );
     }
-    return tool.execute(request.params.arguments, context.http?.authInfo);
+    recordDirectMcpRequestOperation('tools/call', tool.id);
+    try {
+      const result = await tool.execute(request.params.arguments, context.http?.authInfo);
+      if (result.isError) recordDirectMcpToolFailure();
+      return result;
+    } catch (error) {
+      recordDirectMcpToolFailure();
+      throw error;
+    }
   });
 
   return server;

--- a/app/lib/mcp/server/oauth-client-maintenance.ts
+++ b/app/lib/mcp/server/oauth-client-maintenance.ts
@@ -1,0 +1,68 @@
+import 'server-only';
+
+import { openDb } from '@/app/lib/db';
+import { resolveDirectMcpOAuthConfig } from '@/app/lib/mcp/server/config';
+
+export const DIRECT_MCP_UNUSED_DYNAMIC_CLIENT_RETENTION_DAYS = 7;
+export const DIRECT_MCP_UNUSED_DYNAMIC_CLIENT_PRUNE_LIMIT = 100;
+
+const DIRECT_MCP_UNUSED_DYNAMIC_CLIENT_RETENTION_MS = (
+  DIRECT_MCP_UNUSED_DYNAMIC_CLIENT_RETENTION_DAYS * 24 * 60 * 60 * 1000
+);
+
+function changesFromRunResult(result: unknown): number {
+  if (!result || typeof result !== 'object') return 0;
+  const changes = (result as { changes?: unknown }).changes;
+  return typeof changes === 'number' && Number.isFinite(changes) ? changes : 0;
+}
+
+/**
+ * Removes only anonymous public clients that are linked to this Direct MCP
+ * resource and never received a consent or token. A client that was ever
+ * used remains intact; this is intentionally not a general OAuth cleanup.
+ */
+export async function pruneUnusedDirectMcpDynamicClients(
+  now = Date.now(),
+): Promise<number> {
+  const cutoff = now - DIRECT_MCP_UNUSED_DYNAMIC_CLIENT_RETENTION_MS;
+  const { resource } = resolveDirectMcpOAuthConfig();
+  const database = await openDb();
+  try {
+    const result = await database.run(`
+      DELETE FROM oauth_client
+      WHERE client_id IN (
+        SELECT stale_client.client_id
+        FROM oauth_client stale_client
+        INNER JOIN oauth_client_resource direct_resource
+          ON direct_resource.client_id = stale_client.client_id
+        WHERE direct_resource.resource_id = ?
+          AND stale_client.created_at IS NOT NULL
+          AND stale_client.created_at < ?
+          AND stale_client.user_id IS NULL
+          AND stale_client.client_secret IS NULL
+          AND stale_client.token_endpoint_auth_method = 'none'
+          AND COALESCE(stale_client.public, FALSE) = TRUE
+          AND NOT EXISTS (
+            SELECT 1
+            FROM oauth_consent consent
+            WHERE consent.client_id = stale_client.client_id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM oauth_access_token access_token
+            WHERE access_token.client_id = stale_client.client_id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM oauth_refresh_token refresh_token
+            WHERE refresh_token.client_id = stale_client.client_id
+          )
+        ORDER BY stale_client.created_at ASC
+        LIMIT ?
+      )
+    `, [resource, cutoff, DIRECT_MCP_UNUSED_DYNAMIC_CLIENT_PRUNE_LIMIT]);
+    return changesFromRunResult(result);
+  } finally {
+    await database.close();
+  }
+}

--- a/app/lib/mcp/server/protected-resource-metadata.ts
+++ b/app/lib/mcp/server/protected-resource-metadata.ts
@@ -50,14 +50,14 @@ export async function directMcpProtectedResourceMetadataResponse(
           'cache-control': 'no-store',
         },
       }), diagnostics.requestId);
-    completeDirectMcpDiagnostic(diagnostics, {
+    await completeDirectMcpDiagnostic(diagnostics, {
       statusCode: response.status,
       code: response.status === 404 ? 'MCP_DISABLED' : 'MCP_DISCOVERY_COMPLETED',
       startedAt,
     });
     return response;
   } catch {
-    failDirectMcpDiagnostic(diagnostics, {
+    await failDirectMcpDiagnostic(diagnostics, {
       code: 'MCP_DISCOVERY_ERROR',
       startedAt,
       statusCode: 500,

--- a/app/lib/mcp/server/readiness.ts
+++ b/app/lib/mcp/server/readiness.ts
@@ -31,6 +31,7 @@ const REQUIRED_OAUTH_TABLES = [
   'oauth_resource',
   'mcp_direct_grant_revocation',
   'mcp_direct_workspace_grant',
+  'mcp_direct_workspace_setting',
 ] as const;
 
 const REQUIRED_OAUTH_COLUMNS: Record<string, readonly string[]> = {

--- a/app/lib/mcp/server/readiness.ts
+++ b/app/lib/mcp/server/readiness.ts
@@ -30,6 +30,7 @@ const REQUIRED_OAUTH_TABLES = [
   'oauth_refresh_token',
   'oauth_resource',
   'mcp_direct_grant_revocation',
+  'mcp_direct_workspace_grant',
 ] as const;
 
 const REQUIRED_OAUTH_COLUMNS: Record<string, readonly string[]> = {

--- a/app/lib/mcp/server/readiness.ts
+++ b/app/lib/mcp/server/readiness.ts
@@ -29,6 +29,7 @@ const REQUIRED_OAUTH_TABLES = [
   'oauth_consent',
   'oauth_refresh_token',
   'oauth_resource',
+  'mcp_direct_grant_revocation',
 ] as const;
 
 const REQUIRED_OAUTH_COLUMNS: Record<string, readonly string[]> = {

--- a/app/lib/mcp/server/request-history.ts
+++ b/app/lib/mcp/server/request-history.ts
@@ -6,6 +6,7 @@ import { desc, inArray, lte } from 'drizzle-orm';
 
 import { db } from '@/app/lib/db';
 import { directMcpRequestHistory } from '@/app/lib/db/schema';
+import { DIRECT_MCP_SERVER_VERSION } from '@/app/lib/mcp/server/version';
 
 export const DIRECT_MCP_REQUEST_HISTORY_RETENTION_HOURS = 24;
 export const DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES = 100;
@@ -46,6 +47,7 @@ export type DirectMcpRequestHistoryInput = {
 
 export type DirectMcpRequestHistoryEntry = {
   requestId: string;
+  serverVersion: string | null;
   flowRef: string | null;
   phase: string;
   httpMethod: string;
@@ -108,6 +110,7 @@ export async function recordDirectMcpRequestHistory(input: DirectMcpRequestHisto
     await db.insert(directMcpRequestHistory).values({
       id: `direct-mcp-request-${randomUUID()}`,
       requestId: input.requestId,
+      serverVersion: DIRECT_MCP_SERVER_VERSION,
       flowRef: toSafeFlowRef(input.flowRef),
       phase,
       httpMethod: toSafeHttpMethod(input.httpMethod),
@@ -139,6 +142,7 @@ export async function listRecentDirectMcpRequestHistory(): Promise<DirectMcpRequ
     const entries = await db
       .select({
         requestId: directMcpRequestHistory.requestId,
+        serverVersion: directMcpRequestHistory.serverVersion,
         flowRef: directMcpRequestHistory.flowRef,
         phase: directMcpRequestHistory.phase,
         httpMethod: directMcpRequestHistory.httpMethod,

--- a/app/lib/mcp/server/request-history.ts
+++ b/app/lib/mcp/server/request-history.ts
@@ -1,0 +1,164 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+
+import { desc, inArray, lte } from 'drizzle-orm';
+
+import { db } from '@/app/lib/db';
+import { directMcpRequestHistory } from '@/app/lib/db/schema';
+
+export const DIRECT_MCP_REQUEST_HISTORY_RETENTION_HOURS = 24;
+export const DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES = 100;
+const DIRECT_MCP_REQUEST_HISTORY_RETENTION_MS = DIRECT_MCP_REQUEST_HISTORY_RETENTION_HOURS * 60 * 60 * 1000;
+const DIRECT_MCP_REQUEST_HISTORY_LIST_LIMIT = DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES;
+
+const PHASES = new Set([
+  'discovery.authorization_server',
+  'discovery.protected_resource',
+  'mcp.http',
+  'oauth.registration',
+  'oauth.request',
+]);
+const OUTCOMES = new Set(['succeeded', 'failed', 'rejected']);
+const OPERATIONS = new Set(['tools/list', 'tools/call']);
+const TOOL_NAMES = new Set([
+  'auth_probe',
+  'list_workspaces',
+  'get_workspace_overview',
+  'list_knowledge_tree',
+  'search_knowledge',
+  'read_knowledge_source',
+]);
+
+export type DirectMcpRequestHistoryInput = {
+  requestId: string;
+  flowRef?: string | null;
+  phase: string;
+  httpMethod: string;
+  operation?: string | null;
+  toolName?: string | null;
+  outcome: string;
+  statusCode?: number | null;
+  code: string;
+  durationMs: number;
+  createdAt?: Date;
+};
+
+export type DirectMcpRequestHistoryEntry = {
+  requestId: string;
+  flowRef: string | null;
+  phase: string;
+  httpMethod: string;
+  operation: string | null;
+  toolName: string | null;
+  outcome: 'succeeded' | 'failed' | 'rejected';
+  statusCode: number | null;
+  code: string;
+  durationMs: number;
+  createdAt: Date;
+};
+
+function toSafeCode(value: string): string {
+  return /^[A-Z0-9_]{1,120}$/u.test(value) ? value : 'MCP_UNCLASSIFIED';
+}
+
+function toSafeHttpMethod(value: string): string {
+  return /^[A-Z]{1,10}$/u.test(value) ? value : 'UNKNOWN';
+}
+
+function toSafeDuration(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.min(60 * 60 * 1000, Math.trunc(value))) : 0;
+}
+
+function toSafeStatusCode(value: number | null | undefined): number | null {
+  if (!Number.isInteger(value) || !value || value < 100 || value > 599) return null;
+  return value;
+}
+
+function toSafeFlowRef(value: string | null | undefined): string | null {
+  return value && /^[a-f0-9]{24}$/u.test(value) ? value : null;
+}
+
+async function pruneDirectMcpRequestHistory(now: Date): Promise<void> {
+  await db.delete(directMcpRequestHistory).where(lte(directMcpRequestHistory.expiresAt, now));
+
+  while (true) {
+    const overflow = await db
+      .select({ id: directMcpRequestHistory.id })
+      .from(directMcpRequestHistory)
+      .orderBy(desc(directMcpRequestHistory.createdAt), desc(directMcpRequestHistory.id))
+      .limit(DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES)
+      .offset(DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES);
+    if (overflow.length === 0) return;
+    await db.delete(directMcpRequestHistory).where(inArray(
+      directMcpRequestHistory.id,
+      overflow.map((entry) => entry.id),
+    ));
+  }
+}
+
+export async function recordDirectMcpRequestHistory(input: DirectMcpRequestHistoryInput): Promise<void> {
+  const createdAt = input.createdAt ?? new Date();
+  const phase = PHASES.has(input.phase) ? input.phase : 'mcp.http';
+  const outcome = OUTCOMES.has(input.outcome) ? input.outcome as DirectMcpRequestHistoryEntry['outcome'] : 'failed';
+  const operation = input.operation && OPERATIONS.has(input.operation) ? input.operation : null;
+  const toolName = input.toolName && TOOL_NAMES.has(input.toolName) ? input.toolName : null;
+
+  try {
+    await db.insert(directMcpRequestHistory).values({
+      id: `direct-mcp-request-${randomUUID()}`,
+      requestId: input.requestId,
+      flowRef: toSafeFlowRef(input.flowRef),
+      phase,
+      httpMethod: toSafeHttpMethod(input.httpMethod),
+      operation,
+      toolName,
+      outcome,
+      statusCode: toSafeStatusCode(input.statusCode),
+      code: toSafeCode(input.code),
+      durationMs: toSafeDuration(input.durationMs),
+      createdAt,
+      expiresAt: new Date(createdAt.getTime() + DIRECT_MCP_REQUEST_HISTORY_RETENTION_MS),
+    });
+    await pruneDirectMcpRequestHistory(createdAt);
+  } catch {
+    // Request tracing is optional observability. It must never block MCP,
+    // OAuth, or discovery responses, and no database error details are logged.
+    console.warn('[direct-mcp]', JSON.stringify({
+      event: 'direct_mcp_request_history',
+      outcome: 'failed',
+      code: 'MCP_REQUEST_HISTORY_WRITE_FAILED',
+    }));
+  }
+}
+
+export async function listRecentDirectMcpRequestHistory(): Promise<DirectMcpRequestHistoryEntry[]> {
+  const now = new Date();
+  try {
+    await pruneDirectMcpRequestHistory(now);
+    const entries = await db
+      .select({
+        requestId: directMcpRequestHistory.requestId,
+        flowRef: directMcpRequestHistory.flowRef,
+        phase: directMcpRequestHistory.phase,
+        httpMethod: directMcpRequestHistory.httpMethod,
+        operation: directMcpRequestHistory.operation,
+        toolName: directMcpRequestHistory.toolName,
+        outcome: directMcpRequestHistory.outcome,
+        statusCode: directMcpRequestHistory.statusCode,
+        code: directMcpRequestHistory.code,
+        durationMs: directMcpRequestHistory.durationMs,
+        createdAt: directMcpRequestHistory.createdAt,
+      })
+      .from(directMcpRequestHistory)
+      .orderBy(desc(directMcpRequestHistory.createdAt), desc(directMcpRequestHistory.id))
+      .limit(DIRECT_MCP_REQUEST_HISTORY_LIST_LIMIT);
+
+    return entries.map((entry) => ({
+      ...entry,
+      outcome: entry.outcome as DirectMcpRequestHistoryEntry['outcome'],
+    }));
+  } catch {
+    throw new Error('Direct MCP request history is unavailable.');
+  }
+}

--- a/app/lib/mcp/server/settings-status.ts
+++ b/app/lib/mcp/server/settings-status.ts
@@ -12,6 +12,7 @@ import {
   resolveDirectMcpOrigin,
   type DirectMcpToolId,
 } from '@/app/lib/mcp/server/config';
+import { DIRECT_MCP_SERVER_VERSION } from '@/app/lib/mcp/server/version';
 import {
   getDirectMcpServerPreferences,
   type DirectMcpServerPreferences,
@@ -38,6 +39,7 @@ export type DirectMcpServerSettingsStatus = {
   endpoint: string | null;
   issuer: string | null;
   protocolVersion: string;
+  serverVersion: string;
   transport: 'streamable-http';
   authentication: 'oauth-2.1-pkce';
   configurationError: string | null;
@@ -127,6 +129,7 @@ export function buildDirectMcpServerSettingsStatus(
     endpoint: origin ? `${origin}/mcp` : null,
     issuer: origin ? `${origin}/api/auth` : null,
     protocolVersion: DIRECT_MCP_PROTOCOL_VERSION,
+    serverVersion: DIRECT_MCP_SERVER_VERSION,
     transport: 'streamable-http',
     authentication: 'oauth-2.1-pkce',
     configurationError,

--- a/app/lib/mcp/server/streamable-http.ts
+++ b/app/lib/mcp/server/streamable-http.ts
@@ -19,6 +19,7 @@ import {
   beginDirectMcpDiagnostic,
   completeDirectMcpDiagnostic,
   failDirectMcpDiagnostic,
+  runWithDirectMcpDiagnostic,
   type DirectMcpDiagnosticContext,
 } from '@/app/lib/mcp/server/diagnostics';
 import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
@@ -52,7 +53,7 @@ function createModernMcpHandler(
     {
       legacy: 'reject',
       onerror: () => {
-        failDirectMcpDiagnostic(diagnostics, {
+        void failDirectMcpDiagnostic(diagnostics, {
           code: 'MCP_TRANSPORT_ERROR',
           startedAt,
           statusCode: 500,
@@ -182,69 +183,71 @@ async function resolveAuthInfo(request: Request): Promise<AuthInfo | undefined> 
 export async function handleDirectMcpPost(request: Request): Promise<Response> {
   const startedAt = Date.now();
   const diagnostics = beginDirectMcpDiagnostic(request, 'mcp.http');
-  try {
-    const runtimeSettings = await getDirectMcpRuntimeSettings();
-    if (!runtimeSettings.enabled) {
-      const response = withDirectMcpHeaders(directMcpNotFound(), request, diagnostics.requestId);
-      completeDirectMcpDiagnostic(diagnostics, {
-        statusCode: response.status,
-        code: 'MCP_DISABLED',
-        startedAt,
-      });
-      return response;
-    }
-    const originRejection = rejectUntrustedOrigin(request);
-    if (originRejection) {
-      const response = withDirectMcpHeaders(originRejection, request, diagnostics.requestId);
-      completeDirectMcpDiagnostic(diagnostics, {
-        statusCode: response.status,
-        code: 'MCP_ORIGIN_REJECTED',
-        startedAt,
-      });
-      return response;
-    }
-
-    let authInfo: AuthInfo | undefined;
+  return runWithDirectMcpDiagnostic(diagnostics, async () => {
     try {
-      authInfo = await resolveAuthInfo(request);
-    } catch (error) {
-      if (error instanceof DirectMcpAuthorizationError) {
-        const response = withDirectMcpHeaders(error.toResponse(), request, diagnostics.requestId);
-        completeDirectMcpDiagnostic(diagnostics, {
+      const runtimeSettings = await getDirectMcpRuntimeSettings();
+      if (!runtimeSettings.enabled) {
+        const response = withDirectMcpHeaders(directMcpNotFound(), request, diagnostics.requestId);
+        await completeDirectMcpDiagnostic(diagnostics, {
           statusCode: response.status,
-          code: `MCP_${error.code.toUpperCase()}`,
+          code: 'MCP_DISABLED',
           startedAt,
         });
         return response;
       }
-      throw error;
-    }
+      const originRejection = rejectUntrustedOrigin(request);
+      if (originRejection) {
+        const response = withDirectMcpHeaders(originRejection, request, diagnostics.requestId);
+        await completeDirectMcpDiagnostic(diagnostics, {
+          statusCode: response.status,
+          code: 'MCP_ORIGIN_REJECTED',
+          startedAt,
+        });
+        return response;
+      }
 
-    const response = withDirectMcpHeaders(
-      await handleProtocolRequest(
+      let authInfo: AuthInfo | undefined;
+      try {
+        authInfo = await resolveAuthInfo(request);
+      } catch (error) {
+        if (error instanceof DirectMcpAuthorizationError) {
+          const response = withDirectMcpHeaders(error.toResponse(), request, diagnostics.requestId);
+          await completeDirectMcpDiagnostic(diagnostics, {
+            statusCode: response.status,
+            code: `MCP_${error.code.toUpperCase()}`,
+            startedAt,
+          });
+          return response;
+        }
+        throw error;
+      }
+
+      const response = withDirectMcpHeaders(
+        await handleProtocolRequest(
+          request,
+          runtimeSettings.tools,
+          authInfo,
+          diagnostics,
+          startedAt,
+        ),
         request,
-        runtimeSettings.tools,
-        authInfo,
-        diagnostics,
+        diagnostics.requestId,
+      );
+      await completeDirectMcpDiagnostic(diagnostics, {
+        statusCode: response.status,
+        code: response.status >= 500 ? 'MCP_TRANSPORT_ERROR' : 'MCP_REQUEST_COMPLETED',
         startedAt,
-      ),
-      request,
-      diagnostics.requestId,
-    );
-    completeDirectMcpDiagnostic(diagnostics, {
-      statusCode: response.status,
-      code: response.status >= 500 ? 'MCP_TRANSPORT_ERROR' : 'MCP_REQUEST_COMPLETED',
-      startedAt,
-    });
-    return response;
-  } catch {
-    failDirectMcpDiagnostic(diagnostics, {
-      code: 'MCP_INTERNAL_ERROR',
-      startedAt,
-      statusCode: 500,
-    });
-    return withDirectMcpHeaders(internalMcpErrorResponse(), request, diagnostics.requestId);
-  }
+      });
+      return response;
+    } catch {
+      await failDirectMcpDiagnostic(diagnostics, {
+        code: 'MCP_INTERNAL_ERROR',
+        startedAt,
+        statusCode: 500,
+      });
+      return withDirectMcpHeaders(internalMcpErrorResponse(), request, diagnostics.requestId);
+    }
+  });
 }
 
 export async function handleDirectMcpUnsupportedMethod(request: Request): Promise<Response> {
@@ -260,7 +263,7 @@ export async function handleDirectMcpUnsupportedMethod(request: Request): Promis
       request,
       diagnostics.requestId,
     );
-    completeDirectMcpDiagnostic(diagnostics, {
+    await completeDirectMcpDiagnostic(diagnostics, {
       statusCode: responseWithHeaders.status,
       code: responseWithHeaders.status === 404
         ? 'MCP_DISABLED'
@@ -271,7 +274,7 @@ export async function handleDirectMcpUnsupportedMethod(request: Request): Promis
     });
     return responseWithHeaders;
   } catch {
-    failDirectMcpDiagnostic(diagnostics, {
+    await failDirectMcpDiagnostic(diagnostics, {
       code: 'MCP_INTERNAL_ERROR',
       startedAt,
       statusCode: 500,
@@ -295,7 +298,7 @@ export async function handleDirectMcpOptions(request: Request): Promise<Response
         request,
         diagnostics.requestId,
       );
-      completeDirectMcpDiagnostic(diagnostics, {
+      await completeDirectMcpDiagnostic(diagnostics, {
         statusCode: response.status,
         code: 'MCP_DISABLED',
         startedAt,
@@ -309,7 +312,7 @@ export async function handleDirectMcpOptions(request: Request): Promise<Response
         request,
         diagnostics.requestId,
       );
-      completeDirectMcpDiagnostic(diagnostics, {
+      await completeDirectMcpDiagnostic(diagnostics, {
         statusCode: response.status,
         code: 'MCP_ORIGIN_REJECTED',
         startedAt,
@@ -334,14 +337,14 @@ export async function handleDirectMcpOptions(request: Request): Promise<Response
       request,
       diagnostics.requestId,
     );
-    completeDirectMcpDiagnostic(diagnostics, {
+    await completeDirectMcpDiagnostic(diagnostics, {
       statusCode: response.status,
       code: 'MCP_OPTIONS_COMPLETED',
       startedAt,
     });
     return response;
   } catch {
-    failDirectMcpDiagnostic(diagnostics, {
+    await failDirectMcpDiagnostic(diagnostics, {
       code: 'MCP_INTERNAL_ERROR',
       startedAt,
       statusCode: 500,

--- a/app/lib/mcp/server/version.ts
+++ b/app/lib/mcp/server/version.ts
@@ -1,0 +1,7 @@
+import 'server-only';
+
+import packageJson from '@/package.json';
+
+// This is the Canvas Notebook release version, distinct from the separately
+// negotiated MCP protocol version.
+export const DIRECT_MCP_SERVER_VERSION = packageJson.version;

--- a/app/lib/mcp/server/workspace-access-policy.ts
+++ b/app/lib/mcp/server/workspace-access-policy.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { openDb } from '@/app/lib/db';
+import { getDatabaseProvider, openDb, type SqlConnection } from '@/app/lib/db';
 import type { DirectMcpAccessPrincipal } from '@/app/lib/mcp/server/access-token-verifier';
 import { resolveWorkspaceActor } from '@/app/lib/workspaces/context';
 import {
@@ -32,6 +32,39 @@ export type SetDirectMcpWorkspaceEnabledResult =
   | { status: 'updated'; enabled: boolean }
   | { status: 'not_found' }
   | { status: 'forbidden' };
+
+async function lockDirectMcpWorkspaceIds(
+  database: SqlConnection,
+  workspaceIds: readonly string[],
+): Promise<void> {
+  if (!workspaceIds.length || getDatabaseProvider() !== 'postgres') return;
+
+  // Postgres row locks cannot protect a setting that has just been deleted,
+  // so use one transaction-scoped advisory lock per workspace. Every write
+  // path below takes the same locks before changing settings or grants.
+  for (const workspaceId of workspaceIds) {
+    await database.run(
+      "SELECT pg_advisory_xact_lock(hashtext('direct-mcp-workspace:' || ?))",
+      [workspaceId],
+    );
+  }
+}
+
+async function areDirectMcpWorkspacesEnabled(
+  database: SqlConnection,
+  workspaceIds: readonly string[],
+): Promise<boolean> {
+  if (!workspaceIds.length) return true;
+  const placeholders = workspaceIds.map(() => '?').join(', ');
+  const rows = await database.all(`
+    SELECT workspace_id
+    FROM mcp_direct_workspace_setting
+    WHERE workspace_id IN (${placeholders})
+  `, [...workspaceIds]) as Array<{ workspace_id: unknown }>;
+  return new Set(rows
+    .map((row) => typeof row.workspace_id === 'string' ? row.workspace_id : null)
+    .filter((workspaceId): workspaceId is string => Boolean(workspaceId))).size === workspaceIds.length;
+}
 
 export function isDirectMcpReadableWorkspace(workspace: WorkspaceContext): boolean {
   return workspace.permissions.canRead
@@ -137,6 +170,7 @@ export async function setDirectMcpWorkspaceEnabled(input: {
   const now = Date.now();
   try {
     await database.run('BEGIN');
+    await lockDirectMcpWorkspaceIds(database, [input.workspaceId]);
     if (input.enabled) {
       await database.run(`
         INSERT INTO mcp_direct_workspace_setting (
@@ -202,6 +236,11 @@ export async function replaceDirectMcpAllowedWorkspaces(input: {
   const updatedAt = Date.now();
   try {
     await database.run('BEGIN');
+    await lockDirectMcpWorkspaceIds(database, workspaceIds);
+    if (!await areDirectMcpWorkspacesEnabled(database, workspaceIds)) {
+      await database.run('ROLLBACK');
+      return { status: 'invalid_workspace' };
+    }
     await database.run(`
       DELETE FROM mcp_direct_workspace_grant
       WHERE client_id = ? AND user_id = ?

--- a/app/lib/mcp/server/workspace-access-policy.ts
+++ b/app/lib/mcp/server/workspace-access-policy.ts
@@ -1,0 +1,141 @@
+import 'server-only';
+
+import { openDb } from '@/app/lib/db';
+import type { DirectMcpAccessPrincipal } from '@/app/lib/mcp/server/access-token-verifier';
+import { resolveWorkspaceActor } from '@/app/lib/workspaces/context';
+import {
+  loadWorkspaceListingForActor,
+  type WorkspaceListing,
+} from '@/app/lib/workspaces/listing-action';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
+
+const MAX_WORKSPACE_ID_LENGTH = 200;
+const MAX_ALLOWED_WORKSPACES = 200;
+
+export type DirectMcpWorkspaceOption = {
+  workspaceId: string;
+  name: string;
+  description: string | null;
+  type: string;
+};
+
+export type ReplaceDirectMcpWorkspaceAccessResult =
+  | { status: 'saved'; allowedWorkspaceCount: number }
+  | { status: 'invalid_workspace' };
+
+export function isDirectMcpReadableWorkspace(workspace: WorkspaceContext): boolean {
+  return workspace.permissions.canRead
+    && workspace.status !== 'archived'
+    && workspace.status !== 'disabled'
+    && workspace.status !== 'recovery_locked';
+}
+
+export async function loadDirectMcpWorkspaceListingForUser(
+  userId: string,
+): Promise<WorkspaceListing> {
+  const database = await openDb();
+  try {
+    const identity = await database.get(
+      'SELECT email, role FROM "user" WHERE id = ? LIMIT 1',
+      [userId],
+    ) as { email?: unknown; role?: unknown } | undefined;
+    if (!identity || typeof identity.email !== 'string') {
+      throw new Error('The signed-in Canvas user is no longer available.');
+    }
+    return await loadWorkspaceListingForActor(resolveWorkspaceActor({
+      id: userId,
+      email: identity.email,
+      role: typeof identity.role === 'string' ? identity.role : null,
+    }));
+  } finally {
+    await database.close();
+  }
+}
+
+export async function listDirectMcpAllowedWorkspaceIds(
+  principal: Pick<DirectMcpAccessPrincipal, 'clientId' | 'userId'>,
+): Promise<Set<string>> {
+  const database = await openDb();
+  try {
+    const rows = await database.all(`
+      SELECT workspace_id
+      FROM mcp_direct_workspace_grant
+      WHERE client_id = ? AND user_id = ?
+    `, [principal.clientId, principal.userId]) as Array<{ workspace_id: unknown }>;
+    return new Set(rows
+      .map((row) => typeof row.workspace_id === 'string' ? row.workspace_id : null)
+      .filter((workspaceId): workspaceId is string => Boolean(workspaceId)));
+  } finally {
+    await database.close();
+  }
+}
+
+export async function listDirectMcpSelectableWorkspaces(
+  userId: string,
+): Promise<DirectMcpWorkspaceOption[]> {
+  const listing = await loadDirectMcpWorkspaceListingForUser(userId);
+  return listing.workspaces
+    .filter(isDirectMcpReadableWorkspace)
+    .map((workspace) => ({
+      workspaceId: workspace.workspaceId,
+      name: workspace.displayName || 'Workspace',
+      description: workspace.description || null,
+      type: workspace.workspaceType,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function normalizeWorkspaceIds(workspaceIds: readonly unknown[]): string[] | null {
+  if (workspaceIds.length > MAX_ALLOWED_WORKSPACES) return null;
+  const result = new Set<string>();
+  for (const workspaceId of workspaceIds) {
+    if (typeof workspaceId !== 'string') return null;
+    const normalized = workspaceId.trim();
+    if (!normalized || normalized.length > MAX_WORKSPACE_ID_LENGTH) return null;
+    result.add(normalized);
+  }
+  return [...result].sort();
+}
+
+export async function replaceDirectMcpAllowedWorkspaces(input: {
+  clientId: string;
+  userId: string;
+  workspaceIds: readonly string[];
+}): Promise<ReplaceDirectMcpWorkspaceAccessResult> {
+  const workspaceIds = normalizeWorkspaceIds(input.workspaceIds);
+  if (!workspaceIds) return { status: 'invalid_workspace' };
+
+  const selectable = await listDirectMcpSelectableWorkspaces(input.userId);
+  const selectableIds = new Set(selectable.map((workspace) => workspace.workspaceId));
+  if (workspaceIds.some((workspaceId) => !selectableIds.has(workspaceId))) {
+    return { status: 'invalid_workspace' };
+  }
+
+  const database = await openDb();
+  const updatedAt = Date.now();
+  try {
+    await database.run('BEGIN');
+    await database.run(`
+      DELETE FROM mcp_direct_workspace_grant
+      WHERE client_id = ? AND user_id = ?
+    `, [input.clientId, input.userId]);
+    for (const workspaceId of workspaceIds) {
+      await database.run(`
+        INSERT INTO mcp_direct_workspace_grant (
+          client_id, user_id, workspace_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?)
+      `, [input.clientId, input.userId, workspaceId, updatedAt, updatedAt]);
+    }
+    await database.run('COMMIT');
+    return { status: 'saved', allowedWorkspaceCount: workspaceIds.length };
+  } catch (error) {
+    try {
+      await database.run('ROLLBACK');
+    } catch {
+      // The transaction may already have been rolled back by the database.
+    }
+    throw error;
+  } finally {
+    await database.close();
+  }
+}

--- a/app/lib/mcp/server/workspace-access-policy.ts
+++ b/app/lib/mcp/server/workspace-access-policy.ts
@@ -19,9 +19,19 @@ export type DirectMcpWorkspaceOption = {
   type: string;
 };
 
+export type DirectMcpWorkspaceConfiguration = DirectMcpWorkspaceOption & {
+  enabled: boolean;
+  canManage: boolean;
+};
+
 export type ReplaceDirectMcpWorkspaceAccessResult =
   | { status: 'saved'; allowedWorkspaceCount: number }
   | { status: 'invalid_workspace' };
+
+export type SetDirectMcpWorkspaceEnabledResult =
+  | { status: 'updated'; enabled: boolean }
+  | { status: 'not_found' }
+  | { status: 'forbidden' };
 
 export function isDirectMcpReadableWorkspace(workspace: WorkspaceContext): boolean {
   return workspace.permissions.canRead
@@ -70,10 +80,27 @@ export async function listDirectMcpAllowedWorkspaceIds(
   }
 }
 
-export async function listDirectMcpSelectableWorkspaces(
+export async function listDirectMcpEnabledWorkspaceIds(): Promise<Set<string>> {
+  const database = await openDb();
+  try {
+    const rows = await database.all(
+      'SELECT workspace_id FROM mcp_direct_workspace_setting',
+    ) as Array<{ workspace_id: unknown }>;
+    return new Set(rows
+      .map((row) => typeof row.workspace_id === 'string' ? row.workspace_id : null)
+      .filter((workspaceId): workspaceId is string => Boolean(workspaceId)));
+  } finally {
+    await database.close();
+  }
+}
+
+export async function listDirectMcpWorkspaceConfigurations(
   userId: string,
-): Promise<DirectMcpWorkspaceOption[]> {
-  const listing = await loadDirectMcpWorkspaceListingForUser(userId);
+): Promise<DirectMcpWorkspaceConfiguration[]> {
+  const [listing, enabledWorkspaceIds] = await Promise.all([
+    loadDirectMcpWorkspaceListingForUser(userId),
+    listDirectMcpEnabledWorkspaceIds(),
+  ]);
   return listing.workspaces
     .filter(isDirectMcpReadableWorkspace)
     .map((workspace) => ({
@@ -81,8 +108,68 @@ export async function listDirectMcpSelectableWorkspaces(
       name: workspace.displayName || 'Workspace',
       description: workspace.description || null,
       type: workspace.workspaceType,
+      enabled: enabledWorkspaceIds.has(workspace.workspaceId),
+      canManage: workspace.permissions.canManageWorkspace,
     }))
     .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export async function listDirectMcpSelectableWorkspaces(
+  userId: string,
+): Promise<DirectMcpWorkspaceOption[]> {
+  const workspaces = await listDirectMcpWorkspaceConfigurations(userId);
+  return workspaces
+    .filter((workspace) => workspace.enabled)
+    .map(({ enabled: _enabled, canManage: _canManage, ...workspace }) => workspace);
+}
+
+export async function setDirectMcpWorkspaceEnabled(input: {
+  userId: string;
+  workspaceId: string;
+  enabled: boolean;
+}): Promise<SetDirectMcpWorkspaceEnabledResult> {
+  const workspaces = await listDirectMcpWorkspaceConfigurations(input.userId);
+  const workspace = workspaces.find((candidate) => candidate.workspaceId === input.workspaceId);
+  if (!workspace) return { status: 'not_found' };
+  if (!workspace.canManage) return { status: 'forbidden' };
+
+  const database = await openDb();
+  const now = Date.now();
+  try {
+    await database.run('BEGIN');
+    if (input.enabled) {
+      await database.run(`
+        INSERT INTO mcp_direct_workspace_setting (
+          workspace_id, enabled_by_user_id, enabled_at, updated_at
+        ) VALUES (?, ?, ?, ?)
+        ON CONFLICT(workspace_id) DO UPDATE SET
+          enabled_by_user_id = excluded.enabled_by_user_id,
+          updated_at = excluded.updated_at
+      `, [input.workspaceId, input.userId, now, now]);
+    } else {
+      // Disabling a workspace revokes every existing client selection, so a
+      // later re-enable requires an explicit, fresh per-connection choice.
+      await database.run(
+        'DELETE FROM mcp_direct_workspace_grant WHERE workspace_id = ?',
+        [input.workspaceId],
+      );
+      await database.run(
+        'DELETE FROM mcp_direct_workspace_setting WHERE workspace_id = ?',
+        [input.workspaceId],
+      );
+    }
+    await database.run('COMMIT');
+    return { status: 'updated', enabled: input.enabled };
+  } catch (error) {
+    try {
+      await database.run('ROLLBACK');
+    } catch {
+      // The transaction may already have been rolled back by the database.
+    }
+    throw error;
+  } finally {
+    await database.close();
+  }
 }
 
 function normalizeWorkspaceIds(workspaceIds: readonly unknown[]): string[] | null {

--- a/app/lib/mcp/server/workspace-tools.ts
+++ b/app/lib/mcp/server/workspace-tools.ts
@@ -30,6 +30,7 @@ import type { DirectMcpToolDescriptor } from '@/app/lib/mcp/server/tool-descript
 import {
   isDirectMcpReadableWorkspace,
   listDirectMcpAllowedWorkspaceIds,
+  listDirectMcpEnabledWorkspaceIds,
   loadDirectMcpWorkspaceListingForUser,
 } from '@/app/lib/mcp/server/workspace-access-policy';
 import type { WorkspaceContext } from '@/app/lib/workspaces/types';
@@ -361,14 +362,16 @@ async function readableWorkspace(
   principal: DirectMcpAccessPrincipal,
   workspaceId: string,
 ): Promise<WorkspaceContext> {
-  const [listing, allowedWorkspaceIds] = await Promise.all([
+  const [listing, allowedWorkspaceIds, enabledWorkspaceIds] = await Promise.all([
     loadDirectMcpWorkspaceListingForUser(principal.userId),
     listDirectMcpAllowedWorkspaceIds(principal),
+    listDirectMcpEnabledWorkspaceIds(),
   ]);
   const workspace = listing.workspaces.find((candidate) => candidate.workspaceId === workspaceId);
   if (
     !workspace
     || !isDirectMcpReadableWorkspace(workspace)
+    || !enabledWorkspaceIds.has(workspaceId)
     || !allowedWorkspaceIds.has(workspaceId)
   ) {
     throw new Error('The requested workspace is not available to this Canvas user.');
@@ -488,13 +491,15 @@ async function executeListWorkspaces(
   if ('result' in authorization) return authorization.result;
 
   try {
-    const [listing, allowedWorkspaceIds] = await Promise.all([
+    const [listing, allowedWorkspaceIds, enabledWorkspaceIds] = await Promise.all([
       loadDirectMcpWorkspaceListingForUser(authorization.principal.userId),
       listDirectMcpAllowedWorkspaceIds(authorization.principal),
+      listDirectMcpEnabledWorkspaceIds(),
     ]);
     const workspaces = listing.workspaces
       .filter((workspace) => (
         isDirectMcpReadableWorkspace(workspace)
+        && enabledWorkspaceIds.has(workspace.workspaceId)
         && allowedWorkspaceIds.has(workspace.workspaceId)
       ))
       .map(workspaceSummary);

--- a/app/lib/mcp/server/workspace-tools.ts
+++ b/app/lib/mcp/server/workspace-tools.ts
@@ -10,7 +10,6 @@ import {
 } from '@modelcontextprotocol/server';
 
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
-import { openDb } from '@/app/lib/db';
 import {
   getFileStats,
   listDirectory,
@@ -28,11 +27,11 @@ import {
 } from '@/app/lib/mcp/server/config';
 import { directMcpToolAuthorizationError } from '@/app/lib/mcp/server/tool-auth';
 import type { DirectMcpToolDescriptor } from '@/app/lib/mcp/server/tool-descriptor';
-import { resolveWorkspaceActor } from '@/app/lib/workspaces/context';
 import {
-  loadWorkspaceListingForActor,
-  type WorkspaceListing,
-} from '@/app/lib/workspaces/listing-action';
+  isDirectMcpReadableWorkspace,
+  listDirectMcpAllowedWorkspaceIds,
+  loadDirectMcpWorkspaceListingForUser,
+} from '@/app/lib/mcp/server/workspace-access-policy';
 import type { WorkspaceContext } from '@/app/lib/workspaces/types';
 
 export const DIRECT_MCP_WORKSPACE_TOOL_IDS = [
@@ -139,13 +138,6 @@ function isVisibleWorkspaceNode(node: FileNode): boolean {
   return node.path.split('/').every((segment) => segment !== '.' && !segment.startsWith('.'));
 }
 
-function isReadableWorkspace(workspace: WorkspaceContext): boolean {
-  return workspace.permissions.canRead
-    && workspace.status !== 'archived'
-    && workspace.status !== 'disabled'
-    && workspace.status !== 'recovery_locked';
-}
-
 function workspaceSummary(workspace: WorkspaceContext) {
   return {
     id: workspace.workspaceId,
@@ -188,7 +180,7 @@ export function getDirectMcpWorkspaceToolDescriptor(tool: WorkspaceToolName): Di
     return {
       name: tool,
       title: 'List available workspaces',
-      description: 'Lists the Canvas workspaces that the signed-in user can currently access.',
+      description: 'Lists the Canvas workspaces that the signed-in user has explicitly allowed for this MCP connection.',
       inputSchema: {
         type: 'object' as const,
         properties: {},
@@ -350,26 +342,6 @@ export function getDirectMcpWorkspaceToolDescriptor(tool: WorkspaceToolName): Di
   };
 }
 
-async function loadWorkspaceListing(principal: DirectMcpAccessPrincipal): Promise<WorkspaceListing> {
-  const database = await openDb();
-  try {
-    const identity = await database.get(
-      'SELECT email, role FROM "user" WHERE id = ? LIMIT 1',
-      [principal.userId],
-    ) as { email?: unknown; role?: unknown } | undefined;
-    if (!identity || typeof identity.email !== 'string') {
-      throw new Error('The signed-in Canvas user is no longer available.');
-    }
-    return await loadWorkspaceListingForActor(resolveWorkspaceActor({
-      id: principal.userId,
-      email: identity.email,
-      role: typeof identity.role === 'string' ? identity.role : null,
-    }));
-  } finally {
-    await database.close();
-  }
-}
-
 async function authenticateForTool(
   authInfo: AuthInfo | undefined,
   scope: DirectMcpResourceScope,
@@ -389,9 +361,16 @@ async function readableWorkspace(
   principal: DirectMcpAccessPrincipal,
   workspaceId: string,
 ): Promise<WorkspaceContext> {
-  const listing = await loadWorkspaceListing(principal);
+  const [listing, allowedWorkspaceIds] = await Promise.all([
+    loadDirectMcpWorkspaceListingForUser(principal.userId),
+    listDirectMcpAllowedWorkspaceIds(principal),
+  ]);
   const workspace = listing.workspaces.find((candidate) => candidate.workspaceId === workspaceId);
-  if (!workspace || !isReadableWorkspace(workspace)) {
+  if (
+    !workspace
+    || !isDirectMcpReadableWorkspace(workspace)
+    || !allowedWorkspaceIds.has(workspaceId)
+  ) {
     throw new Error('The requested workspace is not available to this Canvas user.');
   }
   return workspace;
@@ -509,9 +488,15 @@ async function executeListWorkspaces(
   if ('result' in authorization) return authorization.result;
 
   try {
-    const listing = await loadWorkspaceListing(authorization.principal);
+    const [listing, allowedWorkspaceIds] = await Promise.all([
+      loadDirectMcpWorkspaceListingForUser(authorization.principal.userId),
+      listDirectMcpAllowedWorkspaceIds(authorization.principal),
+    ]);
     const workspaces = listing.workspaces
-      .filter(isReadableWorkspace)
+      .filter((workspace) => (
+        isDirectMcpReadableWorkspace(workspace)
+        && allowedWorkspaceIds.has(workspace.workspaceId)
+      ))
       .map(workspaceSummary);
     await auditWorkspaceToolCall({
       principal: authorization.principal,

--- a/messages/de.json
+++ b/messages/de.json
@@ -3327,6 +3327,21 @@
         "missing": "Die öffentliche Canvas-Domain ist noch nicht konfiguriert.",
         "notConfigured": "Keine Server-Adresse verfügbar"
       },
+      "connections": {
+        "title": "Deine verbundenen Clients",
+        "description": "Zeigt die MCP-Clients, die du autorisiert hast. Beim Trennen verliert dieser Client sofort den Zugriff auf deine Canvas-Daten; andere Personen bleiben unberührt.",
+        "refresh": "Aktualisieren",
+        "loading": "Lade verbundene Clients …",
+        "empty": "Du hast noch keine MCP-Clients autorisiert.",
+        "authorizedAt": "Autorisiert {time}",
+        "disconnect": "Trennen",
+        "disconnectConfirm": "{client} trennen? Der Zugriff auf deine Canvas-Daten wird sofort entfernt.",
+        "disconnected": "MCP-Client getrennt.",
+        "errors": {
+          "load": "Deine MCP-Verbindungen konnten nicht geladen werden.",
+          "disconnect": "Dieser MCP-Client konnte nicht getrennt werden."
+        }
+      },
       "requestHistory": {
         "title": "Letzte Anfragen",
         "description": "Zeigt die letzten Anfragen an diesen Canvas-MCP-Server. Es werden nur sichere technische Metadaten gespeichert und nach {hours} Stunden automatisch gelöscht.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -3334,6 +3334,7 @@
         "loading": "Lade letzte Anfragen …",
         "empty": "Keine Anfragen in den letzten {hours} Stunden.",
         "requestId": "Request-ID",
+        "serverVersion": "Serverversion",
         "duration": "{duration} ms",
         "outcomes": {
           "succeeded": "Erfolgreich",
@@ -3401,6 +3402,7 @@
         "endpoint": "MCP-Endpunkt",
         "issuer": "OAuth-Aussteller",
         "protocol": "Protokoll",
+        "serverVersion": "Serverversion",
         "authentication": "Anmeldung und Transport",
         "scopes": "Freigegebene Berechtigungen"
       },

--- a/messages/de.json
+++ b/messages/de.json
@@ -3327,6 +3327,23 @@
         "missing": "Die öffentliche Canvas-Domain ist noch nicht konfiguriert.",
         "notConfigured": "Keine Server-Adresse verfügbar"
       },
+      "requestHistory": {
+        "title": "Letzte Anfragen",
+        "description": "Zeigt die letzten Anfragen an diesen Canvas-MCP-Server. Es werden nur sichere technische Metadaten gespeichert und nach {hours} Stunden automatisch gelöscht.",
+        "refresh": "Aktualisieren",
+        "loading": "Lade letzte Anfragen …",
+        "empty": "Keine Anfragen in den letzten {hours} Stunden.",
+        "requestId": "Request-ID",
+        "duration": "{duration} ms",
+        "outcomes": {
+          "succeeded": "Erfolgreich",
+          "failed": "Fehler",
+          "rejected": "Abgewiesen"
+        },
+        "errors": {
+          "load": "Die letzten MCP-Anfragen konnten nicht geladen werden."
+        }
+      },
       "capabilities": {
         "title": "Was Clients verwenden dürfen",
         "description": "Nur aktivierte Werkzeuge werden über MCP bekanntgegeben.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -3340,6 +3340,24 @@
         "errors": {
           "load": "Deine MCP-Verbindungen konnten nicht geladen werden.",
           "disconnect": "Dieser MCP-Client konnte nicht getrennt werden."
+        },
+        "workspaceAccess": {
+          "manage": "Workspace-Zugriff verwalten",
+          "selectedCount": "{count, plural, =0 {Keine Workspaces ausgewählt} one {# Workspace ausgewählt} other {# Workspaces ausgewählt}}",
+          "title": "Workspace-Zugriff",
+          "description": "Wähle genau die Workspaces aus, auf die dieser Client zugreifen darf. Canvas prüft deine aktuellen Workspace-Rechte zusätzlich bei jeder MCP-Anfrage.",
+          "refresh": "Aktualisieren",
+          "loading": "Lade erreichbare Workspaces …",
+          "type": "{type}-Workspace",
+          "noneSelected": "Dieser Client kann erst auf Workspace-Daten zugreifen, nachdem du mindestens einen Workspace ausgewählt und gespeichert hast.",
+          "noWorkspaces": "Es gibt derzeit keine lesbaren Workspaces zur Auswahl.",
+          "save": "Zugriff speichern",
+          "saving": "Wird gespeichert …",
+          "saved": "Workspace-Zugriff gespeichert.",
+          "errors": {
+            "load": "Die verfügbaren Workspaces konnten nicht geladen werden.",
+            "save": "Der Workspace-Zugriff konnte nicht gespeichert werden."
+          }
         }
       },
       "requestHistory": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -3360,6 +3360,22 @@
           }
         }
       },
+      "workspaceCatalog": {
+        "title": "Für Direct MCP verfügbare Workspaces",
+        "description": "Aktiviere einen Workspace hier, bevor du ihn einer bestimmten MCP-Verbindung zuordnen kannst. Die aktuellen Canvas-Workspace-Rechte gelten weiterhin bei jeder Anfrage.",
+        "loading": "Workspaces werden geladen …",
+        "type": "{type}-Workspace",
+        "notManager": "Nur Workspace-Manager können diesen Workspace für MCP aktivieren.",
+        "empty": "Es gibt keine aktiven Workspaces, auf die du zugreifen kannst.",
+        "connectionHint": "Wähle einen aktivierten Workspace anschließend für jede MCP-Verbindung weiter unten aus. Erst wenn beide Schritte abgeschlossen sind, kann eine Verbindung auf den Workspace zugreifen.",
+        "errors": {
+          "load": "Die MCP-Workspace-Einstellungen konnten nicht geladen werden."
+        },
+        "noneEnabled": {
+          "title": "Für Direct MCP ist noch kein Workspace aktiviert",
+          "description": "Aktiviere mindestens einen Workspace unten und ordne ihn dann der gewünschten MCP-Verbindung zu. Ohne aktivierten Workspace kann sich der Server zwar authentifizieren, aber keine Workspace-Daten zurückgeben."
+        }
+      },
       "requestHistory": {
         "title": "Letzte Anfragen",
         "description": "Zeigt die letzten Anfragen an diesen Canvas-MCP-Server. Es werden nur sichere technische Metadaten gespeichert und nach {hours} Stunden automatisch gelöscht.",
@@ -4077,6 +4093,16 @@
           "descriptionFallback": "Name, Kurzbeschreibung, Icon und Zugriff des Workspace anpassen.",
           "cancel": "Abbrechen",
           "save": "Änderungen speichern"
+        },
+        "mcp": {
+          "title": "Direct-MCP-Zugriff",
+          "description": "Erlaube, dass dieser Workspace für Direct-MCP-Verbindungen ausgewählt werden kann. Jede Verbindung benötigt zusätzlich eine eigene explizite Workspace-Auswahl.",
+          "immediate": "Dieser Schalter wird sofort gespeichert. Beim Ausschalten werden alle bisherigen MCP-Verbindungsfreigaben für diesen Workspace widerrufen.",
+          "switchLabel": "Workspace für Direct MCP aktivieren",
+          "errors": {
+            "load": "Der Direct-MCP-Zugriff für den Workspace konnte nicht geladen werden.",
+            "update": "Der Direct-MCP-Zugriff für den Workspace konnte nicht aktualisiert werden."
+          }
         },
         "typeChange": {
           "action": "Typ ändern",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3328,6 +3328,21 @@
         "missing": "The public Canvas domain has not been configured yet.",
         "notConfigured": "No server address available"
       },
+      "connections": {
+        "title": "Your connected clients",
+        "description": "Shows the MCP clients you have authorized. Disconnecting immediately removes this client's access to your Canvas data without affecting other people.",
+        "refresh": "Refresh",
+        "loading": "Loading connected clients…",
+        "empty": "You have not authorized any MCP clients yet.",
+        "authorizedAt": "Authorized {time}",
+        "disconnect": "Disconnect",
+        "disconnectConfirm": "Disconnect {client}? This immediately removes its access to your Canvas data.",
+        "disconnected": "MCP client disconnected.",
+        "errors": {
+          "load": "Could not load your MCP connections.",
+          "disconnect": "Could not disconnect this MCP client."
+        }
+      },
       "requestHistory": {
         "title": "Recent requests",
         "description": "Shows recent requests to this Canvas MCP server. Only safe technical metadata is stored and it is deleted automatically after {hours} hours.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3361,6 +3361,22 @@
           }
         }
       },
+      "workspaceCatalog": {
+        "title": "Workspaces available to Direct MCP",
+        "description": "Enable a workspace here before it can be granted to a specific MCP connection. Current Canvas workspace permissions still apply to every request.",
+        "loading": "Loading workspaces…",
+        "type": "{type} workspace",
+        "notManager": "Only a workspace manager can enable this workspace for MCP.",
+        "empty": "There are no active workspaces you can access.",
+        "connectionHint": "After enabling a workspace, select it for each MCP connection below. A connection cannot access a workspace until both steps are complete.",
+        "errors": {
+          "load": "Could not load MCP workspace settings."
+        },
+        "noneEnabled": {
+          "title": "No workspace is enabled for Direct MCP yet",
+          "description": "Enable at least one workspace below, then grant it to the MCP connection you want to use. Without an enabled workspace, the server can authenticate but cannot return workspace data."
+        }
+      },
       "requestHistory": {
         "title": "Recent requests",
         "description": "Shows recent requests to this Canvas MCP server. Only safe technical metadata is stored and it is deleted automatically after {hours} hours.",
@@ -4078,6 +4094,16 @@
           "descriptionFallback": "Update the workspace name, short description, icon, and access.",
           "cancel": "Cancel",
           "save": "Save changes"
+        },
+        "mcp": {
+          "title": "Direct MCP access",
+          "description": "Allow this workspace to be selected for Direct MCP connections. Each connection still needs its own explicit workspace selection.",
+          "immediate": "This switch is saved immediately. Turning it off revokes all existing MCP connection selections for this workspace.",
+          "switchLabel": "Enable workspace for Direct MCP",
+          "errors": {
+            "load": "Could not load Direct MCP workspace access.",
+            "update": "Could not update Direct MCP workspace access."
+          }
         },
         "typeChange": {
           "action": "Change type",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3341,6 +3341,24 @@
         "errors": {
           "load": "Could not load your MCP connections.",
           "disconnect": "Could not disconnect this MCP client."
+        },
+        "workspaceAccess": {
+          "manage": "Manage workspace access",
+          "selectedCount": "{count, plural, =0 {No workspaces selected} one {# workspace selected} other {# workspaces selected}}",
+          "title": "Workspace access",
+          "description": "Select exactly which workspaces this client may access. Canvas checks your current workspace permissions again for every MCP request.",
+          "refresh": "Refresh",
+          "loading": "Loading accessible workspaces…",
+          "type": "{type} workspace",
+          "noneSelected": "This client cannot access workspace data until you select and save at least one workspace.",
+          "noWorkspaces": "There are no currently readable workspaces available to select.",
+          "save": "Save access",
+          "saving": "Saving…",
+          "saved": "Workspace access saved.",
+          "errors": {
+            "load": "Could not load the available workspaces.",
+            "save": "Could not save workspace access."
+          }
         }
       },
       "requestHistory": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -3328,6 +3328,23 @@
         "missing": "The public Canvas domain has not been configured yet.",
         "notConfigured": "No server address available"
       },
+      "requestHistory": {
+        "title": "Recent requests",
+        "description": "Shows recent requests to this Canvas MCP server. Only safe technical metadata is stored and it is deleted automatically after {hours} hours.",
+        "refresh": "Refresh",
+        "loading": "Loading recent requests…",
+        "empty": "No requests in the last {hours} hours.",
+        "requestId": "Request ID",
+        "duration": "{duration} ms",
+        "outcomes": {
+          "succeeded": "Succeeded",
+          "failed": "Failed",
+          "rejected": "Rejected"
+        },
+        "errors": {
+          "load": "Could not load recent MCP requests."
+        }
+      },
       "capabilities": {
         "title": "What clients may use",
         "description": "Only enabled tools are advertised over MCP.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3335,6 +3335,7 @@
         "loading": "Loading recent requests…",
         "empty": "No requests in the last {hours} hours.",
         "requestId": "Request ID",
+        "serverVersion": "Server version",
         "duration": "{duration} ms",
         "outcomes": {
           "succeeded": "Succeeded",
@@ -3402,6 +3403,7 @@
         "endpoint": "MCP endpoint",
         "issuer": "OAuth issuer",
         "protocol": "Protocol",
+        "serverVersion": "Server version",
         "authentication": "Authentication and transport",
         "scopes": "Granted permissions"
       },

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "test:mcp:server-login-consent": "tsx --conditions react-server scripts/mcp-server-oauth-login-consent-test.ts",
     "test:mcp:server-resource": "tsx --conditions react-server scripts/mcp-server-protected-resource-test.ts",
     "test:mcp:server-oauth-client": "tsx --conditions react-server scripts/mcp-server-oauth-client-test.ts",
+    "test:mcp:server-oauth-hardening": "tsx --conditions react-server scripts/mcp-server-oauth-hardening-test.ts",
     "test:mcp:server-auth-probe": "tsx --conditions react-server scripts/mcp-server-auth-probe-test.ts",
     "test:mcp:server-diagnostics": "tsx --conditions react-server scripts/mcp-server-diagnostics-test.ts",
     "test:mcp:server-request-history": "tsx --conditions react-server scripts/mcp-server-request-history-test.ts",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "test:mcp:server-oauth-client": "tsx --conditions react-server scripts/mcp-server-oauth-client-test.ts",
     "test:mcp:server-auth-probe": "tsx --conditions react-server scripts/mcp-server-auth-probe-test.ts",
     "test:mcp:server-diagnostics": "tsx --conditions react-server scripts/mcp-server-diagnostics-test.ts",
+    "test:mcp:server-request-history": "tsx --conditions react-server scripts/mcp-server-request-history-test.ts",
     "test:mcp:server-settings": "node scripts/mcp-server-runtime-bootstrap-test.mjs && tsx --conditions react-server scripts/mcp-server-settings-test.ts",
     "test:mcp:server-http-smoke": "tsx scripts/mcp-server-http-smoke-test.ts",
     "test:studio:seedance": "tsx scripts/seedance-generation-test.ts",

--- a/scripts/mcp-server-auth-probe-test.ts
+++ b/scripts/mcp-server-auth-probe-test.ts
@@ -154,6 +154,7 @@ async function main(): Promise<void> {
         DIRECT_MCP_AUTH_PROBE_SCOPE,
         DIRECT_MCP_AUTH_PROBE_TOOL,
       },
+      { DIRECT_MCP_SERVER_VERSION },
       { default: appProxy },
       { NextRequest },
     ] = await Promise.all([
@@ -162,6 +163,7 @@ async function main(): Promise<void> {
       import('../app/lib/db'),
       import('../app/mcp/route'),
       import('../app/lib/mcp/server/auth-probe'),
+      import('../app/lib/mcp/server/version'),
       import('../proxy'),
       import('next/server'),
     ]);
@@ -324,6 +326,10 @@ async function main(): Promise<void> {
       (initializeResult.serverInfo as JsonRecord).name,
       'canvas-notebook-direct-mcp',
     );
+    assert.equal(
+      (initializeResult.serverInfo as JsonRecord).version,
+      DIRECT_MCP_SERVER_VERSION,
+    );
 
     const modernDiscovery = await modernRpcRequest({
       post: mcpRoute.POST,
@@ -338,6 +344,10 @@ async function main(): Promise<void> {
     assert.equal(
       ((modernDiscoveryResult._meta as JsonRecord)['io.modelcontextprotocol/serverInfo'] as JsonRecord).name,
       'canvas-notebook-direct-mcp',
+    );
+    assert.equal(
+      ((modernDiscoveryResult._meta as JsonRecord)['io.modelcontextprotocol/serverInfo'] as JsonRecord).version,
+      DIRECT_MCP_SERVER_VERSION,
     );
 
     const modernToolsList = await modernRpcRequest({

--- a/scripts/mcp-server-auth-probe-test.ts
+++ b/scripts/mcp-server-auth-probe-test.ts
@@ -606,6 +606,26 @@ async function main(): Promise<void> {
     assert.equal(JSON.stringify(authenticatedBody).includes('workspace'), true);
     assert.equal(JSON.stringify(authenticatedBody).includes('knowledge'), false);
 
+    const authorizedProbe = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 51,
+        method: 'tools/call',
+        params: {
+          name: DIRECT_MCP_AUTH_PROBE_TOOL,
+          arguments: {},
+        },
+      },
+    });
+    assert.equal(authorizedProbe.status, 200);
+    const authorizedProbeResult = resultFromRpc(await readJson(authorizedProbe));
+    assert.deepEqual(
+      (authorizedProbeResult.structuredContent as JsonRecord).scopes,
+      [...DIRECT_MCP_RESOURCE_SCOPES].sort(),
+    );
+
     const foreignProbe = await rpcRequest({
       post: mcpRoute.POST,
       token: foreignToken,

--- a/scripts/mcp-server-auth-probe-test.ts
+++ b/scripts/mcp-server-auth-probe-test.ts
@@ -678,6 +678,25 @@ async function main(): Promise<void> {
       },
     });
     assert.equal(disabled.status, 404);
+
+    const { listRecentDirectMcpRequestHistory } = await import(
+      '../app/lib/mcp/server/request-history'
+    );
+    const requestHistory = await listRecentDirectMcpRequestHistory();
+    assert.equal(
+      requestHistory.some((entry) => entry.operation === 'tools/list'),
+      true,
+      'Direct MCP tool-list requests should be traceable.',
+    );
+    assert.equal(
+      requestHistory.some((entry) => (
+        entry.operation === 'tools/call'
+        && entry.toolName === DIRECT_MCP_AUTH_PROBE_TOOL
+        && entry.code === 'MCP_TOOL_ERROR'
+      )),
+      true,
+      'Failed Direct MCP tool calls should retain only their safe tool metadata.',
+    );
     assert.deepEqual(
       outboundRequests,
       [],

--- a/scripts/mcp-server-diagnostics-test.ts
+++ b/scripts/mcp-server-diagnostics-test.ts
@@ -1,13 +1,7 @@
 import assert from 'node:assert/strict';
-
-import {
-  beginDirectMcpDiagnostic,
-  completeDirectMcpDiagnostic,
-  failDirectMcpDiagnostic,
-  recordDirectMcpOAuthProviderError,
-  runWithDirectMcpDiagnostic,
-  withDirectMcpRequestId,
-} from '../app/lib/mcp/server/diagnostics';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 const STATE = 'state-value-must-never-appear-in-diagnostics';
 const CLIENT_ID = 'client-id-must-never-appear-in-diagnostics';
@@ -20,6 +14,19 @@ function serialize(args: unknown[]): string {
 }
 
 async function main(): Promise<void> {
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'canvas-mcp-server-diagnostics-'));
+  const previousData = process.env.DATA;
+  process.env.DATA = dataRoot;
+
+  const {
+    beginDirectMcpDiagnostic,
+    completeDirectMcpDiagnostic,
+    failDirectMcpDiagnostic,
+    recordDirectMcpOAuthProviderError,
+    runWithDirectMcpDiagnostic,
+    withDirectMcpRequestId,
+  } = await import('../app/lib/mcp/server/diagnostics');
+  const { listRecentDirectMcpRequestHistory } = await import('../app/lib/mcp/server/request-history');
   const originalInfo = console.info;
   const originalError = console.error;
   const captured: string[] = [];
@@ -34,14 +41,9 @@ async function main(): Promise<void> {
     assert.match(diagnostics.requestId, /^[0-9a-f-]{36}$/iu);
     assert.match(diagnostics.flowRef || '', /^[a-f0-9]{24}$/u);
 
-    completeDirectMcpDiagnostic(diagnostics, {
+    await completeDirectMcpDiagnostic(diagnostics, {
       statusCode: 302,
       code: 'OAUTH_REQUEST_COMPLETED',
-      startedAt: Date.now() - 1,
-    });
-    failDirectMcpDiagnostic(diagnostics, {
-      statusCode: 503,
-      code: 'OAUTH_INTERNAL_ERROR',
       startedAt: Date.now() - 1,
     });
 
@@ -52,22 +54,52 @@ async function main(): Promise<void> {
     assert.equal(response.headers.get('x-request-id'), diagnostics.requestId);
 
     const providerSecret = 'provider-error-must-never-appear-in-diagnostics';
-    await runWithDirectMcpDiagnostic(diagnostics, async () => {
+    const providerDiagnostics = beginDirectMcpDiagnostic(
+      new Request('https://notebook.example.test/api/auth/oauth2/register', { method: 'POST' }),
+      'oauth.registration',
+    );
+    await runWithDirectMcpDiagnostic(providerDiagnostics, async () => {
       recordDirectMcpOAuthProviderError(
         new Error(`relation oauth_client does not exist: ${providerSecret}`),
       );
+    });
+    await completeDirectMcpDiagnostic(providerDiagnostics, {
+      statusCode: 503,
+      code: 'OAUTH_PROVIDER_ERROR',
+      startedAt: Date.now() - 1,
+    });
+    const failedDiagnostics = beginDirectMcpDiagnostic(
+      new Request('https://notebook.example.test/mcp', { method: 'POST' }),
+      'mcp.http',
+    );
+    await failDirectMcpDiagnostic(failedDiagnostics, {
+      statusCode: 503,
+      code: 'MCP_INTERNAL_ERROR',
+      startedAt: Date.now() - 1,
     });
 
     const output = captured.join('\n');
     assert.equal(output.includes(STATE), false);
     assert.equal(output.includes(CLIENT_ID), false);
     assert.equal(output.includes(diagnostics.flowRef || ''), true);
-    assert.equal(output.includes('OAUTH_INTERNAL_ERROR'), true);
+    assert.equal(output.includes('MCP_INTERNAL_ERROR'), true);
     assert.equal(output.includes('OAUTH_PERSISTENCE_SCHEMA_ERROR'), true);
     assert.equal(output.includes(providerSecret), false);
+
+    const history = await listRecentDirectMcpRequestHistory();
+    assert.equal(history.length, 3);
+    assert.equal(history.some((entry) => entry.code === 'OAUTH_PERSISTENCE_SCHEMA_ERROR'), true);
+    assert.equal(history.some((entry) => entry.code === 'MCP_INTERNAL_ERROR'), true);
+    assert.equal(history.some((entry) => entry.requestId === diagnostics.requestId), true);
+    assert.equal(JSON.stringify(history).includes(STATE), false);
+    assert.equal(JSON.stringify(history).includes(CLIENT_ID), false);
+    assert.equal(JSON.stringify(history).includes(providerSecret), false);
   } finally {
     console.info = originalInfo;
     console.error = originalError;
+    if (previousData === undefined) delete process.env.DATA;
+    else process.env.DATA = previousData;
+    await rm(dataRoot, { recursive: true, force: true });
   }
 
   console.log('mcp-server-diagnostics-test: ok');

--- a/scripts/mcp-server-oauth-hardening-test.ts
+++ b/scripts/mcp-server-oauth-hardening-test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { NextRequest } from 'next/server';
+
+import { resolveDirectMcpServerConfig } from '../app/lib/mcp/server/config';
+
+const ORIGIN = 'https://notebook.example.test';
+const REDIRECT_URI = 'https://chatgpt.com/connector/oauth/callback';
+const REGISTRATION_LIMIT = 10;
+
+function configureRuntime(dataDir: string): void {
+  const environment = process.env as Record<string, string | undefined>;
+  environment.DATA = dataDir;
+  environment.NODE_ENV = 'test';
+  environment.CANVAS_DATABASE_PROVIDER = 'sqlite';
+  environment.CANVAS_MCP_DIRECT_ENABLED = 'true';
+  environment.CANVAS_INSTANCE_ID = 'mcp-oauth-hardening-test';
+  environment.BETTER_AUTH_BASE_URL = ORIGIN;
+  environment.BASE_URL = ORIGIN;
+  environment.BETTER_AUTH_TRUSTED_ORIGINS = ORIGIN;
+  environment.BETTER_AUTH_SECRET = 'mcp-oauth-hardening-test-secret-at-least-32-characters';
+  delete environment.DATABASE_URL;
+  delete environment.NEXT_PHASE;
+}
+
+function registrationRequest(issuer: string, name: string): NextRequest {
+  return new NextRequest(`${issuer}/oauth2/register`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: ORIGIN,
+    },
+    body: JSON.stringify({
+      client_name: name,
+      redirect_uris: [REDIRECT_URI],
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      scope: 'openid workspace:list',
+    }),
+  });
+}
+
+async function main(): Promise<void> {
+  const dataDir = await mkdtemp(path.join(tmpdir(), 'canvas-mcp-oauth-hardening-'));
+  configureRuntime(dataDir);
+
+  try {
+    const [{ POST }, { openDb }, {
+      DIRECT_MCP_UNUSED_DYNAMIC_CLIENT_RETENTION_DAYS,
+      pruneUnusedDirectMcpDynamicClients,
+    }] = await Promise.all([
+      import('../app/api/auth/[...all]/route'),
+      import('../app/lib/db'),
+      import('../app/lib/mcp/server/oauth-client-maintenance'),
+    ]);
+    const { issuer, resource } = resolveDirectMcpServerConfig();
+
+    const previousFeatureFlag = process.env.CANVAS_MCP_DIRECT_ENABLED;
+    process.env.CANVAS_MCP_DIRECT_ENABLED = 'false';
+    const disabledRegistration = await POST(registrationRequest(issuer, 'Disabled Registration Test'));
+    assert.equal(disabledRegistration.status, 404);
+    assert.equal((await disabledRegistration.json() as Record<string, unknown>).error, 'not_found');
+    process.env.CANVAS_MCP_DIRECT_ENABLED = previousFeatureFlag;
+
+    for (let index = 0; index < REGISTRATION_LIMIT; index += 1) {
+      const response = await POST(registrationRequest(issuer, `Rate Limit Test ${index}`));
+      assert.equal([200, 201].includes(response.status), true);
+    }
+
+    const rateLimited = await POST(registrationRequest(issuer, 'Rate Limit Test Blocked'));
+    assert.equal(rateLimited.status, 429);
+    assert.equal(rateLimited.headers.get('retry-after'), '60');
+    const rateLimitedBody = await rateLimited.json() as Record<string, unknown>;
+    assert.equal(rateLimitedBody.error, 'temporarily_unavailable');
+    assert.equal(JSON.stringify(rateLimitedBody).includes('Rate Limit Test Blocked'), false);
+
+    const database = await openDb();
+    try {
+      const now = Date.now();
+      const staleCreatedAt = now - ((DIRECT_MCP_UNUSED_DYNAMIC_CLIENT_RETENTION_DAYS + 1) * 24 * 60 * 60 * 1000);
+      const staleClientId = `stale-direct-mcp-${randomUUID()}`;
+      const consentClientId = `consent-direct-mcp-${randomUUID()}`;
+      const tokenClientId = `token-direct-mcp-${randomUUID()}`;
+
+      for (const clientId of [staleClientId, consentClientId, tokenClientId]) {
+        await database.run(`
+          INSERT INTO oauth_client (
+            id, client_id, client_secret, user_id, created_at, updated_at,
+            redirect_uris, token_endpoint_auth_method, public, require_pkce
+          ) VALUES (?, ?, NULL, NULL, ?, ?, ?, 'none', TRUE, TRUE)
+        `, [
+          `client-${randomUUID()}`,
+          clientId,
+          staleCreatedAt,
+          staleCreatedAt,
+          JSON.stringify([REDIRECT_URI]),
+        ]);
+        await database.run(`
+          INSERT INTO oauth_client_resource (id, client_id, resource_id, created_at)
+          VALUES (?, ?, ?, ?)
+        `, [`resource-${randomUUID()}`, clientId, resource, staleCreatedAt]);
+      }
+      await database.run(`
+        INSERT INTO oauth_consent (id, client_id, scopes, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+      `, [
+        `consent-${randomUUID()}`,
+        consentClientId,
+        JSON.stringify(['workspace:list']),
+        staleCreatedAt,
+        staleCreatedAt,
+      ]);
+      await database.run(`
+        INSERT INTO oauth_access_token (id, token, client_id, expires_at, created_at, scopes)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `, [
+        `access-token-${randomUUID()}`,
+        `token-${randomUUID()}`,
+        tokenClientId,
+        now + (60 * 60 * 1000),
+        staleCreatedAt,
+        JSON.stringify(['workspace:list']),
+      ]);
+
+      const pruned = await pruneUnusedDirectMcpDynamicClients(now);
+      assert.equal(pruned >= 1, true);
+      const staleClient = await database.get(
+        'SELECT client_id FROM oauth_client WHERE client_id = ?',
+        [staleClientId],
+      );
+      const consentClient = await database.get(
+        'SELECT client_id FROM oauth_client WHERE client_id = ?',
+        [consentClientId],
+      );
+      const tokenClient = await database.get(
+        'SELECT client_id FROM oauth_client WHERE client_id = ?',
+        [tokenClientId],
+      );
+      assert.equal(staleClient, undefined);
+      assert.equal((consentClient as { client_id?: string } | undefined)?.client_id, consentClientId);
+      assert.equal((tokenClient as { client_id?: string } | undefined)?.client_id, tokenClientId);
+
+      const auditRows = await database.all(`
+        SELECT status, metadata_json AS metadataJson, summary
+        FROM audit_events
+        WHERE source = 'direct_mcp'
+          AND action = 'direct_mcp.dynamic_client_registration'
+        ORDER BY created_at ASC
+      `) as Array<{ status: string; metadataJson: string | null; summary: string | null }>;
+      assert.equal(auditRows.length, REGISTRATION_LIMIT + 2);
+      assert.equal(auditRows.at(-1)?.status, 'blocked');
+      const auditText = JSON.stringify(auditRows);
+      assert.equal(auditText.includes('Rate Limit Test Blocked'), false);
+      assert.equal(auditText.includes('Disabled Registration Test'), false);
+      assert.equal(auditText.includes(REDIRECT_URI), false);
+    } finally {
+      await database.close();
+    }
+
+    console.log('mcp-server-oauth-hardening-test: ok');
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/mcp-server-oauth-hardening-test.ts
+++ b/scripts/mcp-server-oauth-hardening-test.ts
@@ -154,10 +154,14 @@ async function main(): Promise<void> {
       `) as Array<{ status: string; metadataJson: string | null; summary: string | null }>;
       assert.equal(auditRows.length, REGISTRATION_LIMIT + 2);
       assert.equal(auditRows.at(-1)?.status, 'blocked');
-      const auditText = JSON.stringify(auditRows);
-      assert.equal(auditText.includes('Rate Limit Test Blocked'), false);
-      assert.equal(auditText.includes('Disabled Registration Test'), false);
-      assert.equal(auditText.includes(REDIRECT_URI), false);
+      for (const auditRow of auditRows) {
+        const metadata = JSON.parse(auditRow.metadataJson ?? '{}') as Record<string, unknown>;
+        assert.deepEqual(Object.keys(metadata).sort(), ['endpoint', 'rateLimited', 'statusCode']);
+        assert.equal(metadata.endpoint, '/api/auth/oauth2/register');
+        assert.equal(typeof metadata.statusCode, 'number');
+        assert.equal(metadata.rateLimited, metadata.statusCode === 429);
+        assert.match(auditRow.summary ?? '', /^Direct MCP OAuth client registration returned HTTP \d{3}\.$/u);
+      }
     } finally {
       await database.close();
     }

--- a/scripts/mcp-server-request-history-test.ts
+++ b/scripts/mcp-server-request-history-test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+async function main(): Promise<void> {
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'canvas-mcp-request-history-'));
+  const previousData = process.env.DATA;
+  process.env.DATA = dataRoot;
+
+  try {
+    const {
+      DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES,
+      recordDirectMcpRequestHistory,
+      listRecentDirectMcpRequestHistory,
+    } = await import('../app/lib/mcp/server/request-history');
+    const now = new Date();
+
+    await recordDirectMcpRequestHistory({
+      requestId: 'request-safe',
+      flowRef: 'a'.repeat(24),
+      phase: 'oauth.registration',
+      httpMethod: 'POST',
+      operation: 'tools/call',
+      toolName: 'auth_probe',
+      outcome: 'succeeded',
+      statusCode: 201,
+      code: 'OAUTH_REQUEST_COMPLETED',
+      durationMs: 14,
+      createdAt: now,
+    });
+    await recordDirectMcpRequestHistory({
+      requestId: 'request-expired',
+      phase: 'mcp.http',
+      httpMethod: 'POST',
+      outcome: 'failed',
+      statusCode: 500,
+      code: 'MCP_INTERNAL_ERROR',
+      durationMs: 9,
+      createdAt: new Date(now.getTime() - 25 * 60 * 60 * 1000),
+    });
+
+    let entries = await listRecentDirectMcpRequestHistory();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].requestId, 'request-safe');
+    assert.equal(entries[0].flowRef, 'a'.repeat(24));
+    assert.equal(entries[0].phase, 'oauth.registration');
+    assert.equal(entries[0].httpMethod, 'POST');
+    assert.equal(entries[0].operation, 'tools/call');
+    assert.equal(entries[0].toolName, 'auth_probe');
+    assert.equal(entries[0].outcome, 'succeeded');
+    assert.equal(entries[0].statusCode, 201);
+    assert.equal(entries[0].code, 'OAUTH_REQUEST_COMPLETED');
+    assert.equal(entries[0].durationMs, 14);
+    assert.equal(entries[0].createdAt.getTime(), Math.floor(now.getTime() / 1000) * 1000);
+
+    for (let index = 0; index < DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES + 5; index += 1) {
+      await recordDirectMcpRequestHistory({
+        requestId: `request-${index}`,
+        phase: 'mcp.http',
+        httpMethod: 'POST',
+        operation: 'untrusted-operation',
+        toolName: 'untrusted-tool-name',
+        outcome: 'untrusted-outcome',
+        statusCode: 200,
+        code: 'untrusted-code',
+        durationMs: -1,
+        createdAt: new Date(now.getTime() + (index + 1) * 1000),
+      });
+    }
+
+    entries = await listRecentDirectMcpRequestHistory();
+    assert.equal(entries.length, DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES);
+    assert.equal(entries[0].requestId, `request-${DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES + 4}`);
+    assert.equal(entries.every((entry) => entry.operation === null), true);
+    assert.equal(entries.every((entry) => entry.toolName === null), true);
+    assert.equal(entries.every((entry) => entry.outcome === 'failed'), true);
+    assert.equal(entries.every((entry) => entry.code === 'MCP_UNCLASSIFIED'), true);
+    assert.equal(entries.every((entry) => entry.durationMs === 0), true);
+  } finally {
+    if (previousData === undefined) delete process.env.DATA;
+    else process.env.DATA = previousData;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+
+  console.log('mcp-server-request-history-test: ok');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/mcp-server-request-history-test.ts
+++ b/scripts/mcp-server-request-history-test.ts
@@ -3,12 +3,39 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import Database from 'better-sqlite3';
+
 async function main(): Promise<void> {
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'canvas-mcp-request-history-'));
   const previousData = process.env.DATA;
   process.env.DATA = dataRoot;
 
   try {
+    // Simulate the initial request-history release so this test also proves
+    // that the version field is added safely on an existing instance volume.
+    const legacyDatabase = new Database(path.join(dataRoot, 'sqlite.db'));
+    legacyDatabase.exec(`
+      CREATE TABLE direct_mcp_request_history (
+        id TEXT PRIMARY KEY NOT NULL,
+        request_id TEXT NOT NULL,
+        flow_ref TEXT,
+        phase TEXT NOT NULL,
+        http_method TEXT NOT NULL,
+        operation TEXT,
+        tool_name TEXT,
+        outcome TEXT NOT NULL,
+        status_code INTEGER,
+        code TEXT NOT NULL,
+        duration_ms INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL
+      );
+    `);
+    legacyDatabase.close();
+
+    const { DIRECT_MCP_SERVER_VERSION } = await import(
+      '../app/lib/mcp/server/version'
+    );
     const {
       DIRECT_MCP_REQUEST_HISTORY_MAX_ENTRIES,
       recordDirectMcpRequestHistory,
@@ -43,6 +70,7 @@ async function main(): Promise<void> {
     let entries = await listRecentDirectMcpRequestHistory();
     assert.equal(entries.length, 1);
     assert.equal(entries[0].requestId, 'request-safe');
+    assert.equal(entries[0].serverVersion, DIRECT_MCP_SERVER_VERSION);
     assert.equal(entries[0].flowRef, 'a'.repeat(24));
     assert.equal(entries[0].phase, 'oauth.registration');
     assert.equal(entries[0].httpMethod, 'POST');

--- a/scripts/mcp-server-settings-test.ts
+++ b/scripts/mcp-server-settings-test.ts
@@ -27,6 +27,9 @@ async function main(): Promise<void> {
     const { buildDirectMcpServerSettingsStatus } = await import(
       '../app/lib/mcp/server/settings-status'
     );
+    const { DIRECT_MCP_SERVER_VERSION } = await import(
+      '../app/lib/mcp/server/version'
+    );
     const { applyDirectMcpSettingsToRuntime } = await import(
       '../app/lib/mcp/server/runtime-settings'
     );
@@ -78,6 +81,7 @@ async function main(): Promise<void> {
     assert.equal(status.restartRequired, false);
     assert.equal(status.activationManagedByEnvironment, true);
     assert.equal(status.protocolVersion, '2026-07-28');
+    assert.equal(status.serverVersion, DIRECT_MCP_SERVER_VERSION);
     assert.deepEqual(
       status.capabilities.filter((capability) => capability.available),
       [


### PR DESCRIPTION
## Summary

- add Direct MCP connection management, request history, OAuth diagnostics, and server version metadata
- require a workspace to be enabled globally and selected per OAuth client before MCP tools can access it
- provide workspace toggles in both workspace and central MCP settings

## Verification

- npm run build
- npm run lint (two pre-existing warnings, no errors)
- npx tsc --noEmit

## Manual UI check

Pending; no browser session was started for this change.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Direct MCP connection administration, request diagnostics, server metadata, and two-level workspace access control.
- Requires both global workspace enablement and a per-OAuth-client workspace grant before tools expose workspace data.
- Adds APIs and settings UI for workspace configuration, connection management, and recent request history.
- Serializes PostgreSQL workspace-setting and grant updates with transaction-scoped advisory locks and revalidates enablement inside the grant transaction.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/mcp/server/workspace-access-policy.ts | Implements global enablement and per-client grants, with transactional revalidation and PostgreSQL advisory locking that resolves the previously reported stale-grant race. |
| app/lib/mcp/server/workspace-tools.ts | Enforces the intersection of global enablement, client selection, current workspace readability, and current Canvas permissions. |
| app/api/integrations/mcp-server/connections/workspaces/route.ts | Adds authenticated endpoints for listing and replacing each owned MCP connection's workspace allowlist. |
| app/api/integrations/mcp-server/workspaces/route.ts | Adds authenticated workspace enablement APIs with manager authorization and audit recording. |
| app/components/settings/McpServerSettingsPanel.tsx | Adds Direct MCP connection, workspace-access, diagnostics, and request-history management interfaces. |
| app/lib/db/schema.ts | Adds persistent Direct MCP revocation, workspace grant, workspace setting, and request-history models. |
| app/lib/db/migrate.ts | Creates the new Direct MCP tables and indexes for existing SQLite installations. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  U[Signed-in user] --> G[Select workspace for OAuth connection]
  M[Workspace manager] --> E[Enable workspace globally]
  G --> P{Per-client grant exists?}
  E --> W{Workspace globally enabled?}
  T[MCP tool request] --> A{Current Canvas ACL permits access?}
  P --> D{All access conditions satisfied?}
  W --> D
  A --> D
  D -->|Yes| X[Expose workspace to MCP tool]
  D -->|No| R[Reject or omit workspace]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Serialize Direct MCP workspace grants"](https://github.com/canvascoding/canvas-notebook/commit/c99542d1f2e4d184d3c6b31cd1459e4afa4cd475) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57985342)</sub>

<!-- /greptile_comment -->