### PR TITLE
Extend Direct MCP workspace tools

### DIFF
--- a/app/[locale]/(routes)/oauth/consent/oauth-consent-client.tsx
+++ b/app/[locale]/(routes)/oauth/consent/oauth-consent-client.tsx
@@ -27,6 +27,7 @@ const SCOPE_TRANSLATION_KEYS: Record<DirectMcpOAuthScope, string> = {
   'knowledge:tree': 'knowledgeTree',
   'knowledge:search': 'knowledgeSearch',
   'knowledge:read': 'knowledgeRead',
+  'knowledge:write': 'knowledgeWrite',
 };
 
 type OAuthConsentClientProps = {

--- a/app/[locale]/(routes)/oauth/consent/oauth-consent-client.tsx
+++ b/app/[locale]/(routes)/oauth/consent/oauth-consent-client.tsx
@@ -28,6 +28,7 @@ const SCOPE_TRANSLATION_KEYS: Record<DirectMcpOAuthScope, string> = {
   'knowledge:search': 'knowledgeSearch',
   'knowledge:read': 'knowledgeRead',
   'knowledge:write': 'knowledgeWrite',
+  'knowledge:assets': 'knowledgeAssets',
 };
 
 type OAuthConsentClientProps = {

--- a/app/lib/files/text-content-validation.ts
+++ b/app/lib/files/text-content-validation.ts
@@ -1,0 +1,141 @@
+import path from 'node:path';
+
+import { parseDocument } from 'yaml';
+
+import { getRunawaySlashContentMessage } from '@/app/lib/editor/text-editor-guards';
+
+export type TextFileValidationCheck = {
+  name: string;
+  ok: boolean;
+  message: string;
+};
+
+export type TextFileValidationResult = {
+  ok: boolean;
+  checks: TextFileValidationCheck[];
+};
+
+function splitMarkdownTableRow(line: string): string[] | null {
+  if (!line.includes('|')) return null;
+
+  let normalized = line.trim();
+  if (normalized.startsWith('|')) normalized = normalized.slice(1);
+  if (normalized.endsWith('|') && !normalized.endsWith('\\|')) normalized = normalized.slice(0, -1);
+
+  const cells: string[] = [];
+  let current = '';
+  let escaped = false;
+
+  for (const char of normalized) {
+    if (char === '|' && !escaped) {
+      cells.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += char;
+    escaped = char === '\\' && !escaped;
+    if (char !== '\\') escaped = false;
+  }
+
+  cells.push(current.trim());
+  return cells.length > 1 ? cells : null;
+}
+
+function isMarkdownTableSeparator(line: string): boolean {
+  const cells = splitMarkdownTableRow(line);
+  return Boolean(cells && cells.length > 1 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim())));
+}
+
+function validateMarkdownTables(content: string): TextFileValidationCheck {
+  const lines = content.split('\n');
+  const errors: string[] = [];
+  let tableCount = 0;
+
+  for (let index = 1; index < lines.length; index += 1) {
+    if (!isMarkdownTableSeparator(lines[index])) continue;
+
+    const headerCells = splitMarkdownTableRow(lines[index - 1]);
+    const separatorCells = splitMarkdownTableRow(lines[index]);
+    if (!headerCells || !separatorCells) continue;
+
+    tableCount += 1;
+    const expectedColumns = headerCells.length;
+    if (separatorCells.length !== expectedColumns) {
+      errors.push(`line ${index + 1}: separator has ${separatorCells.length} column(s), expected ${expectedColumns}`);
+    }
+
+    for (let rowIndex = index + 1; rowIndex < lines.length; rowIndex += 1) {
+      const row = lines[rowIndex];
+      if (!row.trim() || !row.includes('|') || isMarkdownTableSeparator(row)) break;
+
+      const rowCells = splitMarkdownTableRow(row);
+      if (!rowCells) break;
+      if (rowCells.length !== expectedColumns) {
+        errors.push(`line ${rowIndex + 1}: row has ${rowCells.length} column(s), expected ${expectedColumns}`);
+      }
+    }
+  }
+
+  return {
+    name: 'markdown-tables',
+    ok: errors.length === 0,
+    message: errors.length === 0
+      ? `Markdown table structure OK (${tableCount} table${tableCount === 1 ? '' : 's'} checked).`
+      : errors.join('; '),
+  };
+}
+
+function validateRunawaySlashContent(content: string): TextFileValidationCheck {
+  const message = getRunawaySlashContentMessage(content);
+  return {
+    name: 'runaway-slashes',
+    ok: message === null,
+    message: message === null
+      ? 'No runaway slash/backslash sequences detected.'
+      : `${message}. This usually indicates a stuck key, model output loop, or accidental repeated slash insertion.`,
+  };
+}
+
+export function validateTextFileContent(filePath: string, content: string): TextFileValidationResult {
+  const extension = path.extname(filePath).toLowerCase();
+  const checks: TextFileValidationCheck[] = [];
+
+  if (['.md', '.mdx', '.markdown'].includes(extension)) {
+    checks.push(validateRunawaySlashContent(content));
+    checks.push(validateMarkdownTables(content));
+  }
+
+  if (extension === '.json') {
+    try {
+      JSON.parse(content);
+      checks.push({ name: 'json-parse', ok: true, message: 'JSON syntax OK.' });
+    } catch (error) {
+      checks.push({
+        name: 'json-parse',
+        ok: false,
+        message: error instanceof Error ? error.message : 'Invalid JSON syntax.',
+      });
+    }
+  }
+
+  if (['.yaml', '.yml'].includes(extension)) {
+    const document = parseDocument(content, { prettyErrors: false });
+    checks.push({
+      name: 'yaml-parse',
+      ok: document.errors.length === 0,
+      message: document.errors.length === 0
+        ? 'YAML syntax OK.'
+        : document.errors.map((error) => error.message).join('; '),
+    });
+  }
+
+  if (checks.length === 0) {
+    checks.push({ name: 'read-after-write', ok: true, message: 'No file-type-specific validator configured; read-after-write will verify exact bytes.' });
+  }
+
+  return {
+    ok: checks.every((check) => check.ok),
+    checks,
+  };
+}

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -43,7 +43,7 @@ const FILE_METADATA_CONCURRENCY = 32;
 const FILE_TREE_DIRECTORY_CONCURRENCY = 16;
 const workspaceFileMutationLocks = new Map<string, Promise<void>>();
 
-export async function withWorkspaceFileMutationLock<T>(
+async function withExactWorkspaceFileMutationLock<T>(
   filePath: string,
   options: WorkspaceFileOperationOptions | undefined,
   operation: () => Promise<T>,
@@ -64,15 +64,39 @@ export async function withWorkspaceFileMutationLock<T>(
   }
 }
 
+function workspaceMutationLockPathHierarchy(filePath: string): string[] {
+  const normalizedPath = path.posix.normalize(filePath).replace(/^\.\//, '');
+  if (normalizedPath === '.' || normalizedPath === '') return ['.'];
+
+  const paths = [normalizedPath];
+  let parentPath = path.posix.dirname(normalizedPath);
+  while (parentPath !== '.' && parentPath !== '/') {
+    paths.push(parentPath);
+    const nextParentPath = path.posix.dirname(parentPath);
+    if (nextParentPath === parentPath) break;
+    parentPath = nextParentPath;
+  }
+  return paths;
+}
+
+export async function withWorkspaceFileMutationLock<T>(
+  filePath: string,
+  options: WorkspaceFileOperationOptions | undefined,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return withWorkspaceFileMutationLocks([filePath], options, operation);
+}
+
 export async function withWorkspaceFileMutationLocks<T>(
   filePaths: readonly string[],
   options: WorkspaceFileOperationOptions | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
-  const uniquePaths = [...new Set(filePaths)].sort((left, right) => left.localeCompare(right));
+  const uniquePaths = [...new Set(filePaths.flatMap(workspaceMutationLockPathHierarchy))]
+    .sort((left, right) => left.localeCompare(right));
   const runWithLocks = async (index: number): Promise<T> => {
     if (index >= uniquePaths.length) return operation();
-    return withWorkspaceFileMutationLock(uniquePaths[index], options, () => runWithLocks(index + 1));
+    return withExactWorkspaceFileMutationLock(uniquePaths[index], options, () => runWithLocks(index + 1));
   };
   return runWithLocks(0);
 }

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -43,7 +43,7 @@ const FILE_METADATA_CONCURRENCY = 32;
 const FILE_TREE_DIRECTORY_CONCURRENCY = 16;
 const workspaceFileMutationLocks = new Map<string, Promise<void>>();
 
-async function withWorkspaceFileMutationLock<T>(
+export async function withWorkspaceFileMutationLock<T>(
   filePath: string,
   options: WorkspaceFileOperationOptions | undefined,
   operation: () => Promise<T>,
@@ -62,6 +62,19 @@ async function withWorkspaceFileMutationLock<T>(
     releaseCurrent();
     if (workspaceFileMutationLocks.get(key) === queued) workspaceFileMutationLocks.delete(key);
   }
+}
+
+export async function withWorkspaceFileMutationLocks<T>(
+  filePaths: readonly string[],
+  options: WorkspaceFileOperationOptions | undefined,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const uniquePaths = [...new Set(filePaths)].sort((left, right) => left.localeCompare(right));
+  const runWithLocks = async (index: number): Promise<T> => {
+    if (index >= uniquePaths.length) return operation();
+    return withWorkspaceFileMutationLock(uniquePaths[index], options, () => runWithLocks(index + 1));
+  };
+  return runWithLocks(0);
 }
 
 async function mapWithConcurrency<T, R>(

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -76,6 +76,7 @@ function workspaceMutationLockPathHierarchy(filePath: string): string[] {
     if (nextParentPath === parentPath) break;
     parentPath = nextParentPath;
   }
+  paths.push('.');
   return paths;
 }
 

--- a/app/lib/filesystem/workspace-files.ts
+++ b/app/lib/filesystem/workspace-files.ts
@@ -65,7 +65,7 @@ async function withExactWorkspaceFileMutationLock<T>(
 }
 
 function workspaceMutationLockPathHierarchy(filePath: string): string[] {
-  const normalizedPath = path.posix.normalize(filePath).replace(/^\.\//, '');
+  const normalizedPath = path.posix.normalize(filePath.replaceAll('\\', '/')).replace(/^\.\//, '');
   if (normalizedPath === '.' || normalizedPath === '') return ['.'];
 
   const paths = [normalizedPath];

--- a/app/lib/mcp/server/asset-reader.ts
+++ b/app/lib/mcp/server/asset-reader.ts
@@ -1,0 +1,165 @@
+import 'server-only';
+
+import path from 'node:path';
+
+import {
+  extractPdfTextForRead,
+  imageContentForBuffer,
+} from '@/app/lib/pi/tool-runtime-helpers';
+
+export const DIRECT_MCP_ASSET_MAX_BYTES = 25 * 1024 * 1024;
+export const DIRECT_MCP_ASSET_DEFAULT_MAX_CHARACTERS = 24_000;
+export const DIRECT_MCP_ASSET_MAX_CHARACTERS = 24_000;
+export const DIRECT_MCP_ASSET_DEFAULT_MAX_PDF_TEXT_PAGES = 20;
+export const DIRECT_MCP_ASSET_MAX_PDF_TEXT_PAGES = 40;
+export const DIRECT_MCP_ASSET_DEFAULT_MAX_PDF_IMAGES = 2;
+export const DIRECT_MCP_ASSET_MAX_PDF_IMAGES = 5;
+
+type DirectMcpAssetContent =
+  | { type: 'text'; text: string }
+  | { type: 'image'; data: string; mimeType: string };
+
+type DirectMcpAssetImage = {
+  type: 'image';
+  mimeType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+};
+
+type DirectMcpAssetPdf = {
+  type: 'pdf';
+  mimeType: 'application/pdf';
+};
+
+export type DirectMcpAssetKind = DirectMcpAssetImage | DirectMcpAssetPdf;
+
+export type DirectMcpAssetReadOptions = {
+  maxCharacters: number;
+  maxPdfTextPages: number;
+  pdfTextPages?: number[];
+  includePdfImages?: boolean;
+  pdfImagePages?: number[];
+  maxPdfImages: number;
+};
+
+export type DirectMcpAssetReadResult = {
+  kind: DirectMcpAssetKind;
+  content: DirectMcpAssetContent[];
+  pages?: number;
+  textPagesRead?: number[];
+  textPageLimited?: boolean;
+  truncated?: boolean;
+  images?: Array<{ pageNumber: number; bytes: number; width: number; height: number }>;
+  skippedImageCount?: number;
+};
+
+export class DirectMcpAssetReadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DirectMcpAssetReadError';
+  }
+}
+
+function startsWith(buffer: Buffer, bytes: number[]): boolean {
+  return buffer.length >= bytes.length && bytes.every((byte, index) => buffer[index] === byte);
+}
+
+function isPng(buffer: Buffer): boolean {
+  return startsWith(buffer, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+}
+
+function isJpeg(buffer: Buffer): boolean {
+  return startsWith(buffer, [0xff, 0xd8, 0xff]);
+}
+
+function isGif(buffer: Buffer): boolean {
+  return buffer.subarray(0, 6).toString('ascii') === 'GIF87a'
+    || buffer.subarray(0, 6).toString('ascii') === 'GIF89a';
+}
+
+function isWebp(buffer: Buffer): boolean {
+  return buffer.length >= 12
+    && buffer.subarray(0, 4).toString('ascii') === 'RIFF'
+    && buffer.subarray(8, 12).toString('ascii') === 'WEBP';
+}
+
+function isPdf(buffer: Buffer): boolean {
+  return buffer.subarray(0, 5).toString('latin1') === '%PDF-';
+}
+
+export function identifyDirectMcpAsset(filePath: string, buffer: Buffer): DirectMcpAssetKind {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === '.png' && isPng(buffer)) return { type: 'image', mimeType: 'image/png' };
+  if ((extension === '.jpg' || extension === '.jpeg') && isJpeg(buffer)) {
+    return { type: 'image', mimeType: 'image/jpeg' };
+  }
+  if (extension === '.gif' && isGif(buffer)) return { type: 'image', mimeType: 'image/gif' };
+  if (extension === '.webp' && isWebp(buffer)) return { type: 'image', mimeType: 'image/webp' };
+  if (extension === '.pdf' && isPdf(buffer)) return { type: 'pdf', mimeType: 'application/pdf' };
+
+  if (extension === '.pdf') {
+    throw new DirectMcpAssetReadError('The requested PDF does not have a valid PDF signature.');
+  }
+  throw new DirectMcpAssetReadError(
+    'Only PNG, JPEG, GIF, WebP images, and PDF documents can be read as MCP assets.',
+  );
+}
+
+export async function readDirectMcpAsset(input: {
+  path: string;
+  buffer: Buffer;
+  options: DirectMcpAssetReadOptions;
+}): Promise<DirectMcpAssetReadResult> {
+  if (input.buffer.length > DIRECT_MCP_ASSET_MAX_BYTES) {
+    throw new DirectMcpAssetReadError(
+      `The requested asset is larger than the ${DIRECT_MCP_ASSET_MAX_BYTES / (1024 * 1024)} MB MCP asset limit.`,
+    );
+  }
+
+  const kind = identifyDirectMcpAsset(input.path, input.buffer);
+  if (kind.type === 'image') {
+    try {
+      const image = await imageContentForBuffer(input.path, input.buffer);
+      if (!image) {
+        throw new Error('No image content was produced.');
+      }
+      return {
+        kind,
+        content: [
+          { type: 'text', text: 'Image content is included for visual analysis.' },
+          { type: 'image', data: image.data, mimeType: image.mimeType },
+        ],
+      };
+    } catch {
+      throw new DirectMcpAssetReadError('The requested image could not be prepared for MCP visual context.');
+    }
+  }
+
+  try {
+    const pdf = await extractPdfTextForRead(input.path, input.buffer, {
+      maxChars: input.options.maxCharacters,
+      maxTextPages: input.options.maxPdfTextPages,
+      textPages: input.options.pdfTextPages,
+      includeImages: input.options.includePdfImages,
+      includeImagesExplicit: typeof input.options.includePdfImages === 'boolean',
+      imagePages: input.options.pdfImagePages,
+      maxImages: input.options.maxPdfImages,
+    });
+    const content: DirectMcpAssetContent[] = pdf.content.map((part) => (
+      part.type === 'image'
+        ? { type: 'image', data: part.data, mimeType: part.mimeType }
+        : { type: 'text', text: part.text }
+    ));
+    return {
+      kind,
+      content,
+      pages: pdf.details.pages,
+      textPagesRead: pdf.details.textPagesRead,
+      textPageLimited: pdf.details.textPageLimited,
+      truncated: pdf.details.truncated,
+      images: pdf.details.images,
+      skippedImageCount: pdf.details.skippedImages.length,
+    };
+  } catch (error) {
+    if (error instanceof DirectMcpAssetReadError) throw error;
+    throw new DirectMcpAssetReadError('The requested PDF could not be parsed safely.');
+  }
+}

--- a/app/lib/mcp/server/config.ts
+++ b/app/lib/mcp/server/config.ts
@@ -3,7 +3,7 @@ export const DIRECT_MCP_TOOLS_ENV = 'CANVAS_MCP_DIRECT_TOOLS';
 export const DIRECT_MCP_SETTINGS_SOURCE_ENV = 'CANVAS_MCP_DIRECT_SETTINGS_SOURCE';
 export const DIRECT_MCP_TOOLS_SOURCE_ENV = 'CANVAS_MCP_DIRECT_TOOLS_SOURCE';
 export const DIRECT_MCP_PROTOCOL_VERSION = '2026-07-28';
-export const DIRECT_MCP_TOOL_CONFIGURATION_VERSION = 3;
+export const DIRECT_MCP_TOOL_CONFIGURATION_VERSION = 4;
 
 export const DIRECT_MCP_TOOL_IDS = [
   'auth_probe',
@@ -13,6 +13,7 @@ export const DIRECT_MCP_TOOL_IDS = [
   'search_knowledge',
   'read_knowledge_source',
   'edit_knowledge_source',
+  'read_knowledge_asset',
 ] as const;
 export type DirectMcpToolId = (typeof DIRECT_MCP_TOOL_IDS)[number];
 
@@ -35,6 +36,7 @@ export const DIRECT_MCP_OAUTH_SCOPES = [
   'knowledge:search',
   'knowledge:read',
   'knowledge:write',
+  'knowledge:assets',
 ] as const;
 
 export const DIRECT_MCP_RESOURCE_SCOPES = [
@@ -43,6 +45,7 @@ export const DIRECT_MCP_RESOURCE_SCOPES = [
   'knowledge:search',
   'knowledge:read',
   'knowledge:write',
+  'knowledge:assets',
 ] as const;
 
 export type DirectMcpOAuthScope = (typeof DIRECT_MCP_OAUTH_SCOPES)[number];

--- a/app/lib/mcp/server/config.ts
+++ b/app/lib/mcp/server/config.ts
@@ -3,7 +3,7 @@ export const DIRECT_MCP_TOOLS_ENV = 'CANVAS_MCP_DIRECT_TOOLS';
 export const DIRECT_MCP_SETTINGS_SOURCE_ENV = 'CANVAS_MCP_DIRECT_SETTINGS_SOURCE';
 export const DIRECT_MCP_TOOLS_SOURCE_ENV = 'CANVAS_MCP_DIRECT_TOOLS_SOURCE';
 export const DIRECT_MCP_PROTOCOL_VERSION = '2026-07-28';
-export const DIRECT_MCP_TOOL_CONFIGURATION_VERSION = 2;
+export const DIRECT_MCP_TOOL_CONFIGURATION_VERSION = 3;
 
 export const DIRECT_MCP_TOOL_IDS = [
   'auth_probe',
@@ -12,8 +12,20 @@ export const DIRECT_MCP_TOOL_IDS = [
   'list_knowledge_tree',
   'search_knowledge',
   'read_knowledge_source',
+  'edit_knowledge_source',
 ] as const;
 export type DirectMcpToolId = (typeof DIRECT_MCP_TOOL_IDS)[number];
+
+// Writing is opt-in. Existing Direct MCP installations keep their established
+// read-only capability set until an administrator explicitly enables editing.
+export const DIRECT_MCP_DEFAULT_TOOL_IDS = [
+  'auth_probe',
+  'list_workspaces',
+  'get_workspace_overview',
+  'list_knowledge_tree',
+  'search_knowledge',
+  'read_knowledge_source',
+] as const satisfies readonly DirectMcpToolId[];
 
 export const DIRECT_MCP_OAUTH_SCOPES = [
   'openid',
@@ -22,6 +34,7 @@ export const DIRECT_MCP_OAUTH_SCOPES = [
   'knowledge:tree',
   'knowledge:search',
   'knowledge:read',
+  'knowledge:write',
 ] as const;
 
 export const DIRECT_MCP_RESOURCE_SCOPES = [
@@ -29,6 +42,7 @@ export const DIRECT_MCP_RESOURCE_SCOPES = [
   'knowledge:tree',
   'knowledge:search',
   'knowledge:read',
+  'knowledge:write',
 ] as const;
 
 export type DirectMcpOAuthScope = (typeof DIRECT_MCP_OAUTH_SCOPES)[number];
@@ -119,7 +133,7 @@ export function getDirectMcpEnabledTools(
   environment: DirectMcpEnvironment = process.env,
 ): DirectMcpToolId[] {
   const configured = environment[DIRECT_MCP_TOOLS_ENV];
-  if (configured === undefined) return [...DIRECT_MCP_TOOL_IDS];
+  if (configured === undefined) return [...DIRECT_MCP_DEFAULT_TOOL_IDS];
 
   const requested = configured
     .split(',')

--- a/app/lib/mcp/server/direct-server.ts
+++ b/app/lib/mcp/server/direct-server.ts
@@ -53,7 +53,9 @@ export function createDirectMcpServer(
   const toolsById = new Map(tools.map((tool) => [tool.id, tool]));
   const instructions = tools.length === 0
     ? 'No MCP tools are currently enabled for this Canvas Notebook instance.'
-    : 'Canvas Notebook provides read-only access only to workspaces the signed-in user explicitly allows for this MCP connection.';
+    : enabledTools.has('edit_knowledge_source')
+      ? 'Canvas Notebook provides read access and exact, conflict-protected text edits only for workspaces the signed-in user explicitly allows for this MCP connection.'
+      : 'Canvas Notebook provides read-only access only to workspaces the signed-in user explicitly allows for this MCP connection.';
 
   const server = new Server(
     {

--- a/app/lib/mcp/server/request-history.ts
+++ b/app/lib/mcp/server/request-history.ts
@@ -29,6 +29,7 @@ const TOOL_NAMES = new Set([
   'list_knowledge_tree',
   'search_knowledge',
   'read_knowledge_source',
+  'edit_knowledge_source',
 ]);
 
 export type DirectMcpRequestHistoryInput = {

--- a/app/lib/mcp/server/request-history.ts
+++ b/app/lib/mcp/server/request-history.ts
@@ -30,6 +30,7 @@ const TOOL_NAMES = new Set([
   'search_knowledge',
   'read_knowledge_source',
   'edit_knowledge_source',
+  'read_knowledge_asset',
 ]);
 
 export type DirectMcpRequestHistoryInput = {

--- a/app/lib/mcp/server/settings-status.ts
+++ b/app/lib/mcp/server/settings-status.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import {
   DIRECT_MCP_FEATURE_ENV,
+  DIRECT_MCP_DEFAULT_TOOL_IDS,
   DIRECT_MCP_PROTOCOL_VERSION,
   DIRECT_MCP_SETTINGS_SOURCE_ENV,
   DIRECT_MCP_TOOL_IDS,
@@ -54,6 +55,7 @@ const DIRECT_MCP_CAPABILITIES: ReadonlyArray<Omit<DirectMcpCapabilityStatus, 'en
   { id: 'list_knowledge_tree', available: true, scopes: ['knowledge:tree'] },
   { id: 'search_knowledge', available: true, scopes: ['knowledge:search'] },
   { id: 'read_knowledge_source', available: true, scopes: ['knowledge:read'] },
+  { id: 'edit_knowledge_source', available: true, scopes: ['knowledge:write'] },
 ];
 
 function settingsSource(
@@ -89,7 +91,7 @@ export function buildDirectMcpServerSettingsStatus(
   );
   let configurationError: string | null = null;
   let runtimeEnabled = false;
-  let runtimeTools: DirectMcpToolId[] = [...DIRECT_MCP_TOOL_IDS];
+  let runtimeTools: DirectMcpToolId[] = [...DIRECT_MCP_DEFAULT_TOOL_IDS];
   let origin: string | null = null;
 
   try {

--- a/app/lib/mcp/server/settings-status.ts
+++ b/app/lib/mcp/server/settings-status.ts
@@ -56,6 +56,7 @@ const DIRECT_MCP_CAPABILITIES: ReadonlyArray<Omit<DirectMcpCapabilityStatus, 'en
   { id: 'search_knowledge', available: true, scopes: ['knowledge:search'] },
   { id: 'read_knowledge_source', available: true, scopes: ['knowledge:read'] },
   { id: 'edit_knowledge_source', available: true, scopes: ['knowledge:write'] },
+  { id: 'read_knowledge_asset', available: true, scopes: ['knowledge:assets'] },
 ];
 
 function settingsSource(

--- a/app/lib/mcp/server/workspace-tools.ts
+++ b/app/lib/mcp/server/workspace-tools.ts
@@ -50,6 +50,17 @@ import {
   type DirectMcpAccessPrincipal,
 } from '@/app/lib/mcp/server/access-token-verifier';
 import {
+  DIRECT_MCP_ASSET_DEFAULT_MAX_CHARACTERS,
+  DIRECT_MCP_ASSET_DEFAULT_MAX_PDF_IMAGES,
+  DIRECT_MCP_ASSET_DEFAULT_MAX_PDF_TEXT_PAGES,
+  DIRECT_MCP_ASSET_MAX_BYTES,
+  DIRECT_MCP_ASSET_MAX_CHARACTERS,
+  DIRECT_MCP_ASSET_MAX_PDF_IMAGES,
+  DIRECT_MCP_ASSET_MAX_PDF_TEXT_PAGES,
+  DirectMcpAssetReadError,
+  readDirectMcpAsset,
+} from '@/app/lib/mcp/server/asset-reader';
+import {
   type DirectMcpResourceScope,
   type DirectMcpToolId,
 } from '@/app/lib/mcp/server/config';
@@ -70,6 +81,7 @@ export const DIRECT_MCP_WORKSPACE_TOOL_IDS = [
   'search_knowledge',
   'read_knowledge_source',
   'edit_knowledge_source',
+  'read_knowledge_asset',
 ] as const satisfies readonly DirectMcpToolId[];
 
 const MAX_WORKSPACE_ID_LENGTH = 200;
@@ -162,6 +174,22 @@ function optionalBoolean(args: JsonObject, name: string): boolean | undefined {
   const value = args[name];
   if (value === undefined) return undefined;
   if (typeof value !== 'boolean') invalidParams(`${name} must be a boolean.`);
+  return value;
+}
+
+function optionalPositiveIntegerArray(
+  args: JsonObject,
+  name: string,
+  maximumLength: number,
+): number[] | undefined {
+  const value = args[name];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length > maximumLength) {
+    invalidParams(`${name} must be an array of at most ${maximumLength} positive integers.`);
+  }
+  if (value.some((entry) => !Number.isSafeInteger(entry) || entry < 1)) {
+    invalidParams(`${name} must contain only positive integers.`);
+  }
   return value;
 }
 
@@ -397,6 +425,56 @@ export function getDirectMcpWorkspaceToolDescriptor(tool: WorkspaceToolName): Di
     };
   }
 
+  if (tool === 'read_knowledge_asset') {
+    return {
+      name: tool,
+      title: 'Read workspace image or PDF',
+      description: 'Returns bounded visual context for an image, or bounded text and selected rendered pages for a PDF, from a visible workspace file.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          workspace_id: { type: 'string', description: 'Workspace ID from list_workspaces.' },
+          path: { type: 'string', description: 'Workspace-relative path of a visible PNG, JPEG, GIF, WebP, or PDF file.' },
+          max_characters: { type: 'integer', minimum: 1, maximum: DIRECT_MCP_ASSET_MAX_CHARACTERS, description: 'For PDFs, maximum extracted text characters. Defaults to 24000.' },
+          max_pdf_text_pages: { type: 'integer', minimum: 1, maximum: DIRECT_MCP_ASSET_MAX_PDF_TEXT_PAGES, description: 'For PDFs, maximum pages to parse for text unless pdf_text_pages is provided. Defaults to 20.' },
+          pdf_text_pages: { type: 'array', items: { type: 'integer', minimum: 1 }, maxItems: DIRECT_MCP_ASSET_MAX_PDF_TEXT_PAGES, description: 'For PDFs, specific 1-based pages to parse for text.' },
+          include_pdf_images: { type: 'boolean', description: 'For PDFs, include rendered page images for visual analysis. Defaults to automatic inclusion for bounded PDFs.' },
+          pdf_image_pages: { type: 'array', items: { type: 'integer', minimum: 1 }, maxItems: DIRECT_MCP_ASSET_MAX_PDF_IMAGES, description: 'For PDFs, specific 1-based pages to render as images.' },
+          max_pdf_images: { type: 'integer', minimum: 1, maximum: DIRECT_MCP_ASSET_MAX_PDF_IMAGES, description: 'For PDFs, maximum rendered page images. Defaults to 2.' },
+        },
+        required: ['workspace_id', 'path'],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: 'object' as const,
+        properties: {
+          workspace_id: { type: 'string' },
+          path: { type: 'string' },
+          type: { type: 'string', enum: ['image', 'pdf'] },
+          mime_type: { type: 'string' },
+          sha256: { type: 'string' },
+          size: { type: 'integer' },
+          modified_at: { type: ['string', 'null'] },
+          pages: { type: 'integer' },
+          text_pages_read: { type: 'array', items: { type: 'integer' } },
+          text_page_limited: { type: 'boolean' },
+          truncated: { type: 'boolean' },
+          rendered_pages: { type: 'array', items: { type: 'object' } },
+          skipped_rendered_page_count: { type: 'integer' },
+        },
+        required: ['workspace_id', 'path', 'type', 'mime_type', 'sha256', 'size', 'modified_at'],
+        additionalProperties: false,
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...getToolSecurity('knowledge:assets'),
+    };
+  }
+
   return {
     name: tool,
     title: 'Read workspace document',
@@ -615,6 +693,13 @@ function errorResult(message: string): CallToolResult {
   };
 }
 
+function assetResult(
+  structuredContent: Record<string, unknown>,
+  content: CallToolResult['content'],
+): CallToolResult {
+  return { content, structuredContent };
+}
+
 async function auditWorkspaceToolCall(input: {
   principal: DirectMcpAccessPrincipal;
   tool: WorkspaceToolName;
@@ -625,6 +710,10 @@ async function auditWorkspaceToolCall(input: {
   afterSha256?: string;
   changed?: boolean;
   reviewRequired?: boolean;
+  assetType?: 'image' | 'pdf';
+  mimeType?: string;
+  sizeBytes?: number;
+  pageCount?: number;
 }): Promise<void> {
   await recordAuditEvent({
     organizationId: input.workspace?.organizationId ?? null,
@@ -646,6 +735,10 @@ async function auditWorkspaceToolCall(input: {
       afterSha256: input.afterSha256 ?? null,
       changed: input.changed ?? null,
       reviewRequired: input.reviewRequired ?? null,
+      assetType: input.assetType ?? null,
+      mimeType: input.mimeType ?? null,
+      sizeBytes: input.sizeBytes ?? null,
+      pageCount: input.pageCount ?? null,
     },
   });
 }
@@ -894,6 +987,110 @@ async function executeReadKnowledgeSource(
     return result(structuredContent, `Read ${content.length} characters from ${filePath}.`);
   } catch {
     return errorResult('Could not read the Canvas workspace file.');
+  }
+}
+
+function assetErrorResult(error: unknown): CallToolResult {
+  if (error instanceof DirectMcpAssetReadError) return errorResult(error.message);
+  return errorResult('Could not read the Canvas workspace asset.');
+}
+
+async function executeReadKnowledgeAsset(
+  args: unknown,
+  authInfo?: AuthInfo,
+): Promise<CallToolResult> {
+  const parsed = parseArgs(args);
+  const workspaceId = requiredString(parsed, 'workspace_id', MAX_WORKSPACE_ID_LENGTH);
+  const filePath = requiredString(parsed, 'path', MAX_PATH_LENGTH);
+  assertVisibleWorkspacePath(filePath);
+  const maxCharacters = optionalInteger(
+    parsed,
+    'max_characters',
+    DIRECT_MCP_ASSET_DEFAULT_MAX_CHARACTERS,
+    1,
+    DIRECT_MCP_ASSET_MAX_CHARACTERS,
+  );
+  const maxPdfTextPages = optionalInteger(
+    parsed,
+    'max_pdf_text_pages',
+    DIRECT_MCP_ASSET_DEFAULT_MAX_PDF_TEXT_PAGES,
+    1,
+    DIRECT_MCP_ASSET_MAX_PDF_TEXT_PAGES,
+  );
+  const pdfTextPages = optionalPositiveIntegerArray(
+    parsed,
+    'pdf_text_pages',
+    DIRECT_MCP_ASSET_MAX_PDF_TEXT_PAGES,
+  );
+  const includePdfImages = optionalBoolean(parsed, 'include_pdf_images');
+  const pdfImagePages = optionalPositiveIntegerArray(
+    parsed,
+    'pdf_image_pages',
+    DIRECT_MCP_ASSET_MAX_PDF_IMAGES,
+  );
+  const maxPdfImages = optionalInteger(
+    parsed,
+    'max_pdf_images',
+    DIRECT_MCP_ASSET_DEFAULT_MAX_PDF_IMAGES,
+    1,
+    DIRECT_MCP_ASSET_MAX_PDF_IMAGES,
+  );
+  const authorization = await authenticateForTool(authInfo, 'knowledge:assets');
+  if ('result' in authorization) return authorization.result;
+
+  try {
+    const workspace = await readableWorkspace(authorization.principal, workspaceId);
+    const stats = await getFileStats(filePath, { workspace });
+    if (!stats.isFile) return errorResult('The requested path is a folder, not a file.');
+    if (stats.size > DIRECT_MCP_ASSET_MAX_BYTES) {
+      return errorResult(`The requested asset is larger than the ${DIRECT_MCP_ASSET_MAX_BYTES / (1024 * 1024)} MB MCP asset limit.`);
+    }
+    const buffer = await readFile(filePath, { workspace });
+    const asset = await readDirectMcpAsset({
+      path: filePath,
+      buffer,
+      options: {
+        maxCharacters,
+        maxPdfTextPages,
+        pdfTextPages,
+        includePdfImages,
+        pdfImagePages,
+        maxPdfImages,
+      },
+    });
+    const sha256 = sha256Buffer(buffer);
+    const structuredContent = {
+      workspace_id: workspace.workspaceId,
+      path: filePath,
+      type: asset.kind.type,
+      mime_type: asset.kind.mimeType,
+      sha256,
+      size: buffer.length,
+      modified_at: toIsoDate(stats.modified),
+      ...(asset.kind.type === 'pdf' ? {
+        pages: asset.pages ?? 0,
+        text_pages_read: asset.textPagesRead ?? [],
+        text_page_limited: asset.textPageLimited ?? false,
+        truncated: asset.truncated ?? false,
+        rendered_pages: asset.images ?? [],
+        skipped_rendered_page_count: asset.skippedImageCount ?? 0,
+      } : {}),
+    };
+    await auditWorkspaceToolCall({
+      principal: authorization.principal,
+      tool: 'read_knowledge_asset',
+      workspace,
+      resultCount: asset.content.filter((part) => part.type === 'image').length,
+      path: filePath,
+      afterSha256: sha256,
+      assetType: asset.kind.type,
+      mimeType: asset.kind.mimeType,
+      sizeBytes: buffer.length,
+      pageCount: asset.pages,
+    });
+    return assetResult(structuredContent, asset.content);
+  } catch (error) {
+    return assetErrorResult(error);
   }
 }
 
@@ -1158,6 +1355,11 @@ export function getDirectMcpWorkspaceToolDefinitions(): DirectMcpWorkspaceToolDe
       id: 'edit_knowledge_source',
       descriptor: getDirectMcpWorkspaceToolDescriptor('edit_knowledge_source'),
       execute: executeEditKnowledgeSource,
+    },
+    {
+      id: 'read_knowledge_asset',
+      descriptor: getDirectMcpWorkspaceToolDescriptor('read_knowledge_asset'),
+      execute: executeReadKnowledgeAsset,
     },
   ];
 }

--- a/app/lib/mcp/server/workspace-tools.ts
+++ b/app/lib/mcp/server/workspace-tools.ts
@@ -14,8 +14,36 @@ import {
   getFileStats,
   listDirectory,
   readFile,
+  validatePath,
+  writeFile,
   type FileNode,
 } from '@/app/lib/filesystem/workspace-files';
+import {
+  assertWorkspaceFileRevisionUnchanged,
+  getWorkspaceFileRevision,
+  normalizeExpectedSha256,
+  sha256Buffer,
+  WorkspaceFileRevisionError,
+} from '@/app/lib/files/revision-guard';
+import { applyExactTextEdits, ExactTextPatchError } from '@/app/lib/files/exact-text-patch';
+import { validateTextFileContent } from '@/app/lib/files/text-content-validation';
+import {
+  assertFileCollaborationWriteAllowed,
+  ensureFileRevisionForCurrentContent,
+  getFileCollaborationState,
+} from '@/app/lib/files/collaboration-policy';
+import { publishWorkspaceFileMutation } from '@/app/lib/filesystem/file-watcher';
+import { syncPublicSharesAfterWrite } from '@/app/lib/public-sharing/public-file-shares';
+import {
+  executePreparedCollaborationTextEdit,
+  prepareCollaborationTextEdit,
+  readCurrentCollaborationTextSnapshot,
+} from '@/app/lib/collaboration/agent-file-edits';
+import {
+  resolveTextCollaborationState,
+  selectInitialTextCollaborationRepresentation,
+} from '@/app/lib/collaboration/document-state-service';
+import { getDatabaseProvider } from '@/app/lib/db/provider';
 import {
   DirectMcpAuthorizationError,
   verifyDirectMcpAccessToken,
@@ -41,6 +69,7 @@ export const DIRECT_MCP_WORKSPACE_TOOL_IDS = [
   'list_knowledge_tree',
   'search_knowledge',
   'read_knowledge_source',
+  'edit_knowledge_source',
 ] as const satisfies readonly DirectMcpToolId[];
 
 const MAX_WORKSPACE_ID_LENGTH = 200;
@@ -56,6 +85,8 @@ const MAX_SEARCH_FILE_BYTES = 256 * 1024;
 const MAX_READ_FILE_BYTES = 512 * 1024;
 const DEFAULT_READ_CHARACTERS = 12_000;
 const MAX_READ_CHARACTERS = 24_000;
+const MAX_EDIT_TEXT_LENGTH = 256 * 1024;
+const MAX_EDIT_OCCURRENCES = 10_000;
 const TEXT_FILE_EXTENSIONS = new Set([
   '.csv', '.html', '.json', '.md', '.mdx', '.rst', '.text', '.toml', '.tsv', '.txt', '.xml', '.yaml', '.yml',
 ]);
@@ -123,6 +154,21 @@ function optionalInteger(
   if (value === undefined) return defaultValue;
   if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < minimum || value > maximum) {
     invalidParams(`${name} must be an integer between ${minimum} and ${maximum}.`);
+  }
+  return value;
+}
+
+function optionalBoolean(args: JsonObject, name: string): boolean | undefined {
+  const value = args[name];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'boolean') invalidParams(`${name} must be a boolean.`);
+  return value;
+}
+
+function requiredText(args: JsonObject, name: string, maxLength: number, allowEmpty = false): string {
+  const value = args[name];
+  if (typeof value !== 'string' || value.length > maxLength || (!allowEmpty && value.length === 0)) {
+    invalidParams(`${name} must be ${allowEmpty ? 'a string' : 'a non-empty string'} up to ${maxLength} characters.`);
   }
   return value;
 }
@@ -307,6 +353,50 @@ export function getDirectMcpWorkspaceToolDescriptor(tool: WorkspaceToolName): Di
     };
   }
 
+  if (tool === 'edit_knowledge_source') {
+    return {
+      name: tool,
+      title: 'Edit workspace document',
+      description: 'Applies one exact, conflict-protected text replacement to an existing visible workspace file. Read the file first and pass its current SHA-256 hash.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          workspace_id: { type: 'string', description: 'Workspace ID from list_workspaces.' },
+          path: { type: 'string', description: 'Workspace-relative path of an existing visible text file.' },
+          old_text: { type: 'string', minLength: 1, description: 'Exact text to replace.' },
+          new_text: { type: 'string', description: 'Replacement text. May be empty to remove the matched text.' },
+          expected_sha256: { type: 'string', description: 'Required SHA-256 returned by read_knowledge_source.' },
+          expected_occurrences: { type: 'integer', minimum: 1, maximum: MAX_EDIT_OCCURRENCES, description: 'Expected number of old_text matches. Defaults to 1.' },
+          replace_all: { type: 'boolean', description: 'Replace every matching occurrence. Cannot be combined with expected_occurrences.' },
+        },
+        required: ['workspace_id', 'path', 'old_text', 'new_text', 'expected_sha256'],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: 'object' as const,
+        properties: {
+          workspace_id: { type: 'string' },
+          path: { type: 'string' },
+          changed: { type: 'boolean' },
+          review_required: { type: 'boolean' },
+          before_sha256: { type: 'string' },
+          after_sha256: { type: 'string' },
+          size: { type: 'integer' },
+          modified_at: { type: ['string', 'null'] },
+        },
+        required: ['workspace_id', 'path', 'changed', 'review_required', 'before_sha256', 'after_sha256', 'size', 'modified_at'],
+        additionalProperties: false,
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      ...getToolSecurity('knowledge:write'),
+    };
+  }
+
   return {
     name: tool,
     title: 'Read workspace document',
@@ -327,10 +417,12 @@ export function getDirectMcpWorkspaceToolDescriptor(tool: WorkspaceToolName): Di
       properties: {
         path: { type: 'string' },
         content: { type: 'string' },
+        sha256: { type: 'string' },
+        source: { type: 'string' },
         truncated: { type: 'boolean' },
         next_offset: { type: ['integer', 'null'] },
       },
-      required: ['path', 'content', 'truncated', 'next_offset'],
+      required: ['path', 'content', 'sha256', 'source', 'truncated', 'next_offset'],
       additionalProperties: false,
     },
     annotations: {
@@ -377,6 +469,72 @@ async function readableWorkspace(
     throw new Error('The requested workspace is not available to this Canvas user.');
   }
   return workspace;
+}
+
+async function writableWorkspace(
+  principal: DirectMcpAccessPrincipal,
+  workspaceId: string,
+): Promise<WorkspaceContext> {
+  const workspace = await readableWorkspace(principal, workspaceId);
+  if (!workspace.permissions.canWrite) {
+    throw new Error('The requested workspace is not writable by this Canvas user.');
+  }
+  return workspace;
+}
+
+type DirectMcpTextContent = {
+  content: string;
+  sha256: string;
+  source: 'file' | 'live_yjs';
+  documentId?: string;
+};
+
+async function readDirectMcpTextContent(input: {
+  workspace: WorkspaceContext;
+  path: string;
+  buffer: Buffer;
+  principal: DirectMcpAccessPrincipal;
+}): Promise<DirectMcpTextContent> {
+  const fallback = {
+    content: input.buffer.toString('utf8'),
+    sha256: sha256Buffer(input.buffer),
+    source: 'file' as const,
+  };
+  if (getDatabaseProvider() !== 'postgres') return fallback;
+
+  const collaboration = getFileCollaborationState({
+    workspace: input.workspace,
+    path: input.path,
+    ensureDocument: true,
+  });
+  if (!collaboration.crdtCapable || !collaboration.document) return fallback;
+
+  ensureFileRevisionForCurrentContent({
+    workspace: input.workspace,
+    path: input.path,
+    contentHash: fallback.sha256,
+    sizeBytes: input.buffer.length,
+    actorUserId: input.principal.userId,
+    actorType: 'user',
+    sourceSessionId: input.principal.sessionId,
+  });
+  await resolveTextCollaborationState({
+    document: collaboration.document,
+    workspace: input.workspace,
+    path: input.path,
+    initialRepresentation: selectInitialTextCollaborationRepresentation(input.path, fallback.content),
+    initialContent: fallback.content,
+  });
+  const snapshot = await readCurrentCollaborationTextSnapshot({
+    documentId: collaboration.document.id,
+    workspace: input.workspace,
+  });
+  return {
+    content: snapshot.content,
+    sha256: snapshot.sha256,
+    source: 'live_yjs',
+    documentId: snapshot.documentId,
+  };
 }
 
 async function listBoundedWorkspaceTree(input: {
@@ -462,6 +620,11 @@ async function auditWorkspaceToolCall(input: {
   tool: WorkspaceToolName;
   workspace?: WorkspaceContext;
   resultCount?: number;
+  path?: string;
+  beforeSha256?: string;
+  afterSha256?: string;
+  changed?: boolean;
+  reviewRequired?: boolean;
 }): Promise<void> {
   await recordAuditEvent({
     organizationId: input.workspace?.organizationId ?? null,
@@ -476,7 +639,13 @@ async function auditWorkspaceToolCall(input: {
     summary: `Direct MCP tool ${input.tool} completed.`,
     metadata: {
       tool: input.tool,
+      clientId: input.principal.clientId,
       resultCount: input.resultCount ?? null,
+      path: input.path ?? null,
+      beforeSha256: input.beforeSha256 ?? null,
+      afterSha256: input.afterSha256 ?? null,
+      changed: input.changed ?? null,
+      reviewRequired: input.reviewRequired ?? null,
     },
   });
 }
@@ -692,16 +861,26 @@ async function executeReadKnowledgeSource(
     if (isLikelyBinary(filePath, buffer)) {
       return errorResult('Only text files can be read through this MCP tool.');
     }
-    const text = buffer.toString('utf8');
-    const content = text.slice(offset, offset + maxCharacters);
-    const nextOffset = offset + content.length < text.length ? offset + content.length : null;
+    const text = await readDirectMcpTextContent({
+      workspace,
+      path: filePath,
+      buffer,
+      principal: authorization.principal,
+    });
+    if (Buffer.byteLength(text.content, 'utf8') > MAX_READ_FILE_BYTES) {
+      return errorResult(`The requested file is larger than the ${MAX_READ_FILE_BYTES / 1024} KB MCP read limit.`);
+    }
+    const content = text.content.slice(offset, offset + maxCharacters);
+    const nextOffset = offset + content.length < text.content.length ? offset + content.length : null;
     const structuredContent = {
       workspace_id: workspace.workspaceId,
       path: filePath,
       content,
+      sha256: text.sha256,
+      source: text.source,
       truncated: nextOffset !== null,
       next_offset: nextOffset,
-      size: stats.size,
+      size: Buffer.byteLength(text.content, 'utf8'),
       modified_at: toIsoDate(stats.modified),
     };
     await auditWorkspaceToolCall({
@@ -709,10 +888,242 @@ async function executeReadKnowledgeSource(
       tool: 'read_knowledge_source',
       workspace,
       resultCount: content.length,
+      path: filePath,
+      afterSha256: text.sha256,
     });
     return result(structuredContent, `Read ${content.length} characters from ${filePath}.`);
   } catch {
     return errorResult('Could not read the Canvas workspace file.');
+  }
+}
+
+function editErrorResult(error: unknown): CallToolResult {
+  if (error instanceof WorkspaceFileRevisionError) {
+    return errorResult('The workspace file changed since it was read. Read the current file content again before retrying.');
+  }
+  if (error instanceof ExactTextPatchError) {
+    return errorResult('The requested exact text replacement no longer matches the current file content. Read the file again and retry with a precise replacement.');
+  }
+  return errorResult('Could not safely update the Canvas workspace file.');
+}
+
+async function executeEditKnowledgeSource(
+  args: unknown,
+  authInfo?: AuthInfo,
+): Promise<CallToolResult> {
+  const parsed = parseArgs(args);
+  const workspaceId = requiredString(parsed, 'workspace_id', MAX_WORKSPACE_ID_LENGTH);
+  const filePath = requiredString(parsed, 'path', MAX_PATH_LENGTH);
+  assertVisibleWorkspacePath(filePath);
+  const oldText = requiredText(parsed, 'old_text', MAX_EDIT_TEXT_LENGTH);
+  const newText = requiredText(parsed, 'new_text', MAX_EDIT_TEXT_LENGTH, true);
+  const expectedSha256 = normalizeExpectedSha256(requiredString(parsed, 'expected_sha256', 80));
+  if (!expectedSha256) invalidParams('expected_sha256 must be a SHA-256 hash returned by read_knowledge_source.');
+  const replaceAll = optionalBoolean(parsed, 'replace_all');
+  const expectedOccurrences = replaceAll
+    ? (parsed.expected_occurrences === undefined
+      ? undefined
+      : optionalInteger(parsed, 'expected_occurrences', 1, 1, MAX_EDIT_OCCURRENCES))
+    : optionalInteger(parsed, 'expected_occurrences', 1, 1, MAX_EDIT_OCCURRENCES);
+  const authorization = await authenticateForTool(authInfo, 'knowledge:write');
+  if ('result' in authorization) return authorization.result;
+
+  try {
+    const workspace = await writableWorkspace(authorization.principal, workspaceId);
+    const stats = await getFileStats(filePath, { workspace });
+    if (!stats.isFile) return errorResult('The requested path is a folder, not a file.');
+    if (stats.size > MAX_READ_FILE_BYTES) {
+      return errorResult(`The requested file is larger than the ${MAX_READ_FILE_BYTES / 1024} KB MCP edit limit.`);
+    }
+    const buffer = await readFile(filePath, { workspace });
+    if (isLikelyBinary(filePath, buffer)) {
+      return errorResult('Only text files can be edited through this MCP tool.');
+    }
+    const current = await readDirectMcpTextContent({
+      workspace,
+      path: filePath,
+      buffer,
+      principal: authorization.principal,
+    });
+    if (Buffer.byteLength(current.content, 'utf8') > MAX_READ_FILE_BYTES) {
+      return errorResult(`The requested file is larger than the ${MAX_READ_FILE_BYTES / 1024} KB MCP edit limit.`);
+    }
+    if (current.sha256 !== expectedSha256) {
+      return errorResult('The workspace file changed since it was read. Read the current file content again before retrying.');
+    }
+
+    const edits = [{
+      oldText,
+      newText,
+      expectedOccurrences,
+      replaceAll,
+    }];
+    const proposedContent = applyExactTextEdits(current.content, edits, filePath);
+    if (Buffer.byteLength(proposedContent, 'utf8') > MAX_READ_FILE_BYTES) {
+      return errorResult(`The updated file would exceed the ${MAX_READ_FILE_BYTES / 1024} KB MCP edit limit.`);
+    }
+    const validation = validateTextFileContent(filePath, proposedContent);
+    if (!validation.ok) {
+      return errorResult('The requested edit would leave the file in an invalid state.');
+    }
+    if (proposedContent === current.content) {
+      const structuredContent = {
+        workspace_id: workspace.workspaceId,
+        path: filePath,
+        changed: false,
+        review_required: false,
+        before_sha256: current.sha256,
+        after_sha256: current.sha256,
+        size: Buffer.byteLength(current.content, 'utf8'),
+        modified_at: toIsoDate(stats.modified),
+      };
+      await auditWorkspaceToolCall({
+        principal: authorization.principal,
+        tool: 'edit_knowledge_source',
+        workspace,
+        resultCount: 0,
+        path: filePath,
+        beforeSha256: current.sha256,
+        afterSha256: current.sha256,
+        changed: false,
+        reviewRequired: false,
+      });
+      return result(structuredContent, `No change was needed for ${filePath}.`);
+    }
+
+    if (current.source === 'live_yjs' && current.documentId) {
+      const prepared = await prepareCollaborationTextEdit({
+        documentId: current.documentId,
+        workspace,
+        path: filePath,
+        edits,
+        expectedSha256,
+        groupId: 'direct_mcp_edit',
+      });
+      const preparedValidation = validateTextFileContent(filePath, prepared.proposedContent);
+      if (!preparedValidation.ok) {
+        return errorResult('The requested edit would leave the file in an invalid state.');
+      }
+      const operation = await executePreparedCollaborationTextEdit({
+        prepared,
+        workspace,
+        identity: {
+          initiatedByUserId: authorization.principal.userId,
+          actorId: `direct-mcp:${authorization.principal.clientId}`,
+          actorDisplayName: 'External MCP client',
+          actorSessionId: authorization.principal.sessionId,
+        },
+      });
+      const after = await readCurrentCollaborationTextSnapshot({
+        documentId: prepared.documentId,
+        workspace,
+      });
+      const reviewRequired = operation.operationStatus === 'needs_review'
+        || operation.operationStatus === 'partially_applied'
+        || operation.operationStatus === 'semantic_conflict';
+      const changed = after.sha256 !== prepared.sha256;
+      const afterStats = await getFileStats(filePath, { workspace });
+      const structuredContent = {
+        workspace_id: workspace.workspaceId,
+        path: filePath,
+        changed,
+        review_required: reviewRequired,
+        before_sha256: prepared.sha256,
+        after_sha256: after.sha256,
+        size: Buffer.byteLength(after.content, 'utf8'),
+        modified_at: toIsoDate(afterStats.modified),
+      };
+      await auditWorkspaceToolCall({
+        principal: authorization.principal,
+        tool: 'edit_knowledge_source',
+        workspace,
+        resultCount: changed ? 1 : 0,
+        path: filePath,
+        beforeSha256: prepared.sha256,
+        afterSha256: after.sha256,
+        changed,
+        reviewRequired,
+      });
+      return result(
+        structuredContent,
+        reviewRequired
+          ? `A collaboration review was created for ${filePath}.`
+          : changed
+            ? `Updated ${filePath}.`
+            : `No change was applied to ${filePath}.`,
+      );
+    }
+
+    const beforeRevision = await getWorkspaceFileRevision(filePath, { workspace });
+    if (!beforeRevision || beforeRevision.sha256 !== expectedSha256) {
+      return errorResult('The workspace file changed since it was read. Read the current file content again before retrying.');
+    }
+    const baseRevision = ensureFileRevisionForCurrentContent({
+      workspace,
+      path: filePath,
+      contentHash: beforeRevision.sha256,
+      sizeBytes: beforeRevision.stats.size,
+      actorUserId: authorization.principal.userId,
+      actorType: 'user',
+      sourceSessionId: authorization.principal.sessionId,
+    });
+    assertFileCollaborationWriteAllowed({
+      workspace,
+      path: filePath,
+      actorUserId: authorization.principal.userId,
+      actorSessionId: authorization.principal.sessionId,
+      actorType: 'user',
+      baseRevisionId: baseRevision.id,
+    });
+    await writeFile(filePath, proposedContent, { workspace }, async () => {
+      await assertWorkspaceFileRevisionUnchanged({
+        path: filePath,
+        expectedRevision: beforeRevision,
+        options: { workspace },
+      });
+    });
+    const afterBuffer = await readFile(filePath, { workspace });
+    const afterSha256 = sha256Buffer(afterBuffer);
+    if (afterBuffer.toString('utf8') !== proposedContent) {
+      throw new Error('Read-after-write verification failed.');
+    }
+    const afterRevision = ensureFileRevisionForCurrentContent({
+      workspace,
+      path: filePath,
+      contentHash: afterSha256,
+      sizeBytes: afterBuffer.length,
+      actorUserId: authorization.principal.userId,
+      actorType: 'user',
+      sourceSessionId: authorization.principal.sessionId,
+      baseRevisionId: baseRevision.id,
+    });
+    await syncPublicSharesAfterWrite([validatePath(filePath, { workspace })]);
+    publishWorkspaceFileMutation({ workspace, type: 'change', relativePath: filePath });
+    const afterStats = await getFileStats(filePath, { workspace });
+    const structuredContent = {
+      workspace_id: workspace.workspaceId,
+      path: filePath,
+      changed: true,
+      review_required: false,
+      before_sha256: beforeRevision.sha256,
+      after_sha256: afterRevision.contentHash,
+      size: afterBuffer.length,
+      modified_at: toIsoDate(afterStats.modified),
+    };
+    await auditWorkspaceToolCall({
+      principal: authorization.principal,
+      tool: 'edit_knowledge_source',
+      workspace,
+      resultCount: 1,
+      path: filePath,
+      beforeSha256: beforeRevision.sha256,
+      afterSha256: afterRevision.contentHash,
+      changed: true,
+      reviewRequired: false,
+    });
+    return result(structuredContent, `Updated ${filePath}.`);
+  } catch (error) {
+    return editErrorResult(error);
   }
 }
 
@@ -742,6 +1153,11 @@ export function getDirectMcpWorkspaceToolDefinitions(): DirectMcpWorkspaceToolDe
       id: 'read_knowledge_source',
       descriptor: getDirectMcpWorkspaceToolDescriptor('read_knowledge_source'),
       execute: executeReadKnowledgeSource,
+    },
+    {
+      id: 'edit_knowledge_source',
+      descriptor: getDirectMcpWorkspaceToolDescriptor('edit_knowledge_source'),
+      execute: executeEditKnowledgeSource,
     },
   ];
 }

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -1093,6 +1093,31 @@ type AgentPathMutationState = {
   sha256: string | null;
 };
 
+async function sha256AgentDirectory(fullPath: string): Promise<string> {
+  const hash = createHash('sha256');
+  const visit = async (currentPath: string, relativePath: string): Promise<void> => {
+    const entries = await fs.readdir(currentPath, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const entryRelativePath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
+      const entryFullPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        hash.update(`directory\0${entryRelativePath}\0`);
+        await visit(entryFullPath, entryRelativePath);
+      } else if (entry.isFile()) {
+        hash.update(`file\0${entryRelativePath}\0`);
+        hash.update(await fs.readFile(entryFullPath));
+      } else {
+        const stats = await fs.lstat(entryFullPath);
+        hash.update(`other\0${entryRelativePath}\0${stats.size}\0`);
+      }
+    }
+  };
+
+  await visit(fullPath, '');
+  return hash.digest('hex');
+}
+
 async function captureAgentPathMutationState(inputPath: string, fullPath: string): Promise<AgentPathMutationState> {
   try {
     const stats = await fs.stat(fullPath);
@@ -1102,7 +1127,11 @@ async function captureAgentPathMutationState(inputPath: string, fullPath: string
       fullPath,
       existed: true,
       type,
-      sha256: type === 'file' ? sha256Buffer(await fs.readFile(fullPath)) : null,
+      sha256: type === 'file'
+        ? sha256Buffer(await fs.readFile(fullPath))
+        : type === 'directory'
+          ? await sha256AgentDirectory(fullPath)
+          : null,
     };
   } catch (error) {
     if (!isEnoent(error)) throw error;

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -44,6 +44,7 @@ import {
   syncPublicSharesAfterMove,
   syncPublicSharesAfterWrite,
 } from '@/app/lib/public-sharing/public-file-shares';
+import { writeFile as writeWorkspaceFile } from '@/app/lib/filesystem/workspace-files';
 import { publishWorkspaceFileMutation, type FileEventType } from '@/app/lib/filesystem/file-watcher';
 import { getAgentExecutionContext, type AgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
 import { ensureAgentRuntimeTempDir, resolveAgentRuntimeTempDir } from '@/app/lib/pi/agent-runtime-temp';
@@ -1081,6 +1082,28 @@ async function readExistingFile(fullPath: string): Promise<{ existed: boolean; b
   }
 }
 
+async function assertAgentFileUnchangedBeforeReplace(params: {
+  inputPath: string;
+  fullPath: string;
+  beforeExisted: boolean;
+  beforeBuffer: Buffer | null;
+  operation: string;
+}): Promise<void> {
+  const current = await readExistingFile(params.fullPath);
+  const beforeSha256 = params.beforeBuffer ? sha256Buffer(params.beforeBuffer) : null;
+  const currentSha256 = current.buffer ? sha256Buffer(current.buffer) : null;
+  if (current.existed === params.beforeExisted && currentSha256 === beforeSha256) return;
+
+  throw new WorkspaceFileRevisionError({
+    code: 'FILE_REVISION_CONFLICT',
+    status: 409,
+    path: params.inputPath,
+    expectedSha256: beforeSha256,
+    currentSha256,
+    message: `Refusing to ${params.operation} ${params.inputPath}: the file changed after it was read. Read the file again before retrying.`,
+  });
+}
+
 async function commitTextChange(params: {
   inputPath: string;
   fullPath: string;
@@ -1115,6 +1138,9 @@ async function commitTextChange(params: {
   await fs.mkdir(path.dirname(params.fullPath), { recursive: true });
   const executionContext = getAgentExecutionContext();
   const workspaceContext = getAgentWorkspaceContext();
+  const workspacePath = workspaceContext && isPathWithin(params.fullPath, workspaceContext.rootPath)
+    ? workspaceRelativeAgentPath(workspaceContext, params.fullPath)
+    : null;
   const baseRevision = workspaceContext && params.beforeBuffer
     ? ensureFileRevisionForCurrentContent({
         workspace: workspaceContext,
@@ -1144,7 +1170,19 @@ async function commitTextChange(params: {
     operation: params.operation,
   });
 
-  await fs.writeFile(params.fullPath, params.nextContent, 'utf8');
+  if (workspaceContext && workspacePath) {
+    await writeWorkspaceFile(workspacePath, params.nextContent, { workspace: workspaceContext }, async () => {
+      await assertAgentFileUnchangedBeforeReplace({
+        inputPath: params.inputPath,
+        fullPath: params.fullPath,
+        beforeExisted: params.beforeExisted,
+        beforeBuffer: params.beforeBuffer,
+        operation: params.operation,
+      });
+    });
+  } else {
+    await fs.writeFile(params.fullPath, params.nextContent, 'utf8');
+  }
   const readBack = await fs.readFile(params.fullPath);
   const readBackText = readBack.toString('utf8');
   if (readBackText !== params.nextContent) {

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -44,7 +44,10 @@ import {
   syncPublicSharesAfterMove,
   syncPublicSharesAfterWrite,
 } from '@/app/lib/public-sharing/public-file-shares';
-import { writeFile as writeWorkspaceFile } from '@/app/lib/filesystem/workspace-files';
+import {
+  withWorkspaceFileMutationLocks,
+  writeFile as writeWorkspaceFile,
+} from '@/app/lib/filesystem/workspace-files';
 import { publishWorkspaceFileMutation, type FileEventType } from '@/app/lib/filesystem/file-watcher';
 import { getAgentExecutionContext, type AgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
 import { ensureAgentRuntimeTempDir, resolveAgentRuntimeTempDir } from '@/app/lib/pi/agent-runtime-temp';
@@ -1082,6 +1085,70 @@ async function readExistingFile(fullPath: string): Promise<{ existed: boolean; b
   }
 }
 
+type AgentPathMutationState = {
+  inputPath: string;
+  fullPath: string;
+  existed: boolean;
+  type: AgentPathType;
+  sha256: string | null;
+};
+
+async function captureAgentPathMutationState(inputPath: string, fullPath: string): Promise<AgentPathMutationState> {
+  try {
+    const stats = await fs.stat(fullPath);
+    const type = getPathType(stats);
+    return {
+      inputPath,
+      fullPath,
+      existed: true,
+      type,
+      sha256: type === 'file' ? sha256Buffer(await fs.readFile(fullPath)) : null,
+    };
+  } catch (error) {
+    if (!isEnoent(error)) throw error;
+    return { inputPath, fullPath, existed: false, type: 'missing', sha256: null };
+  }
+}
+
+async function assertAgentPathMutationStatesUnchanged(
+  states: readonly AgentPathMutationState[],
+  operation: string,
+): Promise<void> {
+  for (const state of states) {
+    const current = await captureAgentPathMutationState(state.inputPath, state.fullPath);
+    if (
+      current.existed === state.existed
+      && current.type === state.type
+      && current.sha256 === state.sha256
+    ) {
+      continue;
+    }
+    throw new WorkspaceFileRevisionError({
+      code: 'FILE_REVISION_CONFLICT',
+      status: 409,
+      path: state.inputPath,
+      expectedSha256: state.sha256,
+      currentSha256: current.sha256,
+      message: `Refusing to ${operation} ${state.inputPath}: the path changed after it was read. Read it again before retrying.`,
+    });
+  }
+}
+
+async function withAgentWorkspaceMutationLocks<T>(
+  fullPaths: readonly string[],
+  operation: () => Promise<T>,
+): Promise<T> {
+  const workspace = getAgentWorkspaceContext();
+  if (!workspace) return operation();
+
+  const workspacePaths = fullPaths
+    .filter((fullPath) => isPathWithin(fullPath, workspace.rootPath))
+    .map((fullPath) => workspaceRelativeAgentPath(workspace, fullPath));
+  if (workspacePaths.length === 0) return operation();
+
+  return withWorkspaceFileMutationLocks(workspacePaths, { workspace }, operation);
+}
+
 async function assertAgentFileUnchangedBeforeReplace(params: {
   inputPath: string;
   fullPath: string;
@@ -1678,73 +1745,84 @@ export async function restoreAgentFileSnapshot(params: { snapshotId: string }): 
   await assertAgentWritablePathAllowed(fullPath);
 
   const before = await readExistingFile(fullPath);
-  const workspaceContext = getAgentWorkspaceContext();
-  if (workspaceContext) {
-    assertFileCollaborationWriteAllowed({
-      workspace: workspaceContext,
-      path: workspaceRelativeAgentPath(workspaceContext, fullPath),
-      actorUserId: getAgentExecutionContext()?.userId ?? null,
-      actorSessionId: getAgentExecutionContext()?.sessionId ?? null,
-      actorType: 'agent',
-    });
-  }
-  const undoSnapshot = await createSnapshotFromBuffer({
+  const mutationState: AgentPathMutationState = {
     inputPath: snapshot.path,
     fullPath,
     existed: before.existed,
-    beforeBuffer: before.buffer,
-    operation: 'restore_file_snapshot',
-  });
+    type: before.existed ? 'file' : 'missing',
+    sha256: before.buffer ? sha256Buffer(before.buffer) : null,
+  };
 
-  if (!snapshot.existed) {
-    await fs.rm(fullPath, { force: true });
-    await syncPublicSharesAfterDelete([fullPath]);
+  return withAgentWorkspaceMutationLocks([fullPath], async () => {
+    await assertAgentPathMutationStatesUnchanged([mutationState], 'restore_file_snapshot');
+    const workspaceContext = getAgentWorkspaceContext();
+    if (workspaceContext) {
+      assertFileCollaborationWriteAllowed({
+        workspace: workspaceContext,
+        path: workspaceRelativeAgentPath(workspaceContext, fullPath),
+        actorUserId: getAgentExecutionContext()?.userId ?? null,
+        actorSessionId: getAgentExecutionContext()?.sessionId ?? null,
+        actorType: 'agent',
+      });
+    }
+    const undoSnapshot = await createSnapshotFromBuffer({
+      inputPath: snapshot.path,
+      fullPath,
+      existed: before.existed,
+      beforeBuffer: before.buffer,
+      operation: 'restore_file_snapshot',
+    });
+
+    if (!snapshot.existed) {
+      await fs.rm(fullPath, { force: true });
+      await syncPublicSharesAfterDelete([fullPath]);
+      const result: AgentFileChangeResult = {
+        path: snapshot.path,
+        resolvedPath: fullPath,
+        changed: before.existed,
+        snapshot: undoSnapshot,
+        beforeSha256: before.buffer ? sha256Buffer(before.buffer) : null,
+        afterSha256: sha256Text(''),
+        size: 0,
+        diff: before.buffer && !isProbablyBinary(before.buffer)
+          ? createUnifiedDiff(before.buffer.toString('utf8'), '', `${snapshot.path} (before restore)`, `${snapshot.path} (after restore)`)
+          : '(file removed; textual diff unavailable)',
+        validation: { ok: true, checks: [{ name: 'restore', ok: true, message: 'Restored snapshot by removing file that did not exist before the original edit.' }] },
+      };
+      publishAgentWorkspaceMutation(fullPath, 'unlink');
+      await recordAgentFileChangeAudit(result, 'restore_file_snapshot');
+      return result;
+    }
+
+    const content = await fs.readFile(snapshotContentPath(snapshot.id));
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content);
+    const readBack = await fs.readFile(fullPath);
+    if (sha256Buffer(readBack) !== sha256Buffer(content)) {
+      throw new Error(`Read-after-restore verification failed for ${snapshot.path}.`);
+    }
+    await syncPublicSharesAfterWrite([fullPath]);
+
+    const beforeText = before.buffer && !isProbablyBinary(before.buffer) ? before.buffer.toString('utf8') : null;
+    const afterText = !isProbablyBinary(readBack) ? readBack.toString('utf8') : null;
+
     const result: AgentFileChangeResult = {
       path: snapshot.path,
       resolvedPath: fullPath,
-      changed: before.existed,
+      changed: true,
       snapshot: undoSnapshot,
       beforeSha256: before.buffer ? sha256Buffer(before.buffer) : null,
-      afterSha256: sha256Text(''),
-      size: 0,
-      diff: before.buffer && !isProbablyBinary(before.buffer)
-        ? createUnifiedDiff(before.buffer.toString('utf8'), '', `${snapshot.path} (before restore)`, `${snapshot.path} (after restore)`)
-        : '(file removed; textual diff unavailable)',
-      validation: { ok: true, checks: [{ name: 'restore', ok: true, message: 'Restored snapshot by removing file that did not exist before the original edit.' }] },
+      afterSha256: sha256Buffer(readBack),
+      size: readBack.length,
+      diff: beforeText !== null && afterText !== null
+        ? createUnifiedDiff(beforeText, afterText, `${snapshot.path} (before restore)`, `${snapshot.path} (after restore)`)
+        : '(binary file restored; textual diff unavailable)',
+      validation: validateAgentFileContent(snapshot.path, readBack.toString('utf8')),
     };
-    publishAgentWorkspaceMutation(fullPath, 'unlink');
+    publishAgentWorkspaceMutation(fullPath, 'change');
     await recordAgentFileChangeAudit(result, 'restore_file_snapshot');
     return result;
-  }
-
-  const content = await fs.readFile(snapshotContentPath(snapshot.id));
-  await fs.mkdir(path.dirname(fullPath), { recursive: true });
-  await fs.writeFile(fullPath, content);
-  const readBack = await fs.readFile(fullPath);
-  if (sha256Buffer(readBack) !== sha256Buffer(content)) {
-    throw new Error(`Read-after-restore verification failed for ${snapshot.path}.`);
-  }
-  await syncPublicSharesAfterWrite([fullPath]);
-
-  const beforeText = before.buffer && !isProbablyBinary(before.buffer) ? before.buffer.toString('utf8') : null;
-  const afterText = !isProbablyBinary(readBack) ? readBack.toString('utf8') : null;
-
-  const result: AgentFileChangeResult = {
-    path: snapshot.path,
-    resolvedPath: fullPath,
-    changed: true,
-    snapshot: undoSnapshot,
-    beforeSha256: before.buffer ? sha256Buffer(before.buffer) : null,
-    afterSha256: sha256Buffer(readBack),
-    size: readBack.length,
-    diff: beforeText !== null && afterText !== null
-      ? createUnifiedDiff(beforeText, afterText, `${snapshot.path} (before restore)`, `${snapshot.path} (after restore)`)
-      : '(binary file restored; textual diff unavailable)',
-    validation: validateAgentFileContent(snapshot.path, readBack.toString('utf8')),
-  };
-  publishAgentWorkspaceMutation(fullPath, 'change');
-  await recordAgentFileChangeAudit(result, 'restore_file_snapshot');
-  return result;
+  });
 }
 
 function getPathType(stats: Stats): AgentPathType {
@@ -2039,63 +2117,73 @@ export async function copyAgentPaths(params: {
   assertNoDuplicateDestinations(entries);
   assertNoNestedCopyMoveSources(entries);
 
-  const copyWorkspace = getAgentWorkspaceContext();
-  if (copyWorkspace) {
-    const overwrittenPaths: string[] = [];
-    for (const entry of entries) {
-      if (!entry.overwritten || !entry.destinationResolvedPath) continue;
-      const destinationPath = workspaceRelativeAgentPath(copyWorkspace, entry.destinationResolvedPath);
-      assertFileCollaborationWriteAllowed({
-        workspace: copyWorkspace,
-        path: destinationPath,
-        actorUserId: getAgentExecutionContext()?.userId ?? null,
-        actorSessionId: getAgentExecutionContext()?.sessionId ?? null,
-        actorType: 'agent',
-      });
-      overwrittenPaths.push(destinationPath);
-    }
-    if (overwrittenPaths.length > 0) {
-      archiveFileCollaborationPaths({ workspace: copyWorkspace, paths: overwrittenPaths.map((path) => ({ path })) });
-      await archivePersistedCollaborationPaths({ workspaceId: copyWorkspace.workspaceId, paths: overwrittenPaths });
-    }
-  }
+  const mutationStates = await Promise.all(entries.flatMap((entry) => [
+    captureAgentPathMutationState(entry.sourcePath, entry.sourceResolvedPath),
+    captureAgentPathMutationState(entry.destinationPath!, entry.destinationResolvedPath!),
+  ]));
+  return withAgentWorkspaceMutationLocks(
+    mutationStates.map((state) => state.fullPath),
+    async () => {
+      await assertAgentPathMutationStatesUnchanged(mutationStates, 'copy_path');
+      const copyWorkspace = getAgentWorkspaceContext();
+      if (copyWorkspace) {
+        const overwrittenPaths: string[] = [];
+        for (const entry of entries) {
+          if (!entry.overwritten || !entry.destinationResolvedPath) continue;
+          const destinationPath = workspaceRelativeAgentPath(copyWorkspace, entry.destinationResolvedPath);
+          assertFileCollaborationWriteAllowed({
+            workspace: copyWorkspace,
+            path: destinationPath,
+            actorUserId: getAgentExecutionContext()?.userId ?? null,
+            actorSessionId: getAgentExecutionContext()?.sessionId ?? null,
+            actorType: 'agent',
+          });
+          overwrittenPaths.push(destinationPath);
+        }
+        if (overwrittenPaths.length > 0) {
+          archiveFileCollaborationPaths({ workspace: copyWorkspace, paths: overwrittenPaths.map((path) => ({ path })) });
+          await archivePersistedCollaborationPaths({ workspaceId: copyWorkspace.workspaceId, paths: overwrittenPaths });
+        }
+      }
 
-  for (const entry of entries) {
-    if (!entry.destinationResolvedPath) continue;
-    await fs.mkdir(path.dirname(entry.destinationResolvedPath), { recursive: true });
-    if (entry.overwritten && params.overwrite) {
-      await fs.rm(entry.destinationResolvedPath, { recursive: true, force: true });
-    }
-    await fs.cp(entry.sourceResolvedPath, entry.destinationResolvedPath, {
-      recursive: entry.type === 'directory',
-      force: params.overwrite === true,
-      errorOnExist: params.overwrite !== true,
-    });
-  }
-  await verifyPathOperationEntries({ entries, sourceMustBeRemoved: false });
-  if (copyWorkspace) {
-    initializeCopiedFileCollaborationPaths({
-      workspace: copyWorkspace,
-      paths: entries
-        .map((entry) => entry.destinationResolvedPath)
-        .filter((value): value is string => Boolean(value))
-        .map((destination) => workspaceRelativeAgentPath(copyWorkspace, destination)),
-    });
-  }
-  await syncPublicSharesAfterWrite(entries.map((entry) => entry.destinationResolvedPath).filter((value): value is string => Boolean(value)));
-  for (const entry of entries) {
-    if (entry.destinationResolvedPath) {
-      publishAgentWorkspaceMutation(
-        entry.destinationResolvedPath,
-        entry.overwritten ? 'change' : entry.type === 'directory' ? 'addDir' : 'add',
-      );
-    }
-  }
+      for (const entry of entries) {
+        if (!entry.destinationResolvedPath) continue;
+        await fs.mkdir(path.dirname(entry.destinationResolvedPath), { recursive: true });
+        if (entry.overwritten && params.overwrite) {
+          await fs.rm(entry.destinationResolvedPath, { recursive: true, force: true });
+        }
+        await fs.cp(entry.sourceResolvedPath, entry.destinationResolvedPath, {
+          recursive: entry.type === 'directory',
+          force: params.overwrite === true,
+          errorOnExist: params.overwrite !== true,
+        });
+      }
+      await verifyPathOperationEntries({ entries, sourceMustBeRemoved: false });
+      if (copyWorkspace) {
+        initializeCopiedFileCollaborationPaths({
+          workspace: copyWorkspace,
+          paths: entries
+            .map((entry) => entry.destinationResolvedPath)
+            .filter((value): value is string => Boolean(value))
+            .map((destination) => workspaceRelativeAgentPath(copyWorkspace, destination)),
+        });
+      }
+      await syncPublicSharesAfterWrite(entries.map((entry) => entry.destinationResolvedPath).filter((value): value is string => Boolean(value)));
+      for (const entry of entries) {
+        if (entry.destinationResolvedPath) {
+          publishAgentWorkspaceMutation(
+            entry.destinationResolvedPath,
+            entry.overwritten ? 'change' : entry.type === 'directory' ? 'addDir' : 'add',
+          );
+        }
+      }
 
-  const result = pathOperationSummary('copy_path', entries, params.destinationPath, destinationFullPath);
-  result.verified = entries.every((entry) => entry.verification?.contentVerified === true);
-  await recordAgentPathOperationAudit(result);
-  return result;
+      const result = pathOperationSummary('copy_path', entries, params.destinationPath, destinationFullPath);
+      result.verified = entries.every((entry) => entry.verification?.contentVerified === true);
+      await recordAgentPathOperationAudit(result);
+      return result;
+    },
+  );
 }
 
 export async function moveAgentPath(params: {
@@ -2163,56 +2251,66 @@ export async function moveAgentPaths(params: {
   assertNoDuplicateDestinations(entries);
   assertNoNestedCopyMoveSources(entries);
 
-  const moveWorkspace = getAgentWorkspaceContext();
-  if (moveWorkspace) {
-    const overwrittenPaths = entries
-      .filter((entry) => entry.overwritten && entry.destinationResolvedPath)
-      .map((entry) => workspaceRelativeAgentPath(moveWorkspace, entry.destinationResolvedPath!));
-    if (overwrittenPaths.length > 0) {
-      archiveFileCollaborationPaths({ workspace: moveWorkspace, paths: overwrittenPaths.map((path) => ({ path })) });
-      await archivePersistedCollaborationPaths({ workspaceId: moveWorkspace.workspaceId, paths: overwrittenPaths });
-    }
-  }
-
-  for (const entry of entries) {
-    if (!entry.destinationResolvedPath) continue;
-    await fs.mkdir(path.dirname(entry.destinationResolvedPath), { recursive: true });
-    if (entry.overwritten && params.overwrite) {
-      await fs.rm(entry.destinationResolvedPath, { recursive: true, force: true });
-    }
-
-    try {
-      await fs.rename(entry.sourceResolvedPath, entry.destinationResolvedPath);
-    } catch (error) {
-      if (!(error && typeof error === 'object' && 'code' in error && error.code === 'EXDEV')) {
-        throw error;
-      }
-      await fs.cp(entry.sourceResolvedPath, entry.destinationResolvedPath, { recursive: entry.type === 'directory', force: true });
-      await fs.rm(entry.sourceResolvedPath, { recursive: entry.type === 'directory', force: true });
-    }
-  }
-  await verifyPathOperationEntries({ entries, sourceMustBeRemoved: true });
-  for (const entry of entries) {
-    if (entry.destinationResolvedPath) {
+  const mutationStates = await Promise.all(entries.flatMap((entry) => [
+    captureAgentPathMutationState(entry.sourcePath, entry.sourceResolvedPath),
+    captureAgentPathMutationState(entry.destinationPath!, entry.destinationResolvedPath!),
+  ]));
+  return withAgentWorkspaceMutationLocks(
+    mutationStates.map((state) => state.fullPath),
+    async () => {
+      await assertAgentPathMutationStatesUnchanged(mutationStates, 'move_path');
+      const moveWorkspace = getAgentWorkspaceContext();
       if (moveWorkspace) {
-        const oldPath = workspaceRelativeAgentPath(moveWorkspace, entry.sourceResolvedPath);
-        const newPath = workspaceRelativeAgentPath(moveWorkspace, entry.destinationResolvedPath);
-        moveFileCollaborationPath({ workspace: moveWorkspace, oldPath, newPath });
-        await movePersistedCollaborationPath({ workspaceId: moveWorkspace.workspaceId, oldPath, newPath });
+        const overwrittenPaths = entries
+          .filter((entry) => entry.overwritten && entry.destinationResolvedPath)
+          .map((entry) => workspaceRelativeAgentPath(moveWorkspace, entry.destinationResolvedPath!));
+        if (overwrittenPaths.length > 0) {
+          archiveFileCollaborationPaths({ workspace: moveWorkspace, paths: overwrittenPaths.map((path) => ({ path })) });
+          await archivePersistedCollaborationPaths({ workspaceId: moveWorkspace.workspaceId, paths: overwrittenPaths });
+        }
       }
-      await syncPublicSharesAfterMove(entry.sourceResolvedPath, entry.destinationResolvedPath);
-      publishAgentWorkspaceMutation(entry.sourceResolvedPath, entry.type === 'directory' ? 'unlinkDir' : 'unlink');
-      publishAgentWorkspaceMutation(
-        entry.destinationResolvedPath,
-        entry.overwritten ? 'change' : entry.type === 'directory' ? 'addDir' : 'add',
-      );
-    }
-  }
 
-  const result = pathOperationSummary('move_path', entries, params.destinationPath, destinationFullPath);
-  result.verified = entries.every((entry) => entry.verification?.contentVerified === true && entry.verification.sourceRemoved === true);
-  await recordAgentPathOperationAudit(result);
-  return result;
+      for (const entry of entries) {
+        if (!entry.destinationResolvedPath) continue;
+        await fs.mkdir(path.dirname(entry.destinationResolvedPath), { recursive: true });
+        if (entry.overwritten && params.overwrite) {
+          await fs.rm(entry.destinationResolvedPath, { recursive: true, force: true });
+        }
+
+        try {
+          await fs.rename(entry.sourceResolvedPath, entry.destinationResolvedPath);
+        } catch (error) {
+          if (!(error && typeof error === 'object' && 'code' in error && error.code === 'EXDEV')) {
+            throw error;
+          }
+          await fs.cp(entry.sourceResolvedPath, entry.destinationResolvedPath, { recursive: entry.type === 'directory', force: true });
+          await fs.rm(entry.sourceResolvedPath, { recursive: entry.type === 'directory', force: true });
+        }
+      }
+      await verifyPathOperationEntries({ entries, sourceMustBeRemoved: true });
+      for (const entry of entries) {
+        if (entry.destinationResolvedPath) {
+          if (moveWorkspace) {
+            const oldPath = workspaceRelativeAgentPath(moveWorkspace, entry.sourceResolvedPath);
+            const newPath = workspaceRelativeAgentPath(moveWorkspace, entry.destinationResolvedPath);
+            moveFileCollaborationPath({ workspace: moveWorkspace, oldPath, newPath });
+            await movePersistedCollaborationPath({ workspaceId: moveWorkspace.workspaceId, oldPath, newPath });
+          }
+          await syncPublicSharesAfterMove(entry.sourceResolvedPath, entry.destinationResolvedPath);
+          publishAgentWorkspaceMutation(entry.sourceResolvedPath, entry.type === 'directory' ? 'unlinkDir' : 'unlink');
+          publishAgentWorkspaceMutation(
+            entry.destinationResolvedPath,
+            entry.overwritten ? 'change' : entry.type === 'directory' ? 'addDir' : 'add',
+          );
+        }
+      }
+
+      const result = pathOperationSummary('move_path', entries, params.destinationPath, destinationFullPath);
+      result.verified = entries.every((entry) => entry.verification?.contentVerified === true && entry.verification.sourceRemoved === true);
+      await recordAgentPathOperationAudit(result);
+      return result;
+    },
+  );
 }
 
 export async function deleteAgentPath(params: {
@@ -2279,29 +2377,38 @@ export async function deleteAgentPaths(params: {
     .filter((entry) => entry.changed)
     .sort((a, b) => b.sourceResolvedPath.length - a.sourceResolvedPath.length);
 
-  for (const entry of deletableEntries) {
-    await fs.rm(entry.sourceResolvedPath, {
-      recursive: entry.type === 'directory',
-      force: false,
-    });
-  }
-  const deleteWorkspace = getAgentWorkspaceContext();
-  const workspaceDeletions = deleteWorkspace
-    ? deletableEntries.filter((entry) => isPathWithin(entry.sourceResolvedPath, deleteWorkspace.rootPath))
-    : [];
-  if (deleteWorkspace && workspaceDeletions.length > 0) {
-    const deletedPaths = workspaceDeletions.map((entry) => workspaceRelativeAgentPath(deleteWorkspace, entry.sourceResolvedPath));
-    archiveFileCollaborationPaths({ workspace: deleteWorkspace, paths: deletedPaths.map((path) => ({ path })) });
-    await archivePersistedCollaborationPaths({ workspaceId: deleteWorkspace.workspaceId, paths: deletedPaths });
-  }
-  await syncPublicSharesAfterDelete(deletableEntries.map((entry) => entry.sourceResolvedPath));
-  for (const entry of deletableEntries) {
-    publishAgentWorkspaceMutation(entry.sourceResolvedPath, entry.type === 'directory' ? 'unlinkDir' : 'unlink');
-  }
+  const mutationStates = await Promise.all(
+    deletableEntries.map((entry) => captureAgentPathMutationState(entry.sourcePath, entry.sourceResolvedPath)),
+  );
+  return withAgentWorkspaceMutationLocks(
+    mutationStates.map((state) => state.fullPath),
+    async () => {
+      await assertAgentPathMutationStatesUnchanged(mutationStates, 'delete_path');
+      for (const entry of deletableEntries) {
+        await fs.rm(entry.sourceResolvedPath, {
+          recursive: entry.type === 'directory',
+          force: false,
+        });
+      }
+      const deleteWorkspace = getAgentWorkspaceContext();
+      const workspaceDeletions = deleteWorkspace
+        ? deletableEntries.filter((entry) => isPathWithin(entry.sourceResolvedPath, deleteWorkspace.rootPath))
+        : [];
+      if (deleteWorkspace && workspaceDeletions.length > 0) {
+        const deletedPaths = workspaceDeletions.map((entry) => workspaceRelativeAgentPath(deleteWorkspace, entry.sourceResolvedPath));
+        archiveFileCollaborationPaths({ workspace: deleteWorkspace, paths: deletedPaths.map((path) => ({ path })) });
+        await archivePersistedCollaborationPaths({ workspaceId: deleteWorkspace.workspaceId, paths: deletedPaths });
+      }
+      await syncPublicSharesAfterDelete(deletableEntries.map((entry) => entry.sourceResolvedPath));
+      for (const entry of deletableEntries) {
+        publishAgentWorkspaceMutation(entry.sourceResolvedPath, entry.type === 'directory' ? 'unlinkDir' : 'unlink');
+      }
 
-  const result = pathOperationSummary('delete_path', entries);
-  await recordAgentPathOperationAudit(result);
-  return result;
+      const result = pathOperationSummary('delete_path', entries);
+      await recordAgentPathOperationAudit(result);
+      return result;
+    },
+  );
 }
 
 function isManagedDataPath(target: string): boolean {

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -3,7 +3,6 @@ import { existsSync, promises as fs, realpathSync } from 'node:fs';
 import type { Stats } from 'node:fs';
 import path from 'node:path';
 
-import { parseDocument } from 'yaml';
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { getDatabaseProvider } from '@/app/lib/db/provider';
 import { logger } from '@/app/lib/logging';
@@ -36,12 +35,16 @@ import {
 } from '@/app/lib/collaboration/agent-file-edits';
 import { applyExactTextEdits } from '@/app/lib/files/exact-text-patch';
 import {
+  validateTextFileContent,
+  type TextFileValidationCheck,
+  type TextFileValidationResult,
+} from '@/app/lib/files/text-content-validation';
+import {
   syncPublicSharesAfterDelete,
   syncPublicSharesAfterMove,
   syncPublicSharesAfterWrite,
 } from '@/app/lib/public-sharing/public-file-shares';
 import { publishWorkspaceFileMutation, type FileEventType } from '@/app/lib/filesystem/file-watcher';
-import { getRunawaySlashContentMessage } from '@/app/lib/editor/text-editor-guards';
 import { getAgentExecutionContext, type AgentExecutionContext } from '@/app/lib/pi/agent-execution-context';
 import { ensureAgentRuntimeTempDir, resolveAgentRuntimeTempDir } from '@/app/lib/pi/agent-runtime-temp';
 import { getStudioRoot, getStudioWorkspaceRoot } from '@/app/lib/integrations/studio-workspace';
@@ -62,16 +65,8 @@ const MAX_AUDIT_PATH_ENTRIES = 100;
 const MAX_AUDIT_ENTITY_ID_LENGTH = 500;
 const agentFileAuditLogger = logger.module('AgentFileAudit');
 
-export type AgentFileValidationCheck = {
-  name: string;
-  ok: boolean;
-  message: string;
-};
-
-export type AgentFileValidationResult = {
-  ok: boolean;
-  checks: AgentFileValidationCheck[];
-};
+export type AgentFileValidationCheck = TextFileValidationCheck;
+export type AgentFileValidationResult = TextFileValidationResult;
 
 export type AgentFileSnapshotMetadata = {
   version: 1;
@@ -959,132 +954,8 @@ export function createUnifiedDiff(
   return truncateDiff(lines.join('\n'));
 }
 
-function splitMarkdownTableRow(line: string): string[] | null {
-  if (!line.includes('|')) return null;
-
-  let normalized = line.trim();
-  if (normalized.startsWith('|')) normalized = normalized.slice(1);
-  if (normalized.endsWith('|') && !normalized.endsWith('\\|')) normalized = normalized.slice(0, -1);
-
-  const cells: string[] = [];
-  let current = '';
-  let escaped = false;
-
-  for (const char of normalized) {
-    if (char === '|' && !escaped) {
-      cells.push(current.trim());
-      current = '';
-      continue;
-    }
-
-    current += char;
-    escaped = char === '\\' && !escaped;
-    if (char !== '\\') {
-      escaped = false;
-    }
-  }
-
-  cells.push(current.trim());
-  return cells.length > 1 ? cells : null;
-}
-
-function isMarkdownTableSeparator(line: string): boolean {
-  const cells = splitMarkdownTableRow(line);
-  return Boolean(cells && cells.length > 1 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim())));
-}
-
-function validateMarkdownTables(content: string): AgentFileValidationCheck {
-  const lines = content.split('\n');
-  const errors: string[] = [];
-  let tableCount = 0;
-
-  for (let index = 1; index < lines.length; index += 1) {
-    if (!isMarkdownTableSeparator(lines[index])) continue;
-
-    const headerCells = splitMarkdownTableRow(lines[index - 1]);
-    const separatorCells = splitMarkdownTableRow(lines[index]);
-    if (!headerCells || !separatorCells) continue;
-
-    tableCount += 1;
-    const expectedColumns = headerCells.length;
-    if (separatorCells.length !== expectedColumns) {
-      errors.push(`line ${index + 1}: separator has ${separatorCells.length} column(s), expected ${expectedColumns}`);
-    }
-
-    for (let rowIndex = index + 1; rowIndex < lines.length; rowIndex += 1) {
-      const row = lines[rowIndex];
-      if (!row.trim() || !row.includes('|')) break;
-      if (isMarkdownTableSeparator(row)) break;
-
-      const rowCells = splitMarkdownTableRow(row);
-      if (!rowCells) break;
-      if (rowCells.length !== expectedColumns) {
-        errors.push(`line ${rowIndex + 1}: row has ${rowCells.length} column(s), expected ${expectedColumns}`);
-      }
-    }
-  }
-
-  return {
-    name: 'markdown-tables',
-    ok: errors.length === 0,
-    message: errors.length === 0
-      ? `Markdown table structure OK (${tableCount} table${tableCount === 1 ? '' : 's'} checked).`
-      : errors.join('; '),
-  };
-}
-
-function validateRunawaySlashContent(content: string): AgentFileValidationCheck {
-  const message = getRunawaySlashContentMessage(content);
-  return {
-    name: 'runaway-slashes',
-    ok: message === null,
-    message: message === null
-      ? 'No runaway slash/backslash sequences detected.'
-      : `${message}. This usually indicates a stuck key, model output loop, or accidental repeated slash insertion.`,
-  };
-}
-
 export function validateAgentFileContent(filePath: string, content: string): AgentFileValidationResult {
-  const extension = path.extname(filePath).toLowerCase();
-  const checks: AgentFileValidationCheck[] = [];
-
-  if (['.md', '.mdx', '.markdown'].includes(extension)) {
-    checks.push(validateRunawaySlashContent(content));
-    checks.push(validateMarkdownTables(content));
-  }
-
-  if (extension === '.json') {
-    try {
-      JSON.parse(content);
-      checks.push({ name: 'json-parse', ok: true, message: 'JSON syntax OK.' });
-    } catch (error) {
-      checks.push({
-        name: 'json-parse',
-        ok: false,
-        message: error instanceof Error ? error.message : 'Invalid JSON syntax.',
-      });
-    }
-  }
-
-  if (['.yaml', '.yml'].includes(extension)) {
-    const document = parseDocument(content, { prettyErrors: false });
-    checks.push({
-      name: 'yaml-parse',
-      ok: document.errors.length === 0,
-      message: document.errors.length === 0
-        ? 'YAML syntax OK.'
-        : document.errors.map((error) => error.message).join('; '),
-    });
-  }
-
-  if (checks.length === 0) {
-    checks.push({ name: 'read-after-write', ok: true, message: 'No file-type-specific validator configured; read-after-write will verify exact bytes.' });
-  }
-
-  return {
-    ok: checks.every((check) => check.ok),
-    checks,
-  };
+  return validateTextFileContent(filePath, content);
 }
 
 async function ensureSnapshotRoot(): Promise<string> {

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -1409,83 +1409,93 @@ export async function writeAgentBinaryFile(params: {
     };
   }
 
-  await fs.mkdir(path.dirname(fullPath), { recursive: true });
-  const executionContext = getAgentExecutionContext();
-  const workspaceContext = getAgentWorkspaceContext();
-  const baseRevision = workspaceContext && before.buffer
-    ? ensureFileRevisionForCurrentContent({
-        workspace: workspaceContext,
-        path: params.path,
-        contentHash: beforeSha256!,
-        sizeBytes: before.buffer.length,
-        actorType: 'system',
-      })
-    : null;
-
-  if (workspaceContext) {
-    assertFileCollaborationWriteAllowed({
-      workspace: workspaceContext,
-      path: params.path,
-      actorUserId: executionContext?.userId ?? null,
-      actorSessionId: executionContext?.sessionId ?? null,
-      actorType: 'agent',
-      baseRevisionId: baseRevision?.id ?? null,
-    });
-  }
-
-  const snapshot = await createSnapshotFromBuffer({
+  const mutationState: AgentPathMutationState = {
     inputPath: params.path,
     fullPath,
     existed: before.existed,
-    beforeBuffer: before.buffer,
-    operation,
-  });
-  const stagingPath = path.join(
-    path.dirname(fullPath),
-    `.${path.basename(fullPath)}.canvas-agent-${randomUUID()}.tmp`,
-  );
-  try {
-    await fs.writeFile(stagingPath, params.content, { flag: 'wx', mode: 0o600 });
-    await fs.rename(stagingPath, fullPath);
-  } finally {
-    await fs.rm(stagingPath, { force: true }).catch(() => undefined);
-  }
-
-  const readBack = await fs.readFile(fullPath);
-  const readBackSha256 = sha256Buffer(readBack);
-  if (readBack.length !== params.content.length || readBackSha256 !== afterSha256) {
-    throw new Error(`Read-after-write verification failed for ${params.path}.`);
-  }
-  if (workspaceContext) {
-    ensureFileRevisionForCurrentContent({
-      workspace: workspaceContext,
-      path: params.path,
-      contentHash: readBackSha256,
-      sizeBytes: readBack.length,
-      actorUserId: executionContext?.userId ?? null,
-      actorType: 'agent',
-      sourceSessionId: executionContext?.sessionId ?? null,
-      baseRevisionId: baseRevision?.id ?? null,
-    });
-  }
-  await syncPublicSharesAfterWrite([fullPath]);
-
-  const result: AgentFileChangeResult = {
-    path: params.path,
-    resolvedPath: fullPath,
-    changed: true,
-    snapshot,
-    beforeSha256,
-    afterSha256: readBackSha256,
-    size: readBack.length,
-    diff: before.buffer
-      ? `Binary content changed: ${before.buffer.length} -> ${readBack.length} bytes`
-      : `Binary file created: ${readBack.length} bytes`,
-    validation,
+    type: before.existed ? 'file' : 'missing',
+    sha256: beforeSha256,
   };
-  publishAgentWorkspaceMutation(fullPath, before.existed ? 'change' : 'add');
-  await recordAgentFileChangeAudit(result, operation);
-  return result;
+  return withAgentWorkspaceMutationLocks([fullPath], async () => {
+    await assertAgentPathMutationStatesUnchanged([mutationState], operation);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    const executionContext = getAgentExecutionContext();
+    const workspaceContext = getAgentWorkspaceContext();
+    const baseRevision = workspaceContext && before.buffer
+      ? ensureFileRevisionForCurrentContent({
+          workspace: workspaceContext,
+          path: params.path,
+          contentHash: beforeSha256!,
+          sizeBytes: before.buffer.length,
+          actorType: 'system',
+        })
+      : null;
+
+    if (workspaceContext) {
+      assertFileCollaborationWriteAllowed({
+        workspace: workspaceContext,
+        path: params.path,
+        actorUserId: executionContext?.userId ?? null,
+        actorSessionId: executionContext?.sessionId ?? null,
+        actorType: 'agent',
+        baseRevisionId: baseRevision?.id ?? null,
+      });
+    }
+
+    const snapshot = await createSnapshotFromBuffer({
+      inputPath: params.path,
+      fullPath,
+      existed: before.existed,
+      beforeBuffer: before.buffer,
+      operation,
+    });
+    const stagingPath = path.join(
+      path.dirname(fullPath),
+      `.${path.basename(fullPath)}.canvas-agent-${randomUUID()}.tmp`,
+    );
+    try {
+      await fs.writeFile(stagingPath, params.content, { flag: 'wx', mode: 0o600 });
+      await fs.rename(stagingPath, fullPath);
+    } finally {
+      await fs.rm(stagingPath, { force: true }).catch(() => undefined);
+    }
+
+    const readBack = await fs.readFile(fullPath);
+    const readBackSha256 = sha256Buffer(readBack);
+    if (readBack.length !== params.content.length || readBackSha256 !== afterSha256) {
+      throw new Error(`Read-after-write verification failed for ${params.path}.`);
+    }
+    if (workspaceContext) {
+      ensureFileRevisionForCurrentContent({
+        workspace: workspaceContext,
+        path: params.path,
+        contentHash: readBackSha256,
+        sizeBytes: readBack.length,
+        actorUserId: executionContext?.userId ?? null,
+        actorType: 'agent',
+        sourceSessionId: executionContext?.sessionId ?? null,
+        baseRevisionId: baseRevision?.id ?? null,
+      });
+    }
+    await syncPublicSharesAfterWrite([fullPath]);
+
+    const result: AgentFileChangeResult = {
+      path: params.path,
+      resolvedPath: fullPath,
+      changed: true,
+      snapshot,
+      beforeSha256,
+      afterSha256: readBackSha256,
+      size: readBack.length,
+      diff: before.buffer
+        ? `Binary content changed: ${before.buffer.length} -> ${readBack.length} bytes`
+        : `Binary file created: ${readBack.length} bytes`,
+      validation,
+    };
+    publishAgentWorkspaceMutation(fullPath, before.existed ? 'change' : 'add');
+    await recordAgentFileChangeAudit(result, operation);
+    return result;
+  });
 }
 
 async function applyPreparedCollaborativeFileEdit(input: {

--- a/app/lib/server-settings.ts
+++ b/app/lib/server-settings.ts
@@ -7,6 +7,7 @@ import { resolveSystemSettingsDir } from '@/app/lib/runtime-data-paths';
 import { DEFAULT_USER_TIME_ZONE, isValidTimeZone, normalizeTimeZone } from '@/app/lib/time-zones';
 import {
   DIRECT_MCP_TOOL_CONFIGURATION_VERSION,
+  DIRECT_MCP_DEFAULT_TOOL_IDS,
   DIRECT_MCP_TOOL_IDS,
   type DirectMcpToolId,
 } from '@/app/lib/mcp/server/config';
@@ -113,10 +114,11 @@ function normalizeDirectMcpPreferences(value: unknown): DirectMcpServerPreferenc
     : 1;
   // Before version 2, auth_probe was the only available tool. Treat the old
   // one-tool default as an upgrade, while preserving an explicit empty list.
-  const upgradedTools = configuredVersion < DIRECT_MCP_TOOL_CONFIGURATION_VERSION
+  // New mutating capabilities are deliberately excluded from this migration.
+  const upgradedTools = configuredVersion < 2
     && tools.length === 1
     && tools[0] === 'auth_probe'
-    ? [...DIRECT_MCP_TOOL_IDS]
+    ? [...DIRECT_MCP_DEFAULT_TOOL_IDS]
     : tools;
   return {
     enabled: record.enabled,

--- a/messages/de.json
+++ b/messages/de.json
@@ -132,7 +132,8 @@
       "knowledgeTree": "Die Ordner- und Dateistruktur erlaubter Wissensbereiche anzeigen",
       "knowledgeSearch": "In erlaubten Wissensinhalten suchen",
       "knowledgeRead": "Inhalte erlaubter Wissensquellen lesen",
-      "knowledgeWrite": "Exakte, konfliktgeschützte Änderungen an erlaubten Wissensquellen vornehmen"
+      "knowledgeWrite": "Exakte, konfliktgeschützte Änderungen an erlaubten Wissensquellen vornehmen",
+      "knowledgeAssets": "Erlaubte Bilder und PDFs als visuellen und Dokument-Kontext lesen"
     },
     "securityTitle": "Direkte, lokale Verbindung",
     "securityDescription": "Anmeldung, Berechtigungen und Daten bleiben auf {instanceHost}. Der Zugriff ist auf die von dir freigegebenen Berechtigungen und deine aktuellen lokalen Workspace-Rechte begrenzt.",
@@ -3428,6 +3429,10 @@
           "edit_knowledge_source": {
             "title": "Dateiinhalte bearbeiten",
             "description": "Erlaubt exakte, konfliktgeschützte Änderungen an sichtbaren Textdateien nach einer ausdrücklichen Freigabe durch die Administration."
+          },
+          "read_knowledge_asset": {
+            "title": "Bilder und PDFs lesen",
+            "description": "Stellt begrenzten visuellen und Textkontext aus sichtbaren Bildern und PDF-Dokumenten nach einer ausdrücklichen Freigabe durch die Administration bereit."
           }
         }
       },

--- a/messages/de.json
+++ b/messages/de.json
@@ -131,10 +131,11 @@
       "workspaceList": "Arbeitsbereiche auflisten, auf die du aktuell Lesezugriff hast",
       "knowledgeTree": "Die Ordner- und Dateistruktur erlaubter Wissensbereiche anzeigen",
       "knowledgeSearch": "In erlaubten Wissensinhalten suchen",
-      "knowledgeRead": "Inhalte erlaubter Wissensquellen lesen"
+      "knowledgeRead": "Inhalte erlaubter Wissensquellen lesen",
+      "knowledgeWrite": "Exakte, konfliktgeschützte Änderungen an erlaubten Wissensquellen vornehmen"
     },
     "securityTitle": "Direkte, lokale Verbindung",
-    "securityDescription": "Anmeldung, Berechtigungen und Daten bleiben auf {instanceHost}. Der Client erhält nur Lesezugriff im Umfang deiner aktuellen lokalen Rechte.",
+    "securityDescription": "Anmeldung, Berechtigungen und Daten bleiben auf {instanceHost}. Der Zugriff ist auf die von dir freigegebenen Berechtigungen und deine aktuellen lokalen Workspace-Rechte begrenzt.",
     "deny": "Ablehnen",
     "accept": "Zugriff erlauben",
     "requestFailed": "Die OAuth-Anfrage konnte nicht verarbeitet werden. Starte die Verbindung erneut."
@@ -3423,6 +3424,10 @@
           "read_knowledge_source": {
             "title": "Dateiinhalte lesen",
             "description": "Liest einen begrenzten Textausschnitt aus einer sichtbaren Datei."
+          },
+          "edit_knowledge_source": {
+            "title": "Dateiinhalte bearbeiten",
+            "description": "Erlaubt exakte, konfliktgeschützte Änderungen an sichtbaren Textdateien nach einer ausdrücklichen Freigabe durch die Administration."
           }
         }
       },

--- a/messages/en.json
+++ b/messages/en.json
@@ -132,7 +132,8 @@
       "knowledgeTree": "View the folder and file structure of permitted knowledge areas",
       "knowledgeSearch": "Search permitted knowledge content",
       "knowledgeRead": "Read content from permitted knowledge sources",
-      "knowledgeWrite": "Apply exact, conflict-protected edits to permitted knowledge sources"
+      "knowledgeWrite": "Apply exact, conflict-protected edits to permitted knowledge sources",
+      "knowledgeAssets": "Read permitted images and PDFs for visual and document context"
     },
     "securityTitle": "Direct, local connection",
     "securityDescription": "Sign-in, permissions, and data stay on {instanceHost}. Access is limited by the permissions you approve and your current local workspace permissions.",
@@ -3429,6 +3430,10 @@
           "edit_knowledge_source": {
             "title": "Edit file contents",
             "description": "Allows exact, conflict-protected edits to visible text files after an explicit administrator enablement."
+          },
+          "read_knowledge_asset": {
+            "title": "Read images and PDFs",
+            "description": "Provides bounded visual and text context from visible images and PDF documents after an explicit administrator enablement."
           }
         }
       },

--- a/messages/en.json
+++ b/messages/en.json
@@ -131,10 +131,11 @@
       "workspaceList": "List workspaces you currently have permission to read",
       "knowledgeTree": "View the folder and file structure of permitted knowledge areas",
       "knowledgeSearch": "Search permitted knowledge content",
-      "knowledgeRead": "Read content from permitted knowledge sources"
+      "knowledgeRead": "Read content from permitted knowledge sources",
+      "knowledgeWrite": "Apply exact, conflict-protected edits to permitted knowledge sources"
     },
     "securityTitle": "Direct, local connection",
-    "securityDescription": "Sign-in, permissions, and data stay on {instanceHost}. The client receives read-only access limited by your current local permissions.",
+    "securityDescription": "Sign-in, permissions, and data stay on {instanceHost}. Access is limited by the permissions you approve and your current local workspace permissions.",
     "deny": "Deny",
     "accept": "Allow access",
     "requestFailed": "The OAuth request could not be processed. Start the connection again."
@@ -3424,6 +3425,10 @@
           "read_knowledge_source": {
             "title": "Read file contents",
             "description": "Reads a bounded text excerpt from a visible file."
+          },
+          "edit_knowledge_source": {
+            "title": "Edit file contents",
+            "description": "Allows exact, conflict-protected edits to visible text files after an explicit administrator enablement."
           }
         }
       },

--- a/scripts/atomic-workspace-write-test.ts
+++ b/scripts/atomic-workspace-write-test.ts
@@ -103,6 +103,25 @@ async function main() {
     await Promise.all([backslashMutation, backslashChildMutation]);
     assert.equal(backslashChildMutationRan, true);
 
+    let releaseRootMutation!: () => void;
+    const rootMutationCanFinish = new Promise<void>((resolve) => { releaseRootMutation = resolve; });
+    let rootMutationReady!: () => void;
+    const rootMutationReadySignal = new Promise<void>((resolve) => { rootMutationReady = resolve; });
+    const rootMutation = withWorkspaceFileMutationLocks(['.'], { workspace }, async () => {
+      rootMutationReady();
+      await rootMutationCanFinish;
+    });
+    await rootMutationReadySignal;
+    let rootChildMutationRan = false;
+    const rootChildMutation = withWorkspaceFileMutationLocks(['root-child.md'], { workspace }, async () => {
+      rootChildMutationRan = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(rootChildMutationRan, false);
+    releaseRootMutation();
+    await Promise.all([rootMutation, rootChildMutation]);
+    assert.equal(rootChildMutationRan, true);
+
     const uploadSource = path.join(root, 'upload-source.md');
     await fs.writeFile(uploadSource, 'uploaded\n');
     let releaseUploadReplace!: () => void;

--- a/scripts/atomic-workspace-write-test.ts
+++ b/scripts/atomic-workspace-write-test.ts
@@ -28,7 +28,11 @@ async function main() {
 
   try {
     const { WorkspaceFileRevisionError, assertWorkspaceFileRevisionUnchanged, getWorkspaceFileRevision } = await import('../app/lib/files/revision-guard');
-    const { replaceWorkspaceFileFromPath, writeFile } = await import('../app/lib/filesystem/workspace-files');
+    const {
+      replaceWorkspaceFileFromPath,
+      withWorkspaceFileMutationLocks,
+      writeFile,
+    } = await import('../app/lib/filesystem/workspace-files');
     await fs.writeFile(path.join(root, 'deck.md'), 'before\n', { mode: 0o640 });
     let beforeReplaceCalled = false;
     await writeFile('deck.md', 'after\n', { workspace }, async () => {
@@ -59,6 +63,26 @@ async function main() {
     await Promise.all([firstWrite, secondWrite]);
     assert.equal(secondWriteReachedReplace, true);
     assert.equal(await fs.readFile(path.join(root, 'deck.md'), 'utf8'), 'second\n');
+
+    await fs.mkdir(path.join(root, 'folder'));
+    let releaseDirectoryMutation!: () => void;
+    const directoryMutationCanFinish = new Promise<void>((resolve) => { releaseDirectoryMutation = resolve; });
+    let directoryMutationReady!: () => void;
+    const directoryMutationReadySignal = new Promise<void>((resolve) => { directoryMutationReady = resolve; });
+    const directoryMutation = withWorkspaceFileMutationLocks(['folder'], { workspace }, async () => {
+      directoryMutationReady();
+      await directoryMutationCanFinish;
+    });
+    await directoryMutationReadySignal;
+    let childWriteReachedReplace = false;
+    const childWrite = writeFile('folder/child.md', 'child\n', { workspace }, async () => {
+      childWriteReachedReplace = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(childWriteReachedReplace, false);
+    releaseDirectoryMutation();
+    await Promise.all([directoryMutation, childWrite]);
+    assert.equal(childWriteReachedReplace, true);
 
     const uploadSource = path.join(root, 'upload-source.md');
     await fs.writeFile(uploadSource, 'uploaded\n');

--- a/scripts/atomic-workspace-write-test.ts
+++ b/scripts/atomic-workspace-write-test.ts
@@ -84,6 +84,25 @@ async function main() {
     await Promise.all([directoryMutation, childWrite]);
     assert.equal(childWriteReachedReplace, true);
 
+    let releaseBackslashMutation!: () => void;
+    const backslashMutationCanFinish = new Promise<void>((resolve) => { releaseBackslashMutation = resolve; });
+    let backslashMutationReady!: () => void;
+    const backslashMutationReadySignal = new Promise<void>((resolve) => { backslashMutationReady = resolve; });
+    const backslashMutation = withWorkspaceFileMutationLocks(['folder'], { workspace }, async () => {
+      backslashMutationReady();
+      await backslashMutationCanFinish;
+    });
+    await backslashMutationReadySignal;
+    let backslashChildMutationRan = false;
+    const backslashChildMutation = withWorkspaceFileMutationLocks(['folder\\child.md'], { workspace }, async () => {
+      backslashChildMutationRan = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(backslashChildMutationRan, false);
+    releaseBackslashMutation();
+    await Promise.all([backslashMutation, backslashChildMutation]);
+    assert.equal(backslashChildMutationRan, true);
+
     const uploadSource = path.join(root, 'upload-source.md');
     await fs.writeFile(uploadSource, 'uploaded\n');
     let releaseUploadReplace!: () => void;

--- a/scripts/file-revision-guard-test.ts
+++ b/scripts/file-revision-guard-test.ts
@@ -63,7 +63,12 @@ async function main() {
     } = await import('../app/lib/files/revision-guard');
     const { writeFile } = await import('../app/lib/filesystem/workspace-files');
     const { runWithAgentExecutionContext } = await import('../app/lib/pi/agent-execution-context');
-    const { deleteAgentPath, editAgentFile, writeAgentTextFile } = await import('../app/lib/pi/agent-file-operations');
+    const {
+      deleteAgentPath,
+      editAgentFile,
+      writeAgentBinaryFile,
+      writeAgentTextFile,
+    } = await import('../app/lib/pi/agent-file-operations');
 
     await writeFile('notes.md', 'personal v1\n', { workspace: personalWorkspace });
     await assert.doesNotReject(() => assertWorkspaceFileRevisionAllowed({
@@ -191,6 +196,37 @@ async function main() {
         && error.currentSha256 !== concurrentRevision.sha256,
     );
     assert.equal(await fs.readFile(path.join(teamRoot, 'concurrent.md'), 'utf8'), 'mcp write\n');
+
+    await writeFile('concurrent-binary.md', 'before binary write\n', { workspace: teamWorkspace });
+    const concurrentBinaryRevision = await getWorkspaceFileRevision('concurrent-binary.md', { workspace: teamWorkspace });
+    assert.ok(concurrentBinaryRevision?.sha256);
+
+    let releaseMcpBinaryWrite!: () => void;
+    const mcpBinaryWriteCanFinish = new Promise<void>((resolve) => { releaseMcpBinaryWrite = resolve; });
+    let mcpBinaryWriteReady!: () => void;
+    const mcpBinaryWriteReadySignal = new Promise<void>((resolve) => { mcpBinaryWriteReady = resolve; });
+    const mcpBinaryWrite = writeFile('concurrent-binary.md', 'mcp binary write wins\n', { workspace: teamWorkspace }, async () => {
+      mcpBinaryWriteReady();
+      await mcpBinaryWriteCanFinish;
+    });
+    await mcpBinaryWriteReadySignal;
+
+    const agentBinaryWrite = runWithAgentExecutionContext(agentContext, () => writeAgentBinaryFile({
+      path: 'concurrent-binary.md',
+      content: Buffer.from('agent binary write\n'),
+      expectedSha256: concurrentBinaryRevision.sha256,
+      overwrite: true,
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    releaseMcpBinaryWrite();
+    await mcpBinaryWrite;
+    await assert.rejects(
+      () => agentBinaryWrite,
+      (error) => error instanceof WorkspaceFileRevisionError
+        && error.code === 'FILE_REVISION_CONFLICT'
+        && error.currentSha256 !== concurrentBinaryRevision.sha256,
+    );
+    assert.equal(await fs.readFile(path.join(teamRoot, 'concurrent-binary.md'), 'utf8'), 'mcp binary write wins\n');
 
     await writeFile('concurrent-delete.md', 'before delete\n', { workspace: teamWorkspace });
     const concurrentDeleteRevision = await getWorkspaceFileRevision('concurrent-delete.md', { workspace: teamWorkspace });

--- a/scripts/file-revision-guard-test.ts
+++ b/scripts/file-revision-guard-test.ts
@@ -63,7 +63,7 @@ async function main() {
     } = await import('../app/lib/files/revision-guard');
     const { writeFile } = await import('../app/lib/filesystem/workspace-files');
     const { runWithAgentExecutionContext } = await import('../app/lib/pi/agent-execution-context');
-    const { editAgentFile, writeAgentTextFile } = await import('../app/lib/pi/agent-file-operations');
+    const { deleteAgentPath, editAgentFile, writeAgentTextFile } = await import('../app/lib/pi/agent-file-operations');
 
     await writeFile('notes.md', 'personal v1\n', { workspace: personalWorkspace });
     await assert.doesNotReject(() => assertWorkspaceFileRevisionAllowed({
@@ -191,6 +191,34 @@ async function main() {
         && error.currentSha256 !== concurrentRevision.sha256,
     );
     assert.equal(await fs.readFile(path.join(teamRoot, 'concurrent.md'), 'utf8'), 'mcp write\n');
+
+    await writeFile('concurrent-delete.md', 'before delete\n', { workspace: teamWorkspace });
+    const concurrentDeleteRevision = await getWorkspaceFileRevision('concurrent-delete.md', { workspace: teamWorkspace });
+    assert.ok(concurrentDeleteRevision?.sha256);
+
+    let releaseMcpDeleteWrite!: () => void;
+    const mcpDeleteWriteCanFinish = new Promise<void>((resolve) => { releaseMcpDeleteWrite = resolve; });
+    let mcpDeleteWriteReady!: () => void;
+    const mcpDeleteWriteReadySignal = new Promise<void>((resolve) => { mcpDeleteWriteReady = resolve; });
+    const mcpDeleteWrite = writeFile('concurrent-delete.md', 'mcp write wins\n', { workspace: teamWorkspace }, async () => {
+      mcpDeleteWriteReady();
+      await mcpDeleteWriteCanFinish;
+    });
+    await mcpDeleteWriteReadySignal;
+
+    const agentDelete = runWithAgentExecutionContext(agentContext, () => deleteAgentPath({
+      path: 'concurrent-delete.md',
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    releaseMcpDeleteWrite();
+    await mcpDeleteWrite;
+    await assert.rejects(
+      () => agentDelete,
+      (error) => error instanceof WorkspaceFileRevisionError
+        && error.code === 'FILE_REVISION_CONFLICT'
+        && error.currentSha256 !== concurrentDeleteRevision.sha256,
+    );
+    assert.equal(await fs.readFile(path.join(teamRoot, 'concurrent-delete.md'), 'utf8'), 'mcp write wins\n');
 
     console.log('file-revision-guard-test: ok');
   } finally {

--- a/scripts/file-revision-guard-test.ts
+++ b/scripts/file-revision-guard-test.ts
@@ -220,6 +220,35 @@ async function main() {
     );
     assert.equal(await fs.readFile(path.join(teamRoot, 'concurrent-delete.md'), 'utf8'), 'mcp write wins\n');
 
+    await fs.mkdir(path.join(teamRoot, 'concurrent-directory'));
+    await writeFile('concurrent-directory/note.md', 'before directory delete\n', { workspace: teamWorkspace });
+    let releaseMcpDirectoryWrite!: () => void;
+    const mcpDirectoryWriteCanFinish = new Promise<void>((resolve) => { releaseMcpDirectoryWrite = resolve; });
+    let mcpDirectoryWriteReady!: () => void;
+    const mcpDirectoryWriteReadySignal = new Promise<void>((resolve) => { mcpDirectoryWriteReady = resolve; });
+    const mcpDirectoryWrite = writeFile('concurrent-directory/note.md', 'mcp directory write wins\n', { workspace: teamWorkspace }, async () => {
+      mcpDirectoryWriteReady();
+      await mcpDirectoryWriteCanFinish;
+    });
+    await mcpDirectoryWriteReadySignal;
+
+    const agentDirectoryDelete = runWithAgentExecutionContext(agentContext, () => deleteAgentPath({
+      path: 'concurrent-directory',
+      recursive: true,
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    releaseMcpDirectoryWrite();
+    await mcpDirectoryWrite;
+    await assert.rejects(
+      () => agentDirectoryDelete,
+      (error) => error instanceof WorkspaceFileRevisionError
+        && error.code === 'FILE_REVISION_CONFLICT',
+    );
+    assert.equal(
+      await fs.readFile(path.join(teamRoot, 'concurrent-directory', 'note.md'), 'utf8'),
+      'mcp directory write wins\n',
+    );
+
     console.log('file-revision-guard-test: ok');
   } finally {
     await fs.rm(tempRoot, { recursive: true, force: true });

--- a/scripts/file-revision-guard-test.ts
+++ b/scripts/file-revision-guard-test.ts
@@ -162,6 +162,36 @@ async function main() {
       assert.equal(edited.changed, true);
     });
 
+    await writeFile('concurrent.md', 'before\n', { workspace: teamWorkspace });
+    const concurrentRevision = await getWorkspaceFileRevision('concurrent.md', { workspace: teamWorkspace });
+    assert.ok(concurrentRevision?.sha256);
+
+    let releaseMcpWrite!: () => void;
+    const mcpWriteCanFinish = new Promise<void>((resolve) => { releaseMcpWrite = resolve; });
+    let mcpWriteReady!: () => void;
+    const mcpWriteReadySignal = new Promise<void>((resolve) => { mcpWriteReady = resolve; });
+    const mcpWrite = writeFile('concurrent.md', 'mcp write\n', { workspace: teamWorkspace }, async () => {
+      mcpWriteReady();
+      await mcpWriteCanFinish;
+    });
+    await mcpWriteReadySignal;
+
+    const agentWrite = runWithAgentExecutionContext(agentContext, () => writeAgentTextFile({
+      path: 'concurrent.md',
+      content: 'agent write\n',
+      expectedSha256: concurrentRevision.sha256,
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    releaseMcpWrite();
+    await mcpWrite;
+    await assert.rejects(
+      () => agentWrite,
+      (error) => error instanceof WorkspaceFileRevisionError
+        && error.code === 'FILE_REVISION_CONFLICT'
+        && error.currentSha256 !== concurrentRevision.sha256,
+    );
+    assert.equal(await fs.readFile(path.join(teamRoot, 'concurrent.md'), 'utf8'), 'mcp write\n');
+
     console.log('file-revision-guard-test: ok');
   } finally {
     await fs.rm(tempRoot, { recursive: true, force: true });

--- a/scripts/mcp-server-auth-probe-test.ts
+++ b/scripts/mcp-server-auth-probe-test.ts
@@ -22,12 +22,14 @@ const DIRECT_MCP_TOOL_NAMES = [
   'list_knowledge_tree',
   'search_knowledge',
   'read_knowledge_source',
+  'edit_knowledge_source',
 ] as const;
 const DIRECT_MCP_RESOURCE_SCOPES = [
   'workspace:list',
   'knowledge:tree',
   'knowledge:search',
   'knowledge:read',
+  'knowledge:write',
 ];
 
 type JsonRecord = Record<string, unknown>;
@@ -38,6 +40,7 @@ function configureRuntime(dataDir: string): void {
   environment.NODE_ENV = 'test';
   environment.CANVAS_DATABASE_PROVIDER = 'sqlite';
   environment.CANVAS_MCP_DIRECT_ENABLED = 'true';
+  environment.CANVAS_MCP_DIRECT_TOOLS = DIRECT_MCP_TOOL_NAMES.join(',');
   environment.CANVAS_INSTANCE_ID = 'mcp-auth-probe-test';
   environment.BETTER_AUTH_BASE_URL = ORIGIN;
   environment.BASE_URL = ORIGIN;
@@ -412,6 +415,10 @@ async function main(): Promise<void> {
     const { loadWorkspaceListingForActor } = await import('../app/lib/workspaces/listing-action');
     const { resolveWorkspaceActor } = await import('../app/lib/workspaces/context');
     const { writeFile } = await import('../app/lib/filesystem/workspace-files');
+    const {
+      replaceDirectMcpAllowedWorkspaces,
+      setDirectMcpWorkspaceEnabled,
+    } = await import('../app/lib/mcp/server/workspace-access-policy');
     const workspaceListing = await loadWorkspaceListingForActor(resolveWorkspaceActor({
       id: userId,
       email: EMAIL,
@@ -419,6 +426,16 @@ async function main(): Promise<void> {
     }));
     assert.ok(workspaceListing.defaultWorkspace);
     const workspace = workspaceListing.defaultWorkspace;
+    assert.deepEqual(await setDirectMcpWorkspaceEnabled({
+      userId,
+      workspaceId: workspace.workspaceId,
+      enabled: true,
+    }), { status: 'updated', enabled: true });
+    assert.deepEqual(await replaceDirectMcpAllowedWorkspaces({
+      clientId,
+      userId,
+      workspaceIds: [workspace.workspaceId],
+    }), { status: 'saved', allowedWorkspaceCount: 1 });
     await writeFile(
       'mcp-server-test.md',
       'Canvas MCP workspace search fixture. This document is visible to the authenticated user.',
@@ -506,10 +523,138 @@ async function main(): Promise<void> {
       },
     });
     const sourceResult = resultFromRpc(await readJson(source));
+    const sourceContent = sourceResult.structuredContent as JsonRecord;
     assert.match(
-      String((sourceResult.structuredContent as JsonRecord).content),
+      String(sourceContent.content),
       /Canvas MCP workspace search fixture/u,
     );
+    assert.match(String(sourceContent.sha256), /^[a-f0-9]{64}$/u);
+    assert.equal(sourceContent.source, 'file');
+
+    const edit = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 27,
+        method: 'tools/call',
+        params: {
+          name: 'edit_knowledge_source',
+          arguments: {
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-test.md',
+            old_text: 'search fixture',
+            new_text: 'write fixture',
+            expected_sha256: sourceContent.sha256,
+          },
+        },
+      },
+    });
+    const editResult = resultFromRpc(await readJson(edit));
+    assert.notEqual(editResult.isError, true);
+    const editContent = editResult.structuredContent as JsonRecord;
+    assert.equal(editContent.changed, true);
+    assert.equal(editContent.review_required, false);
+    assert.equal(editContent.before_sha256, sourceContent.sha256);
+    assert.match(String(editContent.after_sha256), /^[a-f0-9]{64}$/u);
+    assert.notEqual(editContent.after_sha256, sourceContent.sha256);
+
+    const updatedSource = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 28,
+        method: 'tools/call',
+        params: {
+          name: 'read_knowledge_source',
+          arguments: { workspace_id: workspace.workspaceId, path: 'mcp-server-test.md' },
+        },
+      },
+    });
+    const updatedSourceResult = resultFromRpc(await readJson(updatedSource));
+    const updatedSourceContent = updatedSourceResult.structuredContent as JsonRecord;
+    assert.match(String(updatedSourceContent.content), /Canvas MCP workspace write fixture/u);
+    assert.equal(updatedSourceContent.sha256, editContent.after_sha256);
+
+    const staleEdit = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 29,
+        method: 'tools/call',
+        params: {
+          name: 'edit_knowledge_source',
+          arguments: {
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-test.md',
+            old_text: 'write fixture',
+            new_text: 'stale write fixture',
+            expected_sha256: sourceContent.sha256,
+          },
+        },
+      },
+    });
+    const staleEditResult = resultFromRpc(await readJson(staleEdit));
+    assert.equal(staleEditResult.isError, true);
+    assert.match(
+      String((staleEditResult.content as Array<{ text?: string }>)[0]?.text),
+      /changed since it was read/u,
+    );
+
+    const noMatchEdit = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 30,
+        method: 'tools/call',
+        params: {
+          name: 'edit_knowledge_source',
+          arguments: {
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-test.md',
+            old_text: 'not present in this file',
+            new_text: 'should not be written',
+            expected_sha256: updatedSourceContent.sha256,
+          },
+        },
+      },
+    });
+    const noMatchEditResult = resultFromRpc(await readJson(noMatchEdit));
+    assert.equal(noMatchEditResult.isError, true);
+    assert.match(
+      String((noMatchEditResult.content as Array<{ text?: string }>)[0]?.text),
+      /exact text replacement no longer matches/u,
+    );
+
+    const missingWriteScopeEdit = await rpcRequest({
+      post: mcpRoute.POST,
+      token: noProbeScopeToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 31,
+        method: 'tools/call',
+        params: {
+          name: 'edit_knowledge_source',
+          arguments: {
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-test.md',
+            old_text: 'write fixture',
+            new_text: 'unauthorized write fixture',
+            expected_sha256: updatedSourceContent.sha256,
+          },
+        },
+      },
+    });
+    const missingWriteScopeResult = resultFromRpc(await readJson(missingWriteScopeEdit));
+    assert.equal(missingWriteScopeResult.isError, true);
+    const writeScopeChallenge = (
+      missingWriteScopeResult._meta as JsonRecord
+    )['mcp/www_authenticate'] as string[];
+    assert.ok(writeScopeChallenge[0].includes('error="insufficient_scope"'));
+    assert.ok(writeScopeChallenge[0].includes('scope="knowledge:write"'));
 
     process.env.CANVAS_MCP_DIRECT_TOOLS = '';
     try {

--- a/scripts/mcp-server-auth-probe-test.ts
+++ b/scripts/mcp-server-auth-probe-test.ts
@@ -23,6 +23,7 @@ const DIRECT_MCP_TOOL_NAMES = [
   'search_knowledge',
   'read_knowledge_source',
   'edit_knowledge_source',
+  'read_knowledge_asset',
 ] as const;
 const DIRECT_MCP_RESOURCE_SCOPES = [
   'workspace:list',
@@ -30,6 +31,7 @@ const DIRECT_MCP_RESOURCE_SCOPES = [
   'knowledge:search',
   'knowledge:read',
   'knowledge:write',
+  'knowledge:assets',
 ];
 
 type JsonRecord = Record<string, unknown>;
@@ -123,6 +125,28 @@ function resultFromRpc(body: JsonRecord): JsonRecord {
   assert.equal(typeof body.result, 'object');
   assert.notEqual(body.result, null);
   return body.result as JsonRecord;
+}
+
+function createPdfFixture(): Buffer {
+  const stream = 'BT /F1 12 Tf 20 100 Td (Canvas MCP PDF asset fixture.) Tj ET';
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>',
+    `<< /Length ${Buffer.byteLength(stream, 'utf8')} >>\nstream\n${stream}\nendstream`,
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  let document = '%PDF-1.4\n';
+  const offsets: number[] = [];
+  for (const [index, object] of objects.entries()) {
+    offsets.push(Buffer.byteLength(document, 'utf8'));
+    document += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  }
+  const xrefOffset = Buffer.byteLength(document, 'utf8');
+  document += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  document += offsets.map((offset) => `${String(offset).padStart(10, '0')} 00000 n \n`).join('');
+  document += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  return Buffer.from(document, 'utf8');
 }
 
 async function main(): Promise<void> {
@@ -411,6 +435,13 @@ async function main(): Promise<void> {
       idempotentHint: true,
       openWorldHint: false,
     });
+    const assetTool = tools.find((tool) => tool.name === 'read_knowledge_asset');
+    assert.ok(assetTool);
+    assert.deepEqual(assetTool.securitySchemes, [{
+      type: 'oauth2',
+      scopes: ['knowledge:assets'],
+    }]);
+    assert.equal((assetTool.annotations as JsonRecord).readOnlyHint, true);
 
     const { loadWorkspaceListingForActor } = await import('../app/lib/workspaces/listing-action');
     const { resolveWorkspaceActor } = await import('../app/lib/workspaces/context');
@@ -441,6 +472,13 @@ async function main(): Promise<void> {
       'Canvas MCP workspace search fixture. This document is visible to the authenticated user.',
       { workspace },
     );
+    await writeFile(
+      'mcp-server-asset.png',
+      Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9JH8sAAAAASUVORK5CYII=', 'base64'),
+      { workspace },
+    );
+    await writeFile('mcp-server-asset.pdf', createPdfFixture(), { workspace });
+    await writeFile('mcp-server-asset.bin', Buffer.from([0, 1, 2, 3]), { workspace });
 
     const listWorkspaces = await rpcRequest({
       post: mcpRoute.POST,
@@ -576,6 +614,103 @@ async function main(): Promise<void> {
     const updatedSourceContent = updatedSourceResult.structuredContent as JsonRecord;
     assert.match(String(updatedSourceContent.content), /Canvas MCP workspace write fixture/u);
     assert.equal(updatedSourceContent.sha256, editContent.after_sha256);
+
+    const imageAsset = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 32,
+        method: 'tools/call',
+        params: {
+          name: 'read_knowledge_asset',
+          arguments: { workspace_id: workspace.workspaceId, path: 'mcp-server-asset.png' },
+        },
+      },
+    });
+    const imageAssetResult = resultFromRpc(await readJson(imageAsset));
+    assert.notEqual(imageAssetResult.isError, true);
+    const imageAssetContent = imageAssetResult.structuredContent as JsonRecord;
+    assert.equal(imageAssetContent.type, 'image');
+    assert.equal(imageAssetContent.mime_type, 'image/png');
+    assert.match(String(imageAssetContent.sha256), /^[a-f0-9]{64}$/u);
+    assert.ok((imageAssetResult.content as JsonRecord[]).some((part) => (
+      part.type === 'image' && part.mimeType === 'image/png' && typeof part.data === 'string'
+    )));
+
+    const pdfAsset = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 33,
+        method: 'tools/call',
+        params: {
+          name: 'read_knowledge_asset',
+          arguments: {
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-asset.pdf',
+            pdf_text_pages: [1],
+            include_pdf_images: true,
+            pdf_image_pages: [1],
+          },
+        },
+      },
+    });
+    const pdfAssetResult = resultFromRpc(await readJson(pdfAsset));
+    assert.notEqual(pdfAssetResult.isError, true);
+    const pdfAssetContent = pdfAssetResult.structuredContent as JsonRecord;
+    assert.equal(pdfAssetContent.type, 'pdf');
+    assert.equal(pdfAssetContent.mime_type, 'application/pdf');
+    assert.equal(pdfAssetContent.pages, 1);
+    assert.deepEqual(pdfAssetContent.text_pages_read, [1]);
+    assert.ok((pdfAssetResult.content as JsonRecord[]).some((part) => (
+      part.type === 'text' && String(part.text).includes('Canvas MCP PDF asset fixture')
+    )));
+    assert.ok((pdfAssetResult.content as JsonRecord[]).some((part) => (
+      part.type === 'image' && part.mimeType === 'image/png' && typeof part.data === 'string'
+    )));
+
+    const missingAssetScope = await rpcRequest({
+      post: mcpRoute.POST,
+      token: noProbeScopeToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 34,
+        method: 'tools/call',
+        params: {
+          name: 'read_knowledge_asset',
+          arguments: { workspace_id: workspace.workspaceId, path: 'mcp-server-asset.png' },
+        },
+      },
+    });
+    const missingAssetScopeResult = resultFromRpc(await readJson(missingAssetScope));
+    assert.equal(missingAssetScopeResult.isError, true);
+    const assetScopeChallenge = (
+      missingAssetScopeResult._meta as JsonRecord
+    )['mcp/www_authenticate'] as string[];
+    assert.ok(assetScopeChallenge[0].includes('error="insufficient_scope"'));
+    assert.ok(assetScopeChallenge[0].includes('scope="knowledge:assets"'));
+
+    const unsupportedAsset = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 35,
+        method: 'tools/call',
+        params: {
+          name: 'read_knowledge_asset',
+          arguments: { workspace_id: workspace.workspaceId, path: 'mcp-server-asset.bin' },
+        },
+      },
+    });
+    const unsupportedAssetResult = resultFromRpc(await readJson(unsupportedAsset));
+    assert.equal(unsupportedAssetResult.isError, true);
+    assert.match(
+      String((unsupportedAssetResult.content as Array<{ text?: string }>)[0]?.text),
+      /Only PNG, JPEG, GIF, WebP images, and PDF documents/u,
+    );
 
     const staleEdit = await rpcRequest({
       post: mcpRoute.POST,

--- a/scripts/mcp-server-http-smoke-test.ts
+++ b/scripts/mcp-server-http-smoke-test.ts
@@ -171,6 +171,7 @@ async function main(): Promise<void> {
     'knowledge:tree',
     'knowledge:search',
     'knowledge:read',
+    'knowledge:write',
   ]) {
     assert.ok(supportedScopes.includes(scope), `Missing OAuth scope ${scope}.`);
   }

--- a/scripts/mcp-server-http-smoke-test.ts
+++ b/scripts/mcp-server-http-smoke-test.ts
@@ -172,6 +172,7 @@ async function main(): Promise<void> {
     'knowledge:search',
     'knowledge:read',
     'knowledge:write',
+    'knowledge:assets',
   ]) {
     assert.ok(supportedScopes.includes(scope), `Missing OAuth scope ${scope}.`);
   }

--- a/scripts/mcp-server-oauth-client-test.ts
+++ b/scripts/mcp-server-oauth-client-test.ts
@@ -416,7 +416,7 @@ async function main(): Promise<void> {
       clientId,
       resource,
       state: 'unknown-scope',
-      scopes: ['openid', 'knowledge:write'],
+      scopes: ['openid', 'knowledge:delete'],
     }), {
       headers: { cookie: sessionCookie },
     }));

--- a/scripts/mcp-server-oauth-provider-test.ts
+++ b/scripts/mcp-server-oauth-provider-test.ts
@@ -273,7 +273,7 @@ async function assertRegistrationPolicy(
     token_endpoint_auth_method: 'none',
     grant_types: ['authorization_code'],
     response_types: ['code'],
-    scope: 'openid knowledge:write',
+    scope: 'openid knowledge:delete',
   }, prepareRequest);
   assert.equal(invalidScope.status, 400);
   assert.equal((await readJson(invalidScope)).error, 'invalid_scope');
@@ -367,7 +367,7 @@ async function assertAuthorizePolicy(
   assert.match(pkceError.searchParams.get('error_description') || '', /pkce is required/u);
 
   const unknownScope = await auth.handler(new Request(authorizeUrl(clientId, {
-    scope: 'openid knowledge:write',
+    scope: 'openid knowledge:delete',
   })));
   assert.equal(unknownScope.status, 302);
   assert.equal(

--- a/scripts/mcp-server-request-history-test.ts
+++ b/scripts/mcp-server-request-history-test.ts
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
       phase: 'oauth.registration',
       httpMethod: 'POST',
       operation: 'tools/call',
-      toolName: 'auth_probe',
+      toolName: 'read_knowledge_asset',
       outcome: 'succeeded',
       statusCode: 201,
       code: 'OAUTH_REQUEST_COMPLETED',
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
     assert.equal(entries[0].phase, 'oauth.registration');
     assert.equal(entries[0].httpMethod, 'POST');
     assert.equal(entries[0].operation, 'tools/call');
-    assert.equal(entries[0].toolName, 'auth_probe');
+    assert.equal(entries[0].toolName, 'read_knowledge_asset');
     assert.equal(entries[0].outcome, 'succeeded');
     assert.equal(entries[0].statusCode, 201);
     assert.equal(entries[0].code, 'OAUTH_REQUEST_COMPLETED');

--- a/scripts/mcp-server-runtime-bootstrap-test.mjs
+++ b/scripts/mcp-server-runtime-bootstrap-test.mjs
@@ -60,14 +60,14 @@ async function main() {
 
     await writePreferences(dataDir, {
       enabled: true,
-      tools: ['auth_probe', 'read_knowledge_source', 'edit_knowledge_source'],
-      toolsVersion: 3,
+      tools: ['auth_probe', 'read_knowledge_source', 'edit_knowledge_source', 'read_knowledge_asset'],
+      toolsVersion: 4,
     });
     loadAppEnv(process.cwd());
     assert.equal(process.env.CANVAS_MCP_DIRECT_ENABLED, 'true');
     assert.equal(
       process.env.CANVAS_MCP_DIRECT_TOOLS,
-      'auth_probe,read_knowledge_source,edit_knowledge_source',
+      'auth_probe,read_knowledge_source,edit_knowledge_source,read_knowledge_asset',
     );
 
     process.env.CANVAS_MCP_DIRECT_ENABLED = 'true';

--- a/scripts/mcp-server-runtime-bootstrap-test.mjs
+++ b/scripts/mcp-server-runtime-bootstrap-test.mjs
@@ -58,6 +58,18 @@ async function main() {
     loadAppEnv(process.cwd());
     assert.equal(process.env.CANVAS_MCP_DIRECT_TOOLS, 'auth_probe');
 
+    await writePreferences(dataDir, {
+      enabled: true,
+      tools: ['auth_probe', 'read_knowledge_source', 'edit_knowledge_source'],
+      toolsVersion: 3,
+    });
+    loadAppEnv(process.cwd());
+    assert.equal(process.env.CANVAS_MCP_DIRECT_ENABLED, 'true');
+    assert.equal(
+      process.env.CANVAS_MCP_DIRECT_TOOLS,
+      'auth_probe,read_knowledge_source,edit_knowledge_source',
+    );
+
     process.env.CANVAS_MCP_DIRECT_ENABLED = 'true';
     process.env.CANVAS_MCP_DIRECT_TOOLS = '';
     delete process.env.CANVAS_MCP_DIRECT_SETTINGS_SOURCE;

--- a/scripts/mcp-server-settings-test.ts
+++ b/scripts/mcp-server-settings-test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -30,6 +30,9 @@ async function main(): Promise<void> {
     const { DIRECT_MCP_SERVER_VERSION } = await import(
       '../app/lib/mcp/server/version'
     );
+    const { getDirectMcpEnabledTools } = await import(
+      '../app/lib/mcp/server/config'
+    );
     const { applyDirectMcpSettingsToRuntime } = await import(
       '../app/lib/mcp/server/runtime-settings'
     );
@@ -38,6 +41,14 @@ async function main(): Promise<void> {
     );
 
     assert.equal(await getDirectMcpServerPreferences(), null);
+    assert.deepEqual(getDirectMcpEnabledTools({}), [
+      'auth_probe',
+      'list_workspaces',
+      'get_workspace_overview',
+      'list_knowledge_tree',
+      'search_knowledge',
+      'read_knowledge_source',
+    ]);
     await setServerPreferredTimeZone('admin-1', 'Europe/Berlin');
     const preferences = await setDirectMcpServerPreferences('admin-1', {
       enabled: true,
@@ -45,7 +56,7 @@ async function main(): Promise<void> {
     });
     assert.equal(preferences.enabled, true);
     assert.deepEqual(preferences.tools, ['auth_probe']);
-    assert.equal(preferences.toolsVersion, 2);
+    assert.equal(preferences.toolsVersion, 3);
     assert.equal(typeof preferences.updatedAt, 'string');
     assert.equal(preferences.updatedBy, 'admin-1');
 
@@ -59,6 +70,45 @@ async function main(): Promise<void> {
     };
     assert.deepEqual(persisted.settings?.directMcp, preferences);
     assert.equal((await stat(settingsPath)).mode & 0o777, 0o600);
+
+    await writeFile(settingsPath, JSON.stringify({
+      version: 1,
+      settings: {
+        directMcp: {
+          enabled: true,
+          tools: ['auth_probe'],
+          toolsVersion: 2,
+        },
+      },
+    }));
+    assert.deepEqual(await getDirectMcpServerPreferences(), {
+      enabled: true,
+      tools: ['auth_probe'],
+      toolsVersion: 3,
+    });
+
+    await writeFile(settingsPath, JSON.stringify({
+      version: 1,
+      settings: {
+        directMcp: {
+          enabled: true,
+          tools: ['auth_probe'],
+          toolsVersion: 1,
+        },
+      },
+    }));
+    assert.deepEqual((await getDirectMcpServerPreferences())?.tools, [
+      'auth_probe',
+      'list_workspaces',
+      'get_workspace_overview',
+      'list_knowledge_tree',
+      'search_knowledge',
+      'read_knowledge_source',
+    ]);
+    await setDirectMcpServerPreferences('admin-1', {
+      enabled: true,
+      tools: ['auth_probe'],
+    });
 
     await assert.rejects(
       setDirectMcpServerPreferences('admin-1', {
@@ -91,6 +141,7 @@ async function main(): Promise<void> {
         { id: 'list_knowledge_tree', available: true, enabled: false, scopes: ['knowledge:tree'] },
         { id: 'search_knowledge', available: true, enabled: false, scopes: ['knowledge:search'] },
         { id: 'read_knowledge_source', available: true, enabled: false, scopes: ['knowledge:read'] },
+        { id: 'edit_knowledge_source', available: true, enabled: false, scopes: ['knowledge:write'] },
       ],
     );
 

--- a/scripts/mcp-server-settings-test.ts
+++ b/scripts/mcp-server-settings-test.ts
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
     });
     assert.equal(preferences.enabled, true);
     assert.deepEqual(preferences.tools, ['auth_probe']);
-    assert.equal(preferences.toolsVersion, 3);
+    assert.equal(preferences.toolsVersion, 4);
     assert.equal(typeof preferences.updatedAt, 'string');
     assert.equal(preferences.updatedBy, 'admin-1');
 
@@ -84,7 +84,7 @@ async function main(): Promise<void> {
     assert.deepEqual(await getDirectMcpServerPreferences(), {
       enabled: true,
       tools: ['auth_probe'],
-      toolsVersion: 3,
+      toolsVersion: 4,
     });
 
     await writeFile(settingsPath, JSON.stringify({
@@ -117,6 +117,17 @@ async function main(): Promise<void> {
       }),
       /unsupported value/u,
     );
+    assert.deepEqual(
+      (await setDirectMcpServerPreferences('admin-1', {
+        enabled: true,
+        tools: ['read_knowledge_asset'],
+      })).tools,
+      ['read_knowledge_asset'],
+    );
+    await setDirectMcpServerPreferences('admin-1', {
+      enabled: true,
+      tools: ['auth_probe'],
+    });
 
     const status = buildDirectMcpServerSettingsStatus(preferences, {
       NODE_ENV: 'production',
@@ -142,6 +153,7 @@ async function main(): Promise<void> {
         { id: 'search_knowledge', available: true, enabled: false, scopes: ['knowledge:search'] },
         { id: 'read_knowledge_source', available: true, enabled: false, scopes: ['knowledge:read'] },
         { id: 'edit_knowledge_source', available: true, enabled: false, scopes: ['knowledge:write'] },
+        { id: 'read_knowledge_asset', available: true, enabled: false, scopes: ['knowledge:assets'] },
       ],
     );
 

--- a/server/load-app-env.js
+++ b/server/load-app-env.js
@@ -19,6 +19,7 @@ const DIRECT_MCP_DEFAULT_TOOLS = [
 const DIRECT_MCP_TOOLS = [
   ...DIRECT_MCP_DEFAULT_TOOLS,
   'edit_knowledge_source',
+  'read_knowledge_asset',
 ];
 const DIRECT_MCP_TOOL_SET = new Set(DIRECT_MCP_TOOLS);
 

--- a/server/load-app-env.js
+++ b/server/load-app-env.js
@@ -7,14 +7,18 @@ const DIRECT_MCP_FEATURE_ENV = 'CANVAS_MCP_DIRECT_ENABLED';
 const DIRECT_MCP_TOOLS_ENV = 'CANVAS_MCP_DIRECT_TOOLS';
 const DIRECT_MCP_SETTINGS_SOURCE_ENV = 'CANVAS_MCP_DIRECT_SETTINGS_SOURCE';
 const DIRECT_MCP_TOOLS_SOURCE_ENV = 'CANVAS_MCP_DIRECT_TOOLS_SOURCE';
-const DIRECT_MCP_TOOL_CONFIGURATION_VERSION = 2;
-const DIRECT_MCP_TOOLS = [
+const DIRECT_MCP_LEGACY_AUTH_PROBE_CONFIGURATION_VERSION = 2;
+const DIRECT_MCP_DEFAULT_TOOLS = [
   'auth_probe',
   'list_workspaces',
   'get_workspace_overview',
   'list_knowledge_tree',
   'search_knowledge',
   'read_knowledge_source',
+];
+const DIRECT_MCP_TOOLS = [
+  ...DIRECT_MCP_DEFAULT_TOOLS,
+  'edit_knowledge_source',
 ];
 const DIRECT_MCP_TOOL_SET = new Set(DIRECT_MCP_TOOLS);
 
@@ -62,12 +66,12 @@ function readDirectMcpPreferences(cwd) {
     const toolsVersion = Number.isSafeInteger(preferences.toolsVersion)
       ? preferences.toolsVersion
       : 1;
-    const isLegacyAuthProbeDefault = toolsVersion < DIRECT_MCP_TOOL_CONFIGURATION_VERSION
+    const isLegacyAuthProbeDefault = toolsVersion < DIRECT_MCP_LEGACY_AUTH_PROBE_CONFIGURATION_VERSION
       && tools.length === 1
       && tools[0] === 'auth_probe';
     return {
       enabled: preferences.enabled,
-      tools: isLegacyAuthProbeDefault ? [...DIRECT_MCP_TOOLS] : tools,
+      tools: isLegacyAuthProbeDefault ? [...DIRECT_MCP_DEFAULT_TOOLS] : tools,
     };
   } catch (error) {
     console.warn('[Startup] Ignoring invalid Direct MCP server preferences.', {


### PR DESCRIPTION
## Summary
- add conflict-protected workspace text editing with explicit opt-in
- keep persisted Direct MCP tool preferences intact across restarts
- add separately scoped, opt-in image and PDF context reading

## Verification
- npm run lint
- npx tsc --noEmit
- npm run test:mcp:server-settings
- npm run test:mcp:server-auth-probe
- npm run test:mcp:server-provider
- npm run test:mcp:server-oauth-client
- npm run test:mcp:server-resource
- npm run test:mcp:server-request-history
- npm run test:mcp:server-diagnostics
- npm run build

No browser or Playwright tests were run.











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends Direct MCP with opt-in conflict-protected text editing and scoped image/PDF reading while preserving existing tool preferences.
- Adds hierarchical workspace mutation locks shared by Direct MCP and agent file operations.
- Adds exact text editing with revision checks, validation, collaboration support, auditing, and public-share synchronization.
- Adds bounded image and PDF asset extraction under a separate OAuth scope.
- Extends settings persistence, consent messaging, request history, and regression coverage for the new capabilities.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/filesystem/workspace-files.ts | Normalizes separator variants and serializes mutations across each path’s full ancestor hierarchy, including the workspace root. |
| app/lib/pi/agent-file-operations.ts | Moves agent text, binary, restore, copy, move, and delete mutations under shared workspace locks with in-lock conflict checks. |
| app/lib/mcp/server/workspace-tools.ts | Adds scoped asset reads and exact revision-protected text edits, including collaborative and non-collaborative write paths. |
| app/lib/mcp/server/asset-reader.ts | Implements bounded signature-checked image and PDF context extraction. |
| app/lib/mcp/server/config.ts | Adds separate write and asset scopes while retaining a read-only default tool set. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  R[Direct MCP reads workspace text] --> H[Return content and SHA-256]
  H --> E[Client requests exact text edit]
  E --> A[Verify write scope and workspace permission]
  A --> C{Collaborative document?}
  C -- Yes --> Y[Apply collaboration-aware edit]
  C -- No --> L[Acquire normalized path and ancestor locks]
  L --> V[Recheck file revision inside lock]
  V --> W[Atomically replace file]
  W --> S[Verify bytes and synchronize side effects]
  Y --> O[Return hashes and review status]
  S --> O
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Fix remaining MCP mutation races"](https://github.com/canvascoding/canvas-notebook/commit/a16a801e2c12ce4ee960c2c1a27c6ab2902333d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58197366)</sub>

<!-- /greptile_comment -->