### PR TITLE
Add personal profile photos, icons, and initials

### DIFF
--- a/app/[locale]/(routes)/onboarding/onboarding-wizard.tsx
+++ b/app/[locale]/(routes)/onboarding/onboarding-wizard.tsx
@@ -16,6 +16,8 @@ import { AiProviderCredentialsPanel } from '@/app/components/settings/AiProvider
 import { AiProvidersModelsPanel } from '@/app/components/settings/AiProvidersModelsPanel';
 import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { PublicBrandLogo } from '@/app/components/branding/PublicBrandLogo';
+import { ProfileAppearanceEditor } from '@/app/components/user-profile/ProfileAppearanceEditor';
+import type { ResolvedUserProfile } from '@/app/lib/user-profile/types';
 import { DEFAULT_USER_TIME_ZONE, getSupportedTimeZones, normalizeTimeZone } from '@/app/lib/time-zones';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -189,12 +191,14 @@ export default function OnboardingWizard({
   initialTimeZone,
   mode,
   initialStep,
+  initialUserProfile,
 }: {
   defaultEmail: string;
   initialLicenseKey: string;
   initialTimeZone: string;
   mode: OnboardingMode;
   initialStep: Step;
+  initialUserProfile: ResolvedUserProfile;
 }) {
   const t = useTranslations('onboarding');
   const currentLocale = useLocale();
@@ -351,7 +355,7 @@ export default function OnboardingWizard({
         </div>
 
         <div className="flex flex-1 items-start justify-center py-4">
-          <div className={`w-full ${step === 'provider' || step === 'profile' || step === 'workspace' ? 'max-w-5xl' : 'max-w-lg'}`}>
+          <div className={`w-full ${step === 'provider' || step === 'profile' || step === 'workspace' || step === 'language' ? 'max-w-5xl' : 'max-w-lg'}`}>
             <div className="rounded-xl border border-border bg-card p-6 shadow-sm sm:p-8">
               <div className="mb-3 flex flex-col items-center justify-center gap-3 sm:flex-row">
                 <PublicBrandLogo
@@ -388,6 +392,7 @@ export default function OnboardingWizard({
 
               {step === 'language' && (
                 <LanguageStep
+                  initialUserProfile={initialUserProfile}
                   onContinue={() => advanceTo('workspace')}
                 />
               )}
@@ -1301,8 +1306,10 @@ function InstanceReviewStep({ onComplete }: { onComplete: () => void }) {
 }
 
 function LanguageStep({
+  initialUserProfile,
   onContinue,
 }: {
+  initialUserProfile: ResolvedUserProfile;
   onContinue: () => Promise<void> | void;
 }) {
   const t = useTranslations('onboarding');
@@ -1397,6 +1404,8 @@ function LanguageStep({
           </button>
         ))}
       </div>
+
+      <ProfileAppearanceEditor initialProfile={initialUserProfile} />
 
       <div className="flex justify-center">
         <Button onClick={handleContinue} className="min-w-[200px]" disabled={!isHydrated || isSaving || isSwitchingLocale}>

--- a/app/[locale]/(routes)/onboarding/page.tsx
+++ b/app/[locale]/(routes)/onboarding/page.tsx
@@ -7,6 +7,7 @@ import { isAdminUser } from '@/app/lib/admin-auth';
 import { getUserOnboardingState } from '@/app/lib/user-preferences';
 import { resolveOnboardingPhase } from '@/app/lib/onboarding/flow';
 import { PublicBrandLogo } from '@/app/components/branding/PublicBrandLogo';
+import { resolveUserProfile } from '@/app/lib/user-profile/service';
 import OnboardingWizard from './onboarding-wizard';
 import { OnboardingWaitingActions } from './onboarding-waiting-actions';
 
@@ -75,6 +76,12 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
   const initialStep = instanceComplete
     ? (userOnboarding.step === 'complete' ? 'done' : userOnboarding.step)
     : await getInstanceOnboardingStep();
+  const initialUserProfile = await resolveUserProfile({
+    userId: session.user.id,
+    name: session.user.name,
+    email: session.user.email,
+    locale,
+  });
 
   return (
     <OnboardingWizard
@@ -83,6 +90,7 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
       initialTimeZone={initialTimeZone}
       mode={phase === 'instance' ? 'instance' : 'user'}
       initialStep={initialStep}
+      initialUserProfile={initialUserProfile}
     />
   );
 }

--- a/app/[locale]/(routes)/page.tsx
+++ b/app/[locale]/(routes)/page.tsx
@@ -28,7 +28,8 @@ export default async function Home() {
   const tHome = await getTranslations('home');
   const onboardingHintsEnabled = isOnboardingHintsEnabled();
   const session = await requirePageSession();
-  const userOnboarding = session ? await getUserOnboardingState(session.user.id) : null;
+  if (!session) return null;
+  const userOnboarding = await getUserOnboardingState(session.user.id);
   const userProfile = await resolveUserProfile({
     userId: session.user.id,
     name: session.user.name,
@@ -76,7 +77,7 @@ export default async function Home() {
               {showPersonalTour && <GettingStartedCard />}
 
               <HomeWorkspaceView
-                showBrowserLab={Boolean(session && isBrowserLabAllowed(session.user))}
+                showBrowserLab={isBrowserLabAllowed(session.user)}
               />
             </div>
           </main>

--- a/app/[locale]/(routes)/page.tsx
+++ b/app/[locale]/(routes)/page.tsx
@@ -16,6 +16,8 @@ import { VersionUpdateIndicator } from '@/app/components/VersionUpdateIndicator'
 import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 import { WorkspaceBrandLogo } from '@/app/components/workspaces/WorkspaceBrandLogo';
 import { isBrowserLabAllowed } from '@/app/lib/pi/browser/view-access';
+import { resolveUserProfile } from '@/app/lib/user-profile/service';
+import { UserProfileBadge } from '@/app/components/user-profile/UserProfileBadge';
 
 const repositoryUrl = 'https://github.com/canvascoding/canvas-notebook';
 const releaseVersion = packageJson.version;
@@ -27,6 +29,11 @@ export default async function Home() {
   const onboardingHintsEnabled = isOnboardingHintsEnabled();
   const session = await requirePageSession();
   const userOnboarding = session ? await getUserOnboardingState(session.user.id) : null;
+  const userProfile = await resolveUserProfile({
+    userId: session.user.id,
+    name: session.user.name,
+    email: session.user.email,
+  });
   const showPersonalTour = userOnboarding?.tour === 'started';
 
   return (
@@ -58,6 +65,7 @@ export default async function Home() {
                 <div className="hidden min-[380px]:block">
                   <ThemeToggle />
                 </div>
+                <UserProfileBadge profile={userProfile} />
                 <LogoutButton />
               </div>
             </div>

--- a/app/[locale]/(routes)/settings/page.tsx
+++ b/app/[locale]/(routes)/settings/page.tsx
@@ -10,6 +10,7 @@ import { getServerPreferredTimeZone } from '@/app/lib/server-settings';
 import { getUserOnboardingState } from '@/app/lib/user-preferences';
 import { SETTINGS_SIDEBAR_COLLAPSED_COOKIE } from '@/app/lib/settings-navigation';
 import { isOnboardingLicenseRecoveryRequest } from '@/app/lib/onboarding/flow';
+import { resolveUserProfile } from '@/app/lib/user-profile/service';
 import { cookies } from 'next/headers';
 
 type SettingsPageProps = {
@@ -33,6 +34,11 @@ export default async function SettingsPage({ searchParams }: SettingsPageProps) 
   const initialTimeZone = await getServerPreferredTimeZone();
   const initialSettingsSidebarCollapsed = cookieStore.get(SETTINGS_SIDEBAR_COLLAPSED_COOKIE)?.value === 'true';
   const userOnboarding = currentUserId ? await getUserOnboardingState(currentUserId) : null;
+  const initialUserProfile = await resolveUserProfile({
+    userId: currentUserId,
+    name: userName,
+    email: userEmail,
+  });
   let organizationPermission = null;
   if (currentUserId) {
     try {
@@ -49,6 +55,7 @@ export default async function SettingsPage({ searchParams }: SettingsPageProps) 
           currentUserId={currentUserId}
           userName={userName}
           userEmail={userEmail}
+          initialUserProfile={initialUserProfile}
           isManagedControlPlane={isManagedControlPlane}
           initialTimeZone={initialTimeZone}
           initialSettingsSidebarCollapsed={initialSettingsSidebarCollapsed}

--- a/app/api/account/profile/avatar/route.ts
+++ b/app/api/account/profile/avatar/route.ts
@@ -1,0 +1,159 @@
+import { createHash } from 'node:crypto';
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { parseMultipartFormData } from '@/app/lib/api/form-data';
+import { auth } from '@/app/lib/auth';
+import { requireTrustedMutationOrigin } from '@/app/lib/security/mutation-origin';
+import {
+  readUserProfileImage,
+  resolveUserProfile,
+  saveUserProfileImage,
+  selectUserProfileInitials,
+  UserProfileError,
+} from '@/app/lib/user-profile/service';
+import {
+  normalizeUserProfileUpload,
+  USER_PROFILE_AVATAR_MAX_UPLOAD_BYTES,
+  UserProfileUploadError,
+} from '@/app/lib/user-profile/upload';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+const MULTIPART_OVERHEAD_ALLOWANCE_BYTES = 64 * 1024;
+
+function mutationLimit(request: NextRequest) {
+  return rateLimit(request, {
+    limit: 10,
+    windowMs: 60_000,
+    keyPrefix: 'user-profile-avatar-mutation',
+  });
+}
+
+function profileResponse(data: Awaited<ReturnType<typeof resolveUserProfile>>) {
+  return NextResponse.json(
+    { success: true, data },
+    { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const image = await readUserProfileImage(session.user.id);
+    if (!image) {
+      return NextResponse.json({ success: false, error: 'Profile image not found.' }, { status: 404 });
+    }
+    const etag = `"${createHash('sha256').update(image.buffer).digest('base64url')}"`;
+    if (request.headers.get('if-none-match') === etag) {
+      return new NextResponse(null, {
+        status: 304,
+        headers: {
+          ETag: etag,
+          'Cache-Control': 'private, max-age=31536000, immutable',
+          Vary: 'Cookie',
+        },
+      });
+    }
+
+    return new NextResponse(new Uint8Array(image.buffer), {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/webp',
+        'Content-Length': String(image.buffer.length),
+        'Cache-Control': 'private, max-age=31536000, immutable',
+        ETag: etag,
+        ...(image.updatedAt ? { 'Last-Modified': new Date(image.updatedAt).toUTCString() } : {}),
+        'X-Content-Type-Options': 'nosniff',
+        'Cross-Origin-Resource-Policy': 'same-origin',
+        Vary: 'Cookie',
+      },
+    });
+  } catch (error) {
+    console.error('[UserProfile] Failed to read the current user avatar.', error);
+    return NextResponse.json({ success: false, error: 'Could not load the profile image.' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+  const origin = requireTrustedMutationOrigin(request);
+  if (!origin.ok) return origin.response;
+  const limited = mutationLimit(request);
+  if (!limited.ok) return limited.response;
+
+  const contentLength = Number(request.headers.get('content-length'));
+  if (
+    Number.isFinite(contentLength)
+    && contentLength > USER_PROFILE_AVATAR_MAX_UPLOAD_BYTES + MULTIPART_OVERHEAD_ALLOWANCE_BYTES
+  ) {
+    return NextResponse.json(
+      { success: false, error: 'Profile image is too large. Maximum size is 5 MB.' },
+      { status: 413 },
+    );
+  }
+
+  try {
+    const parsed = await parseMultipartFormData(request);
+    if (!parsed.ok) return parsed.response;
+    const files = parsed.formData.getAll('file').filter((value): value is File => value instanceof File);
+    if (files.length !== 1) {
+      return NextResponse.json(
+        { success: false, error: 'Upload exactly one profile image.' },
+        { status: 400 },
+      );
+    }
+    if (files[0].size > USER_PROFILE_AVATAR_MAX_UPLOAD_BYTES) {
+      return NextResponse.json(
+        { success: false, error: 'Profile image is too large. Maximum size is 5 MB.' },
+        { status: 413 },
+      );
+    }
+
+    const normalized = await normalizeUserProfileUpload(Buffer.from(await files[0].arrayBuffer()));
+    await saveUserProfileImage({ userId: session.user.id, buffer: normalized });
+    return profileResponse(await resolveUserProfile({
+      userId: session.user.id,
+      name: session.user.name,
+      email: session.user.email,
+    }));
+  } catch (error) {
+    if (error instanceof UserProfileUploadError || error instanceof UserProfileError) {
+      return NextResponse.json({ success: false, error: error.message }, { status: error.status });
+    }
+    console.error('[UserProfile] Failed to upload the current user avatar.', error);
+    return NextResponse.json({ success: false, error: 'Could not upload the profile image.' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+  const origin = requireTrustedMutationOrigin(request);
+  if (!origin.ok) return origin.response;
+  const limited = mutationLimit(request);
+  if (!limited.ok) return limited.response;
+
+  try {
+    await selectUserProfileInitials(session.user.id);
+    return profileResponse(await resolveUserProfile({
+      userId: session.user.id,
+      name: session.user.name,
+      email: session.user.email,
+    }));
+  } catch (error) {
+    if (error instanceof UserProfileError) {
+      return NextResponse.json({ success: false, error: error.message }, { status: error.status });
+    }
+    console.error('[UserProfile] Failed to remove the current user avatar.', error);
+    return NextResponse.json({ success: false, error: 'Could not remove the profile image.' }, { status: 500 });
+  }
+}

--- a/app/api/account/profile/avatar/route.ts
+++ b/app/api/account/profile/avatar/route.ts
@@ -102,7 +102,7 @@ export async function POST(request: NextRequest) {
   try {
     const parsed = await parseMultipartFormData(request);
     if (!parsed.ok) return parsed.response;
-    const files = parsed.formData.getAll('file').filter((value): value is File => value instanceof File);
+    const files = parsed.formData.getAll('avatar').filter((value): value is File => value instanceof File);
     if (files.length !== 1) {
       return NextResponse.json(
         { success: false, error: 'Upload exactly one profile image.' },

--- a/app/api/account/profile/route.ts
+++ b/app/api/account/profile/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@/app/lib/auth';
+import { requireTrustedMutationOrigin } from '@/app/lib/security/mutation-origin';
+import {
+  resolveUserProfile,
+  selectUserProfileIcon,
+  selectUserProfileInitials,
+  UserProfileError,
+} from '@/app/lib/user-profile/service';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+function profileResponse(data: Awaited<ReturnType<typeof resolveUserProfile>>) {
+  return NextResponse.json(
+    { success: true, data },
+    { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    return profileResponse(await resolveUserProfile({
+      userId: session.user.id,
+      name: session.user.name,
+      email: session.user.email,
+    }));
+  } catch (error) {
+    console.error('[UserProfile] Failed to read the current user profile.', error);
+    return NextResponse.json({ success: false, error: 'Could not load the user profile.' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+  const origin = requireTrustedMutationOrigin(request);
+  if (!origin.ok) return origin.response;
+  const limited = rateLimit(request, {
+    limit: 10,
+    windowMs: 60_000,
+    keyPrefix: 'user-profile-update',
+  });
+  if (!limited.ok) return limited.response;
+
+  const payload = await request.json().catch(() => null) as Record<string, unknown> | null;
+  if (!payload || Array.isArray(payload)) {
+    return NextResponse.json({ success: false, error: 'Invalid profile update.' }, { status: 400 });
+  }
+
+  try {
+    if (payload.avatarKind === 'icon') {
+      await selectUserProfileIcon({ userId: session.user.id, iconId: payload.iconId });
+    } else if (payload.avatarKind === 'initials') {
+      await selectUserProfileInitials(session.user.id);
+    } else {
+      return NextResponse.json(
+        { success: false, error: 'Choose a supported icon or the initials fallback.' },
+        { status: 400 },
+      );
+    }
+
+    return profileResponse(await resolveUserProfile({
+      userId: session.user.id,
+      name: session.user.name,
+      email: session.user.email,
+    }));
+  } catch (error) {
+    if (error instanceof UserProfileError) {
+      return NextResponse.json({ success: false, error: error.message }, { status: error.status });
+    }
+    console.error('[UserProfile] Failed to update the current user profile.', error);
+    return NextResponse.json({ success: false, error: 'Could not update the user profile.' }, { status: 500 });
+  }
+}

--- a/app/api/mobile/v1/bootstrap/route.ts
+++ b/app/api/mobile/v1/bootstrap/route.ts
@@ -54,7 +54,7 @@ export async function GET(request: Request) {
     });
 
     return NextResponse.json(
-      createMobileBootstrap({ compatibility, user: session.user, listing }),
+      createMobileBootstrap({ compatibility, request, user: session.user, listing }),
       { headers: responseHeaders },
     );
   } catch (error) {

--- a/app/components/editor/MarkdownEditor.tsx
+++ b/app/components/editor/MarkdownEditor.tsx
@@ -5564,7 +5564,22 @@ function RichMarkdownEditor({
       ) : null}
       <MarkdownFindBar editor={markdownEditor} onOpenChange={setFindOpen} open={findOpen} />
       <div ref={scrollContainerRef} data-testid="markdown-scroll-container" className="relative min-h-0 flex-1 overflow-auto">
-        <div className="pointer-events-none sticky top-3 z-30 ml-auto h-0 w-fit pr-3">
+        <div className="pointer-events-none sticky top-2 z-30 ml-auto flex h-0 w-fit items-start gap-2 pr-3">
+          {collaborationEnabled ? (
+            <div className="rounded bg-background/85 px-2 py-1 text-[10px] text-muted-foreground shadow-sm" role="status">
+              {collaboration?.status === 'degraded'
+                ? collaboration.error || t('collaboration.degraded')
+                : collaboration?.status === 'saved' || collaboration?.status === 'live'
+                  ? t('collaboration.live')
+                  : collaboration?.status === 'persisting'
+                    ? t('collaboration.persisting')
+                    : collaboration?.status === 'offline' || collaboration?.status === 'reconnecting'
+                      ? t('collaboration.offline')
+                  : collaboration?.status === 'read_only'
+                    ? t('collaboration.readOnly')
+                    : collaboration?.status || t('collaboration.connecting')}
+            </div>
+          ) : null}
           <MarkdownOutlinePanel
             editor={editor}
             onPinnedChange={setOutlinePinned}
@@ -5572,21 +5587,6 @@ function RichMarkdownEditor({
             scrollContainerRef={scrollContainerRef}
           />
         </div>
-        {collaborationEnabled ? (
-          <div className="pointer-events-none sticky right-3 top-2 z-20 ml-auto mr-3 w-fit rounded bg-background/85 px-2 py-1 text-[10px] text-muted-foreground shadow-sm" role="status">
-            {collaboration?.status === 'degraded'
-              ? collaboration.error || t('collaboration.degraded')
-              : collaboration?.status === 'saved' || collaboration?.status === 'live'
-                ? t('collaboration.live')
-                : collaboration?.status === 'persisting'
-                  ? t('collaboration.persisting')
-                  : collaboration?.status === 'offline' || collaboration?.status === 'reconnecting'
-                    ? t('collaboration.offline')
-                : collaboration?.status === 'read_only'
-                  ? t('collaboration.readOnly')
-                  : collaboration?.status || t('collaboration.connecting')}
-          </div>
-        ) : null}
         <div className={cn('min-w-0 transition-[padding] duration-200', outlinePinned && 'md:pr-[17.5rem]')}>
           {!effectiveReadOnly ? (
             <div className="hidden md:block">

--- a/app/components/settings/GeneralSettingsPanel.tsx
+++ b/app/components/settings/GeneralSettingsPanel.tsx
@@ -14,6 +14,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { getSupportedTimeZones, normalizeTimeZone } from '@/app/lib/time-zones';
+import type { ResolvedUserProfile } from '@/app/lib/user-profile/types';
+import { ProfileAppearanceEditor } from '@/app/components/user-profile/ProfileAppearanceEditor';
 import { SettingsAccordionCard } from './SettingsAccordionCard';
 
 async function saveUserPreferences(payload: { locale?: string }): Promise<void> {
@@ -73,11 +75,13 @@ async function updatePassword(payload: { currentPassword: string; newPassword: s
 export function GeneralSettingsPanel({
   userName = '',
   userEmail = '',
+  initialUserProfile,
   isAdmin = false,
   initialTimeZone,
 }: {
   userName?: string;
   userEmail?: string;
+  initialUserProfile: ResolvedUserProfile;
   isAdmin?: boolean;
   initialTimeZone?: string;
 }) {
@@ -295,6 +299,8 @@ export function GeneralSettingsPanel({
             </div>
           </form>
       </SettingsAccordionCard>
+
+      <ProfileAppearanceEditor initialProfile={initialUserProfile} />
 
       <Card>
         <CardHeader className="px-4 sm:px-6">

--- a/app/components/settings/IntegrationsSettingsClient.tsx
+++ b/app/components/settings/IntegrationsSettingsClient.tsx
@@ -7,6 +7,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { ChevronDown, ChevronLeft, Copy, ExternalLink, Eye, EyeOff, Inbox, Loader2, Mail, MoreHorizontal, Plus, RefreshCw, Save, Search, Send, Server, Settings, ShieldCheck, Star, Trash2 } from 'lucide-react';
 
 import { GeneralSettingsPanel } from '@/app/components/settings/GeneralSettingsPanel';
+import type { ResolvedUserProfile } from '@/app/lib/user-profile/types';
 import { MailboxConnectionForm } from '@/app/components/email/MailboxConnectionForm';
 import { McpServerSettingsPanel } from '@/app/components/settings/McpServerSettingsPanel';
 import { SystemEmailSettingsPanel } from '@/app/components/settings/SystemEmailSettingsPanel';
@@ -2390,6 +2391,7 @@ export function IntegrationsSettingsClient({
   currentUserId = '',
   userName = '',
   userEmail = '',
+  initialUserProfile,
   isManagedControlPlane = false,
   initialTimeZone,
   initialSettingsSidebarCollapsed = false,
@@ -2399,6 +2401,7 @@ export function IntegrationsSettingsClient({
   currentUserId?: string;
   userName?: string;
   userEmail?: string;
+  initialUserProfile: ResolvedUserProfile;
   isManagedControlPlane?: boolean;
   initialTimeZone?: string;
   initialSettingsSidebarCollapsed?: boolean;
@@ -3201,6 +3204,7 @@ export function IntegrationsSettingsClient({
             <GeneralSettingsPanel
               userName={userName}
               userEmail={userEmail}
+              initialUserProfile={initialUserProfile}
               isAdmin={isAdmin}
               initialTimeZone={initialTimeZone}
             />,

--- a/app/components/user-profile/ProfileAppearanceEditor.tsx
+++ b/app/components/user-profile/ProfileAppearanceEditor.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { DragEvent, useRef, useState } from 'react';
+import { Check, ImagePlus, Loader2, Type } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+
+import { USER_AVATAR_ICON_IDS, type UserAvatarIconId } from '@/app/lib/user-profile/icon-catalog';
+import type { ResolvedUserProfile } from '@/app/lib/user-profile/types';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { UserAvatar } from './UserAvatar';
+
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+const ACCEPTED_UPLOAD_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+
+type ProfileResponse = {
+  success?: boolean;
+  data?: ResolvedUserProfile;
+  error?: string;
+};
+
+async function readProfileResponse(response: Response): Promise<ResolvedUserProfile> {
+  const body = await response.json().catch(() => ({})) as ProfileResponse;
+  if (!response.ok || !body.success || !body.data) {
+    throw new Error(body.error || `Profile update failed (${response.status}).`);
+  }
+  return body.data;
+}
+
+export function ProfileAppearanceEditor({
+  initialProfile,
+  className,
+}: {
+  initialProfile: ResolvedUserProfile;
+  className?: string;
+}) {
+  const t = useTranslations('userProfile');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [profile, setProfile] = useState(initialProfile);
+  const [pendingChoice, setPendingChoice] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const updateChoice = async (avatarKind: 'icon' | 'initials', iconId?: UserAvatarIconId) => {
+    if (pendingChoice) return;
+    const choice = iconId ?? avatarKind;
+    setPendingChoice(choice);
+    try {
+      const response = await fetch('/api/account/profile', {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ avatarKind, ...(iconId ? { iconId } : {}) }),
+      });
+      setProfile(await readProfileResponse(response));
+      toast.success(iconId ? t('iconUpdated') : t('initialsUpdated'));
+    } catch (error) {
+      console.warn('[UserProfile] Failed to update avatar choice.', error);
+      toast.error(t('updateFailed'));
+    } finally {
+      setPendingChoice(null);
+    }
+  };
+
+  const uploadImage = async (file: File | undefined) => {
+    if (!file || pendingChoice) return;
+    if (!ACCEPTED_UPLOAD_TYPES.has(file.type)) {
+      toast.error(t('invalidFile'));
+      return;
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      toast.error(t('fileTooLarge'));
+      return;
+    }
+
+    setPendingChoice('image');
+    try {
+      const formData = new FormData();
+      formData.set('avatar', file);
+      const response = await fetch('/api/account/profile/avatar', {
+        method: 'POST',
+        credentials: 'include',
+        body: formData,
+      });
+      setProfile(await readProfileResponse(response));
+      toast.success(t('imageUpdated'));
+    } catch (error) {
+      console.warn('[UserProfile] Failed to upload avatar image.', error);
+      toast.error(t('updateFailed'));
+    } finally {
+      setPendingChoice(null);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+    if (event.dataTransfer.files.length !== 1) {
+      toast.error(t('singleFileOnly'));
+      return;
+    }
+    void uploadImage(event.dataTransfer.files[0]);
+  };
+
+  const isBusy = Boolean(pendingChoice);
+
+  return (
+    <section
+      className={cn('overflow-hidden rounded-2xl border border-border/70 bg-card shadow-sm', className)}
+      aria-labelledby="profile-appearance-title"
+    >
+      <div className="grid md:grid-cols-[minmax(220px,0.8fr)_minmax(300px,1.2fr)]">
+        <div className="relative flex min-h-52 flex-col justify-between overflow-hidden border-b bg-muted/25 p-6 md:border-r md:border-b-0">
+          <div className="pointer-events-none absolute -top-16 -right-16 size-48 rounded-full bg-primary/10 blur-3xl" />
+          <div className="relative">
+            <p className="mb-4 text-xs font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+              {t('previewLabel')}
+            </p>
+            <UserAvatar profile={profile} className="size-20 text-4xl" />
+          </div>
+          <div className="relative mt-6 min-w-0">
+            <p className="truncate text-lg font-semibold">{profile.name}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{t('shownAs')}</p>
+          </div>
+        </div>
+
+        <div className="space-y-7 p-6">
+          <header>
+            <h2 id="profile-appearance-title" className="text-base font-semibold">{t('title')}</h2>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">{t('description')}</p>
+          </header>
+
+          <div className="space-y-3">
+            <div>
+              <h3 className="text-sm font-medium">{t('uploadTitle')}</h3>
+              <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{t('uploadDescription')}</p>
+            </div>
+            <div
+              className={cn(
+                'flex min-h-24 items-center justify-between gap-4 rounded-xl border border-dashed p-4 transition-colors',
+                isDragging ? 'border-primary bg-primary/5' : 'border-border bg-muted/15 hover:bg-muted/30',
+              )}
+              onDragEnter={(event) => {
+                event.preventDefault();
+                setIsDragging(true);
+              }}
+              onDragOver={(event) => event.preventDefault()}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={handleDrop}
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-background shadow-sm ring-1 ring-border">
+                  <ImagePlus aria-hidden="true" className="size-5 text-muted-foreground" />
+                </span>
+                <p className="text-sm text-muted-foreground">{t('dropImage')}</p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={isBusy}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {pendingChoice === 'image' ? <Loader2 className="animate-spin" /> : <ImagePlus />}
+                {profile.avatarKind === 'image' ? t('replaceImage') : t('chooseImage')}
+              </Button>
+              <input
+                ref={fileInputRef}
+                className="sr-only"
+                type="file"
+                accept="image/png,image/jpeg,image/webp,image/heic,image/heif,.heic,.heif"
+                onChange={(event) => void uploadImage(event.target.files?.[0])}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div>
+              <h3 className="text-sm font-medium">{t('iconsTitle')}</h3>
+              <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{t('iconsDescription')}</p>
+            </div>
+            <div className="grid grid-cols-4 gap-2 sm:grid-cols-6" role="group" aria-label={t('iconsTitle')}>
+              {USER_AVATAR_ICON_IDS.map((iconId) => {
+                const isSelected = profile.avatarKind === 'icon' && profile.iconId === iconId;
+                return (
+                  <button
+                    key={iconId}
+                    type="button"
+                    disabled={isBusy}
+                    aria-label={t(`icons.${iconId}`)}
+                    aria-pressed={isSelected}
+                    className={cn(
+                      'group relative flex aspect-square items-center justify-center rounded-xl border outline-none transition-all',
+                      'hover:-translate-y-0.5 hover:border-primary/50 hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring',
+                      'disabled:pointer-events-none disabled:opacity-50',
+                      isSelected ? 'border-primary bg-primary/8 shadow-sm' : 'border-border bg-background',
+                    )}
+                    onClick={() => void updateChoice('icon', iconId)}
+                  >
+                    <UserAvatar
+                      profile={{ ...profile, avatarKind: 'icon', iconId, imageUrl: null }}
+                      className="size-10 border-0 bg-transparent shadow-none"
+                    />
+                    {pendingChoice === iconId ? (
+                      <Loader2 className="absolute top-1 right-1 size-3 animate-spin text-primary" />
+                    ) : isSelected ? (
+                      <Check className="absolute top-1 right-1 size-3 text-primary" strokeWidth={3} />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 rounded-xl bg-muted/35 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-background ring-1 ring-border">
+                <Type aria-hidden="true" className="size-4 text-muted-foreground" />
+              </span>
+              <div>
+                <p className="text-sm font-medium">{t('initialsTitle')}</p>
+                <p className="text-xs leading-5 text-muted-foreground">{t('initialsDescription')}</p>
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant={profile.avatarKind === 'initials' ? 'secondary' : 'outline'}
+              size="sm"
+              disabled={isBusy}
+              onClick={() => void updateChoice('initials')}
+            >
+              {pendingChoice === 'initials' ? <Loader2 className="animate-spin" /> : null}
+              {profile.avatarKind === 'initials' ? t('selected') : t('useInitials')}
+            </Button>
+          </div>
+
+          <p className="sr-only" aria-live="polite">
+            {pendingChoice ? t('saving') : ''}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/components/user-profile/ProfileAppearanceEditor.tsx
+++ b/app/components/user-profile/ProfileAppearanceEditor.tsx
@@ -45,6 +45,7 @@ export function ProfileAppearanceEditor({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [profile, setProfile] = useState(initialProfile);
   const [pendingChoice, setPendingChoice] = useState<string | null>(null);
+  const [pendingImageUrl, setPendingImageUrl] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
 
   const updateChoice = async (avatarKind: 'icon' | 'initials', iconId?: UserAvatarIconId) => {
@@ -79,6 +80,8 @@ export function ProfileAppearanceEditor({
       return;
     }
 
+    const previewUrl = URL.createObjectURL(file);
+    setPendingImageUrl(previewUrl);
     setPendingChoice('image');
     try {
       const formData = new FormData();
@@ -94,6 +97,8 @@ export function ProfileAppearanceEditor({
       console.warn('[UserProfile] Failed to upload avatar image.', error);
       toast.error(t('updateFailed'));
     } finally {
+      URL.revokeObjectURL(previewUrl);
+      setPendingImageUrl(null);
       setPendingChoice(null);
       if (fileInputRef.current) fileInputRef.current.value = '';
     }
@@ -110,6 +115,9 @@ export function ProfileAppearanceEditor({
   };
 
   const isBusy = Boolean(pendingChoice);
+  const previewProfile: ResolvedUserProfile = pendingImageUrl
+    ? { ...profile, avatarKind: 'image', iconId: null, imageUrl: pendingImageUrl }
+    : profile;
 
   return (
     <section
@@ -123,7 +131,7 @@ export function ProfileAppearanceEditor({
             <p className="mb-4 text-xs font-semibold tracking-[0.14em] text-muted-foreground uppercase">
               {t('previewLabel')}
             </p>
-            <UserAvatar profile={profile} className="size-20 text-4xl" />
+            <UserAvatar profile={previewProfile} className="size-20 text-4xl" />
           </div>
           <div className="relative mt-6 min-w-0">
             <p className="truncate text-lg font-semibold">{profile.name}</p>

--- a/app/components/user-profile/ProfileAppearanceEditor.tsx
+++ b/app/components/user-profile/ProfileAppearanceEditor.tsx
@@ -45,7 +45,6 @@ export function ProfileAppearanceEditor({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [profile, setProfile] = useState(initialProfile);
   const [pendingChoice, setPendingChoice] = useState<string | null>(null);
-  const [pendingImageUrl, setPendingImageUrl] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
 
   const updateChoice = async (avatarKind: 'icon' | 'initials', iconId?: UserAvatarIconId) => {
@@ -80,8 +79,6 @@ export function ProfileAppearanceEditor({
       return;
     }
 
-    const previewUrl = URL.createObjectURL(file);
-    setPendingImageUrl(previewUrl);
     setPendingChoice('image');
     try {
       const formData = new FormData();
@@ -97,8 +94,6 @@ export function ProfileAppearanceEditor({
       console.warn('[UserProfile] Failed to upload avatar image.', error);
       toast.error(t('updateFailed'));
     } finally {
-      URL.revokeObjectURL(previewUrl);
-      setPendingImageUrl(null);
       setPendingChoice(null);
       if (fileInputRef.current) fileInputRef.current.value = '';
     }
@@ -115,9 +110,6 @@ export function ProfileAppearanceEditor({
   };
 
   const isBusy = Boolean(pendingChoice);
-  const previewProfile: ResolvedUserProfile = pendingImageUrl
-    ? { ...profile, avatarKind: 'image', iconId: null, imageUrl: pendingImageUrl }
-    : profile;
 
   return (
     <section
@@ -131,7 +123,7 @@ export function ProfileAppearanceEditor({
             <p className="mb-4 text-xs font-semibold tracking-[0.14em] text-muted-foreground uppercase">
               {t('previewLabel')}
             </p>
-            <UserAvatar profile={previewProfile} className="size-20 text-4xl" />
+            <UserAvatar profile={profile} className="size-20 text-4xl" />
           </div>
           <div className="relative mt-6 min-w-0">
             <p className="truncate text-lg font-semibold">{profile.name}</p>

--- a/app/components/user-profile/UserAvatar.tsx
+++ b/app/components/user-profile/UserAvatar.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState, type ComponentType, type SVGProps } from 'react';
+import {
+  BookOpen,
+  Camera,
+  Code2,
+  Coffee,
+  Leaf,
+  Mountain,
+  Music2,
+  Palette,
+  Rocket,
+  Smile,
+  Sparkles,
+  UserRound,
+} from 'lucide-react';
+
+import type { ResolvedUserProfile } from '@/app/lib/user-profile/types';
+import type { UserAvatarIconId } from '@/app/lib/user-profile/icon-catalog';
+import { cn } from '@/lib/utils';
+
+type AvatarIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+export const USER_AVATAR_ICONS: Record<UserAvatarIconId, AvatarIcon> = {
+  'user-round': UserRound,
+  smile: Smile,
+  sparkles: Sparkles,
+  rocket: Rocket,
+  palette: Palette,
+  'code-2': Code2,
+  'book-open': BookOpen,
+  camera: Camera,
+  music: Music2,
+  coffee: Coffee,
+  mountain: Mountain,
+  leaf: Leaf,
+};
+
+export function UserAvatar({
+  profile,
+  className,
+  iconClassName,
+}: {
+  profile: ResolvedUserProfile;
+  className?: string;
+  iconClassName?: string;
+}) {
+  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
+  const Icon = profile.iconId
+    ? USER_AVATAR_ICONS[profile.iconId as UserAvatarIconId]
+    : undefined;
+  const showImage = profile.avatarKind === 'image'
+    && Boolean(profile.imageUrl)
+    && failedImageUrl !== profile.imageUrl;
+
+  return (
+    <span
+      className={cn(
+        'relative inline-flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-xl',
+        'border border-border/70 bg-gradient-to-br from-primary/15 via-background to-accent text-foreground shadow-sm',
+        className,
+      )}
+      data-avatar-kind={showImage ? 'image' : profile.avatarKind}
+    >
+      {showImage ? (
+        // The file is already normalized server-side; an img element also lets us fall back on load errors.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          alt=""
+          className="size-full object-cover"
+          src={profile.imageUrl ?? undefined}
+          onError={() => setFailedImageUrl(profile.imageUrl)}
+        />
+      ) : profile.avatarKind === 'icon' && Icon ? (
+        <Icon aria-hidden="true" className={cn('size-1/2', iconClassName)} strokeWidth={1.8} />
+      ) : profile.initials ? (
+        <span className="select-none text-[0.38em] font-semibold uppercase tracking-[0.08em]">
+          {profile.initials}
+        </span>
+      ) : (
+        <UserRound aria-hidden="true" className={cn('size-1/2', iconClassName)} strokeWidth={1.8} />
+      )}
+    </span>
+  );
+}

--- a/app/components/user-profile/UserProfileBadge.tsx
+++ b/app/components/user-profile/UserProfileBadge.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { ResolvedUserProfile } from '@/app/lib/user-profile/types';
+import { Link } from '@/i18n/navigation';
+import { cn } from '@/lib/utils';
+import { UserAvatar } from './UserAvatar';
+
+export function UserProfileBadge({
+  profile,
+  href = '/settings',
+  className,
+}: {
+  profile: ResolvedUserProfile;
+  href?: string;
+  className?: string;
+}) {
+  const t = useTranslations('userProfile');
+
+  return (
+    <Link
+      href={href}
+      aria-label={t('profileLinkLabel', { name: profile.name })}
+      className={cn(
+        'group inline-flex min-w-0 items-center gap-2 rounded-xl px-2 py-1.5',
+        'text-sm font-medium outline-none transition-colors hover:bg-accent',
+        'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        className,
+      )}
+    >
+      <UserAvatar profile={profile} className="size-9 transition-transform group-hover:scale-[1.03]" />
+      <span className="hidden max-w-40 truncate sm:inline">{profile.name}</span>
+    </Link>
+  );
+}

--- a/app/lib/mobile/bootstrap.ts
+++ b/app/lib/mobile/bootstrap.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import type { MobileCompatibility } from './compatibility';
 import type { WorkspaceListing } from '@/app/lib/workspaces/listing-action';
 import type { WorkspaceContext, WorkspacePermissions, WorkspaceUserRole } from '@/app/lib/workspaces/types';
+import { buildPublicRequestUrl } from '@/app/lib/utils/request-origin';
 
 export type MobileWorkspaceAccess = 'manage' | 'edit' | 'read';
 
@@ -71,6 +72,10 @@ function normalizeRole(value: string | null | undefined): WorkspaceUserRole {
 
 export function createMobileBootstrap(input: {
   compatibility: MobileCompatibility;
+  request: {
+    headers: Pick<Headers, 'get'>;
+    url: string | URL;
+  };
   user: {
     id: string;
     name?: string | null;
@@ -169,7 +174,7 @@ export function createMobileBootstrap(input: {
       id: input.user.id,
       name: input.user.name?.trim() || input.user.email,
       email: input.user.email,
-      image: input.user.image || null,
+      image: resolveMobileUserImageUrl(input.user.image, input.request),
       role: normalizeRole(input.user.role),
     },
     workspace: {
@@ -181,4 +186,23 @@ export function createMobileBootstrap(input: {
       items: input.listing.workspaces.map(serializeMobileWorkspace),
     },
   };
+}
+
+function resolveMobileUserImageUrl(
+  value: string | null | undefined,
+  request: { headers: Pick<Headers, 'get'>; url: string | URL },
+): string | null {
+  const imageUrl = value?.trim();
+  if (!imageUrl) return null;
+  if (imageUrl.startsWith('/')) {
+    return buildPublicRequestUrl(request, imageUrl).toString();
+  }
+  try {
+    const parsed = new URL(imageUrl);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.toString()
+      : null;
+  } catch {
+    return null;
+  }
 }

--- a/app/lib/user-profile/icon-catalog.ts
+++ b/app/lib/user-profile/icon-catalog.ts
@@ -1,0 +1,26 @@
+export const USER_AVATAR_ICON_IDS = [
+  'user-round',
+  'smile',
+  'sparkles',
+  'rocket',
+  'palette',
+  'code-2',
+  'book-open',
+  'camera',
+  'music',
+  'coffee',
+  'mountain',
+  'leaf',
+] as const;
+
+export type UserAvatarIconId = typeof USER_AVATAR_ICON_IDS[number];
+
+const USER_AVATAR_ICON_ID_SET = new Set<string>(USER_AVATAR_ICON_IDS);
+
+export function normalizeUserAvatarIconId(value: unknown): UserAvatarIconId | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  return USER_AVATAR_ICON_ID_SET.has(normalized)
+    ? normalized as UserAvatarIconId
+    : null;
+}

--- a/app/lib/user-profile/initials.ts
+++ b/app/lib/user-profile/initials.ts
@@ -1,0 +1,34 @@
+function firstGrapheme(value: string, locale?: string): string {
+  if (typeof Intl.Segmenter === 'function') {
+    const segmenter = new Intl.Segmenter(locale, { granularity: 'grapheme' });
+    return segmenter.segment(value)[Symbol.iterator]().next().value?.segment ?? '';
+  }
+  return Array.from(value)[0] ?? '';
+}
+
+function identityTokens(value: string): string[] {
+  return value
+    .trim()
+    .split(/[\s\p{Z}._\-–—]+/u)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function getUserInitials(input: {
+  name?: string | null;
+  email?: string | null;
+  locale?: string;
+}): string {
+  const normalizedName = input.name?.trim() ?? '';
+  const emailLocalPart = input.email?.split('@')[0]?.trim() ?? '';
+  const tokens = identityTokens(normalizedName || emailLocalPart);
+  if (tokens.length === 0) return '';
+
+  const selected = tokens.length === 1
+    ? [tokens[0]]
+    : [tokens[0], tokens[tokens.length - 1]];
+  return selected
+    .map((token) => firstGrapheme(token, input.locale))
+    .join('')
+    .toLocaleUpperCase(input.locale);
+}

--- a/app/lib/user-profile/service.ts
+++ b/app/lib/user-profile/service.ts
@@ -1,0 +1,174 @@
+import 'server-only';
+
+import { eq } from 'drizzle-orm';
+
+import { withKeyedOperationLock } from '@/app/lib/concurrency/keyed-operation-lock';
+import { db } from '@/app/lib/db';
+import { user } from '@/app/lib/db/schema';
+import { getUserInitials } from './initials';
+import {
+  normalizeUserAvatarIconId,
+  type UserAvatarIconId,
+} from './icon-catalog';
+import {
+  deleteUserProfileAvatar,
+  readUserProfileAppearance,
+  readUserProfileAvatar,
+  restoreUserProfileStorage,
+  snapshotUserProfileStorage,
+  writeUserProfileAppearance,
+  writeUserProfileAvatar,
+} from './storage';
+import type {
+  ResolvedUserProfile,
+  UserAvatarKind,
+  UserProfileAppearance,
+} from './types';
+
+const USER_PROFILE_WRITE_LOCK_NAMESPACE = 'user-profile-write';
+
+export class UserProfileError extends Error {
+  constructor(
+    message: string,
+    public readonly status = 400,
+  ) {
+    super(message);
+    this.name = 'UserProfileError';
+  }
+}
+
+function nextAppearance(
+  current: UserProfileAppearance,
+  input: { avatarKind: UserAvatarKind; iconId?: UserAvatarIconId | null },
+): UserProfileAppearance {
+  return {
+    version: 1,
+    avatarKind: input.avatarKind,
+    iconId: input.avatarKind === 'icon' ? input.iconId ?? null : null,
+    revision: current.revision + 1,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function profileImageUrl(revision: number): string {
+  return `/api/account/profile/avatar?v=${revision}`;
+}
+
+async function readDatabaseImage(userId: string): Promise<string | null> {
+  const rows = await db
+    .select({ image: user.image })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+  if (!rows[0]) throw new UserProfileError('User profile not found.', 404);
+  return rows[0].image ?? null;
+}
+
+async function updateDatabaseImage(userId: string, image: string | null): Promise<void> {
+  await db
+    .update(user)
+    .set({ image, updatedAt: new Date() })
+    .where(eq(user.id, userId));
+}
+
+export async function resolveUserProfile(input: {
+  userId: string;
+  name?: string | null;
+  email?: string | null;
+  locale?: string;
+}): Promise<ResolvedUserProfile> {
+  const appearance = await readUserProfileAppearance(input.userId);
+  const imageAvailable = appearance.avatarKind === 'image'
+    ? Boolean(await readUserProfileAvatar(input.userId))
+    : false;
+  const iconId = appearance.avatarKind === 'icon'
+    ? normalizeUserAvatarIconId(appearance.iconId)
+    : null;
+  const avatarKind: UserAvatarKind = imageAvailable
+    ? 'image'
+    : iconId ? 'icon' : 'initials';
+  const name = input.name?.trim() || input.email?.trim() || 'User';
+
+  return {
+    name,
+    avatarKind,
+    iconId: avatarKind === 'icon' ? iconId : null,
+    initials: getUserInitials({ name, email: input.email, locale: input.locale }),
+    imageUrl: avatarKind === 'image' ? profileImageUrl(appearance.revision) : null,
+    revision: appearance.revision,
+  };
+}
+
+async function runProfileMutation(
+  userId: string,
+  operation: (current: UserProfileAppearance) => Promise<UserProfileAppearance>,
+): Promise<UserProfileAppearance> {
+  return withKeyedOperationLock(USER_PROFILE_WRITE_LOCK_NAMESPACE, userId, async () => {
+    const previousDatabaseImage = await readDatabaseImage(userId);
+    const storageSnapshot = await snapshotUserProfileStorage(userId);
+    const current = await readUserProfileAppearance(userId);
+    try {
+      return await operation(current);
+    } catch (error) {
+      await restoreUserProfileStorage(userId, storageSnapshot).catch((restoreError) => {
+        console.error('[UserProfile] Failed to restore profile storage after a mutation error.', restoreError);
+      });
+      await updateDatabaseImage(userId, previousDatabaseImage).catch((restoreError) => {
+        console.error('[UserProfile] Failed to restore profile metadata after a mutation error.', restoreError);
+      });
+      throw error;
+    }
+  });
+}
+
+export async function saveUserProfileImage(input: {
+  userId: string;
+  buffer: Buffer;
+}): Promise<UserProfileAppearance> {
+  return runProfileMutation(input.userId, async (current) => {
+    const appearance = nextAppearance(current, { avatarKind: 'image' });
+    await writeUserProfileAvatar(input.userId, input.buffer);
+    await writeUserProfileAppearance(input.userId, appearance);
+    await updateDatabaseImage(input.userId, profileImageUrl(appearance.revision));
+    return appearance;
+  });
+}
+
+export async function selectUserProfileIcon(input: {
+  userId: string;
+  iconId: unknown;
+}): Promise<UserProfileAppearance> {
+  const iconId = normalizeUserAvatarIconId(input.iconId);
+  if (!iconId) throw new UserProfileError('Unsupported profile icon.');
+
+  return runProfileMutation(input.userId, async (current) => {
+    const appearance = nextAppearance(current, { avatarKind: 'icon', iconId });
+    await deleteUserProfileAvatar(input.userId);
+    await writeUserProfileAppearance(input.userId, appearance);
+    await updateDatabaseImage(input.userId, null);
+    return appearance;
+  });
+}
+
+export async function selectUserProfileInitials(userId: string): Promise<UserProfileAppearance> {
+  return runProfileMutation(userId, async (current) => {
+    const appearance = nextAppearance(current, { avatarKind: 'initials' });
+    await deleteUserProfileAvatar(userId);
+    await writeUserProfileAppearance(userId, appearance);
+    await updateDatabaseImage(userId, null);
+    return appearance;
+  });
+}
+
+export async function readUserProfileImage(userId: string): Promise<{
+  buffer: Buffer;
+  revision: number;
+  updatedAt: string | null;
+} | null> {
+  const [appearance, buffer] = await Promise.all([
+    readUserProfileAppearance(userId),
+    readUserProfileAvatar(userId),
+  ]);
+  if (appearance.avatarKind !== 'image' || !buffer) return null;
+  return { buffer, revision: appearance.revision, updatedAt: appearance.updatedAt };
+}

--- a/app/lib/user-profile/storage.ts
+++ b/app/lib/user-profile/storage.ts
@@ -1,0 +1,182 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { fileTypeFromBuffer } from 'file-type';
+
+import {
+  normalizeDataScopeId,
+  resolveUserDataRoot,
+} from '@/app/lib/runtime-data-paths';
+import { normalizeUserAvatarIconId } from './icon-catalog';
+import {
+  USER_PROFILE_APPEARANCE_VERSION,
+  type UserProfileAppearance,
+} from './types';
+
+export const USER_PROFILE_DIRECTORY_NAME = 'profile';
+export const USER_PROFILE_APPEARANCE_FILE_NAME = 'appearance.json';
+export const USER_PROFILE_AVATAR_FILE_NAME = 'avatar.webp';
+export const USER_PROFILE_AVATAR_MAX_STORED_BYTES = 256 * 1024;
+
+const USER_PROFILE_APPEARANCE_MAX_BYTES = 16 * 1024;
+
+export type UserProfileStorageSnapshot = {
+  appearance: Buffer | null;
+  avatar: Buffer | null;
+};
+
+function isMissingFileError(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT');
+}
+
+export function createDefaultUserProfileAppearance(): UserProfileAppearance {
+  return {
+    version: USER_PROFILE_APPEARANCE_VERSION,
+    avatarKind: 'initials',
+    iconId: null,
+    revision: 0,
+    updatedAt: null,
+  };
+}
+
+function normalizeUserProfileAppearance(value: unknown): UserProfileAppearance | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const avatarKind = record.avatarKind;
+  if (avatarKind !== 'image' && avatarKind !== 'icon' && avatarKind !== 'initials') return null;
+  const iconId = normalizeUserAvatarIconId(record.iconId);
+  if (avatarKind === 'icon' && !iconId) return null;
+  const revision = Number(record.revision);
+  if (!Number.isSafeInteger(revision) || revision < 0) return null;
+
+  return {
+    version: USER_PROFILE_APPEARANCE_VERSION,
+    avatarKind,
+    iconId: avatarKind === 'icon' ? iconId : null,
+    revision,
+    updatedAt: typeof record.updatedAt === 'string' && record.updatedAt.trim()
+      ? record.updatedAt
+      : null,
+  };
+}
+
+export function resolveUserProfileDirectory(userId: string, cwd?: string): string {
+  const normalizedUserId = normalizeDataScopeId(userId, 'userId');
+  return path.join(resolveUserDataRoot(normalizedUserId, cwd), USER_PROFILE_DIRECTORY_NAME);
+}
+
+export function resolveUserProfileAppearancePath(userId: string, cwd?: string): string {
+  return path.join(resolveUserProfileDirectory(userId, cwd), USER_PROFILE_APPEARANCE_FILE_NAME);
+}
+
+export function resolveUserProfileAvatarPath(userId: string, cwd?: string): string {
+  return path.join(resolveUserProfileDirectory(userId, cwd), USER_PROFILE_AVATAR_FILE_NAME);
+}
+
+async function readFileIfExists(filePath: string, maxBytes?: number): Promise<Buffer | null> {
+  try {
+    const stats = await fs.stat(filePath);
+    if (!stats.isFile() || stats.size <= 0 || (maxBytes !== undefined && stats.size > maxBytes)) {
+      return null;
+    }
+    return await fs.readFile(filePath);
+  } catch (error) {
+    if (isMissingFileError(error)) return null;
+    throw error;
+  }
+}
+
+async function writeFileAtomic(filePath: string, buffer: Buffer): Promise<void> {
+  const directory = path.dirname(filePath);
+  await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+  await fs.chmod(directory, 0o700).catch(() => undefined);
+  const temporaryPath = path.join(directory, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
+  try {
+    await fs.writeFile(temporaryPath, buffer, { mode: 0o600, flag: 'wx' });
+    await fs.rename(temporaryPath, filePath);
+    await fs.chmod(filePath, 0o600).catch(() => undefined);
+  } finally {
+    await fs.unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+async function restoreFile(filePath: string, buffer: Buffer | null): Promise<void> {
+  if (buffer) {
+    await writeFileAtomic(filePath, buffer);
+    return;
+  }
+  await fs.unlink(filePath).catch((error) => {
+    if (!isMissingFileError(error)) throw error;
+  });
+}
+
+export async function readUserProfileAppearance(userId: string): Promise<UserProfileAppearance> {
+  const buffer = await readFileIfExists(
+    resolveUserProfileAppearancePath(userId),
+    USER_PROFILE_APPEARANCE_MAX_BYTES,
+  );
+  if (!buffer) return createDefaultUserProfileAppearance();
+  try {
+    return normalizeUserProfileAppearance(JSON.parse(buffer.toString('utf8')))
+      ?? createDefaultUserProfileAppearance();
+  } catch {
+    return createDefaultUserProfileAppearance();
+  }
+}
+
+export async function writeUserProfileAppearance(
+  userId: string,
+  appearance: UserProfileAppearance,
+): Promise<void> {
+  const normalized = normalizeUserProfileAppearance(appearance);
+  if (!normalized) throw new Error('Invalid user profile appearance.');
+  await writeFileAtomic(
+    resolveUserProfileAppearancePath(userId),
+    Buffer.from(`${JSON.stringify(normalized, null, 2)}\n`, 'utf8'),
+  );
+}
+
+export async function readUserProfileAvatar(userId: string): Promise<Buffer | null> {
+  const buffer = await readFileIfExists(
+    resolveUserProfileAvatarPath(userId),
+    USER_PROFILE_AVATAR_MAX_STORED_BYTES,
+  );
+  if (!buffer) return null;
+  const detected = await fileTypeFromBuffer(buffer).catch(() => undefined);
+  return detected?.mime === 'image/webp' ? buffer : null;
+}
+
+export async function writeUserProfileAvatar(userId: string, buffer: Buffer): Promise<void> {
+  if (buffer.length === 0 || buffer.length > USER_PROFILE_AVATAR_MAX_STORED_BYTES) {
+    throw new Error('Invalid stored avatar size.');
+  }
+  const detected = await fileTypeFromBuffer(buffer).catch(() => undefined);
+  if (detected?.mime !== 'image/webp') {
+    throw new Error('Stored avatar must be a WebP image.');
+  }
+  await writeFileAtomic(resolveUserProfileAvatarPath(userId), buffer);
+}
+
+export async function deleteUserProfileAvatar(userId: string): Promise<void> {
+  await fs.unlink(resolveUserProfileAvatarPath(userId)).catch((error) => {
+    if (!isMissingFileError(error)) throw error;
+  });
+}
+
+export async function snapshotUserProfileStorage(userId: string): Promise<UserProfileStorageSnapshot> {
+  return {
+    appearance: await readFileIfExists(resolveUserProfileAppearancePath(userId)),
+    avatar: await readFileIfExists(resolveUserProfileAvatarPath(userId)),
+  };
+}
+
+export async function restoreUserProfileStorage(
+  userId: string,
+  snapshot: UserProfileStorageSnapshot,
+): Promise<void> {
+  await restoreFile(resolveUserProfileAppearancePath(userId), snapshot.appearance);
+  await restoreFile(resolveUserProfileAvatarPath(userId), snapshot.avatar);
+}

--- a/app/lib/user-profile/types.ts
+++ b/app/lib/user-profile/types.ts
@@ -1,0 +1,20 @@
+export const USER_PROFILE_APPEARANCE_VERSION = 1 as const;
+
+export type UserAvatarKind = 'image' | 'icon' | 'initials';
+
+export type UserProfileAppearance = {
+  version: typeof USER_PROFILE_APPEARANCE_VERSION;
+  avatarKind: UserAvatarKind;
+  iconId: string | null;
+  revision: number;
+  updatedAt: string | null;
+};
+
+export type ResolvedUserProfile = {
+  name: string;
+  avatarKind: UserAvatarKind;
+  iconId: string | null;
+  initials: string;
+  imageUrl: string | null;
+  revision: number;
+};

--- a/app/lib/user-profile/upload.ts
+++ b/app/lib/user-profile/upload.ts
@@ -1,0 +1,86 @@
+import 'server-only';
+
+import { fileTypeFromBuffer } from 'file-type';
+import sharp from 'sharp';
+
+import { USER_PROFILE_AVATAR_MAX_STORED_BYTES } from './storage';
+
+export const USER_PROFILE_AVATAR_MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+export const USER_PROFILE_AVATAR_SIZE_PX = 256;
+
+const USER_PROFILE_AVATAR_MAX_INPUT_PIXELS = 20_000_000;
+const ALLOWED_AVATAR_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+
+export class UserProfileUploadError extends Error {
+  constructor(
+    message: string,
+    public readonly status = 400,
+  ) {
+    super(message);
+    this.name = 'UserProfileUploadError';
+  }
+}
+
+async function encodeAvatar(buffer: Buffer, quality: number): Promise<Buffer> {
+  return sharp(buffer, {
+    failOn: 'error',
+    limitInputPixels: USER_PROFILE_AVATAR_MAX_INPUT_PIXELS,
+    pages: 1,
+  })
+    .rotate()
+    .resize(USER_PROFILE_AVATAR_SIZE_PX, USER_PROFILE_AVATAR_SIZE_PX, {
+      fit: 'cover',
+      position: 'centre',
+    })
+    .webp({ quality, alphaQuality: 92, effort: 4 })
+    .toBuffer();
+}
+
+export async function normalizeUserProfileUpload(buffer: Buffer): Promise<Buffer> {
+  if (buffer.length === 0) {
+    throw new UserProfileUploadError('The profile image is empty.');
+  }
+  if (buffer.length > USER_PROFILE_AVATAR_MAX_UPLOAD_BYTES) {
+    throw new UserProfileUploadError('Profile image is too large. Maximum size is 5 MB.', 413);
+  }
+
+  const detected = await fileTypeFromBuffer(buffer).catch(() => undefined);
+  if (!detected || !ALLOWED_AVATAR_MIME_TYPES.has(detected.mime)) {
+    throw new UserProfileUploadError('Unsupported image format. Use PNG, JPG, WebP, HEIC, or HEIF.');
+  }
+
+  try {
+    const metadata = await sharp(buffer, {
+      failOn: 'error',
+      limitInputPixels: USER_PROFILE_AVATAR_MAX_INPUT_PIXELS,
+      pages: 1,
+    }).metadata();
+    if (!metadata.width || !metadata.height) {
+      throw new UserProfileUploadError('The image dimensions could not be determined.');
+    }
+    if ((metadata.pages ?? 1) > 1) {
+      throw new UserProfileUploadError('Animated or multi-page profile images are not supported.');
+    }
+    if (metadata.width * metadata.height > USER_PROFILE_AVATAR_MAX_INPUT_PIXELS) {
+      throw new UserProfileUploadError('Profile image dimensions are too large.');
+    }
+
+    let output = await encodeAvatar(buffer, 88);
+    if (output.length > USER_PROFILE_AVATAR_MAX_STORED_BYTES) {
+      output = await encodeAvatar(buffer, 74);
+    }
+    if (output.length > USER_PROFILE_AVATAR_MAX_STORED_BYTES) {
+      throw new UserProfileUploadError('The processed profile image is still too large.');
+    }
+    return output;
+  } catch (error) {
+    if (error instanceof UserProfileUploadError) throw error;
+    throw new UserProfileUploadError('The uploaded file is not a valid supported image.');
+  }
+}

--- a/docs/architecture/canvas-notebook/user-profile-avatar/plan.md
+++ b/docs/architecture/canvas-notebook/user-profile-avatar/plan.md
@@ -1,7 +1,7 @@
 # Plan: persoenliches Benutzerprofil mit Foto, Icons und Initialen
 
 Stand: 2026-08-31  
-Status: geplant, noch nicht implementiert  
+Status: implementiert und technisch verifiziert
 Branch: `codex/user-profile-avatar-plan`
 
 ## Zielbild

--- a/docs/architecture/canvas-notebook/user-profile-avatar/plan.md
+++ b/docs/architecture/canvas-notebook/user-profile-avatar/plan.md
@@ -1,6 +1,6 @@
 # Plan: persoenliches Benutzerprofil mit Foto, Icons und Initialen
 
-Stand: 2026-08-31  
+Stand: 2026-08-31
 Status: implementiert und technisch verifiziert
 Branch: `codex/user-profile-avatar-plan`
 

--- a/docs/architecture/canvas-notebook/user-profile-avatar/plan.md
+++ b/docs/architecture/canvas-notebook/user-profile-avatar/plan.md
@@ -1,0 +1,423 @@
+# Plan: persoenliches Benutzerprofil mit Foto, Icons und Initialen
+
+Stand: 2026-08-31  
+Status: geplant, noch nicht implementiert  
+Branch: `codex/user-profile-avatar-plan`
+
+## Zielbild
+
+Jeder angemeldete Benutzer kann seine persoenliche Darstellung selbst waehlen:
+
+1. ein eigenes Profilfoto hochladen,
+2. alternativ ein Icon aus einem kuratierten Katalog auswaehlen oder
+3. die automatisch gebildeten Initialen verwenden.
+
+Auf der Startseite wird eine kompakte Profilanzeige aus Avatar und Benutzername dargestellt. Dieselbe Darstellung wird im persoenlichen Bereich der allgemeinen Einstellungen bearbeitet und bereits waehrend des persoenlichen Onboardings angeboten.
+
+Die Aufloesungsreihenfolge ist verbindlich:
+
+`hochgeladenes Foto -> ausgewaehltes Icon -> Initialen`
+
+Als Form wird fuer V1 ein abgerundetes Quadrat (`rounded-lg`) verwendet. Das passt zu den bestehenden kompakten Controls in Canvas Notebook und funktioniert gleich gut fuer Fotos, Icons und Initialen. Eine frei waehlbare Form ist nicht Teil von V1.
+
+## Bestehender Stand
+
+- Better Auth liefert bereits `session.user.name` und `session.user.image`.
+- Die Tabelle `user` besitzt bereits die Spalten `name` und `image`. Eine neue Profil- oder Bildspalte ist fuer V1 nicht erforderlich.
+- Die Startseite wird serverseitig in `app/[locale]/(routes)/page.tsx` aufgebaut.
+- Die allgemeinen persoenlichen Einstellungen liegen in `GeneralSettingsPanel` und zeigen den Namen bisher nur lesend an.
+- Das persoenliche Onboarding beginnt mit der Sprachauswahl. Der vorhandene spaetere Schritt `profile` erstellt dagegen das Profil des Canvas Agents und darf nicht fuer das Benutzerbild umgedeutet werden.
+- User-spezifische Dateien haben bereits einen vorgesehenen persistenten Bereich unter `/data/users/<userId>/`.
+- Fuer sichere Bildnormalisierung stehen `sharp`, `file-type`, multipart-Helfer und bestehende Logo-Upload-Muster zur Verfuegung.
+
+## Architekturentscheidung
+
+### Kein neuer Onboarding-Schritt
+
+Die Avatar-Auswahl wird als Abschnitt direkt in den vorhandenen `LanguageStep` integriert. Damit liegt sie wie gewuenscht bei der persoenlichen Sprachwahl, bleibt optional und fuehrt keine zweite Bedeutung fuer den bereits belegten Schritt `profile` ein.
+
+Diese Entscheidung vermeidet ausserdem eine Migration des zentralen `UserOnboardingState`. Die GitNexus-Analyse bewertet `normalizeUserOnboardingState` als `CRITICAL` (21 betroffene Symbole, 12 Module) und den allgemeinen Preferences-Writer als `HIGH`. Ein neuer resumierbarer Onboarding-Schritt waere fuer eine optionale Personalisierung unverhaeltnismaessig riskant.
+
+### Eigener User-Profile-Service
+
+Die Logik wird nicht in den allgemeinen User Preferences untergebracht. Ein eigener serverseitiger Service kapselt:
+
+- Lesen der effektiven Profildarstellung,
+- Validieren und Speichern einer Icon-Auswahl,
+- Bildnormalisierung und atomisches Ersetzen,
+- Entfernen eines Bildes,
+- Synchronisieren von `user.image`,
+- Revision und Cache-Busting sowie
+- den Fallback auf Initialen.
+
+Damit bleiben Locale-, E-Mail-, Mobile- und Agent-Preferences von den neuen Schreibpfaden unberuehrt.
+
+## Datenmodell und Speicherung
+
+### Persistente Dateien
+
+```text
+/data/users/<normalisierte-user-id>/profile/
+  appearance.json
+  avatar.webp
+```
+
+`appearance.json` ist die kanonische Auswahl fuer die Darstellung:
+
+```json
+{
+  "version": 1,
+  "avatarKind": "image",
+  "iconId": null,
+  "revision": 3,
+  "updatedAt": "2026-08-31T12:00:00.000Z"
+}
+```
+
+Zulaessige Werte fuer `avatarKind` sind `image`, `icon` und `initials`. `iconId` ist nur bei `icon` gesetzt und muss in der serverseitigen Allowlist enthalten sein.
+
+`user.image` enthaelt bei einem aktiven Foto nur eine stabile interne URL, beispielsweise `/api/account/profile/avatar?v=3`. Es werden weder Bilddaten noch absolute Dateisystempfade in der Datenbank gespeichert. Bei Icon oder Initialen wird `user.image` auf `null` gesetzt.
+
+Vorteile dieser Aufteilung:
+
+- keine Datenbankmigration fuer SQLite oder PostgreSQL,
+- keine Base64-Bilder in Session- oder API-Payloads,
+- persistente Sicherung zusammen mit dem bestehenden `/data`-Volume,
+- user-spezifische Isolation und einfache spaetere Bereinigung,
+- Better-Auth- und Mobile-Clients sehen ein Foto weiterhin ueber das bestehende Feld `image`.
+
+### Dateirechte und Konsistenz
+
+- Profilverzeichnis: Modus `0700`.
+- Dateien: Modus `0600`.
+- User-IDs werden ausschliesslich ueber `normalizeDataScopeId` in Pfade ueberfuehrt.
+- Schreibvorgaenge laufen unter einem per User gekeyten Lock.
+- `appearance.json` und `avatar.webp` werden ueber temporaere Dateien und atomisches Rename ersetzt.
+- Bei einem Fehler zwischen Dateischreibvorgang und DB-Update wird der vorherige Zustand wiederhergestellt oder der neue unvollstaendige Zustand entfernt.
+- Beim Wechsel zu Icon oder Initialen wird das alte Foto geloescht, damit keine unerwartet weiter gespeicherten personenbezogenen Bilddaten zurueckbleiben.
+- Eine Sperrung des Users behaelt die Dateien entsprechend dem bestehenden Recovery-Modell. Ein spaeterer Hard-Delete muss das Verzeichnis mit entfernen.
+
+## Bild-Pipeline
+
+Der Server akzeptiert genau eine Datei und vertraut weder Dateiendung noch Browser-MIME-Type.
+
+- Eingabeformate: PNG, JPEG, WebP und HEIC/HEIF, soweit der vorhandene Decoder sie sicher verarbeiten kann.
+- Maximale Request-/Dateigroesse: 5 MB.
+- Maximale Eingangspixelzahl: 20 Megapixel.
+- Animierte oder mehrseitige Dateien werden abgelehnt.
+- EXIF-Orientierung wird angewendet; Metadaten werden beim Neuschreiben entfernt.
+- Ausgabe: quadratisches WebP, 256 x 256 Pixel, `fit: cover`, mittiger Ausschnitt.
+- Zielgroesse: maximal 256 KB; bei Ueberschreitung wird mit niedrigerer Qualitaet erneut kodiert oder der Upload abgelehnt.
+- Kein Import ueber externe URLs. Dadurch entstehen weder SSRF- noch Tracking-Risiken.
+
+Ein eigenes Crop-UI ist nicht Teil von V1. Die Vorschau muss den tatsaechlichen mittigen Zuschnitt zeigen, bevor der Benutzer speichert.
+
+## Icon-Katalog
+
+Der Katalog wird als gemeinsame, versionierte Allowlist mit stabilen IDs definiert. Die UI importiert die zugehoerigen Lucide-Komponenten ueber eine explizite Map; der Server akzeptiert keine beliebigen Icon-Namen.
+
+Vorgesehene V1-Auswahl:
+
+| ID | Bedeutung |
+| --- | --- |
+| `user-round` | neutral/personenbezogen |
+| `smile` | freundlich |
+| `sparkles` | kreativ |
+| `rocket` | ambitioniert |
+| `palette` | Design/Kreativitaet |
+| `code-2` | Entwicklung |
+| `book-open` | Lernen/Wissen |
+| `camera` | Foto/Medien |
+| `music` | Musik |
+| `coffee` | Alltag/Fokus |
+| `mountain` | Outdoor/Ziele |
+| `leaf` | Natur/Ruhe |
+
+Die Auswahl bleibt bewusst klein und eindeutig. Bezeichnungen und Hilfetexte werden in Deutsch und Englisch uebersetzt. Farbe und Hintergrund folgen in V1 dem Theme; eine eigene Farbauswahl ist ein moeglicher spaeterer Ausbau.
+
+## Initialen-Fallback
+
+Eine reine Helper-Funktion erzeugt hoechstens zwei Unicode-faehige Initialen:
+
+- Vor- und Nachname: erstes Graphem des ersten und letzten Namensbestandteils (`Alex Weber -> AW`).
+- Einteiliger Name: erstes Graphem.
+- Leerzeichen und Bindestriche werden robust normalisiert.
+- Wenn der Name wider Erwarten leer ist, wird der lokale Teil der E-Mail verwendet.
+- Wenn auch dieser fehlt, wird ein neutrales User-Icon dargestellt.
+- Die Grossschreibung erfolgt locale-aware; Zeichen ausserhalb des ASCII-Bereichs duerfen nicht abgeschnitten werden.
+
+Die Funktion wird separat getestet, damit Startseite, Settings und Onboarding exakt denselben Fallback anzeigen.
+
+## API-Vertrag
+
+Alle Endpunkte arbeiten ausschliesslich auf dem aktuell authentifizierten User. Ein `userId` aus Query oder Body wird nicht akzeptiert.
+
+### `GET /api/account/profile`
+
+Liefert die effektive Darstellung:
+
+```json
+{
+  "success": true,
+  "data": {
+    "name": "Alex Weber",
+    "avatarKind": "icon",
+    "iconId": "sparkles",
+    "initials": "AW",
+    "imageUrl": null,
+    "revision": 3
+  }
+}
+```
+
+### `PATCH /api/account/profile`
+
+Erlaubte Bodies:
+
+```json
+{ "avatarKind": "icon", "iconId": "sparkles" }
+```
+
+oder
+
+```json
+{ "avatarKind": "initials" }
+```
+
+Der Wechsel entfernt ein vorhandenes Foto, setzt `user.image` auf `null` und liefert das vollstaendig aufgeloeste Profil zurueck.
+
+### `GET /api/account/profile/avatar?v=<revision>`
+
+Liefert nur das eigene normalisierte Bild mit:
+
+- `Content-Type: image/webp`,
+- `X-Content-Type-Options: nosniff`,
+- privatem Cache und revisionsbasierter URL sowie
+- `ETag` beziehungsweise `Last-Modified` fuer effiziente Wiederholungsaufrufe.
+
+Der Endpunkt bleibt authentifiziert. Eine spaetere Anzeige fremder Benutzerbilder in Collaboration-Ansichten braucht einen getrennten ACL-bewussten Vertrag und wird nicht stillschweigend ueber diesen Self-Endpunkt geloest.
+
+### `POST /api/account/profile/avatar`
+
+Multipart-Upload mit exakt einem Feld `file`. Der Endpunkt validiert Groesse, Magic Bytes, Dimensionen und Bildtyp, normalisiert das Bild, setzt `avatarKind=image`, aktualisiert `user.image` und liefert das aufgeloeste Profil zurueck.
+
+### `DELETE /api/account/profile/avatar`
+
+Loescht das Foto, setzt `user.image` auf `null` und faellt auf Initialen zurueck. Eine Icon-Auswahl erfolgt explizit ueber den PATCH-Endpunkt.
+
+### Schutzmassnahmen
+
+- Session-Pruefung vor dem Parsen grosser Bodies.
+- Same-Origin-/CSRF-Pruefung fuer Mutationen.
+- Rate Limit, zum Beispiel 10 Mutationen pro Minute und User/IP.
+- Content-Length-Pruefung vor `request.formData()` und zusaetzliche File-Size-Pruefung danach.
+- Keine User-ID und keine Dateipfade in Fehlermeldungen oder Logs.
+- Keine Bildinhalte in Sentry oder normalen Logs.
+
+## Gemeinsame UI-Komponenten
+
+### `UserAvatar`
+
+Eine kleine presentational component erhaelt `name`, `imageUrl`, `iconId`, Groesse und optionale Klassen. Sie entscheidet nicht selbst ueber Storage oder Fetching.
+
+- Foto: `<img>` mit `object-cover` und internem authentifiziertem Endpunkt.
+- Icon: explizit gemappte Lucide-Komponente.
+- Fallback: Initialen.
+- Standardform: abgerundetes Quadrat.
+- Fehler beim Laden eines Bildes wechseln clientseitig auf Icon beziehungsweise Initialen.
+- Aussagekraeftiger Alt-Text beziehungsweise accessible Name; dekorative Icon-Pfade selbst sind `aria-hidden`.
+
+### `UserProfileBadge`
+
+Kombiniert Avatar und gekuerzten Namen. Auf kleinen Viewports bleibt mindestens der Avatar sichtbar, der volle Name bleibt fuer Screenreader verfuegbar. Auf groesseren Viewports wird der Name visuell angezeigt.
+
+### `ProfileAppearanceEditor`
+
+Wird von Settings und Onboarding gemeinsam verwendet:
+
+- aktuelle Vorschau mit Name,
+- Datei-Auswahl inklusive Drop-/Choose-UI,
+- Icon-Grid mit klar erkennbarem Auswahlzustand,
+- Option „Initialen verwenden“,
+- Upload-/Speicherzustand und lokale Validierungsfehler,
+- Entfernen/Ersetzen des vorhandenen Fotos,
+- keine optimistische dauerhafte Anzeige vor erfolgreicher Serverantwort.
+
+## Einbindung in die Oberflaechen
+
+### Startseite
+
+In `app/[locale]/(routes)/page.tsx` wird das Profil serverseitig gemeinsam mit der Session aufgeloest. Im rechten Headerbereich erscheint `UserProfileBadge` vor dem Logout-Button und verlinkt auf `/<locale>/settings?tab=general`.
+
+- Desktop/Tablet: Avatar plus gekuerzter Name.
+- Sehr schmale Viewports: Avatar sichtbar, Name visuell ausgeblendet, aber accessible.
+- Kein zusaetzlicher Client-Fetch beim ersten Rendern.
+
+### Persoenliche Einstellungen
+
+Im allgemeinen Settings-Bereich wird vor den Login-Informationen ein eigener Accordion-Abschnitt „Persoenliches Profil“ eingefuegt. Er verwendet `ProfileAppearanceEditor` und liegt damit in derselben persoenlichen Umgebung wie Sprache und Zeitzone.
+
+Der Name bleibt in V1 lesend und kommt aus Better Auth. Eine spaetere Selbstbearbeitung des Namens ist eine gesonderte Entscheidung, weil der Name auch Collaboration-Attribution, Admin-Ansichten und Auditdarstellung beeinflusst.
+
+### Persoenliches Onboarding
+
+Der bestehende `LanguageStep` erhaelt nach der Sprachauswahl einen klar getrennten Abschnitt „So wirst du angezeigt“. Die Seite uebergibt den bestehenden Namen und den aufgeloesten Avatarzustand als Initialdaten an den Wizard.
+
+- Foto, Icon und Initialen werden sofort ueber die Profil-API gespeichert.
+- Die Personalisierung ist optional; ohne Aktion funktioniert „Weiter“ und die Initialen erscheinen automatisch.
+- Ein fehlgeschlagener Upload blockiert nicht das gesamte Onboarding. Der Fehler wird angezeigt, und der Benutzer kann Icon, Initialen oder spaeteres Bearbeiten waehlen.
+- Ein Locale-Wechsel laedt den Wizard wie bisher neu; eine bereits gespeicherte Avatar-Auswahl bleibt serverseitig erhalten.
+- Der spaetere bestehende `profile`-Schritt bleibt unveraendert der Canvas-Agent-Personalisierung vorbehalten.
+
+## Erwartete Dateien bei der Implementierung
+
+Neue Dateien:
+
+- `app/lib/user-profile/types.ts`
+- `app/lib/user-profile/icon-catalog.ts`
+- `app/lib/user-profile/initials.ts`
+- `app/lib/user-profile/service.ts`
+- `app/lib/user-profile/upload.ts`
+- `app/api/account/profile/route.ts`
+- `app/api/account/profile/avatar/route.ts`
+- `app/components/user-profile/UserAvatar.tsx`
+- `app/components/user-profile/UserProfileBadge.tsx`
+- `app/components/user-profile/ProfileAppearanceEditor.tsx`
+- gezielte Service-, API- und UI-Tests unter `scripts/`
+
+Bestehende Dateien mit voraussichtlichen Anpassungen:
+
+- `app/[locale]/(routes)/page.tsx`
+- `app/[locale]/(routes)/settings/page.tsx`
+- `app/[locale]/(routes)/onboarding/page.tsx`
+- `app/[locale]/(routes)/onboarding/onboarding-wizard.tsx`
+- `app/components/settings/IntegrationsSettingsClient.tsx`
+- `app/components/settings/GeneralSettingsPanel.tsx`
+- `messages/de.json`
+- `messages/en.json`
+
+`app/lib/db/schema.ts`, `app/lib/db/migrate.ts` und der zentrale `UserOnboardingState` sollen nach aktueller Planung nicht geaendert werden.
+
+## Sequenzieller Umsetzungsplan
+
+Die Todos werden gemaess Repository-Regel streng nacheinander abgeschlossen und jeweils separat committed.
+
+### 1. Domain-Modell und Storage-Service
+
+- Typen, Icon-Allowlist und Initialen-Helper anlegen.
+- Pfadauflosung unter `/data/users/<userId>/profile` implementieren.
+- atomare JSON-/Bild-Schreibvorgaenge, Revision und DB-Synchronisierung implementieren.
+- Service-Tests fuer Lesen, Foto/Icon/Initialen-Wechsel, Parallelzugriffe und Recovery abschliessen.
+
+Abnahmekriterium: Der Service kann jeden Zustand ohne UI und ohne API reproduzierbar aufloesen; keine Aenderung am zentralen Preferences- oder Onboarding-State.
+
+### 2. Authentifizierte Profil-API
+
+- Metadata-, Auswahl- und Avatar-Endpunkte implementieren.
+- Upload-Limits, Magic-Byte-Validierung, Bildnormalisierung, Rate Limit und Same-Origin-Schutz hinzufuegen.
+- API-Tests fuer Auth, Cross-User-Isolation, ungueltige IDs/MIME-Typen, Oversize, Delete und Cache-Revision abschliessen.
+
+Abnahmekriterium: Kein Request kann einen fremden User oder einen Pfad ausserhalb des eigenen Profilverzeichnisses beeinflussen.
+
+### 3. Gemeinsame Avatar- und Editor-Komponenten
+
+- `UserAvatar`, `UserProfileBadge` und `ProfileAppearanceEditor` implementieren.
+- Bildfehler-Fallback, Tastaturbedienung, Fokuszustand, Screenreader-Texte und responsive Darstellung pruefen.
+- DE/EN-Texte ergaenzen.
+
+Abnahmekriterium: Eine Komponente zeigt fuer alle drei Varianten denselben aufgeloesten Zustand und kann ohne surface-spezifische Sonderlogik wiederverwendet werden.
+
+### 4. Persoenliche Einstellungen integrieren
+
+- Profilzustand serverseitig in der Settings-Seite laden.
+- Editor im allgemeinen persoenlichen Bereich vor den Login-Informationen einbauen.
+- Nach jeder Mutation Vorschau und Session-nahe UI aktualisieren.
+
+Abnahmekriterium: Foto, Icon und Initialen koennen nach dem Onboarding jederzeit gewechselt werden und bleiben nach Reload erhalten.
+
+### 5. Onboarding integrieren
+
+- Initialprofil an den Wizard uebergeben.
+- Editor als optionalen Abschnitt in `LanguageStep` einbauen.
+- Weiter-Navigation bei unveraenderten Initialen sowie bei recoverbaren Uploadfehlern absichern.
+- Bestehenden Agent-`profile`-Schritt und seine Completion-Guards unveraendert halten.
+
+Abnahmekriterium: Neue User koennen die Darstellung neben der Sprache personalisieren; bestehende oder bereits begonnene Onboardings brauchen keine State-Migration.
+
+### 6. Startseite integrieren
+
+- Profil serverseitig aufloesen.
+- Badge mit Avatar und Name in den Header einsetzen und auf General Settings verlinken.
+- schmale, mittlere und grosse Viewports pruefen.
+
+Abnahmekriterium: Auf der Startseite wird der Name mit der gewaehlen Darstellung gezeigt; ohne Auswahl erscheinen korrekte Initialen.
+
+### 7. Vollstaendige Verifikation
+
+- gezielte Service-/API-/UI-Tests ausfuehren,
+- `npm run lint`,
+- `npm run build`,
+- UI und E2E auf dem vorhandenen oder einzigen Dev-Server auf `localhost:3000` pruefen,
+- vorher explizite Freigabe fuer Playwright oder Chrome DevTools einholen,
+- `detect_changes({scope: "compare", base_ref: "main"})` vor dem finalen Commit ausfuehren.
+
+Es wird kein Container gebaut, solange dies nicht explizit beauftragt ist.
+
+## Testmatrix
+
+### Unit/Service
+
+- `Alex Weber -> AW`, einteilige und Unicode-Namen, leere Werte.
+- alle erlaubten und unerlaubten Icon-IDs.
+- Default ohne Dateien -> Initialen.
+- fehlende oder korrupte `appearance.json` -> sicherer Fallback.
+- fehlendes Bild trotz `avatarKind=image` -> Icon/Initialen statt Broken Image.
+- parallele Mutationen desselben Users werden serialisiert.
+- zwei User koennen keine Dateien oder Metadaten gegenseitig lesen/aendern.
+
+### API
+
+- 401 ohne Session.
+- Mutation nur bei gueltigem Same-Origin-Request.
+- genau eine Datei, Groessenlimit vor und nach Multipart-Parsing.
+- Dateiendung/MIME-Spoofing wird erkannt.
+- animierte, korrupte und uebergrosse Bilder werden abgelehnt.
+- Ausgabe ist 256 x 256 WebP ohne EXIF.
+- Icon/Initialen entfernen Foto und leeren `user.image`.
+- Upload setzt `user.image` und erhoeht die Revision.
+- GET liefert private Cache-Header und `nosniff`.
+
+### UI/E2E
+
+- Settings: Foto hochladen, Icon auswaehlen, Initialen waehlen, Reload.
+- Onboarding: ohne Auswahl weiter; Icon und Foto bleiben nach Locale-Reload erhalten.
+- Startseite: Name plus Foto/Icon/Initialen nach Reload.
+- Bild-404 fuehrt sichtbar zum Fallback.
+- Tastaturbedienung des Icon-Grids und sichtbarer Fokus.
+- responsive Header-Pruefung auf schmalem Mobile-Viewport und Desktop.
+- Dark/Light Theme sowie deutsche und englische Texte.
+
+## Risiken und Gegenmassnahmen
+
+| Risiko | Gegenmassnahme |
+| --- | --- |
+| Zentraler Onboarding-State hat kritischen Blast Radius | Kein neuer Step/Status; Personalisierung bleibt optional im LanguageStep. |
+| Bilddatei wird als Schad- oder Dekompressionslast missbraucht | fruehes Request-Limit, Magic Bytes, Pixel-Limit, Einzelbild, serverseitiges Re-Encoding. |
+| Fremde User-Bilder werden erraten | Self-only Route ohne `userId`; Auth vor Dateizugriff. |
+| Browser zeigt nach Wechsel ein altes Bild | monotone Revision in URL plus private Cache-Header. |
+| Foto und Icon laufen auseinander | ein Service, per-User Lock, atomische Dateien, kompensierter DB-Update. |
+| Profilfoto landet in DB/Session oder Logs | nur URL in `user.image`; Bytes ausschliesslich im `/data`-Dateisystem. |
+| Header wird auf Mobile zu eng | Name responsiv kuerzen/ausblenden, Avatar und accessible Name beibehalten. |
+| Bestehender `profile`-Begriff wird verwechselt | Code und Texte verwenden fuer den User `profile appearance`/`account identity`; Agent-Profil bleibt separat. |
+
+## Nicht Teil von V1
+
+- freie Avatar-Farben,
+- frei waehlbare runde/eckige Form,
+- interaktives Crop-/Zoom-UI,
+- Gravatar oder externe Bild-URLs,
+- Anzeige fremder Avatare in Collaboration, Admin- oder Member-Listen,
+- Selbstbearbeitung des Anzeigenamens,
+- automatische Moderation von Bildinhalten.
+
+Diese Punkte koennen spaeter auf Basis desselben `UserAvatar`- und Profile-Service-Vertrags ergaenzt werden.

--- a/docs/architecture/canvas-notebook/user-profile-avatar/plan.md
+++ b/docs/architecture/canvas-notebook/user-profile-avatar/plan.md
@@ -110,7 +110,7 @@ Der Server akzeptiert genau eine Datei und vertraut weder Dateiendung noch Brows
 - Zielgroesse: maximal 256 KB; bei Ueberschreitung wird mit niedrigerer Qualitaet erneut kodiert oder der Upload abgelehnt.
 - Kein Import ueber externe URLs. Dadurch entstehen weder SSRF- noch Tracking-Risiken.
 
-Ein eigenes Crop-UI ist nicht Teil von V1. Die Vorschau muss den tatsaechlichen mittigen Zuschnitt zeigen, bevor der Benutzer speichert.
+Ein eigenes Crop-UI ist nicht Teil von V1. Nach dem Upload zeigt die Vorschau ausschliesslich die bereits serverseitig normalisierte und gespeicherte Fassung.
 
 ## Icon-Katalog
 

--- a/docs/architecture/canvas-notebook/user-profile-avatar/todo.json
+++ b/docs/architecture/canvas-notebook/user-profile-avatar/todo.json
@@ -73,7 +73,7 @@
     {
       "id": 7,
       "title": "Final repository and UI verification",
-      "status": "completed",
+      "status": "in_progress",
       "dependsOn": [6],
       "verification": [
         "targeted tests",
@@ -82,7 +82,7 @@
         "UI/E2E on localhost:3000 after explicit browser automation approval",
         "GitNexus detect_changes against main"
       ],
-      "note": "Automated service, API, UI-contract, lint and production-build checks completed. Browser automation was not run because explicit approval was not provided."
+      "note": "Automated service, API, UI-contract, lint and production-build checks completed. Browser automation still requires explicit approval and remains open."
     }
   ]
 }

--- a/docs/architecture/canvas-notebook/user-profile-avatar/todo.json
+++ b/docs/architecture/canvas-notebook/user-profile-avatar/todo.json
@@ -6,7 +6,7 @@
     {
       "id": 1,
       "title": "User-profile domain model, icon catalog, initials helper and persistent storage service",
-      "status": "pending",
+      "status": "completed",
       "dependsOn": [],
       "verification": [
         "service tests",
@@ -17,7 +17,7 @@
     {
       "id": 2,
       "title": "Authenticated self-scoped profile metadata and avatar API",
-      "status": "pending",
+      "status": "completed",
       "dependsOn": [1],
       "verification": [
         "authentication and same-origin tests",
@@ -29,7 +29,7 @@
     {
       "id": 3,
       "title": "Shared UserAvatar, UserProfileBadge and ProfileAppearanceEditor components",
-      "status": "pending",
+      "status": "completed",
       "dependsOn": [2],
       "verification": [
         "photo, icon and initials rendering",
@@ -41,7 +41,7 @@
     {
       "id": 4,
       "title": "Personal profile editor in General Settings",
-      "status": "pending",
+      "status": "completed",
       "dependsOn": [3],
       "verification": [
         "switch photo, icon and initials",
@@ -51,7 +51,7 @@
     {
       "id": 5,
       "title": "Optional profile personalization inside the onboarding language step",
-      "status": "pending",
+      "status": "completed",
       "dependsOn": [4],
       "verification": [
         "onboarding continues without explicit selection",
@@ -62,7 +62,7 @@
     {
       "id": 6,
       "title": "Avatar and user name badge on the home page",
-      "status": "pending",
+      "status": "completed",
       "dependsOn": [5],
       "verification": [
         "server-rendered initial state",
@@ -73,7 +73,7 @@
     {
       "id": 7,
       "title": "Final repository and UI verification",
-      "status": "pending",
+      "status": "completed",
       "dependsOn": [6],
       "verification": [
         "targeted tests",
@@ -81,7 +81,8 @@
         "npm run build",
         "UI/E2E on localhost:3000 after explicit browser automation approval",
         "GitNexus detect_changes against main"
-      ]
+      ],
+      "note": "Automated service, API, UI-contract, lint and production-build checks completed. Browser automation was not run because explicit approval was not provided."
     }
   ]
 }

--- a/docs/architecture/canvas-notebook/user-profile-avatar/todo.json
+++ b/docs/architecture/canvas-notebook/user-profile-avatar/todo.json
@@ -1,0 +1,87 @@
+{
+  "updatedAt": "2026-08-31",
+  "source": "User profile avatar plan",
+  "branch": "codex/user-profile-avatar-plan",
+  "tasks": [
+    {
+      "id": 1,
+      "title": "User-profile domain model, icon catalog, initials helper and persistent storage service",
+      "status": "pending",
+      "dependsOn": [],
+      "verification": [
+        "service tests",
+        "concurrency and recovery tests",
+        "no changes to central onboarding or preferences state"
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Authenticated self-scoped profile metadata and avatar API",
+      "status": "pending",
+      "dependsOn": [1],
+      "verification": [
+        "authentication and same-origin tests",
+        "cross-user isolation tests",
+        "image validation and normalization tests",
+        "cache revision tests"
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Shared UserAvatar, UserProfileBadge and ProfileAppearanceEditor components",
+      "status": "pending",
+      "dependsOn": [2],
+      "verification": [
+        "photo, icon and initials rendering",
+        "keyboard and screen-reader behavior",
+        "responsive and theme states",
+        "German and English copy"
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Personal profile editor in General Settings",
+      "status": "pending",
+      "dependsOn": [3],
+      "verification": [
+        "switch photo, icon and initials",
+        "state persists after reload"
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Optional profile personalization inside the onboarding language step",
+      "status": "pending",
+      "dependsOn": [4],
+      "verification": [
+        "onboarding continues without explicit selection",
+        "selection survives locale reload",
+        "existing agent profile step remains unchanged"
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Avatar and user name badge on the home page",
+      "status": "pending",
+      "dependsOn": [5],
+      "verification": [
+        "server-rendered initial state",
+        "photo, icon and initials fallback",
+        "mobile and desktop header layout"
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Final repository and UI verification",
+      "status": "pending",
+      "dependsOn": [6],
+      "verification": [
+        "targeted tests",
+        "npm run lint",
+        "npm run build",
+        "UI/E2E on localhost:3000 after explicit browser automation approval",
+        "GitNexus detect_changes against main"
+      ]
+    }
+  ]
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -2505,6 +2505,46 @@
       "password": "Wähle ein Passwort mit 8 bis 128 Zeichen."
     }
   },
+  "userProfile": {
+    "title": "Dein persönlicher Auftritt",
+    "description": "Wähle ein Foto, ein persönliches Icon oder deine Initialen. Diese Identität erscheint auf deiner Canvas-Startseite.",
+    "previewLabel": "Profilvorschau",
+    "shownAs": "So wirst du an den persönlichen Stellen in Canvas angezeigt.",
+    "profileLinkLabel": "Einstellungen für {name} öffnen",
+    "uploadTitle": "Profilfoto",
+    "uploadDescription": "PNG, JPEG, WebP, HEIC oder HEIF bis 5 MB. Canvas schneidet das Bild quadratisch zu und speichert eine optimierte Kopie.",
+    "dropImage": "Lege ein Bild hier ab oder wähle eine Datei aus.",
+    "chooseImage": "Bild auswählen",
+    "replaceImage": "Bild ersetzen",
+    "iconsTitle": "Icon auswählen",
+    "iconsDescription": "Wähle eines der ausgesuchten Icons, wenn du kein Foto verwenden möchtest.",
+    "initialsTitle": "Initialen verwenden",
+    "initialsDescription": "Canvas leitet sie automatisch aus deinem Namen ab.",
+    "useInitials": "Initialen verwenden",
+    "selected": "Ausgewählt",
+    "saving": "Profilauftritt wird gespeichert…",
+    "imageUpdated": "Profilfoto aktualisiert.",
+    "iconUpdated": "Profil-Icon aktualisiert.",
+    "initialsUpdated": "Initialen ausgewählt.",
+    "invalidFile": "Wähle eine unterstützte Bilddatei aus.",
+    "fileTooLarge": "Das Bild darf höchstens 5 MB groß sein.",
+    "singleFileOnly": "Wähle genau ein Bild aus.",
+    "updateFailed": "Der Profilauftritt konnte nicht aktualisiert werden.",
+    "icons": {
+      "user-round": "Person",
+      "smile": "Lächeln",
+      "sparkles": "Funkeln",
+      "rocket": "Rakete",
+      "palette": "Palette",
+      "code-2": "Code",
+      "book-open": "Offenes Buch",
+      "camera": "Kamera",
+      "music": "Musik",
+      "coffee": "Kaffee",
+      "mountain": "Berg",
+      "leaf": "Blatt"
+    }
+  },
   "settings": {
     "title": "Einstellungen",
     "tabs": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -2506,6 +2506,46 @@
       "password": "Choose a password between 8 and 128 characters."
     }
   },
+  "userProfile": {
+    "title": "Your profile appearance",
+    "description": "Choose a photo, a personal icon, or your initials. This identity appears on your Canvas home page.",
+    "previewLabel": "Profile preview",
+    "shownAs": "This is how other profile surfaces will show you.",
+    "profileLinkLabel": "Open settings for {name}",
+    "uploadTitle": "Profile photo",
+    "uploadDescription": "PNG, JPEG, WebP, HEIC, or HEIF up to 5 MB. Canvas crops it to a square and stores an optimized copy.",
+    "dropImage": "Drop one image here or choose a file.",
+    "chooseImage": "Choose image",
+    "replaceImage": "Replace image",
+    "iconsTitle": "Choose an icon",
+    "iconsDescription": "Pick one of the curated icons if you prefer not to use a photo.",
+    "initialsTitle": "Use initials",
+    "initialsDescription": "Canvas derives them automatically from your name.",
+    "useInitials": "Use initials",
+    "selected": "Selected",
+    "saving": "Saving profile appearance…",
+    "imageUpdated": "Profile photo updated.",
+    "iconUpdated": "Profile icon updated.",
+    "initialsUpdated": "Initials selected.",
+    "invalidFile": "Choose a supported image file.",
+    "fileTooLarge": "The image must be no larger than 5 MB.",
+    "singleFileOnly": "Choose exactly one image.",
+    "updateFailed": "The profile appearance could not be updated.",
+    "icons": {
+      "user-round": "Person",
+      "smile": "Smile",
+      "sparkles": "Sparkles",
+      "rocket": "Rocket",
+      "palette": "Palette",
+      "code-2": "Code",
+      "book-open": "Open book",
+      "camera": "Camera",
+      "music": "Music",
+      "coffee": "Coffee",
+      "mountain": "Mountain",
+      "leaf": "Leaf"
+    }
+  },
   "settings": {
     "title": "Settings",
     "tabs": {

--- a/scripts/mobile-bootstrap-test.ts
+++ b/scripts/mobile-bootstrap-test.ts
@@ -47,16 +47,29 @@ const bootstrap = createMobileBootstrap({
     serverVersion: '2026.7.19',
     deploymentMode: 'managed-team',
   }),
+  request: {
+    headers: new Headers({
+      host: 'internal-canvas:3000',
+      'x-forwarded-host': 'canvas.example.test',
+      'x-forwarded-proto': 'https',
+    }),
+    url: 'http://internal-canvas:3000/api/mobile/v1/bootstrap',
+  },
   user: {
     id: 'user-1',
     name: 'Mobile User',
     email: 'mobile@example.test',
+    image: '/api/account/profile/avatar?v=3',
     role: 'admin',
   },
   listing,
 });
 
 assert.equal(bootstrap.product, 'canvas-notebook');
+assert.equal(
+  bootstrap.user.image,
+  'https://canvas.example.test/api/account/profile/avatar?v=3',
+);
 assert.deepEqual(bootstrap.mobileApi.capabilities, [
   'account.preferences',
   'workspace.read',

--- a/scripts/user-profile-api-test.ts
+++ b/scripts/user-profile-api-test.ts
@@ -28,7 +28,10 @@ async function importServerModule<T>(specifier: string): Promise<T> {
   }
 }
 
-function request(url: string, init?: RequestInit): NextRequest {
+function request(
+  url: string,
+  init?: { body?: BodyInit | null; headers?: HeadersInit; method?: string },
+): NextRequest {
   const headers = new Headers(init?.headers);
   if (init?.method && init.method !== 'GET') {
     headers.set('Origin', 'http://localhost:3000');
@@ -139,7 +142,7 @@ async function main() {
       assert.equal(oversized.status, 413);
 
       const invalidForm = new FormData();
-      invalidForm.append('file', new File([Buffer.from('not an image')], 'avatar.png', { type: 'image/png' }));
+      invalidForm.append('avatar', new File([Buffer.from('not an image')], 'avatar.png', { type: 'image/png' }));
       const invalidImage = await avatarRoute.POST(request('http://localhost:3000/api/account/profile/avatar', {
         method: 'POST',
         body: invalidForm,
@@ -155,7 +158,7 @@ async function main() {
         },
       }).png().toBuffer();
       const form = new FormData();
-      form.append('file', new File([sourceImage], 'alex.png', { type: 'image/png' }));
+      form.append('avatar', new File([sourceImage], 'alex.png', { type: 'image/png' }));
       const uploaded = await avatarRoute.POST(request('http://localhost:3000/api/account/profile/avatar', {
         method: 'POST',
         body: form,

--- a/scripts/user-profile-api-test.ts
+++ b/scripts/user-profile-api-test.ts
@@ -1,0 +1,243 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import Module from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { NextRequest } from 'next/server';
+import sharp from 'sharp';
+
+type RouteSession = {
+  user: { id: string; email: string; name: string; image: string | null; role: string };
+  session: { id: string };
+};
+
+async function importServerModule<T>(specifier: string): Promise<T> {
+  const moduleInternals = Module as typeof Module & {
+    _load: (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+  };
+  const originalLoad = moduleInternals._load;
+  moduleInternals._load = (request, parent, isMain) => (
+    request === 'server-only' ? {} : originalLoad(request, parent, isMain)
+  );
+  try {
+    return await import(specifier) as T;
+  } finally {
+    moduleInternals._load = originalLoad;
+  }
+}
+
+function request(url: string, init?: RequestInit): NextRequest {
+  const headers = new Headers(init?.headers);
+  if (init?.method && init.method !== 'GET') {
+    headers.set('Origin', 'http://localhost:3000');
+    headers.set('Sec-Fetch-Site', 'same-origin');
+  }
+  return new NextRequest(url, { ...init, headers });
+}
+
+async function main() {
+  const dataRoot = await mkdtemp(path.join(os.tmpdir(), 'canvas-user-profile-api-'));
+  process.env.DATA = dataRoot;
+  delete process.env.CANVAS_DATA_ROOT;
+  process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
+  process.env.BASE_URL = 'http://localhost:3000';
+
+  try {
+    const { runMigrations } = await import('../app/lib/db/migrate');
+    const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+    runMigrations(sqlite);
+    const now = Date.now();
+    for (const [id, name, email] of [
+      ['profile-api-a', 'Alex Weber', 'alex@example.test'],
+      ['profile-api-b', 'Berta Beispiel', 'berta@example.test'],
+    ]) {
+      sqlite.prepare(`
+        INSERT INTO user (id, name, email, email_verified, image, role, created_at, updated_at)
+        VALUES (?, ?, ?, 1, NULL, 'user', ?, ?)
+      `).run(id, name, email, now, now);
+    }
+    sqlite.close();
+
+    const { auth } = await import('../app/lib/auth');
+    let currentSession: RouteSession | null = null;
+    const originalGetSession = auth.api.getSession;
+    assert.equal(Reflect.set(auth.api, 'getSession', async () => currentSession), true);
+
+    try {
+      const profileRoute = await importServerModule<typeof import('../app/api/account/profile/route')>(
+        '../app/api/account/profile/route',
+      );
+      const avatarRoute = await importServerModule<typeof import('../app/api/account/profile/avatar/route')>(
+        '../app/api/account/profile/avatar/route',
+      );
+
+      const unauthorized = await profileRoute.GET(request('http://localhost:3000/api/account/profile'));
+      assert.equal(unauthorized.status, 401);
+
+      currentSession = {
+        user: {
+          id: 'profile-api-a',
+          email: 'alex@example.test',
+          name: 'Alex Weber',
+          image: null,
+          role: 'user',
+        },
+        session: { id: 'profile-api-session-a' },
+      };
+
+      const initial = await profileRoute.GET(request('http://localhost:3000/api/account/profile'));
+      assert.equal(initial.status, 200);
+      assert.equal(initial.headers.get('cache-control'), 'no-store, max-age=0');
+      assert.deepEqual((await initial.json() as { data: { initials: string; avatarKind: string } }).data, {
+        name: 'Alex Weber',
+        avatarKind: 'initials',
+        iconId: null,
+        initials: 'AW',
+        imageUrl: null,
+        revision: 0,
+      });
+
+      const crossOrigin = await profileRoute.PATCH(new NextRequest(
+        'http://localhost:3000/api/account/profile',
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://attacker.example.test',
+            'Sec-Fetch-Site': 'cross-site',
+          },
+          body: JSON.stringify({ avatarKind: 'icon', iconId: 'rocket' }),
+        },
+      ));
+      assert.equal(crossOrigin.status, 403);
+
+      const icon = await profileRoute.PATCH(request('http://localhost:3000/api/account/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ avatarKind: 'icon', iconId: 'rocket', userId: 'profile-api-b', role: 'admin' }),
+      }));
+      assert.equal(icon.status, 200);
+      assert.equal((await icon.json() as { data: { iconId: string } }).data.iconId, 'rocket');
+
+      const invalidIcon = await profileRoute.PATCH(request('http://localhost:3000/api/account/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ avatarKind: 'icon', iconId: '../escape' }),
+      }));
+      assert.equal(invalidIcon.status, 400);
+
+      const oversized = await avatarRoute.POST(request('http://localhost:3000/api/account/profile/avatar', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'multipart/form-data; boundary=test',
+          'Content-Length': String(6 * 1024 * 1024),
+        },
+        body: '--test--',
+      }));
+      assert.equal(oversized.status, 413);
+
+      const invalidForm = new FormData();
+      invalidForm.append('file', new File([Buffer.from('not an image')], 'avatar.png', { type: 'image/png' }));
+      const invalidImage = await avatarRoute.POST(request('http://localhost:3000/api/account/profile/avatar', {
+        method: 'POST',
+        body: invalidForm,
+      }));
+      assert.equal(invalidImage.status, 400);
+
+      const sourceImage = await sharp({
+        create: {
+          width: 640,
+          height: 360,
+          channels: 4,
+          background: { r: 10, g: 99, b: 172, alpha: 1 },
+        },
+      }).png().toBuffer();
+      const form = new FormData();
+      form.append('file', new File([sourceImage], 'alex.png', { type: 'image/png' }));
+      const uploaded = await avatarRoute.POST(request('http://localhost:3000/api/account/profile/avatar', {
+        method: 'POST',
+        body: form,
+      }));
+      assert.equal(uploaded.status, 200);
+      const uploadedData = (await uploaded.json() as { data: { avatarKind: string; imageUrl: string } }).data;
+      assert.equal(uploadedData.avatarKind, 'image');
+      assert.match(uploadedData.imageUrl, /^\/api\/account\/profile\/avatar\?v=\d+$/u);
+
+      const image = await avatarRoute.GET(request('http://localhost:3000/api/account/profile/avatar?v=2'));
+      assert.equal(image.status, 200);
+      assert.equal(image.headers.get('content-type'), 'image/webp');
+      assert.equal(image.headers.get('x-content-type-options'), 'nosniff');
+      assert.match(image.headers.get('cache-control') ?? '', /private/u);
+      const imageBuffer = Buffer.from(await image.arrayBuffer());
+      const metadata = await sharp(imageBuffer).metadata();
+      assert.equal(metadata.width, 256);
+      assert.equal(metadata.height, 256);
+      assert.equal(metadata.format, 'webp');
+
+      const notModified = await avatarRoute.GET(request(
+        'http://localhost:3000/api/account/profile/avatar?v=2',
+        { headers: { 'If-None-Match': image.headers.get('etag') ?? '' } },
+      ));
+      assert.equal(notModified.status, 304);
+
+      currentSession = {
+        user: {
+          id: 'profile-api-b',
+          email: 'berta@example.test',
+          name: 'Berta Beispiel',
+          image: null,
+          role: 'user',
+        },
+        session: { id: 'profile-api-session-b' },
+      };
+      assert.equal(
+        (await avatarRoute.GET(request('http://localhost:3000/api/account/profile/avatar'))).status,
+        404,
+      );
+
+      currentSession = {
+        user: {
+          id: 'profile-api-a',
+          email: 'alex@example.test',
+          name: 'Alex Weber',
+          image: uploadedData.imageUrl,
+          role: 'user',
+        },
+        session: { id: 'profile-api-session-a' },
+      };
+      const removed = await avatarRoute.DELETE(request('http://localhost:3000/api/account/profile/avatar', {
+        method: 'DELETE',
+      }));
+      assert.equal(removed.status, 200);
+      assert.equal((await removed.json() as { data: { avatarKind: string } }).data.avatarKind, 'initials');
+      assert.equal(
+        (await avatarRoute.GET(request('http://localhost:3000/api/account/profile/avatar'))).status,
+        404,
+      );
+
+      const verificationDb = new Database(path.join(dataRoot, 'sqlite.db'));
+      try {
+        const rows = verificationDb.prepare('SELECT id, image FROM user ORDER BY id').all() as Array<{ id: string; image: string | null }>;
+        assert.deepEqual(rows, [
+          { id: 'profile-api-a', image: null },
+          { id: 'profile-api-b', image: null },
+        ]);
+      } finally {
+        verificationDb.close();
+      }
+    } finally {
+      Reflect.set(auth.api, 'getSession', originalGetSession);
+    }
+
+    console.log('user-profile-api-test: ok');
+  } finally {
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/user-profile-service-test.ts
+++ b/scripts/user-profile-service-test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import Module from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import sharp from 'sharp';
+
+async function importServerModule<T>(specifier: string): Promise<T> {
+  const moduleInternals = Module as typeof Module & {
+    _load: (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+  };
+  const originalLoad = moduleInternals._load;
+  moduleInternals._load = (request, parent, isMain) => (
+    request === 'server-only' ? {} : originalLoad(request, parent, isMain)
+  );
+  try {
+    return await import(specifier) as T;
+  } finally {
+    moduleInternals._load = originalLoad;
+  }
+}
+
+async function main() {
+  const dataRoot = await mkdtemp(path.join(os.tmpdir(), 'canvas-user-profile-'));
+  process.env.DATA = dataRoot;
+  delete process.env.CANVAS_DATA_ROOT;
+  process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
+
+  try {
+    const { runMigrations } = await import('../app/lib/db/migrate');
+    const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+    runMigrations(sqlite);
+    const now = Date.now();
+    sqlite.prepare(`
+      INSERT INTO user (id, name, email, email_verified, image, role, created_at, updated_at)
+      VALUES (?, ?, ?, 1, NULL, 'user', ?, ?)
+    `).run('profile-user-a', 'Alex Weber', 'alex.weber@example.test', now, now);
+    sqlite.prepare(`
+      INSERT INTO user (id, name, email, email_verified, image, role, created_at, updated_at)
+      VALUES (?, ?, ?, 1, NULL, 'user', ?, ?)
+    `).run('profile-user-b', 'Berta Beispiel', 'berta@example.test', now, now);
+
+    const { getUserInitials } = await import('../app/lib/user-profile/initials');
+    const {
+      normalizeUserAvatarIconId,
+      USER_AVATAR_ICON_IDS,
+    } = await import('../app/lib/user-profile/icon-catalog');
+    const storage = await importServerModule<typeof import('../app/lib/user-profile/storage')>(
+      '../app/lib/user-profile/storage',
+    );
+    const service = await importServerModule<typeof import('../app/lib/user-profile/service')>(
+      '../app/lib/user-profile/service',
+    );
+
+    assert.equal(getUserInitials({ name: 'Alex Weber', locale: 'de' }), 'AW');
+    assert.equal(getUserInitials({ name: '  Élodie   van der Meer ', locale: 'de' }), 'ÉM');
+    assert.equal(getUserInitials({ name: '李雷', locale: 'zh' }), '李');
+    assert.equal(getUserInitials({ name: '', email: 'alex.weber@example.test' }), 'AW');
+    assert.equal(getUserInitials({ name: '', email: '' }), '');
+    assert.equal(USER_AVATAR_ICON_IDS.length, 12);
+    assert.equal(normalizeUserAvatarIconId(' SPARKLES '), 'sparkles');
+    assert.equal(normalizeUserAvatarIconId('script-alert'), null);
+
+    const initial = await service.resolveUserProfile({
+      userId: 'profile-user-a',
+      name: 'Alex Weber',
+      email: 'alex.weber@example.test',
+    });
+    assert.equal(initial.avatarKind, 'initials');
+    assert.equal(initial.initials, 'AW');
+    assert.equal(initial.revision, 0);
+
+    await service.selectUserProfileIcon({ userId: 'profile-user-a', iconId: 'sparkles' });
+    const icon = await service.resolveUserProfile({
+      userId: 'profile-user-a',
+      name: 'Alex Weber',
+      email: 'alex.weber@example.test',
+    });
+    assert.equal(icon.avatarKind, 'icon');
+    assert.equal(icon.iconId, 'sparkles');
+    assert.equal(icon.revision, 1);
+    await assert.rejects(
+      () => service.selectUserProfileIcon({ userId: 'profile-user-a', iconId: '../escape' }),
+      service.UserProfileError,
+    );
+
+    const source = await sharp({
+      create: {
+        width: 256,
+        height: 256,
+        channels: 4,
+        background: { r: 34, g: 74, b: 120, alpha: 1 },
+      },
+    }).webp({ quality: 88 }).toBuffer();
+    await service.saveUserProfileImage({ userId: 'profile-user-a', buffer: source });
+    const image = await service.resolveUserProfile({
+      userId: 'profile-user-a',
+      name: 'Alex Weber',
+      email: 'alex.weber@example.test',
+    });
+    assert.equal(image.avatarKind, 'image');
+    assert.equal(image.imageUrl, '/api/account/profile/avatar?v=2');
+    assert.deepEqual((await service.readUserProfileImage('profile-user-a'))?.buffer, source);
+    const databaseImage = sqlite.prepare('SELECT image FROM user WHERE id = ?').get('profile-user-a') as { image: string | null };
+    assert.equal(databaseImage.image, '/api/account/profile/avatar?v=2');
+
+    const profileDir = path.join(dataRoot, 'users', 'profile-user-a', 'profile');
+    assert.equal((await stat(profileDir)).mode & 0o777, 0o700);
+    assert.equal((await stat(path.join(profileDir, 'avatar.webp'))).mode & 0o777, 0o600);
+    const appearanceJson = JSON.parse(await readFile(path.join(profileDir, 'appearance.json'), 'utf8')) as { avatarKind: string };
+    assert.equal(appearanceJson.avatarKind, 'image');
+
+    const bInitial = await service.resolveUserProfile({
+      userId: 'profile-user-b',
+      name: 'Berta Beispiel',
+      email: 'berta@example.test',
+    });
+    assert.equal(bInitial.avatarKind, 'initials');
+    assert.equal(bInitial.revision, 0);
+
+    const mutations = await Promise.all([
+      service.selectUserProfileIcon({ userId: 'profile-user-a', iconId: 'rocket' }),
+      service.selectUserProfileIcon({ userId: 'profile-user-a', iconId: 'leaf' }),
+      service.selectUserProfileIcon({ userId: 'profile-user-a', iconId: 'coffee' }),
+    ]);
+    assert.deepEqual(mutations.map((entry) => entry.revision).sort((a, b) => a - b), [3, 4, 5]);
+    assert.equal((await service.resolveUserProfile({ userId: 'profile-user-a', name: 'Alex Weber' })).revision, 5);
+
+    await service.selectUserProfileInitials('profile-user-a');
+    assert.equal((await service.resolveUserProfile({ userId: 'profile-user-a', name: 'Alex Weber' })).avatarKind, 'initials');
+    assert.equal((sqlite.prepare('SELECT image FROM user WHERE id = ?').get('profile-user-a') as { image: string | null }).image, null);
+    await assert.rejects(() => readFile(path.join(profileDir, 'avatar.webp')), { code: 'ENOENT' });
+
+    await writeFile(path.join(profileDir, 'appearance.json'), '{not json', 'utf8');
+    const corruptFallback = await service.resolveUserProfile({ userId: 'profile-user-a', name: 'Alex Weber' });
+    assert.equal(corruptFallback.avatarKind, 'initials');
+    assert.equal(corruptFallback.revision, 0);
+
+    await service.saveUserProfileImage({ userId: 'profile-user-a', buffer: source });
+    await unlink(storage.resolveUserProfileAvatarPath('profile-user-a'));
+    const missingImageFallback = await service.resolveUserProfile({ userId: 'profile-user-a', name: 'Alex Weber' });
+    assert.equal(missingImageFallback.avatarKind, 'initials');
+
+    assert.throws(() => storage.resolveUserProfileDirectory('../profile-user-a'), /Invalid userId/u);
+    sqlite.close();
+    console.log('user-profile-service-test: ok');
+  } finally {
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/user-profile-ui-test.ts
+++ b/scripts/user-profile-ui-test.ts
@@ -13,11 +13,13 @@ type Messages = {
 
 async function main() {
   const root = process.cwd();
-  const [english, german, editorSource, avatarSource] = await Promise.all([
+  const [english, german, editorSource, avatarSource, settingsPageSource, generalSettingsSource] = await Promise.all([
     readFile(path.join(root, 'messages/en.json'), 'utf8').then((value) => JSON.parse(value) as Messages),
     readFile(path.join(root, 'messages/de.json'), 'utf8').then((value) => JSON.parse(value) as Messages),
     readFile(path.join(root, 'app/components/user-profile/ProfileAppearanceEditor.tsx'), 'utf8'),
     readFile(path.join(root, 'app/components/user-profile/UserAvatar.tsx'), 'utf8'),
+    readFile(path.join(root, 'app/[locale]/(routes)/settings/page.tsx'), 'utf8'),
+    readFile(path.join(root, 'app/components/settings/GeneralSettingsPanel.tsx'), 'utf8'),
   ]);
 
   for (const messages of [english, german]) {
@@ -33,6 +35,9 @@ async function main() {
   assert.doesNotMatch(editorSource, /userId/, 'profile mutations must not accept a client-selected user ID');
   assert.match(avatarSource, /failedImageUrl/, 'broken profile images must fall back locally');
   assert.match(avatarSource, /profile\.initials/, 'avatar must render initials as the final fallback');
+  assert.match(settingsPageSource, /resolveUserProfile/, 'settings must resolve the signed-in user profile server-side');
+  assert.match(settingsPageSource, /initialUserProfile=\{initialUserProfile\}/, 'settings must pass the profile to the client');
+  assert.match(generalSettingsSource, /<ProfileAppearanceEditor initialProfile=\{initialUserProfile\}/, 'general settings must render the shared editor');
 
   console.log(`User profile UI contract passed with ${USER_AVATAR_ICON_IDS.length} curated icons.`);
 }

--- a/scripts/user-profile-ui-test.ts
+++ b/scripts/user-profile-ui-test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { USER_AVATAR_ICON_IDS } from '../app/lib/user-profile/icon-catalog';
+
+type Messages = {
+  userProfile?: {
+    icons?: Record<string, string>;
+    [key: string]: unknown;
+  };
+};
+
+async function main() {
+  const root = process.cwd();
+  const [english, german, editorSource, avatarSource] = await Promise.all([
+    readFile(path.join(root, 'messages/en.json'), 'utf8').then((value) => JSON.parse(value) as Messages),
+    readFile(path.join(root, 'messages/de.json'), 'utf8').then((value) => JSON.parse(value) as Messages),
+    readFile(path.join(root, 'app/components/user-profile/ProfileAppearanceEditor.tsx'), 'utf8'),
+    readFile(path.join(root, 'app/components/user-profile/UserAvatar.tsx'), 'utf8'),
+  ]);
+
+  for (const messages of [english, german]) {
+    assert.ok(messages.userProfile, 'profile translations must exist');
+    for (const iconId of USER_AVATAR_ICON_IDS) {
+      assert.equal(typeof messages.userProfile.icons?.[iconId], 'string', `missing icon label: ${iconId}`);
+    }
+  }
+
+  assert.match(editorSource, /USER_AVATAR_ICON_IDS\.map/, 'editor must render the complete icon allowlist');
+  assert.match(editorSource, /MAX_UPLOAD_BYTES = 5 \* 1024 \* 1024/, 'client must advertise the server upload limit');
+  assert.match(editorSource, /credentials: 'include'/, 'profile mutations must use the authenticated session');
+  assert.doesNotMatch(editorSource, /userId/, 'profile mutations must not accept a client-selected user ID');
+  assert.match(avatarSource, /failedImageUrl/, 'broken profile images must fall back locally');
+  assert.match(avatarSource, /profile\.initials/, 'avatar must render initials as the final fallback');
+
+  console.log(`User profile UI contract passed with ${USER_AVATAR_ICON_IDS.length} curated icons.`);
+}
+
+void main();

--- a/scripts/user-profile-ui-test.ts
+++ b/scripts/user-profile-ui-test.ts
@@ -46,7 +46,7 @@ async function main() {
   assert.match(editorSource, /MAX_UPLOAD_BYTES = 5 \* 1024 \* 1024/, 'client must advertise the server upload limit');
   assert.match(editorSource, /credentials: 'include'/, 'profile mutations must use the authenticated session');
   assert.match(editorSource, /formData\.set\('avatar', file\)/, 'the editor must use the avatar upload field');
-  assert.match(editorSource, /URL\.createObjectURL\(file\)/, 'the editor must preview the selected image immediately');
+  assert.doesNotMatch(editorSource, /URL\.createObjectURL/, 'untrusted local files must not flow directly into image URLs');
   assert.doesNotMatch(editorSource, /userId/, 'profile mutations must not accept a client-selected user ID');
   assert.match(avatarSource, /failedImageUrl/, 'broken profile images must fall back locally');
   assert.match(avatarSource, /profile\.initials/, 'avatar must render initials as the final fallback');

--- a/scripts/user-profile-ui-test.ts
+++ b/scripts/user-profile-ui-test.ts
@@ -13,13 +13,24 @@ type Messages = {
 
 async function main() {
   const root = process.cwd();
-  const [english, german, editorSource, avatarSource, settingsPageSource, generalSettingsSource] = await Promise.all([
+  const [
+    english,
+    german,
+    editorSource,
+    avatarSource,
+    settingsPageSource,
+    generalSettingsSource,
+    onboardingPageSource,
+    onboardingWizardSource,
+  ] = await Promise.all([
     readFile(path.join(root, 'messages/en.json'), 'utf8').then((value) => JSON.parse(value) as Messages),
     readFile(path.join(root, 'messages/de.json'), 'utf8').then((value) => JSON.parse(value) as Messages),
     readFile(path.join(root, 'app/components/user-profile/ProfileAppearanceEditor.tsx'), 'utf8'),
     readFile(path.join(root, 'app/components/user-profile/UserAvatar.tsx'), 'utf8'),
     readFile(path.join(root, 'app/[locale]/(routes)/settings/page.tsx'), 'utf8'),
     readFile(path.join(root, 'app/components/settings/GeneralSettingsPanel.tsx'), 'utf8'),
+    readFile(path.join(root, 'app/[locale]/(routes)/onboarding/page.tsx'), 'utf8'),
+    readFile(path.join(root, 'app/[locale]/(routes)/onboarding/onboarding-wizard.tsx'), 'utf8'),
   ]);
 
   for (const messages of [english, german]) {
@@ -38,6 +49,9 @@ async function main() {
   assert.match(settingsPageSource, /resolveUserProfile/, 'settings must resolve the signed-in user profile server-side');
   assert.match(settingsPageSource, /initialUserProfile=\{initialUserProfile\}/, 'settings must pass the profile to the client');
   assert.match(generalSettingsSource, /<ProfileAppearanceEditor initialProfile=\{initialUserProfile\}/, 'general settings must render the shared editor');
+  assert.match(onboardingPageSource, /resolveUserProfile/, 'onboarding must resolve the signed-in user profile server-side');
+  assert.match(onboardingWizardSource, /step === 'language'[\s\S]*?<LanguageStep/, 'profile appearance must remain in the existing language step');
+  assert.match(onboardingWizardSource, /<ProfileAppearanceEditor initialProfile=\{initialUserProfile\}/, 'language step must render the shared editor');
 
   console.log(`User profile UI contract passed with ${USER_AVATAR_ICON_IDS.length} curated icons.`);
 }

--- a/scripts/user-profile-ui-test.ts
+++ b/scripts/user-profile-ui-test.ts
@@ -45,6 +45,8 @@ async function main() {
   assert.match(editorSource, /USER_AVATAR_ICON_IDS\.map/, 'editor must render the complete icon allowlist');
   assert.match(editorSource, /MAX_UPLOAD_BYTES = 5 \* 1024 \* 1024/, 'client must advertise the server upload limit');
   assert.match(editorSource, /credentials: 'include'/, 'profile mutations must use the authenticated session');
+  assert.match(editorSource, /formData\.set\('avatar', file\)/, 'the editor must use the avatar upload field');
+  assert.match(editorSource, /URL\.createObjectURL\(file\)/, 'the editor must preview the selected image immediately');
   assert.doesNotMatch(editorSource, /userId/, 'profile mutations must not accept a client-selected user ID');
   assert.match(avatarSource, /failedImageUrl/, 'broken profile images must fall back locally');
   assert.match(avatarSource, /profile\.initials/, 'avatar must render initials as the final fallback');

--- a/scripts/user-profile-ui-test.ts
+++ b/scripts/user-profile-ui-test.ts
@@ -22,6 +22,7 @@ async function main() {
     generalSettingsSource,
     onboardingPageSource,
     onboardingWizardSource,
+    homePageSource,
   ] = await Promise.all([
     readFile(path.join(root, 'messages/en.json'), 'utf8').then((value) => JSON.parse(value) as Messages),
     readFile(path.join(root, 'messages/de.json'), 'utf8').then((value) => JSON.parse(value) as Messages),
@@ -31,6 +32,7 @@ async function main() {
     readFile(path.join(root, 'app/components/settings/GeneralSettingsPanel.tsx'), 'utf8'),
     readFile(path.join(root, 'app/[locale]/(routes)/onboarding/page.tsx'), 'utf8'),
     readFile(path.join(root, 'app/[locale]/(routes)/onboarding/onboarding-wizard.tsx'), 'utf8'),
+    readFile(path.join(root, 'app/[locale]/(routes)/page.tsx'), 'utf8'),
   ]);
 
   for (const messages of [english, german]) {
@@ -52,6 +54,8 @@ async function main() {
   assert.match(onboardingPageSource, /resolveUserProfile/, 'onboarding must resolve the signed-in user profile server-side');
   assert.match(onboardingWizardSource, /step === 'language'[\s\S]*?<LanguageStep/, 'profile appearance must remain in the existing language step');
   assert.match(onboardingWizardSource, /<ProfileAppearanceEditor initialProfile=\{initialUserProfile\}/, 'language step must render the shared editor');
+  assert.match(homePageSource, /resolveUserProfile/, 'home must resolve the signed-in user profile server-side');
+  assert.match(homePageSource, /<UserProfileBadge profile=\{userProfile\}/, 'home header must show the profile badge');
 
   console.log(`User profile UI contract passed with ${USER_AVATAR_ICON_IDS.length} curated icons.`);
 }


### PR DESCRIPTION
## Summary

- add self-service profile photos with a curated 12-icon alternative and automatic initials fallback
- show the shared profile editor in General Settings and the personal onboarding language step
- display the signed-in user avatar and name in the home header
- persist normalized profile data per user under /data/users/<userId>/profile without a database migration

## Security and storage

- authenticate every profile endpoint and scope all reads and writes to the current session user
- enforce trusted mutation origins, rate limits, upload size and pixel limits, magic-byte validation, and WebP normalization
- store files with restricted permissions, atomic replacement, per-user locking, and rollback on partial failures
- serve profile images with private revisioned caching and content-sniffing protection

## Verification

- npx tsx --conditions react-server scripts/user-profile-service-test.ts
- npx tsx --conditions react-server scripts/user-profile-api-test.ts
- npx tsx scripts/user-profile-ui-test.ts
- npm run lint (0 errors; 3 pre-existing warnings)
- npm run build
- GitNexus staged and main comparison checks

## Screenshots

Not included because browser or Playwright automation was not explicitly approved for this task.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds persisted personal profile avatars, curated icons, initials fallback, profile-editing UI, and profile display across onboarding, settings, home, and mobile bootstrap.
- Adds authenticated profile and avatar APIs with normalized file storage.
- Introduces shared avatar, badge, and appearance-editor components.
- Resolves internal mobile avatar paths against the public request origin.
- Keeps browser-level UI verification explicitly open pending approval.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains established on the current head.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/user-profile/service.ts | Coordinates profile resolution and locked, rollback-aware avatar mutations across storage and user metadata. |
| app/api/account/profile/avatar/route.ts | Adds authenticated avatar retrieval, upload, deletion, validation, and private revisioned caching. |
| app/lib/mobile/bootstrap.ts | Converts relative profile-image paths into absolute public HTTP(S) URLs for bootstrap consumers. |
| app/components/user-profile/ProfileAppearanceEditor.tsx | Adds the shared client editor for image uploads, curated icon selection, and initials fallback. |
| docs/architecture/canvas-notebook/user-profile-avatar/todo.json | Tracks implementation completion while leaving final browser-based UI verification open. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  U[Signed-in user] --> E[Profile editor]
  E --> P[Profile API]
  P --> S[Per-user profile storage]
  P --> D[User image metadata]
  S --> A[Avatar endpoint]
  D --> B[Mobile bootstrap]
  A --> W[Web profile display]
  B --> M[Mobile consumer]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/canvascoding/canvas-notebook/commit/170ce832daf1f24f5a2603eb1188446f143fefa5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58566567)</sub>

<!-- /greptile_comment -->