### PR TITLE
Fix rich mode for safely normalizable Markdown

### DIFF
--- a/app/lib/collaboration/checkpoint.ts
+++ b/app/lib/collaboration/checkpoint.ts
@@ -25,6 +25,80 @@ export class CollaborationCheckpointSupersededError extends Error {
   }
 }
 
+export type CollaborationCheckpointFileWrite = {
+  content: string;
+  revisionId: string;
+  serializedContent: string;
+};
+
+export async function writeCollaborationCheckpointFile(input: {
+  state: PersistedCollaborationState;
+  workspace: WorkspaceContext;
+  canonicalContent: string;
+  actorUserId?: string | null;
+  actorType?: 'user' | 'agent' | 'system';
+  sourceSessionId?: string | null;
+}): Promise<CollaborationCheckpointFileWrite> {
+  if (input.state.workspaceId !== input.workspace.workspaceId) {
+    throw new Error('Collaboration checkpoint workspace mismatch.');
+  }
+  if (Buffer.byteLength(input.canonicalContent, 'utf8') > 5 * 1024 * 1024) {
+    throw new Error('Collaboration checkpoint exceeds the 5 MiB text limit.');
+  }
+
+  const canonical = input.canonicalContent.replace(/\r\n?/gu, '\n');
+  const serialized = serializeCanonicalText(canonical, input.state);
+  const fileOptions = workspaceFileOptions(input.workspace);
+  await writeFile(input.state.path, serialized, fileOptions);
+  const fileRevision = await getWorkspaceFileRevision(input.state.path, fileOptions);
+  if (!fileRevision) throw new Error('Collaboration checkpoint could not be read after write.');
+
+  const revision = ensureFileRevisionForCurrentContent({
+    workspace: input.workspace,
+    path: input.state.path,
+    contentHash: fileRevision.sha256,
+    sizeBytes: fileRevision.stats.size,
+    actorUserId: input.actorUserId ?? null,
+    actorType: input.actorType ?? 'system',
+    sourceSessionId: input.sourceSessionId ?? null,
+  });
+  return {
+    content: serialized,
+    revisionId: revision.id,
+    serializedContent: serialized,
+  };
+}
+
+export function finalizeCollaborationCheckpointProjection(input: {
+  state: PersistedCollaborationState;
+  workspace: WorkspaceContext;
+  revisionId: string;
+}): void {
+  const projectedDocument = markCollaborationDocumentCheckpoint({
+    workspace: input.workspace,
+    path: input.state.path,
+    documentId: input.state.documentId,
+    stateVersion: input.state.checkpointSequence,
+    snapshotRevisionId: input.revisionId,
+  });
+  if (
+    !projectedDocument
+    || projectedDocument.id !== input.state.documentId
+    || projectedDocument.stateVersion !== input.state.checkpointSequence
+    || projectedDocument.snapshotRevisionId !== input.revisionId
+  ) {
+    throw new Error('Collaboration checkpoint could not update the authoritative file projection.');
+  }
+
+  const fileOptions = workspaceFileOptions(input.workspace);
+  invalidateWorkspaceFileViews({
+    fileOptions,
+    subtreeDirs: [getParentDirectory(input.state.path)],
+    mutations: [{ path: input.state.path, type: 'change' }],
+  });
+  queuePublicSharesAfterWrite([input.state.path], input.workspace);
+}
+
 export async function materializeCollaborationCheckpoint(input: {
   state: PersistedCollaborationState;
   workspace: WorkspaceContext;
@@ -51,22 +125,11 @@ export async function materializeCollaborationCheckpoint(input: {
       input.state.documentSequence,
     );
   }
-  if (Buffer.byteLength(input.canonicalContent, 'utf8') > 5 * 1024 * 1024) {
-    throw new Error('Collaboration checkpoint exceeds the 5 MiB text limit.');
-  }
-
   const canonical = input.canonicalContent.replace(/\r\n?/gu, '\n');
-  const serialized = serializeCanonicalText(canonical, input.state);
-  const fileOptions = workspaceFileOptions(input.workspace);
-  await writeFile(input.state.path, serialized, fileOptions);
-  const fileRevision = await getWorkspaceFileRevision(input.state.path, fileOptions);
-  if (!fileRevision) throw new Error('Collaboration checkpoint could not be read after write.');
-
-  const revision = ensureFileRevisionForCurrentContent({
+  const fileWrite = await writeCollaborationCheckpointFile({
+    state: input.state,
     workspace: input.workspace,
-    path: input.state.path,
-    contentHash: fileRevision.sha256,
-    sizeBytes: fileRevision.stats.size,
+    canonicalContent: canonical,
     actorUserId: input.actorUserId ?? null,
     actorType: input.actorType ?? 'system',
     sourceSessionId: input.sourceSessionId ?? null,
@@ -79,7 +142,7 @@ export async function materializeCollaborationCheckpoint(input: {
     schemaVersion: input.state.schemaVersion,
     sequence: input.state.documentSequence,
     canonicalContent: canonical,
-    serializedContent: serialized,
+    serializedContent: fileWrite.serializedContent,
   });
   if (!checkpointedState) {
     throw new CollaborationCheckpointSupersededError(
@@ -87,27 +150,10 @@ export async function materializeCollaborationCheckpoint(input: {
       input.state.documentSequence,
     );
   }
-  const projectedDocument = markCollaborationDocumentCheckpoint({
+  finalizeCollaborationCheckpointProjection({
+    state: checkpointedState,
     workspace: input.workspace,
-    path: checkpointedState.path,
-    documentId: checkpointedState.documentId,
-    stateVersion: checkpointedState.checkpointSequence,
-    snapshotRevisionId: revision.id,
+    revisionId: fileWrite.revisionId,
   });
-  if (
-    !projectedDocument
-    || projectedDocument.id !== checkpointedState.documentId
-    || projectedDocument.stateVersion !== checkpointedState.checkpointSequence
-    || projectedDocument.snapshotRevisionId !== revision.id
-  ) {
-    throw new Error('Collaboration checkpoint could not update the authoritative file projection.');
-  }
-
-  invalidateWorkspaceFileViews({
-    fileOptions,
-    subtreeDirs: [getParentDirectory(input.state.path)],
-    mutations: [{ path: input.state.path, type: 'change' }],
-  });
-  queuePublicSharesAfterWrite([input.state.path], input.workspace);
-  return { content: serialized, revisionId: revision.id };
+  return { content: fileWrite.content, revisionId: fileWrite.revisionId };
 }

--- a/app/lib/collaboration/persistence.ts
+++ b/app/lib/collaboration/persistence.ts
@@ -4,6 +4,8 @@ import crypto from 'node:crypto';
 import type * as YTypes from 'yjs';
 
 import { getDatabaseProvider, openDb } from '@/app/lib/db';
+import { composeCanvasMarkdownDocument } from '@/app/lib/markdown/obsidian-metadata';
+import { analyzeMarkdownRichMode } from '@/app/lib/markdown/rich-markdown-codec';
 import type { TextCollaborationRepresentation } from './types';
 import {
   createPlainTextYDoc,
@@ -528,7 +530,12 @@ async function changeCollaborationRepresentationWhileLocked(input: {
   expectedLifecycleGeneration: number;
   representation: TextCollaborationRepresentation;
   schemaVersion: number;
-}): Promise<PersistedCollaborationState> {
+  normalizeSafeMarkdown?: boolean;
+}): Promise<{
+  canonicalContent: string;
+  checkpointRequired: boolean;
+  state: PersistedCollaborationState;
+}> {
   assertPostgres();
   if (getCollaborationRoomConnectionCount(input.documentId) > 0) {
     throw new CollaborationRepresentationMigrationError(
@@ -549,7 +556,30 @@ async function changeCollaborationRepresentationWhileLocked(input: {
       'checkpoint_stale',
     );
   }
-  const canonicalContent = canonicalContentFromState(state);
+  const currentCanonicalContent = canonicalContentFromState(state);
+  let canonicalContent = currentCanonicalContent;
+  if (input.normalizeSafeMarkdown) {
+    if (input.representation !== 'tiptap_xml') {
+      throw new CollaborationRepresentationMigrationError(
+        'Safe Markdown normalization is only available for rich-text migration.',
+        'content_unsupported',
+      );
+    }
+    const analysis = analyzeMarkdownRichMode(currentCanonicalContent);
+    if (analysis.mode === 'normalizable') {
+      canonicalContent = composeCanvasMarkdownDocument(
+        analysis.prefix,
+        analysis.normalizedBody,
+      );
+    } else if (analysis.mode !== 'rich') {
+      throw new CollaborationRepresentationMigrationError(
+        'The collaboration content cannot be normalized safely for rich text.',
+        'content_unsupported',
+      );
+    }
+  }
+  canonicalContent = encodingProfile(canonicalContent).canonical;
+  const checkpointRequired = canonicalContent !== currentCanonicalContent;
   let fresh: YTypes.Doc;
   try {
     fresh = createValidatedFreshDocument(input.representation, canonicalContent);
@@ -599,9 +629,9 @@ async function changeCollaborationRepresentationWhileLocked(input: {
         Buffer.from(update),
         Buffer.from(vector),
         nextSequence,
-        nextSequence,
+        checkpointRequired ? state.checkpointSequence : nextSequence,
         now,
-        now,
+        checkpointRequired ? state.checkpointedAt : now,
         sha256Text(canonicalContent),
         now,
         state.documentId,
@@ -615,7 +645,11 @@ async function changeCollaborationRepresentationWhileLocked(input: {
       );
     }
     await database.run('COMMIT');
-    return mapState(row);
+    return {
+      canonicalContent,
+      checkpointRequired,
+      state: mapState(row),
+    };
   } catch (error) {
     try { await database.run('ROLLBACK'); } catch {}
     throw error;
@@ -632,9 +666,30 @@ export async function changeCollaborationRepresentation(input: {
   schemaVersion: number;
 }): Promise<PersistedCollaborationState> {
   assertPostgres();
-  return withCollaborationRoomLifecycleLock(
+  const result = await withCollaborationRoomLifecycleLock(
     input.documentId,
     () => changeCollaborationRepresentationWhileLocked(input),
+  );
+  return result.state;
+}
+
+export async function changeCollaborationRepresentationWithSafeMarkdownNormalization(input: {
+  documentId: string;
+  expectedLifecycleGeneration: number;
+  schemaVersion: number;
+}): Promise<{
+  canonicalContent: string;
+  checkpointRequired: boolean;
+  state: PersistedCollaborationState;
+}> {
+  assertPostgres();
+  return withCollaborationRoomLifecycleLock(
+    input.documentId,
+    () => changeCollaborationRepresentationWhileLocked({
+      ...input,
+      representation: 'tiptap_xml',
+      normalizeSafeMarkdown: true,
+    }),
   );
 }
 

--- a/app/lib/collaboration/persistence.ts
+++ b/app/lib/collaboration/persistence.ts
@@ -46,6 +46,30 @@ export interface PersistedCollaborationState {
   status: 'active' | 'archived';
 }
 
+export type SafeMarkdownNormalizationCheckpoint = {
+  write: (input: {
+    state: PersistedCollaborationState;
+    canonicalContent: string;
+  }) => Promise<{
+    content: string;
+    revisionId: string;
+    serializedContent: string;
+  }>;
+  restore: (input: {
+    state: PersistedCollaborationState;
+    canonicalContent: string;
+  }) => Promise<void>;
+  finalize: (input: {
+    state: PersistedCollaborationState;
+    canonicalContent: string;
+    fileWrite: {
+      content: string;
+      revisionId: string;
+      serializedContent: string;
+    };
+  }) => Promise<void> | void;
+};
+
 type StateRow = {
   document_id: string;
   workspace_id: string;
@@ -403,7 +427,8 @@ export class CollaborationRepresentationMigrationError extends Error {
       | 'checkpoint_stale'
       | 'content_unsupported'
       | 'agent_operation_pending'
-      | 'state_changed',
+      | 'state_changed'
+      | 'checkpoint_failed',
   ) {
     super(message);
     this.name = 'CollaborationRepresentationMigrationError';
@@ -531,6 +556,7 @@ async function changeCollaborationRepresentationWhileLocked(input: {
   representation: TextCollaborationRepresentation;
   schemaVersion: number;
   normalizeSafeMarkdown?: boolean;
+  checkpoint?: SafeMarkdownNormalizationCheckpoint;
 }): Promise<{
   canonicalContent: string;
   checkpointRequired: boolean;
@@ -594,6 +620,9 @@ async function changeCollaborationRepresentationWhileLocked(input: {
   const now = Date.now();
   const nextSequence = state.documentSequence + 1;
   const database = await openDb();
+  let checkpointAttempted = false;
+  let checkpointFileWrite: Awaited<ReturnType<SafeMarkdownNormalizationCheckpoint['write']>> | null = null;
+  let committed = false;
   try {
     await database.run('BEGIN');
     const applying = await database.get(
@@ -644,14 +673,80 @@ async function changeCollaborationRepresentationWhileLocked(input: {
         'state_changed',
       );
     }
+    let migratedState = mapState(row);
+    if (checkpointRequired && input.checkpoint) {
+      checkpointAttempted = true;
+      checkpointFileWrite = await input.checkpoint.write({
+        state: migratedState,
+        canonicalContent,
+      });
+      const checkpointedRow = await database.get(
+        `UPDATE collaboration_yjs_states
+         SET checkpointed_at = ?, checkpoint_sequence = ?, canonical_hash = ?,
+             serialized_hash = ?, degraded = 0
+         WHERE document_id = ? AND status = 'active' AND lifecycle_generation = ?
+           AND schema_version = ? AND document_sequence = ?
+         RETURNING *`,
+        [
+          now,
+          nextSequence,
+          sha256Text(canonicalContent),
+          sha256Text(checkpointFileWrite.serializedContent),
+          state.documentId,
+          migratedState.lifecycleGeneration,
+          input.schemaVersion,
+          nextSequence,
+        ],
+      ) as StateRow | undefined;
+      if (!checkpointedRow) {
+        throw new CollaborationRepresentationMigrationError(
+          'Collaboration state changed before the normalized checkpoint could be confirmed.',
+          'state_changed',
+        );
+      }
+      migratedState = mapState(checkpointedRow);
+    }
     await database.run('COMMIT');
+    committed = true;
+    if (checkpointFileWrite && input.checkpoint) {
+      await input.checkpoint.finalize({
+        state: migratedState,
+        canonicalContent,
+        fileWrite: checkpointFileWrite,
+      });
+    }
     return {
       canonicalContent,
       checkpointRequired,
-      state: mapState(row),
+      state: migratedState,
     };
   } catch (error) {
-    try { await database.run('ROLLBACK'); } catch {}
+    if (!committed) {
+      try { await database.run('ROLLBACK'); } catch {}
+    }
+    if (!committed && checkpointAttempted && input.checkpoint) {
+      try {
+        await input.checkpoint.restore({
+          state,
+          canonicalContent: currentCanonicalContent,
+        });
+      } catch (restoreError) {
+        await markCollaborationDegraded(state.documentId, state.lifecycleGeneration);
+        throw new AggregateError(
+          [error, restoreError],
+          'Normalized collaboration migration failed and its file checkpoint could not be restored.',
+        );
+      }
+      if (!(error instanceof CollaborationRepresentationMigrationError)) {
+        throw new CollaborationRepresentationMigrationError(
+          error instanceof Error ? error.message : 'The normalized file checkpoint failed.',
+          'checkpoint_failed',
+        );
+      }
+    }
+    if (committed) {
+      await markCollaborationDegraded(state.documentId, state.lifecycleGeneration + 1);
+    }
     throw error;
   } finally {
     fresh.destroy();
@@ -677,6 +772,7 @@ export async function changeCollaborationRepresentationWithSafeMarkdownNormaliza
   documentId: string;
   expectedLifecycleGeneration: number;
   schemaVersion: number;
+  checkpoint: SafeMarkdownNormalizationCheckpoint;
 }): Promise<{
   canonicalContent: string;
   checkpointRequired: boolean;
@@ -689,6 +785,7 @@ export async function changeCollaborationRepresentationWithSafeMarkdownNormaliza
       ...input,
       representation: 'tiptap_xml',
       normalizeSafeMarkdown: true,
+      checkpoint: input.checkpoint,
     }),
   );
 }

--- a/app/lib/collaboration/session-service.ts
+++ b/app/lib/collaboration/session-service.ts
@@ -2,12 +2,14 @@ import 'server-only';
 
 import { readFile, type WorkspaceFileOperationOptions } from '@/app/lib/filesystem/workspace-files';
 import { getFileCollaborationState } from '@/app/lib/files/collaboration-policy';
+import { analyzeMarkdownRichMode } from '@/app/lib/markdown/rich-markdown-codec';
 import { importPortableExcalidrawAssets } from '@/app/lib/excalidraw-collaboration/assets';
 import {
   ensureExcalidrawScene,
   loadExcalidrawScene,
 } from '@/app/lib/excalidraw-collaboration/repository';
 import type { WorkspaceContext } from '@/app/lib/workspaces/types';
+import { materializeCollaborationCheckpoint } from './checkpoint';
 import {
   CollaborationDocumentStateError,
   resolveTextCollaborationState,
@@ -16,6 +18,8 @@ import {
 import {
   CollaborationRepresentationMigrationError,
   changeCollaborationRepresentation,
+  changeCollaborationRepresentationWithSafeMarkdownNormalization,
+  loadCollaborationState,
   loadCollaborationStateIncludingArchived,
 } from './persistence';
 import { COLLABORATION_SCHEMA_VERSION } from './types';
@@ -151,11 +155,18 @@ export async function createCollaborationSessionGrant(input: {
   } else {
     const initialContent = (await readFile(request.path, fileOptions)).toString('utf8');
     const selectedInitialRepresentation = selectInitialTextCollaborationRepresentation(request.path, initialContent);
+    const richModeAnalysis = extension(request.path) === 'txt'
+      ? null
+      : analyzeMarkdownRichMode(initialContent);
+    const selectedTargetRepresentation: TextCollaborationRepresentation = richModeAnalysis
+      && richModeAnalysis.mode !== 'source'
+      ? 'tiptap_xml'
+      : selectedInitialRepresentation;
     const existingState = await loadCollaborationStateIncludingArchived(collaboration.document.id);
     if (
       !existingState
       && request.representation === 'tiptap_xml'
-      && selectedInitialRepresentation !== 'tiptap_xml'
+      && selectedTargetRepresentation !== 'tiptap_xml'
     ) {
       throw new CollaborationSessionError(
         'This Markdown document can only collaborate in source mode so its representation is preserved.',
@@ -177,20 +188,39 @@ export async function createCollaborationSessionGrant(input: {
       });
       if (
         request.representation === 'auto'
-        && !resolved.initialized
         && resolved.state.representation === 'plain_text'
-        && selectedInitialRepresentation === 'tiptap_xml'
+        && selectedTargetRepresentation === 'tiptap_xml'
       ) {
         try {
-          resolved = {
-            state: await changeCollaborationRepresentation({
+          if (richModeAnalysis?.mode === 'normalizable') {
+            const migration = await changeCollaborationRepresentationWithSafeMarkdownNormalization({
               documentId: resolved.state.documentId,
               expectedLifecycleGeneration: resolved.state.lifecycleGeneration,
-              representation: 'tiptap_xml',
               schemaVersion: COLLABORATION_SCHEMA_VERSION,
-            }),
-            initialized: false,
-          };
+            });
+            if (migration.checkpointRequired) {
+              await materializeCollaborationCheckpoint({
+                state: migration.state,
+                workspace,
+                canonicalContent: migration.canonicalContent,
+                actorType: 'system',
+              });
+            }
+            resolved = {
+              state: await loadCollaborationState(migration.state.documentId) || migration.state,
+              initialized: false,
+            };
+          } else {
+            resolved = {
+              state: await changeCollaborationRepresentation({
+                documentId: resolved.state.documentId,
+                expectedLifecycleGeneration: resolved.state.lifecycleGeneration,
+                representation: 'tiptap_xml',
+                schemaVersion: COLLABORATION_SCHEMA_VERSION,
+              }),
+              initialized: false,
+            };
+          }
         } catch (error) {
           if (!(error instanceof CollaborationRepresentationMigrationError)) throw error;
           // Migration is opportunistic: active clients, pending checkpoints,

--- a/app/lib/collaboration/session-service.ts
+++ b/app/lib/collaboration/session-service.ts
@@ -9,7 +9,11 @@ import {
   loadExcalidrawScene,
 } from '@/app/lib/excalidraw-collaboration/repository';
 import type { WorkspaceContext } from '@/app/lib/workspaces/types';
-import { materializeCollaborationCheckpoint } from './checkpoint';
+import {
+  finalizeCollaborationCheckpointProjection,
+  materializeCollaborationCheckpoint,
+  writeCollaborationCheckpointFile,
+} from './checkpoint';
 import {
   CollaborationDocumentStateError,
   resolveTextCollaborationState,
@@ -19,7 +23,6 @@ import {
   CollaborationRepresentationMigrationError,
   changeCollaborationRepresentation,
   changeCollaborationRepresentationWithSafeMarkdownNormalization,
-  loadCollaborationState,
   loadCollaborationStateIncludingArchived,
 } from './persistence';
 import { COLLABORATION_SCHEMA_VERSION } from './types';
@@ -197,17 +200,32 @@ export async function createCollaborationSessionGrant(input: {
               documentId: resolved.state.documentId,
               expectedLifecycleGeneration: resolved.state.lifecycleGeneration,
               schemaVersion: COLLABORATION_SCHEMA_VERSION,
+              checkpoint: {
+                write: ({ state, canonicalContent }) => writeCollaborationCheckpointFile({
+                  state,
+                  workspace,
+                  canonicalContent,
+                  actorType: 'system',
+                }),
+                restore: async ({ state, canonicalContent }) => {
+                  await materializeCollaborationCheckpoint({
+                    state,
+                    workspace,
+                    canonicalContent,
+                    actorType: 'system',
+                  });
+                },
+                finalize: ({ state, fileWrite }) => {
+                  finalizeCollaborationCheckpointProjection({
+                    state,
+                    workspace,
+                    revisionId: fileWrite.revisionId,
+                  });
+                },
+              },
             });
-            if (migration.checkpointRequired) {
-              await materializeCollaborationCheckpoint({
-                state: migration.state,
-                workspace,
-                canonicalContent: migration.canonicalContent,
-                actorType: 'system',
-              });
-            }
             resolved = {
-              state: await loadCollaborationState(migration.state.documentId) || migration.state,
+              state: migration.state,
               initialized: false,
             };
           } else {

--- a/app/lib/markdown/rich-markdown-codec.ts
+++ b/app/lib/markdown/rich-markdown-codec.ts
@@ -30,7 +30,9 @@ export type MarkdownRichModeReason =
 
 export type MarkdownSafeNormalization =
   | 'ordered_list_spacing'
-  | 'hard_break_marker';
+  | 'hard_break_marker'
+  | 'html_entity_escaping'
+  | 'table_formatting';
 
 export type MarkdownRichModeAnalysis =
   | {
@@ -109,6 +111,128 @@ function hasMarpBodyDirective(markdown: string): boolean {
   return /<!--\s*(?:_?[a-z][\w-]*\s*:|marp\s*:)/iu.test(markdown);
 }
 
+function decodeComparableHtmlEntities(markdown: string): string {
+  return markdown.replace(
+    /&(amp|lt|gt|quot|#39|#x27);/giu,
+    (entity, name: string) => {
+      switch (name.toLowerCase()) {
+        case 'amp': return '&';
+        case 'lt': return '<';
+        case 'gt': return '>';
+        case 'quot': return '"';
+        case '#39':
+        case '#x27': return "'";
+        default: return entity;
+      }
+    },
+  );
+}
+
+function simpleMarkdownTableCells(line: string): string[] | null {
+  const content = line.replace(/\r$/u, '');
+  if (!content.startsWith('|') || !content.endsWith('|')) return null;
+
+  const inner = content.slice(1, -1);
+  // Complex escaped/code-span pipes stay source-only until a Markdown-aware
+  // table tokenizer can prove that their cell boundaries are unchanged.
+  if (/\\\||`/u.test(inner)) return null;
+  return inner.split('|').map((cell) => cell.trim());
+}
+
+function simpleMarkdownTableDelimiter(cells: string[]): string[] | null {
+  if (cells.length === 0) return null;
+  const canonical: string[] = [];
+  for (const cell of cells) {
+    const match = cell.match(/^(:?)-{3,}(:?)$/u);
+    if (!match) return null;
+    canonical.push(`${match[1]}---${match[2]}`);
+  }
+  return canonical;
+}
+
+type SafeMarkdownTableToken =
+  | { kind: 'line'; value: string }
+  | { kind: 'table'; value: string };
+
+function normalizeComparableMarkdownTables(markdown: string): { changed: boolean; value: string } {
+  const lines = markdown.split('\n');
+  const tokens: SafeMarkdownTableToken[] = [];
+  let changed = false;
+  let fence: { marker: '`' | '~'; length: number } | null = null;
+
+  for (let index = 0; index < lines.length;) {
+    const content = lines[index].replace(/\r$/u, '');
+    const fenceMarker = content.match(/^\s*(`{3,}|~{3,})/u)?.[1];
+    if (fenceMarker) {
+      const marker = fenceMarker[0] as '`' | '~';
+      if (!fence) fence = { marker, length: fenceMarker.length };
+      else if (marker === fence.marker && fenceMarker.length >= fence.length) fence = null;
+      tokens.push({ kind: 'line', value: lines[index] });
+      index += 1;
+      continue;
+    }
+    if (fence) {
+      tokens.push({ kind: 'line', value: lines[index] });
+      index += 1;
+      continue;
+    }
+
+    const header = simpleMarkdownTableCells(lines[index]);
+    const delimiterCells = index + 1 < lines.length
+      ? simpleMarkdownTableCells(lines[index + 1])
+      : null;
+    const delimiter = delimiterCells ? simpleMarkdownTableDelimiter(delimiterCells) : null;
+    if (!header || !delimiter || header.length !== delimiter.length) {
+      tokens.push({ kind: 'line', value: lines[index] });
+      index += 1;
+      continue;
+    }
+
+    const rows = [header, delimiter];
+    let nextIndex = index + 2;
+    while (nextIndex < lines.length) {
+      const row = simpleMarkdownTableCells(lines[nextIndex]);
+      if (!row || row.length !== header.length) break;
+      rows.push(row);
+      nextIndex += 1;
+    }
+    const canonical = rows.map((row) => `|${row.join('|')}|`).join('\n');
+    const original = lines.slice(index, nextIndex).join('\n').replace(/\r/gu, '');
+    if (canonical !== original) changed = true;
+    tokens.push({ kind: 'table', value: canonical });
+    index = nextIndex;
+  }
+
+  const normalized: SafeMarkdownTableToken[] = [];
+  for (let index = 0; index < tokens.length;) {
+    const token = tokens[index];
+    if (token.kind !== 'line' || !/^\r?$/u.test(token.value)) {
+      normalized.push(token);
+      index += 1;
+      continue;
+    }
+
+    let nextIndex = index + 1;
+    while (
+      nextIndex < tokens.length
+      && tokens[nextIndex].kind === 'line'
+      && /^\r?$/u.test(tokens[nextIndex].value)
+    ) {
+      nextIndex += 1;
+    }
+    const touchesTable = normalized.at(-1)?.kind === 'table' || tokens[nextIndex]?.kind === 'table';
+    if (touchesTable) {
+      normalized.push({ kind: 'line', value: '' });
+      if (nextIndex - index !== 1 || token.value !== '') changed = true;
+    } else {
+      normalized.push(...tokens.slice(index, nextIndex));
+    }
+    index = nextIndex;
+  }
+
+  return { changed, value: normalized.map((token) => token.value).join('\n') };
+}
+
 function safeRichMarkdownNormalization(
   markdown: string,
   serialized: string,
@@ -140,6 +264,13 @@ function safeRichMarkdownNormalization(
     }
   }
 
+  if (lines.some((line, index) => (
+    !protectedLines[index]
+    && /<(?:!--|\/?[a-z][^>\n]*>)/iu.test(line)
+  ))) {
+    return null;
+  }
+
   const orderedItem = /^(\s*)\d+[.)]\s+\S/u;
   const compacted: string[] = [];
   for (let index = 0; index < lines.length; index += 1) {
@@ -161,8 +292,35 @@ function safeRichMarkdownNormalization(
     compacted.push(lines[index]);
   }
 
-  if (normalizations.size === 0 || compacted.join('\n') !== serialized) return null;
-  return (['ordered_list_spacing', 'hard_break_marker'] as const).filter((normalization) => (
+  let comparableMarkdown = compacted.join('\n');
+  let comparableSerialized = serialized;
+  if (comparableMarkdown === comparableSerialized) {
+    return (['ordered_list_spacing', 'hard_break_marker'] as const).filter((normalization) => (
+      normalizations.has(normalization)
+    ));
+  }
+
+  const decodedMarkdown = decodeComparableHtmlEntities(comparableMarkdown);
+  const decodedSerialized = decodeComparableHtmlEntities(comparableSerialized);
+  if (decodedMarkdown !== comparableMarkdown || decodedSerialized !== comparableSerialized) {
+    normalizations.add('html_entity_escaping');
+    comparableMarkdown = decodedMarkdown;
+    comparableSerialized = decodedSerialized;
+  }
+
+  const normalizedMarkdownTables = normalizeComparableMarkdownTables(comparableMarkdown);
+  const normalizedSerializedTables = normalizeComparableMarkdownTables(comparableSerialized);
+  if (normalizedMarkdownTables.changed || normalizedSerializedTables.changed) {
+    normalizations.add('table_formatting');
+  }
+  if (normalizedMarkdownTables.value !== normalizedSerializedTables.value) return null;
+
+  return ([
+    'ordered_list_spacing',
+    'hard_break_marker',
+    'html_entity_escaping',
+    'table_formatting',
+  ] as const).filter((normalization) => (
     normalizations.has(normalization)
   ));
 }

--- a/scripts/file-agent-operation-integration-test.ts
+++ b/scripts/file-agent-operation-integration-test.ts
@@ -30,11 +30,13 @@ import {
 import { installCollaborationDirectConnection } from '../app/lib/collaboration/direct-connection';
 import { installCollaborationDocumentReader } from '../app/lib/collaboration/document-access';
 import {
+  CollaborationRepresentationMigrationError,
   CollaborationStateInactiveError,
   CollaborationStateStaleError,
   archivePersistedCollaborationPaths,
   ensureCollaborationState,
   changeCollaborationRepresentation,
+  changeCollaborationRepresentationWithSafeMarkdownNormalization,
   compactCollaborationState,
   loadCollaborationState,
   markCollaborationCheckpoint,
@@ -1182,6 +1184,59 @@ try {
     representation: 'plain_text',
     initialContent: safeNormalizationMigrationContent,
   });
+  const safeNormalizationStateBeforeFailedCheckpoint = await loadCollaborationState(
+    safeNormalizationMigrationDocumentId,
+  );
+  assert(safeNormalizationStateBeforeFailedCheckpoint);
+  let restoredFailedNormalizationCheckpoint = false;
+  await assert.rejects(
+    () => changeCollaborationRepresentationWithSafeMarkdownNormalization({
+      documentId: safeNormalizationMigrationDocumentId!,
+      expectedLifecycleGeneration: safeNormalizationStateBeforeFailedCheckpoint.lifecycleGeneration,
+      schemaVersion: 1,
+      checkpoint: {
+        write: async ({ canonicalContent }) => {
+          await fs.writeFile(
+            path.join(workspace.rootPath, safeNormalizationMigrationPath),
+            canonicalContent,
+            'utf8',
+          );
+          throw new Error('synthetic normalized checkpoint failure');
+        },
+        restore: async ({ canonicalContent }) => {
+          restoredFailedNormalizationCheckpoint = true;
+          await fs.writeFile(
+            path.join(workspace.rootPath, safeNormalizationMigrationPath),
+            canonicalContent,
+            'utf8',
+          );
+        },
+        finalize: () => {
+          assert.fail('A failed normalized checkpoint must not finalize its file projection.');
+        },
+      },
+    }),
+    (error: unknown) => error instanceof CollaborationRepresentationMigrationError
+      && error.code === 'checkpoint_failed',
+  );
+  assert.equal(restoredFailedNormalizationCheckpoint, true);
+  const safeNormalizationStateAfterFailedCheckpoint = await loadCollaborationState(
+    safeNormalizationMigrationDocumentId,
+  );
+  assert(safeNormalizationStateAfterFailedCheckpoint);
+  assert.equal(safeNormalizationStateAfterFailedCheckpoint.representation, 'plain_text');
+  assert.equal(
+    safeNormalizationStateAfterFailedCheckpoint.lifecycleGeneration,
+    safeNormalizationStateBeforeFailedCheckpoint.lifecycleGeneration,
+  );
+  assert.equal(
+    safeNormalizationStateAfterFailedCheckpoint.documentSequence,
+    safeNormalizationStateBeforeFailedCheckpoint.documentSequence,
+  );
+  assert.equal(
+    await fs.readFile(path.join(workspace.rootPath, safeNormalizationMigrationPath), 'utf8'),
+    safeNormalizationMigrationContent,
+  );
   const safeNormalizationGrant = await createCollaborationSessionGrant({
     workspace,
     fileOptions: { workspace },

--- a/scripts/file-agent-operation-integration-test.ts
+++ b/scripts/file-agent-operation-integration-test.ts
@@ -50,6 +50,8 @@ import {
   createCollaborationSessionGrant,
 } from '../app/lib/collaboration/session-service';
 import { openDb } from '../app/lib/db';
+import { composeCanvasMarkdownDocument } from '../app/lib/markdown/obsidian-metadata';
+import { analyzeMarkdownRichMode } from '../app/lib/markdown/rich-markdown-codec';
 import {
   ensureFileRevisionForCurrentContent,
   getFileCollaborationState,
@@ -76,6 +78,7 @@ let toolDocumentId: string | null = null;
 let uninitializedToolDocumentId: string | null = null;
 let representationRoutingDocumentId: string | null = null;
 let autoMigrationDocumentId: string | null = null;
+let safeNormalizationMigrationDocumentId: string | null = null;
 let concurrentAutoMigrationDocumentId: string | null = null;
 const workspace: WorkspaceContext = {
   workspaceId,
@@ -1128,6 +1131,74 @@ try {
   assert.equal(stateAfterStaleStore?.lifecycleGeneration, 2);
   assert.equal(await persistedText(autoMigrationDocumentId), autoMigrationContent);
 
+  // Serializer-only entity and table formatting changes are normalized once,
+  // checkpointed, and then promoted from source collaboration to rich text.
+  const safeNormalizationMigrationPath = `agent-safe-normalization-migration-${suffix}.md`;
+  const safeNormalizationMigrationContent = [
+    '---',
+    'title: Brand & UI options',
+    '---',
+    '',
+    '# Brand & UI options',
+    '',
+    '| Name | Meaning |',
+    '| ---- | ------- |',
+    '| **Mosa** | Many pieces become one |',
+    '| **Lino** | Woven structure |',
+    '',
+  ].join('\n');
+  const safeNormalizationAnalysis = analyzeMarkdownRichMode(safeNormalizationMigrationContent);
+  assert.equal(safeNormalizationAnalysis.mode, 'normalizable');
+  assert(safeNormalizationAnalysis.mode === 'normalizable');
+  const safeNormalizationExpected = composeCanvasMarkdownDocument(
+    safeNormalizationAnalysis.prefix,
+    safeNormalizationAnalysis.normalizedBody,
+  );
+  await fs.writeFile(
+    path.join(workspace.rootPath, safeNormalizationMigrationPath),
+    safeNormalizationMigrationContent,
+    'utf8',
+  );
+  ensureFileRevisionForCurrentContent({
+    workspace,
+    path: safeNormalizationMigrationPath,
+    contentHash: createHash('sha256').update(safeNormalizationMigrationContent, 'utf8').digest('hex'),
+    sizeBytes: Buffer.byteLength(safeNormalizationMigrationContent, 'utf8'),
+    actorUserId: userId,
+    actorType: 'user',
+  });
+  const safeNormalizationProjection = getFileCollaborationState({
+    workspace,
+    path: safeNormalizationMigrationPath,
+    ensureDocument: true,
+  });
+  assert(safeNormalizationProjection.document);
+  safeNormalizationMigrationDocumentId = safeNormalizationProjection.document.id;
+  await ensureCollaborationState({
+    documentId: safeNormalizationMigrationDocumentId,
+    workspaceId,
+    organizationId: workspace.organizationId || null,
+    path: safeNormalizationMigrationPath,
+    representation: 'plain_text',
+    initialContent: safeNormalizationMigrationContent,
+  });
+  const safeNormalizationGrant = await createCollaborationSessionGrant({
+    workspace,
+    fileOptions: { workspace },
+    request: { path: safeNormalizationMigrationPath, provider: 'yjs', representation: 'auto' },
+  });
+  assert.equal(safeNormalizationGrant.representation, 'tiptap_xml');
+  assert.equal(safeNormalizationGrant.lifecycleGeneration, 2);
+  const safeNormalizationState = await loadCollaborationState(safeNormalizationMigrationDocumentId);
+  assert(safeNormalizationState);
+  assert.equal(safeNormalizationState.checkpointSequence, safeNormalizationState.documentSequence);
+  assert.equal(safeNormalizationState.degraded, false);
+  assert.equal(await persistedText(safeNormalizationMigrationDocumentId), safeNormalizationExpected);
+  assert.equal(
+    await fs.readFile(path.join(workspace.rootPath, safeNormalizationMigrationPath), 'utf8'),
+    safeNormalizationExpected,
+  );
+
   // Connected source clients block migration. Once the room is empty, two
   // simultaneous session requests converge on the same new rich lifecycle;
   // the earlier plain-text grant is stale and cannot re-enter that room.
@@ -1528,6 +1599,7 @@ try {
       ...(uninitializedToolDocumentId ? [uninitializedToolDocumentId] : []),
       ...(representationRoutingDocumentId ? [representationRoutingDocumentId] : []),
       ...(autoMigrationDocumentId ? [autoMigrationDocumentId] : []),
+      ...(safeNormalizationMigrationDocumentId ? [safeNormalizationMigrationDocumentId] : []),
       ...(concurrentAutoMigrationDocumentId ? [concurrentAutoMigrationDocumentId] : []),
     ]) {
       await database.run('DELETE FROM collaboration_agent_operations WHERE document_id = ?', [cleanupDocumentId]);

--- a/scripts/markdown-roundtrip-preservation-test.ts
+++ b/scripts/markdown-roundtrip-preservation-test.ts
@@ -85,6 +85,43 @@ assert.deepEqual(analyzeMarkdownRichMode('1. Item\n\n   continuation paragraph\n
   reason: 'roundtrip_changed',
 });
 
+const entityFixture = '# Research & Development\n\nA < B > C\n';
+assert.deepEqual(analyzeMarkdownRichMode(entityFixture), {
+  mode: 'normalizable',
+  prefix: '',
+  body: entityFixture,
+  normalizedBody: serializeRichMarkdownBody(entityFixture),
+  normalizations: ['html_entity_escaping'],
+});
+
+const tableFixture = [
+  '# Options',
+  '',
+  '| Name | Meaning |',
+  '| ---- | ------- |',
+  '| **Mosa** | Many pieces become one |',
+  '| **Lino** | Woven structure |',
+  '',
+].join('\n');
+assert.deepEqual(analyzeMarkdownRichMode(tableFixture), {
+  mode: 'normalizable',
+  prefix: '',
+  body: tableFixture,
+  normalizedBody: serializeRichMarkdownBody(tableFixture),
+  normalizations: ['table_formatting'],
+});
+
+const brandedTableFixture = tableFixture.replace('# Options', '# Brand & UI options');
+const brandedTableNormalized = serializeRichMarkdownBody(brandedTableFixture);
+assert.deepEqual(analyzeMarkdownRichMode(brandedTableFixture), {
+  mode: 'normalizable',
+  prefix: '',
+  body: brandedTableFixture,
+  normalizedBody: brandedTableNormalized,
+  normalizations: ['html_entity_escaping', 'table_formatting'],
+});
+assert.equal(analyzeMarkdownRichMode(brandedTableNormalized).mode, 'rich');
+
 const markdownEditorSource = fs.readFileSync(
   path.join(process.cwd(), 'app', 'components', 'editor', 'MarkdownEditor.tsx'),
   'utf8',


### PR DESCRIPTION
## Summary

- recognize safe TipTap round-trip differences from HTML entity escaping and simple GFM table formatting
- migrate collaboration sessions from plain text to validated rich-text state when only those safe normalizations are required
- persist the canonical Markdown checkpoint immediately so reopened documents stay in rich mode
- add codec and PostgreSQL integration coverage for the migration path

## Root cause

The rich-mode guard required byte-identical Markdown after the TipTap round trip. The affected document only differed because `&` became `&amp;` and simple GFM tables were canonicalized, so it was unnecessarily forced into source mode.

## Verification

- `npm run test:editor:preservation`
- exact affected document analyzed as `normalizable` with `html_entity_escaping` and `table_formatting`
- `npx tsx --conditions react-server scripts/markdown-rich-blocks-collaboration-test.ts`
- `npm run test:editor:markdown`
- `npm run test:editor:collaboration-lifecycle`
- `npm run test:collaboration:hardening`
- scoped ESLint for all five changed files
- `npm run build`
- `git diff --check origin/main...HEAD`

The PostgreSQL operation suite exited successfully but skipped its database-backed cases because the local PostgreSQL test profile was not enabled. No container was built. UI automation was not run because Playwright permission was not granted.

## Risk

Raw HTML and complex tables remain source-only. GitNexus reports low risk for this isolated branch and no affected execution flows.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR allows safely normalizable Markdown to migrate from plain-text collaboration into validated rich-text state while synchronously checkpointing the canonical Markdown.

- Recognizes HTML entity escaping and simple GFM table formatting as safe round-trip normalizations.
- Splits checkpoint file writing from projection finalization so migration can restore the original checkpoint if its transaction fails.
- Adds codec and PostgreSQL integration coverage for successful migration and checkpoint-write rollback.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/collaboration/checkpoint.ts | Extracts checkpoint file writing and projection finalization while preserving the existing materialization flow. |
| app/lib/collaboration/persistence.ts | Adds transactional rich-text migration with safe Markdown normalization, checkpoint confirmation, rollback restoration, and degraded-state handling. |
| app/lib/collaboration/session-service.ts | Routes normalizable Markdown through the new checkpointed migration path when automatic rich collaboration is requested. |
| app/lib/markdown/rich-markdown-codec.ts | Recognizes entity escaping and conservative simple-table canonicalization as safe rich-mode normalization differences. |
| scripts/file-agent-operation-integration-test.ts | Covers normalized migration success and restoration after a synthetic checkpoint failure. |
| scripts/markdown-roundtrip-preservation-test.ts | Adds preservation fixtures for entity escaping, table formatting, and their combined normalization. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Session as Session service
    participant Migration as Representation migration
    participant DB as PostgreSQL
    participant File as Workspace file
    participant Projection as File projection

    Session->>Migration: Request safe rich-text migration
    Migration->>DB: BEGIN and update Yjs representation
    Migration->>File: Write normalized canonical Markdown
    Migration->>DB: Confirm checkpoint state
    alt Transaction succeeds
        Migration->>DB: COMMIT
        Migration->>Projection: Finalize checkpoint projection
        Migration-->>Session: Return rich-text state
    else Write or transaction fails
        Migration->>DB: ROLLBACK
        Migration->>File: Restore original canonical Markdown
        Migration-->>Session: Report or suppress opportunistic migration failure
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/canvascoding/canvas-notebook/commit/7b819ec1d0c911bbcc517fe1388528d0729a5ed8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58569773)</sub>

<!-- /greptile_comment -->