### PR TITLE
Fix MCP OAuth consent and client permissions

### DIFF
--- a/app/[locale]/(routes)/oauth/consent/oauth-consent-client.tsx
+++ b/app/[locale]/(routes)/oauth/consent/oauth-consent-client.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Check, LoaderCircle, ShieldCheck } from 'lucide-react';
-import { toast } from 'sonner';
+import { Check, ShieldCheck } from 'lucide-react';
 
 import { LanguageSwitcher } from '@/app/components/language-switcher';
 import { PublicBrandLogo } from '@/app/components/branding/PublicBrandLogo';
-import { authClient } from '@/app/lib/auth-client';
 import type { DirectMcpOAuthScope } from '@/app/lib/mcp/server/config';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -38,14 +35,6 @@ type OAuthConsentClientProps = {
   scopes: DirectMcpOAuthScope[];
 };
 
-function readRedirectUrl(data: unknown): string | null {
-  if (!data || typeof data !== 'object') return null;
-  const record = data as Record<string, unknown>;
-  return record.redirect === true && typeof record.url === 'string' && record.url
-    ? record.url
-    : null;
-}
-
 export function OAuthConsentClient({
   clientName,
   instanceHost,
@@ -53,36 +42,14 @@ export function OAuthConsentClient({
   scopes,
 }: OAuthConsentClientProps) {
   const t = useTranslations('oauthConsent');
-  const [submitting, setSubmitting] = useState<'accept' | 'deny' | null>(null);
-
-  async function submitConsent(accept: boolean) {
-    if (submitting) return;
-    setSubmitting(accept ? 'accept' : 'deny');
-    try {
-      const { data, error } = await authClient.oauth2.consent({
-        accept,
-        oauth_query: oauthQuery,
-      });
-      if (error) {
-        toast.error(t('requestFailed'));
-        setSubmitting(null);
-        return;
-      }
-      const redirectUrl = readRedirectUrl(data);
-      if (!redirectUrl) {
-        toast.error(t('requestFailed'));
-        setSubmitting(null);
-        return;
-      }
-      window.location.assign(redirectUrl);
-    } catch {
-      toast.error(t('requestFailed'));
-      setSubmitting(null);
-    }
-  }
 
   return (
-    <main className="relative flex min-h-screen items-center justify-center bg-background px-4 py-10">
+    <form
+      action="/api/auth/oauth2/consent/redirect"
+      method="post"
+      className="relative flex min-h-screen items-center justify-center bg-background px-4 py-10"
+    >
+      <input type="hidden" name="oauth_query" value={oauthQuery} />
       <div className="absolute right-4 top-4">
         <LanguageSwitcher preserveSearch />
       </div>
@@ -142,26 +109,24 @@ export function OAuthConsentClient({
 
         <CardFooter className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
           <Button
-            type="button"
+            type="submit"
+            name="accept"
+            value="false"
             variant="outline"
             className="w-full sm:w-auto"
-            disabled={submitting !== null}
-            onClick={() => void submitConsent(false)}
           >
-            {submitting === 'deny' && <LoaderCircle className="animate-spin" />}
             {t('deny')}
           </Button>
           <Button
-            type="button"
+            type="submit"
+            name="accept"
+            value="true"
             className="w-full sm:w-auto"
-            disabled={submitting !== null}
-            onClick={() => void submitConsent(true)}
           >
-            {submitting === 'accept' && <LoaderCircle className="animate-spin" />}
             {t('accept')}
           </Button>
         </CardFooter>
       </Card>
-    </main>
+    </form>
   );
 }

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -19,6 +19,7 @@ import {
   failDirectMcpDiagnostic,
   runWithDirectMcpDiagnostic,
   withDirectMcpRequestId,
+  type DirectMcpDiagnosticPhase,
 } from '@/app/lib/mcp/server/diagnostics';
 import { pruneUnusedDirectMcpDynamicClients } from '@/app/lib/mcp/server/oauth-client-maintenance';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
@@ -191,6 +192,37 @@ async function runDirectMcpOAuthStage<T>(
   }
 }
 
+function directMcpOAuthDiagnosticPhase(pathname: string): DirectMcpDiagnosticPhase {
+  if (pathname === '/api/auth/oauth2/register') return 'oauth.registration';
+  if (pathname === '/api/auth/oauth2/authorize') return 'oauth.authorization';
+  if (pathname === '/api/auth/oauth2/consent') return 'oauth.consent';
+  if (pathname === '/api/auth/oauth2/token') return 'oauth.token';
+  if (pathname === '/api/auth/oauth2/revoke') return 'oauth.revocation';
+  return 'oauth.introspection';
+}
+
+function directMcpOAuthCompletionCode(pathname: string, status: number): string {
+  if (pathname === '/api/auth/oauth2/register' && status === 429) {
+    return 'OAUTH_REGISTRATION_RATE_LIMITED';
+  }
+  if (status >= 400) {
+    if (pathname === '/api/auth/oauth2/register') return 'OAUTH_REGISTRATION_REJECTED';
+    if (pathname === '/api/auth/oauth2/authorize') return 'OAUTH_AUTHORIZATION_REJECTED';
+    if (pathname === '/api/auth/oauth2/consent') return 'OAUTH_CONSENT_REJECTED';
+    if (pathname === '/api/auth/oauth2/token') return 'OAUTH_TOKEN_EXCHANGE_REJECTED';
+    if (pathname === '/api/auth/oauth2/revoke') return 'OAUTH_REVOCATION_REJECTED';
+    return 'OAUTH_INTROSPECTION_REJECTED';
+  }
+  if (pathname === '/api/auth/oauth2/authorize' && status >= 300 && status < 400) {
+    return 'OAUTH_AUTHORIZATION_REDIRECT_ISSUED';
+  }
+  if (pathname === '/api/auth/oauth2/consent') return 'OAUTH_CONSENT_COMPLETED';
+  if (pathname === '/api/auth/oauth2/token') return 'OAUTH_TOKEN_EXCHANGE_COMPLETED';
+  if (pathname === '/api/auth/oauth2/revoke') return 'OAUTH_REVOCATION_COMPLETED';
+  if (pathname === '/api/auth/oauth2/introspect') return 'OAUTH_INTROSPECTION_COMPLETED';
+  return 'OAUTH_REGISTRATION_COMPLETED';
+}
+
 async function handleDirectMcpOAuthRequest(
   request: NextRequest,
   handler: () => Promise<Response>,
@@ -200,9 +232,7 @@ async function handleDirectMcpOAuthRequest(
   const startedAt = Date.now();
   const diagnostics = beginDirectMcpDiagnostic(
     request,
-    request.nextUrl.pathname === '/api/auth/oauth2/register'
-      ? 'oauth.registration'
-      : 'oauth.request',
+    directMcpOAuthDiagnosticPhase(request.nextUrl.pathname),
   );
   const isRegistration = request.nextUrl.pathname === '/api/auth/oauth2/register';
   try {
@@ -229,9 +259,7 @@ async function handleDirectMcpOAuthRequest(
     if (isRegistration) await recordDirectMcpRegistrationAudit(response);
     await completeDirectMcpDiagnostic(diagnostics, {
       statusCode: response.status,
-      code: isRegistration && response.status === 429
-        ? 'OAUTH_REGISTRATION_RATE_LIMITED'
-        : 'OAUTH_REQUEST_COMPLETED',
+      code: directMcpOAuthCompletionCode(request.nextUrl.pathname, response.status),
       startedAt,
     });
     return response;

--- a/app/api/auth/oauth2/consent/redirect/route.ts
+++ b/app/api/auth/oauth2/consent/redirect/route.ts
@@ -1,0 +1,49 @@
+import { auth } from '@/app/lib/auth';
+import { completeDirectMcpOAuthConsentRedirect } from '@/app/lib/mcp/server/oauth-consent-redirect';
+import {
+  beginDirectMcpDiagnostic,
+  completeDirectMcpDiagnostic,
+  failDirectMcpDiagnostic,
+  runWithDirectMcpDiagnostic,
+  withDirectMcpRequestId,
+} from '@/app/lib/mcp/server/diagnostics';
+
+export async function POST(request: Request): Promise<Response> {
+  const startedAt = Date.now();
+  const diagnostics = beginDirectMcpDiagnostic(request, 'oauth.consent');
+  try {
+    const response = withDirectMcpRequestId(
+      await runWithDirectMcpDiagnostic(
+        diagnostics,
+        () => completeDirectMcpOAuthConsentRedirect(request, auth.handler),
+      ),
+      diagnostics.requestId,
+    );
+    await completeDirectMcpDiagnostic(diagnostics, {
+      statusCode: response.status,
+      code: response.status === 303
+        ? 'OAUTH_CONSENT_REDIRECT_ISSUED'
+        : response.status >= 500
+          ? 'OAUTH_CONSENT_SERVICE_UNAVAILABLE'
+          : 'OAUTH_CONSENT_REJECTED',
+      startedAt,
+    });
+    return response;
+  } catch {
+    await failDirectMcpDiagnostic(diagnostics, {
+      statusCode: 503,
+      code: 'OAUTH_CONSENT_INTERNAL_ERROR',
+      startedAt,
+    });
+    return withDirectMcpRequestId(Response.json({
+      error: 'temporarily_unavailable',
+      error_description: 'The OAuth consent service is temporarily unavailable.',
+    }, {
+      status: 503,
+      headers: {
+        'cache-control': 'no-store',
+        pragma: 'no-cache',
+      },
+    }), diagnostics.requestId);
+  }
+}

--- a/app/components/settings/McpServerSettingsPanel.tsx
+++ b/app/components/settings/McpServerSettingsPanel.tsx
@@ -13,6 +13,7 @@ import {
   Save,
   Server,
   ShieldCheck,
+  TriangleAlert,
   Unplug,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -29,6 +30,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import { DirectMcpWorkspaceAccessSwitch } from '@/app/components/settings/DirectMcpWorkspaceAccessSwitch';
+import {
+  buildCodexMcpServerConfiguration,
+  missingScopesForEnabledCapabilities,
+} from '@/app/lib/mcp/client-configuration';
 
 type McpCapabilityStatus = {
   id: string;
@@ -423,13 +428,10 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
   const configuredMcpWorkspaces = mcpWorkspaceConfigurations ?? [];
   const enabledMcpWorkspaceCount = configuredMcpWorkspaces.filter((workspace) => workspace.enabled).length;
   const connectionConfig = serverIsActive && status?.endpoint
-    ? JSON.stringify({
-      mcpServers: {
-        canvas: {
-          url: status.endpoint,
-        },
-      },
-    }, null, 2)
+    ? buildCodexMcpServerConfiguration({
+      endpoint: status.endpoint,
+      enabledTools: enabledTools(status),
+    })
     : null;
 
   const statusLabel = status?.configurationError
@@ -685,6 +687,12 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
             <div className="divide-y overflow-hidden rounded-lg border">
               {connections.map((connection) => {
                 const authorizedAt = connection.updatedAt || connection.connectedAt;
+                const missingScopes = status
+                  ? missingScopesForEnabledCapabilities({
+                    grantedScopes: connection.scopes,
+                    capabilities: status.capabilities,
+                  })
+                  : [];
                 const isWorkspaceAccessExpanded = expandedWorkspaceAccessConnectionId === connection.connectionId;
                 const accessForConnection = workspaceAccess?.connectionId === connection.connectionId
                   ? workspaceAccess
@@ -700,6 +708,24 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
                             <Badge key={scope} variant="outline" className="font-mono font-normal">{scope}</Badge>
                           ))}
                         </div>
+                        {missingScopes.length > 0 ? (
+                          <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-900 dark:text-amber-100">
+                            <p className="flex items-center gap-2 font-medium">
+                              <TriangleAlert className="h-3.5 w-3.5" aria-hidden="true" />
+                              {t('connections.permissionsMissing.title')}
+                            </p>
+                            <p className="mt-1 leading-5">
+                              {t('connections.permissionsMissing.description', {
+                                scopes: missingScopes.join(', '),
+                              })}
+                            </p>
+                          </div>
+                        ) : (
+                          <p className="mt-3 flex items-center gap-2 text-xs text-primary">
+                            <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                            {t('connections.permissionsComplete')}
+                          </p>
+                        )}
                         <p className="mt-2 text-xs text-muted-foreground">
                           {t('connections.workspaceAccess.selectedCount', { count: connection.allowedWorkspaceCount })}
                         </p>
@@ -977,7 +1003,7 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
                   <div className="flex items-center justify-between border-b border-white/10 px-4 py-2.5">
                     <div className="flex items-center gap-2 text-xs text-slate-300">
                       <KeyRound className="h-3.5 w-3.5" aria-hidden="true" />
-                      {t('developer.example')}
+                      {t('developer.codexExample')}
                     </div>
                     <Button
                       type="button"
@@ -993,6 +1019,7 @@ export function McpServerSettingsPanel({ isAdmin }: { isAdmin: boolean }) {
                   </div>
                   <pre className="overflow-x-auto p-4 text-xs leading-5"><code>{connectionConfig ?? t('endpoint.notConfigured')}</code></pre>
                 </div>
+                <p className="text-xs leading-5 text-muted-foreground">{t('developer.codexHint')}</p>
                 <dl className="grid gap-3 text-sm sm:grid-cols-2">
                   <div>
                     <dt className="text-muted-foreground">{t('developer.endpoint')}</dt>

--- a/app/lib/mcp/client-configuration.ts
+++ b/app/lib/mcp/client-configuration.ts
@@ -1,0 +1,33 @@
+export type DirectMcpClientCapability = {
+  id: string;
+  available: boolean;
+  enabled: boolean;
+  scopes: string[];
+};
+
+export function buildCodexMcpServerConfiguration(input: {
+  endpoint: string;
+  enabledTools: readonly string[];
+}): string {
+  const tools = [...new Set(input.enabledTools)].sort();
+  return [
+    '[mcp_servers.canvas]',
+    `url = ${JSON.stringify(input.endpoint)}`,
+    'enabled_tools = [',
+    ...tools.map((tool) => `  ${JSON.stringify(tool)},`),
+    ']',
+  ].join('\n');
+}
+
+export function missingScopesForEnabledCapabilities(input: {
+  grantedScopes: readonly string[];
+  capabilities: readonly DirectMcpClientCapability[];
+}): string[] {
+  const granted = new Set(input.grantedScopes);
+  return [...new Set(
+    input.capabilities
+      .filter((capability) => capability.available && capability.enabled)
+      .flatMap((capability) => capability.scopes)
+      .filter((scope) => !granted.has(scope)),
+  )].sort();
+}

--- a/app/lib/mcp/server/diagnostics.ts
+++ b/app/lib/mcp/server/diagnostics.ts
@@ -13,8 +13,12 @@ export type DirectMcpDiagnosticPhase =
   | 'discovery.authorization_server'
   | 'discovery.protected_resource'
   | 'mcp.http'
+  | 'oauth.authorization'
+  | 'oauth.consent'
+  | 'oauth.introspection'
   | 'oauth.registration'
-  | 'oauth.request';
+  | 'oauth.revocation'
+  | 'oauth.token';
 
 const directMcpDiagnosticStorage = new AsyncLocalStorage<DirectMcpDiagnosticContext>();
 

--- a/app/lib/mcp/server/direct-server.ts
+++ b/app/lib/mcp/server/direct-server.ts
@@ -13,7 +13,11 @@ import {
   getDirectMcpAuthProbeToolDescriptor,
   runDirectMcpAuthProbe,
 } from '@/app/lib/mcp/server/auth-probe';
-import { getDirectMcpEnabledTools, type DirectMcpToolId } from '@/app/lib/mcp/server/config';
+import {
+  DIRECT_MCP_TOOL_IDS,
+  getDirectMcpEnabledTools,
+  type DirectMcpToolId,
+} from '@/app/lib/mcp/server/config';
 import {
   recordDirectMcpRequestOperation,
   recordDirectMcpToolFailure,
@@ -78,9 +82,13 @@ export function createDirectMcpServer(
     const tool = toolsById.get(request.params.name as DirectMcpToolId);
     if (!tool) {
       recordDirectMcpToolFailure();
+      const requestedTool = request.params.name;
+      const isKnownCanvasTool = (DIRECT_MCP_TOOL_IDS as readonly string[]).includes(requestedTool);
       throw new ProtocolError(
         ProtocolErrorCode.MethodNotFound,
-        'The requested tool is not available.',
+        isKnownCanvasTool
+          ? `The Canvas tool "${requestedTool}" is disabled for this server. Enable it under Canvas Settings > MCP Server, then reload the MCP server in your client.`
+          : 'The requested tool is not available.',
       );
     }
     recordDirectMcpRequestOperation('tools/call', tool.id);

--- a/app/lib/mcp/server/oauth-client-maintenance.ts
+++ b/app/lib/mcp/server/oauth-client-maintenance.ts
@@ -18,8 +18,11 @@ function changesFromRunResult(result: unknown): number {
 
 /**
  * Removes only anonymous public clients that are linked to this Direct MCP
- * resource and never received a consent or token. A client that was ever
- * used remains intact; this is intentionally not a general OAuth cleanup.
+ * resource and never received a consent or token. Public-client status is
+ * derived from no client secret plus the `none` token auth method; the legacy
+ * `public` column is deliberately ignored because deployed schemas represent
+ * it as boolean, integer, bigint, or null. A client that was ever used remains
+ * intact; this is intentionally not a general OAuth cleanup.
  */
 export async function pruneUnusedDirectMcpDynamicClients(
   now = Date.now(),
@@ -41,7 +44,6 @@ export async function pruneUnusedDirectMcpDynamicClients(
           AND stale_client.user_id IS NULL
           AND stale_client.client_secret IS NULL
           AND stale_client.token_endpoint_auth_method = 'none'
-          AND COALESCE(stale_client.public, FALSE) = TRUE
           AND NOT EXISTS (
             SELECT 1
             FROM oauth_consent consent

--- a/app/lib/mcp/server/oauth-consent-redirect.ts
+++ b/app/lib/mcp/server/oauth-consent-redirect.ts
@@ -1,10 +1,7 @@
 import 'server-only';
 
 import { resolveDirectMcpOAuthConfig } from '@/app/lib/mcp/server/config';
-import {
-  type OAuthPageSearchParams,
-  verifyOAuthPageQuery,
-} from '@/app/lib/mcp/server/oauth-page-query';
+import { refreshOAuthConsentQuery } from '@/app/lib/mcp/server/oauth-page-query';
 import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
 
 const MAX_OAUTH_QUERY_LENGTH = 8_192;
@@ -33,15 +30,6 @@ function singleFormValue(form: FormData, name: string): string | null {
   return values.length === 1 && typeof values[0] === 'string'
     ? values[0]
     : null;
-}
-
-function toPageSearchParams(params: URLSearchParams): OAuthPageSearchParams {
-  const result: OAuthPageSearchParams = {};
-  for (const key of new Set(params.keys())) {
-    const values = params.getAll(key);
-    result[key] = values.length === 1 ? values[0] : values;
-  }
-  return result;
 }
 
 function readProviderRedirect(responseBody: unknown): string | null {
@@ -108,6 +96,7 @@ function copyProviderCookies(source: Response, target: Headers): void {
 export async function completeDirectMcpOAuthConsentRedirect(
   request: Request,
   oauthHandler: OAuthHandler,
+  now = Date.now(),
 ): Promise<Response> {
   if (!(await getDirectMcpRuntimeSettings()).enabled) {
     return oauthError('not_found', 'Direct MCP OAuth is not enabled.', 404);
@@ -134,10 +123,12 @@ export async function completeDirectMcpOAuthConsentRedirect(
     return oauthError('invalid_request', 'The OAuth consent form is invalid.', 400);
   }
 
-  const query = new URLSearchParams(oauthQuery);
-  const verified = await verifyOAuthPageQuery(toPageSearchParams(query));
-  const registeredRedirectUri = query.get('redirect_uri');
-  if (!verified || !registeredRedirectUri) {
+  const refreshedOAuthQuery = await refreshOAuthConsentQuery(oauthQuery, now);
+  const query = refreshedOAuthQuery
+    ? new URLSearchParams(refreshedOAuthQuery)
+    : null;
+  const registeredRedirectUri = query?.get('redirect_uri');
+  if (!refreshedOAuthQuery || !registeredRedirectUri) {
     return oauthError('invalid_request', 'The OAuth consent request is invalid or expired.', 400);
   }
 
@@ -148,7 +139,7 @@ export async function completeDirectMcpOAuthConsentRedirect(
       headers: consentRequestHeaders(request, config.origin),
       body: JSON.stringify({
         accept: acceptValue === 'true',
-        oauth_query: oauthQuery,
+        oauth_query: refreshedOAuthQuery,
       }),
     },
   ));

--- a/app/lib/mcp/server/oauth-consent-redirect.ts
+++ b/app/lib/mcp/server/oauth-consent-redirect.ts
@@ -1,0 +1,183 @@
+import 'server-only';
+
+import { resolveDirectMcpOAuthConfig } from '@/app/lib/mcp/server/config';
+import {
+  type OAuthPageSearchParams,
+  verifyOAuthPageQuery,
+} from '@/app/lib/mcp/server/oauth-page-query';
+import { getDirectMcpRuntimeSettings } from '@/app/lib/mcp/server/runtime-settings';
+
+const MAX_OAUTH_QUERY_LENGTH = 8_192;
+
+type OAuthHandler = (request: Request) => Promise<Response>;
+
+function oauthError(
+  error: string,
+  errorDescription: string,
+  status: number,
+): Response {
+  return Response.json({
+    error,
+    error_description: errorDescription,
+  }, {
+    status,
+    headers: {
+      'cache-control': 'no-store',
+      pragma: 'no-cache',
+    },
+  });
+}
+
+function singleFormValue(form: FormData, name: string): string | null {
+  const values = form.getAll(name);
+  return values.length === 1 && typeof values[0] === 'string'
+    ? values[0]
+    : null;
+}
+
+function toPageSearchParams(params: URLSearchParams): OAuthPageSearchParams {
+  const result: OAuthPageSearchParams = {};
+  for (const key of new Set(params.keys())) {
+    const values = params.getAll(key);
+    result[key] = values.length === 1 ? values[0] : values;
+  }
+  return result;
+}
+
+function readProviderRedirect(responseBody: unknown): string | null {
+  if (!responseBody || typeof responseBody !== 'object') return null;
+  const record = responseBody as Record<string, unknown>;
+  return record.redirect === true && typeof record.url === 'string' && record.url
+    ? record.url
+    : null;
+}
+
+function isExpectedOAuthRedirect(
+  redirectUrl: string,
+  registeredRedirectUri: string,
+): boolean {
+  try {
+    const redirect = new URL(redirectUrl);
+    const registered = new URL(registeredRedirectUri);
+    if (
+      redirect.protocol !== registered.protocol
+      || redirect.username !== registered.username
+      || redirect.password !== registered.password
+      || redirect.host !== registered.host
+      || redirect.pathname !== registered.pathname
+      || redirect.hash
+    ) {
+      return false;
+    }
+    for (const [key, value] of registered.searchParams) {
+      if (!redirect.searchParams.getAll(key).includes(value)) return false;
+    }
+    return Boolean(
+      redirect.searchParams.get('code')
+      || redirect.searchParams.get('error'),
+    );
+  } catch {
+    return false;
+  }
+}
+
+function consentRequestHeaders(request: Request, origin: string): Headers {
+  const headers = new Headers({
+    accept: 'application/json',
+    'content-type': 'application/json',
+    origin,
+  });
+  const cookie = request.headers.get('cookie');
+  if (cookie) headers.set('cookie', cookie);
+  const userAgent = request.headers.get('user-agent');
+  if (userAgent) headers.set('user-agent', userAgent);
+  return headers;
+}
+
+function copyProviderCookies(source: Response, target: Headers): void {
+  for (const cookie of source.headers.getSetCookie()) {
+    target.append('set-cookie', cookie);
+  }
+}
+
+/**
+ * Completes consent as a top-level form navigation and returns an actual HTTP
+ * redirect to the registered client callback. This avoids relying on a
+ * browser-side fetch followed by JavaScript navigation to a loopback URL.
+ */
+export async function completeDirectMcpOAuthConsentRedirect(
+  request: Request,
+  oauthHandler: OAuthHandler,
+): Promise<Response> {
+  if (!(await getDirectMcpRuntimeSettings()).enabled) {
+    return oauthError('not_found', 'Direct MCP OAuth is not enabled.', 404);
+  }
+
+  const config = resolveDirectMcpOAuthConfig();
+  if (request.headers.get('origin') !== config.origin) {
+    return oauthError('invalid_request', 'The OAuth consent origin is invalid.', 403);
+  }
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return oauthError('invalid_request', 'The OAuth consent form is invalid.', 400);
+  }
+  const acceptValue = singleFormValue(form, 'accept');
+  const oauthQuery = singleFormValue(form, 'oauth_query');
+  if (
+    (acceptValue !== 'true' && acceptValue !== 'false')
+    || !oauthQuery
+    || oauthQuery.length > MAX_OAUTH_QUERY_LENGTH
+  ) {
+    return oauthError('invalid_request', 'The OAuth consent form is invalid.', 400);
+  }
+
+  const query = new URLSearchParams(oauthQuery);
+  const verified = await verifyOAuthPageQuery(toPageSearchParams(query));
+  const registeredRedirectUri = query.get('redirect_uri');
+  if (!verified || !registeredRedirectUri) {
+    return oauthError('invalid_request', 'The OAuth consent request is invalid or expired.', 400);
+  }
+
+  const providerResponse = await oauthHandler(new Request(
+    `${config.issuer}/oauth2/consent`,
+    {
+      method: 'POST',
+      headers: consentRequestHeaders(request, config.origin),
+      body: JSON.stringify({
+        accept: acceptValue === 'true',
+        oauth_query: oauthQuery,
+      }),
+    },
+  ));
+  if (!providerResponse.ok) {
+    return oauthError(
+      providerResponse.status >= 500 ? 'temporarily_unavailable' : 'invalid_request',
+      providerResponse.status >= 500
+        ? 'The OAuth consent service is temporarily unavailable.'
+        : 'The OAuth consent request could not be completed.',
+      providerResponse.status >= 500 ? 503 : 400,
+    );
+  }
+
+  let responseBody: unknown;
+  try {
+    responseBody = await providerResponse.json();
+  } catch {
+    return oauthError('temporarily_unavailable', 'The OAuth consent response was invalid.', 503);
+  }
+  const redirectUrl = readProviderRedirect(responseBody);
+  if (!redirectUrl || !isExpectedOAuthRedirect(redirectUrl, registeredRedirectUri)) {
+    return oauthError('temporarily_unavailable', 'The OAuth consent response was invalid.', 503);
+  }
+
+  const headers = new Headers({
+    location: redirectUrl,
+    'cache-control': 'no-store',
+    pragma: 'no-cache',
+  });
+  copyProviderCookies(providerResponse, headers);
+  return new Response(null, { status: 303, headers });
+}

--- a/app/lib/mcp/server/oauth-page-query.ts
+++ b/app/lib/mcp/server/oauth-page-query.ts
@@ -28,6 +28,9 @@ export type DirectMcpConsentPresentation = VerifiedOAuthPageQuery & {
   instanceHost: string;
 };
 
+const MAX_CONSENT_DELIBERATION_MS = 60 * 60 * 1_000;
+const REFRESHED_OAUTH_QUERY_LIFETIME_MS = 5 * 60 * 1_000;
+
 function toSearchParams(searchParams: OAuthPageSearchParams): URLSearchParams {
   const result = new URLSearchParams();
   for (const [name, value] of Object.entries(searchParams)) {
@@ -63,6 +66,15 @@ function safeSignatureEqual(actual: string, expected: string): boolean {
 function readSingle(params: URLSearchParams, key: string): string | null {
   const values = params.getAll(key);
   return values.length === 1 && values[0] ? values[0] : null;
+}
+
+function fromSearchParams(params: URLSearchParams): OAuthPageSearchParams {
+  const result: OAuthPageSearchParams = {};
+  for (const key of new Set(params.keys())) {
+    const values = params.getAll(key);
+    result[key] = values.length === 1 ? values[0] : values;
+  }
+  return result;
 }
 
 export async function verifyOAuthPageQuery(
@@ -145,6 +157,47 @@ export async function verifyOAuthPageQuery(
     clientId,
     scopes: scopes as DirectMcpOAuthScope[],
   };
+}
+
+/**
+ * Re-signs a previously valid consent query with a fresh provider expiration.
+ * The original issue time remains unchanged so login-freshness semantics are
+ * preserved, while users can safely deliberate on the consent page for up to
+ * one hour without the provider's five-minute transport signature expiring.
+ */
+export async function refreshOAuthConsentQuery(
+  oauthQuery: string,
+  now = Date.now(),
+): Promise<string | null> {
+  if (!Number.isFinite(now) || oauthQuery.length > 8_192) return null;
+
+  const params = new URLSearchParams(oauthQuery);
+  const issuedAt = Number(readSingle(params, 'ba_iat'));
+  if (
+    !Number.isFinite(issuedAt)
+    || issuedAt > now + 60_000
+    || issuedAt < now - MAX_CONSENT_DELIBERATION_MS
+  ) {
+    return null;
+  }
+
+  // Verify the original signature and its bounded lifetime at the time it was
+  // issued. This deliberately does not treat normal consent deliberation as
+  // tampering, but still rejects malformed or long-lived source queries.
+  const verified = await verifyOAuthPageQuery(fromSearchParams(params), issuedAt);
+  if (!verified) return null;
+
+  params.delete('sig');
+  params.set(
+    'exp',
+    String(Math.floor((now + REFRESHED_OAUTH_QUERY_LIFETIME_MS) / 1_000)),
+  );
+  const signature = await makeSignature(
+    canonicalize(params),
+    resolveAuthSecret(process.env, { allowProductionBuildFallback: true }),
+  );
+  params.append('sig', signature);
+  return params.toString();
 }
 
 function safeClientName(value: string | null): string {

--- a/app/lib/mcp/server/oauth-request-policy.ts
+++ b/app/lib/mcp/server/oauth-request-policy.ts
@@ -54,6 +54,7 @@ export function isDirectMcpOAuthPath(pathname: string): boolean {
   return [
     '/api/auth/oauth2/register',
     '/api/auth/oauth2/authorize',
+    '/api/auth/oauth2/consent',
     '/api/auth/oauth2/token',
     '/api/auth/oauth2/revoke',
     '/api/auth/oauth2/introspect',

--- a/app/lib/mcp/server/request-history.ts
+++ b/app/lib/mcp/server/request-history.ts
@@ -17,8 +17,12 @@ const PHASES = new Set([
   'discovery.authorization_server',
   'discovery.protected_resource',
   'mcp.http',
+  'oauth.authorization',
+  'oauth.consent',
+  'oauth.introspection',
   'oauth.registration',
-  'oauth.request',
+  'oauth.revocation',
+  'oauth.token',
 ]);
 const OUTCOMES = new Set(['succeeded', 'failed', 'rejected']);
 const OPERATIONS = new Set(['tools/list', 'tools/call']);

--- a/app/lib/mcp/server/tool-auth.ts
+++ b/app/lib/mcp/server/tool-auth.ts
@@ -6,6 +6,7 @@ import { DirectMcpAuthorizationError } from '@/app/lib/mcp/server/access-token-v
 
 export function directMcpToolAuthorizationError(
   error?: DirectMcpAuthorizationError,
+  requiredScope?: string,
 ): CallToolResult {
   const authorizationError = error ?? new DirectMcpAuthorizationError(
     'invalid_token',
@@ -13,12 +14,15 @@ export function directMcpToolAuthorizationError(
     'Authentication is required.',
     { challengeError: 'invalid_token' },
   );
+  const text = authorizationError.status === 503
+    ? 'Canvas authorization is temporarily unavailable. Try this tool again shortly.'
+    : authorizationError.code === 'insufficient_scope'
+      ? `This tool requires the additional OAuth permission "${requiredScope || 'requested scope'}". In Canvas, verify the capability under Settings > MCP Server, reload the MCP server in your client, and approve the new permission once. You do not need to register a new client.`
+      : 'Sign in to Canvas again to use this tool. If the tool is disabled, enable it under Settings > MCP Server and reload the MCP server in your client.';
   const result: CallToolResult = {
     content: [{
       type: 'text',
-      text: authorizationError.status === 503
-        ? 'Authorization is temporarily unavailable.'
-        : 'Sign in to Canvas to use this tool.',
+      text,
     }],
     isError: true,
   };

--- a/app/lib/mcp/server/workspace-tools.ts
+++ b/app/lib/mcp/server/workspace-tools.ts
@@ -517,12 +517,12 @@ async function authenticateForTool(
   authInfo: AuthInfo | undefined,
   scope: DirectMcpResourceScope,
 ): Promise<{ principal: DirectMcpAccessPrincipal } | { result: CallToolResult }> {
-  if (!authInfo?.token) return { result: directMcpToolAuthorizationError() };
+  if (!authInfo?.token) return { result: directMcpToolAuthorizationError(undefined, scope) };
   try {
     return { principal: await verifyDirectMcpAccessToken(authInfo.token, [scope]) };
   } catch (error) {
     if (error instanceof DirectMcpAuthorizationError) {
-      return { result: directMcpToolAuthorizationError(error) };
+      return { result: directMcpToolAuthorizationError(error, scope) };
     }
     throw error;
   }

--- a/messages/de.json
+++ b/messages/de.json
@@ -3412,6 +3412,11 @@
         "disconnect": "Trennen",
         "disconnectConfirm": "{client} trennen? Der Zugriff auf deine Canvas-Daten wird sofort entfernt.",
         "disconnected": "MCP-Client getrennt.",
+        "permissionsComplete": "OAuth deckt alle derzeit auf dem Server aktivierten Werkzeuge ab.",
+        "permissionsMissing": {
+          "title": "Zusätzliche OAuth-Berechtigung erforderlich",
+          "description": "Für aktivierte Werkzeuge fehlen diesem Client: {scopes}. Lade den MCP-Server im Client neu und bestätige diese Berechtigung einmalig. Eine neue Client-Registrierung ist nicht nötig."
+        },
         "errors": {
           "load": "Deine MCP-Verbindungen konnten nicht geladen werden.",
           "disconnect": "Dieser MCP-Client konnte nicht getrennt werden."
@@ -3531,6 +3536,8 @@
         "title": "Technische Details für Entwickler",
         "description": "Die Verbindung verwendet den aktuellen Remote-MCP-Standard. Diese Angaben brauchst du nur für eine eigene Client-Integration oder die Fehlersuche.",
         "example": "Beispiel für eine Client-Konfiguration",
+        "codexExample": "Codex-Konfiguration mit aktivierten Werkzeugen",
+        "codexHint": "Codex verwendet enabled_tools als lokale Werkzeugfreigabe. Kopiere diese Konfiguration in die MCP-Einstellungen von Codex und lade den Server dort nach Änderungen neu. Canvas kann diese lokale Liste nicht auslesen oder verändern; nur ein tatsächlich neuer OAuth-Scope erfordert einmalig eine erneute Bestätigung.",
         "endpoint": "MCP-Endpunkt",
         "issuer": "OAuth-Aussteller",
         "protocol": "Protokoll",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3413,6 +3413,11 @@
         "disconnect": "Disconnect",
         "disconnectConfirm": "Disconnect {client}? This immediately removes its access to your Canvas data.",
         "disconnected": "MCP client disconnected.",
+        "permissionsComplete": "OAuth covers every tool currently enabled on the server.",
+        "permissionsMissing": {
+          "title": "Additional OAuth permission required",
+          "description": "This client is missing the following permissions for enabled tools: {scopes}. Reload the MCP server in the client and approve these permissions once. You do not need to register a new client."
+        },
         "errors": {
           "load": "Could not load your MCP connections.",
           "disconnect": "Could not disconnect this MCP client."
@@ -3532,6 +3537,8 @@
         "title": "Technical details for developers",
         "description": "This connection follows the current remote MCP standard. You only need these details for a custom client integration or troubleshooting.",
         "example": "Client configuration example",
+        "codexExample": "Codex configuration with enabled tools",
+        "codexHint": "Codex uses enabled_tools as its local tool allowlist. Copy this configuration into Codex MCP settings and reload the server there after changes. Canvas cannot read or change that local list; only a genuinely new OAuth scope needs one additional approval.",
         "endpoint": "MCP endpoint",
         "issuer": "OAuth issuer",
         "protocol": "Protocol",

--- a/scripts/mcp-server-auth-probe-test.ts
+++ b/scripts/mcp-server-auth-probe-test.ts
@@ -691,6 +691,12 @@ async function main(): Promise<void> {
     )['mcp/www_authenticate'] as string[];
     assert.ok(assetScopeChallenge[0].includes('error="insufficient_scope"'));
     assert.ok(assetScopeChallenge[0].includes('scope="knowledge:assets"'));
+    const assetScopeMessage = String(
+      (missingAssetScopeResult.content as Array<{ text?: string }>)[0]?.text,
+    );
+    assert.match(assetScopeMessage, /knowledge:assets/u);
+    assert.match(assetScopeMessage, /Settings > MCP Server/u);
+    assert.match(assetScopeMessage, /do not need to register a new client/u);
 
     const unsupportedAsset = await rpcRequest({
       post: mcpRoute.POST,
@@ -790,6 +796,10 @@ async function main(): Promise<void> {
     )['mcp/www_authenticate'] as string[];
     assert.ok(writeScopeChallenge[0].includes('error="insufficient_scope"'));
     assert.ok(writeScopeChallenge[0].includes('scope="knowledge:write"'));
+    assert.match(
+      String((missingWriteScopeResult.content as Array<{ text?: string }>)[0]?.text),
+      /knowledge:write/u,
+    );
 
     process.env.CANVAS_MCP_DIRECT_TOOLS = '';
     try {
@@ -805,6 +815,25 @@ async function main(): Promise<void> {
       assert.equal(disabledToolsList.status, 200);
       const disabledToolsResult = resultFromRpc(await readJson(disabledToolsList));
       assert.deepEqual(disabledToolsResult.tools, []);
+
+      const disabledToolCall = await rpcRequest({
+        post: mcpRoute.POST,
+        body: {
+          jsonrpc: '2.0',
+          id: 22,
+          method: 'tools/call',
+          params: {
+            name: 'read_knowledge_asset',
+            arguments: {},
+          },
+        },
+      });
+      const disabledToolBody = await readJson(disabledToolCall);
+      assert.equal(typeof disabledToolBody.error, 'object');
+      assert.match(
+        String((disabledToolBody.error as JsonRecord).message),
+        /disabled for this server.*Settings > MCP Server.*reload/iu,
+      );
     } finally {
       delete process.env.CANVAS_MCP_DIRECT_TOOLS;
     }

--- a/scripts/mcp-server-diagnostics-test.ts
+++ b/scripts/mcp-server-diagnostics-test.ts
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
     const request = new Request(
       `https://notebook.example.test/api/auth/oauth2/authorize?client_id=${CLIENT_ID}&state=${STATE}`,
     );
-    const diagnostics = beginDirectMcpDiagnostic(request, 'oauth.request');
+    const diagnostics = beginDirectMcpDiagnostic(request, 'oauth.authorization');
     assert.match(diagnostics.requestId, /^[0-9a-f-]{36}$/iu);
     assert.match(diagnostics.flowRef || '', /^[a-f0-9]{24}$/u);
 
@@ -68,6 +68,24 @@ async function main(): Promise<void> {
       code: 'OAUTH_PROVIDER_ERROR',
       startedAt: Date.now() - 1,
     });
+    const consentDiagnostics = beginDirectMcpDiagnostic(
+      new Request('https://notebook.example.test/api/auth/oauth2/consent/redirect', { method: 'POST' }),
+      'oauth.consent',
+    );
+    await completeDirectMcpDiagnostic(consentDiagnostics, {
+      statusCode: 303,
+      code: 'OAUTH_CONSENT_REDIRECT_ISSUED',
+      startedAt: Date.now() - 1,
+    });
+    const tokenDiagnostics = beginDirectMcpDiagnostic(
+      new Request('https://notebook.example.test/api/auth/oauth2/token', { method: 'POST' }),
+      'oauth.token',
+    );
+    await completeDirectMcpDiagnostic(tokenDiagnostics, {
+      statusCode: 200,
+      code: 'OAUTH_TOKEN_EXCHANGE_COMPLETED',
+      startedAt: Date.now() - 1,
+    });
     const failedDiagnostics = beginDirectMcpDiagnostic(
       new Request('https://notebook.example.test/mcp', { method: 'POST' }),
       'mcp.http',
@@ -84,13 +102,17 @@ async function main(): Promise<void> {
     assert.equal(output.includes(diagnostics.flowRef || ''), true);
     assert.equal(output.includes('MCP_INTERNAL_ERROR'), true);
     assert.equal(output.includes('OAUTH_PERSISTENCE_SCHEMA_ERROR'), true);
+    assert.equal(output.includes('OAUTH_CONSENT_REDIRECT_ISSUED'), true);
+    assert.equal(output.includes('OAUTH_TOKEN_EXCHANGE_COMPLETED'), true);
     assert.equal(output.includes(providerSecret), false);
 
     const history = await listRecentDirectMcpRequestHistory();
-    assert.equal(history.length, 3);
+    assert.equal(history.length, 5);
     assert.equal(history.some((entry) => entry.code === 'OAUTH_PERSISTENCE_SCHEMA_ERROR'), true);
     assert.equal(history.some((entry) => entry.code === 'MCP_INTERNAL_ERROR'), true);
     assert.equal(history.some((entry) => entry.requestId === diagnostics.requestId), true);
+    assert.equal(history.some((entry) => entry.phase === 'oauth.consent'), true);
+    assert.equal(history.some((entry) => entry.phase === 'oauth.token'), true);
     assert.equal(JSON.stringify(history).includes(STATE), false);
     assert.equal(JSON.stringify(history).includes(CLIENT_ID), false);
     assert.equal(JSON.stringify(history).includes(providerSecret), false);

--- a/scripts/mcp-server-oauth-hardening-test.ts
+++ b/scripts/mcp-server-oauth-hardening-test.ts
@@ -92,7 +92,7 @@ async function main(): Promise<void> {
           INSERT INTO oauth_client (
             id, client_id, client_secret, user_id, created_at, updated_at,
             redirect_uris, token_endpoint_auth_method, public, require_pkce
-          ) VALUES (?, ?, NULL, NULL, ?, ?, ?, 'none', TRUE, TRUE)
+          ) VALUES (?, ?, NULL, NULL, ?, ?, ?, 'none', NULL, TRUE)
         `, [
           `client-${randomUUID()}`,
           clientId,

--- a/scripts/mcp-server-oauth-login-consent-test.ts
+++ b/scripts/mcp-server-oauth-login-consent-test.ts
@@ -61,6 +61,15 @@ function readSessionCookie(response: Response): string {
   return sessionCookie.split(';', 1)[0];
 }
 
+function readStoredStringArray(value: string): string[] {
+  const parsed = JSON.parse(value) as unknown;
+  const normalized = typeof parsed === 'string'
+    ? JSON.parse(parsed) as unknown
+    : parsed;
+  assert.equal(Array.isArray(normalized), true);
+  return normalized as string[];
+}
+
 function authorizationUrl(
   clientId: string,
   resource: string,
@@ -97,6 +106,7 @@ async function main(): Promise<void> {
     const [
       { auth },
       { enforceDirectMcpOAuthRequestPolicy },
+      { POST: completeConsentRedirect },
       {
         resolveDirectMcpConsentPresentation,
         verifyOAuthPageQuery,
@@ -104,6 +114,7 @@ async function main(): Promise<void> {
     ] = await Promise.all([
       import('../app/lib/auth'),
       import('../app/lib/mcp/server/oauth-request-policy'),
+      import('../app/api/auth/oauth2/consent/redirect/route'),
       import('../app/lib/mcp/server/oauth-page-query'),
     ]);
     const { issuer, resource } = resolveDirectMcpServerConfig();
@@ -220,7 +231,7 @@ async function main(): Promise<void> {
           disabled: storedClient.disabled,
           public: storedClient.public,
           tokenEndpointAuthMethod: storedClient.tokenEndpointAuthMethod,
-          scopes: JSON.parse(storedClient.scopes),
+          scopes: readStoredStringArray(storedClient.scopes),
         },
         {
           disabled: 0,
@@ -292,22 +303,43 @@ async function main(): Promise<void> {
     );
     assert.equal(secondConsentLocation.pathname, '/oauth/consent');
 
-    const acceptResponse = await dispatch(new Request(`${issuer}/oauth2/consent`, {
-      method: 'POST',
-      headers: {
-        accept: 'application/json',
-        'content-type': 'application/json',
-        cookie: oauthCookie,
-        origin: ORIGIN,
-      },
-      body: JSON.stringify({
-        accept: true,
-        oauth_query: secondConsentLocation.searchParams.toString(),
+    const invalidOriginForm = new URLSearchParams({
+      accept: 'true',
+      oauth_query: secondConsentLocation.searchParams.toString(),
+    });
+    const invalidOriginResponse = await completeConsentRedirect(
+      new Request(`${ORIGIN}/api/auth/oauth2/consent/redirect`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          cookie: oauthCookie,
+          origin: 'https://attacker.example.test',
+        },
+        body: invalidOriginForm,
       }),
-    }));
-    assert.equal(acceptResponse.status, 200);
+    );
+    assert.equal(invalidOriginResponse.status, 403);
+    assert.ok(invalidOriginResponse.headers.get('x-request-id'));
+
+    const acceptForm = new URLSearchParams({
+      accept: 'true',
+      oauth_query: secondConsentLocation.searchParams.toString(),
+    });
+    const acceptResponse = await completeConsentRedirect(new Request(
+      `${ORIGIN}/api/auth/oauth2/consent/redirect`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          cookie: oauthCookie,
+          origin: ORIGIN,
+        },
+        body: acceptForm,
+      },
+    ));
+    assert.equal(acceptResponse.status, 303);
     const acceptedRedirect = new URL(
-      readRedirect(await readJson(acceptResponse)),
+      acceptResponse.headers.get('location') || '',
       ORIGIN,
     );
     assert.equal(acceptedRedirect.origin + acceptedRedirect.pathname, REDIRECT_URI);
@@ -315,21 +347,23 @@ async function main(): Promise<void> {
     assert.equal(acceptedRedirect.searchParams.get('state'), 'state-consent');
     assert.equal(acceptedRedirect.searchParams.get('iss'), issuer);
 
-    const tamperedConsent = await dispatch(new Request(`${issuer}/oauth2/consent`, {
-      method: 'POST',
-      headers: {
-        accept: 'application/json',
-        'content-type': 'application/json',
-        cookie: oauthCookie,
-        origin: ORIGIN,
+    const tamperedConsent = await completeConsentRedirect(new Request(
+      `${ORIGIN}/api/auth/oauth2/consent/redirect`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          cookie: oauthCookie,
+          origin: ORIGIN,
+        },
+        body: new URLSearchParams({
+          accept: 'true',
+          oauth_query: `${secondConsentLocation.searchParams.toString()}tampered`,
+        }),
       },
-      body: JSON.stringify({
-        accept: true,
-        oauth_query: `${secondConsentLocation.searchParams.toString()}tampered`,
-      }),
-    }));
+    ));
     assert.equal(tamperedConsent.status, 400);
-    assert.equal((await readJson(tamperedConsent)).error, 'invalid_signature');
+    assert.equal((await readJson(tamperedConsent)).error, 'invalid_request');
 
     console.log('mcp-server-oauth-login-consent-test: ok');
   } finally {

--- a/scripts/mcp-server-oauth-login-consent-test.ts
+++ b/scripts/mcp-server-oauth-login-consent-test.ts
@@ -107,6 +107,7 @@ async function main(): Promise<void> {
       { auth },
       { enforceDirectMcpOAuthRequestPolicy },
       { POST: completeConsentRedirect },
+      { completeDirectMcpOAuthConsentRedirect },
       {
         resolveDirectMcpConsentPresentation,
         verifyOAuthPageQuery,
@@ -115,6 +116,7 @@ async function main(): Promise<void> {
       import('../app/lib/auth'),
       import('../app/lib/mcp/server/oauth-request-policy'),
       import('../app/api/auth/oauth2/consent/redirect/route'),
+      import('../app/lib/mcp/server/oauth-consent-redirect'),
       import('../app/lib/mcp/server/oauth-page-query'),
     ]);
     const { issuer, resource } = resolveDirectMcpServerConfig();
@@ -325,6 +327,45 @@ async function main(): Promise<void> {
       accept: 'true',
       oauth_query: secondConsentLocation.searchParams.toString(),
     });
+    const consentIssuedAt = Number(
+      secondConsentLocation.searchParams.get('ba_iat'),
+    );
+    assert.equal(Number.isFinite(consentIssuedAt), true);
+    const delayedAcceptResponse = await completeDirectMcpOAuthConsentRedirect(
+      new Request(`${ORIGIN}/api/auth/oauth2/consent/redirect`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          cookie: oauthCookie,
+          origin: ORIGIN,
+        },
+        body: acceptForm,
+      }),
+      auth.handler,
+      consentIssuedAt + 10 * 60 * 1_000,
+    );
+    assert.equal(delayedAcceptResponse.status, 303);
+    assert.ok(new URL(
+      delayedAcceptResponse.headers.get('location') || '',
+      ORIGIN,
+    ).searchParams.get('code'));
+
+    const staleAcceptResponse = await completeDirectMcpOAuthConsentRedirect(
+      new Request(`${ORIGIN}/api/auth/oauth2/consent/redirect`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          cookie: oauthCookie,
+          origin: ORIGIN,
+        },
+        body: acceptForm,
+      }),
+      auth.handler,
+      consentIssuedAt + 61 * 60 * 1_000,
+    );
+    assert.equal(staleAcceptResponse.status, 400);
+    assert.equal((await readJson(staleAcceptResponse)).error, 'invalid_request');
+
     const acceptResponse = await completeConsentRedirect(new Request(
       `${ORIGIN}/api/auth/oauth2/consent/redirect`,
       {

--- a/scripts/mcp-server-settings-test.ts
+++ b/scripts/mcp-server-settings-test.ts
@@ -33,6 +33,10 @@ async function main(): Promise<void> {
     const { getDirectMcpEnabledTools } = await import(
       '../app/lib/mcp/server/config'
     );
+    const {
+      buildCodexMcpServerConfiguration,
+      missingScopesForEnabledCapabilities,
+    } = await import('../app/lib/mcp/client-configuration');
     const { applyDirectMcpSettingsToRuntime } = await import(
       '../app/lib/mcp/server/runtime-settings'
     );
@@ -155,6 +159,31 @@ async function main(): Promise<void> {
         { id: 'edit_knowledge_source', available: true, enabled: false, scopes: ['knowledge:write'] },
         { id: 'read_knowledge_asset', available: true, enabled: false, scopes: ['knowledge:assets'] },
       ],
+    );
+    assert.equal(
+      buildCodexMcpServerConfiguration({
+        endpoint: status.endpoint || '',
+        enabledTools: ['read_knowledge_asset', 'auth_probe', 'auth_probe'],
+      }),
+      [
+        '[mcp_servers.canvas]',
+        'url = "https://canvas.example.test/mcp"',
+        'enabled_tools = [',
+        '  "auth_probe",',
+        '  "read_knowledge_asset",',
+        ']',
+      ].join('\n'),
+    );
+    assert.deepEqual(
+      missingScopesForEnabledCapabilities({
+        grantedScopes: ['workspace:list'],
+        capabilities: status.capabilities.map((capability) => (
+          capability.id === 'read_knowledge_asset'
+            ? { ...capability, enabled: true }
+            : capability
+        )),
+      }),
+      ['knowledge:assets'],
     );
 
     const localDockerStatus = buildDirectMcpServerSettingsStatus(preferences, {


### PR DESCRIPTION
## Summary

- complete OAuth consent with a validated server-side HTTP 303 redirect so local clients reliably receive their callback
- expose copyable Codex MCP configuration and show missing OAuth scopes for enabled server capabilities
- improve actionable errors, request diagnostics, and public dynamic-client cleanup compatibility
- add focused coverage for consent redirects, invalid requests, permissions, diagnostics, client configuration, and cleanup

## Verification

- npm run test:mcp:server-login-consent
- npm run test:mcp:server-auth-probe
- npm run test:mcp:server-settings
- npm run test:mcp:server-oauth-hardening
- npm run test:mcp:server-diagnostics
- npm run test:mcp:server-request-history
- npm run test:mcp:server-provider
- npm run test:mcp:server-resource
- npm run test:mcp:server-oauth-client
- npx tsc --noEmit
- npm run lint (passes with three pre-existing warnings)
- node --disable-warning=DEP0205 ./node_modules/next/dist/bin/next build

## Known verification note

The regular npm run build reaches the prebuild license inventory check and stops on an unrelated existing generated inventory mismatch: actual allowed package count 1985 versus expected 1984. The direct Next.js production build completes successfully. No compliance artifact was changed as part of this PR.

## UI verification

No browser or Playwright run was performed because repository instructions require explicit approval before using them. Screenshots are therefore not included.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces client-side consent completion with a validated server-side HTTP 303 redirect and refreshes signed consent queries so users can deliberate for up to one hour.

- Adds origin, form, signature, and callback validation around consent completion.
- Adds per-stage OAuth diagnostics and request-history phases.
- Exposes Codex MCP configuration and highlights missing scopes for enabled capabilities.
- Improves tool authorization errors and dynamic-client cleanup compatibility.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/mcp/server/oauth-page-query.ts | Refreshes an originally valid signed consent query while retaining the original issuance time and enforcing a one-hour deliberation limit. |
| app/lib/mcp/server/oauth-consent-redirect.ts | Validates consent submissions and provider callback URLs before returning a top-level HTTP 303 redirect. |
| app/api/auth/oauth2/consent/redirect/route.ts | Adds the server-side consent completion endpoint with request diagnostics and controlled error responses. |
| app/[locale]/(routes)/oauth/consent/oauth-consent-client.tsx | Replaces JavaScript consent submission and navigation with a native top-level form POST. |
| app/lib/mcp/client-configuration.ts | Generates Codex TOML configuration and computes missing scopes for enabled MCP capabilities. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Browser
    participant Consent as Consent Redirect Route
    participant Provider as OAuth Provider
    Browser->>Consent: POST accept + signed oauth_query
    Consent->>Consent: Validate origin and refresh signature
    Consent->>Provider: POST refreshed consent request
    Provider-->>Consent: Validated callback URL
    Consent-->>Browser: HTTP 303 Location: client callback
    Browser->>Client: Authorization callback
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix delayed MCP OAuth consent submission"](https://github.com/canvascoding/canvas-notebook/commit/2b399443fc3eec16ac06662fc8ac04726b9baa70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58616160)</sub>

<!-- /greptile_comment -->