### PR TITLE
Fix team memory bootstrap permissions

### DIFF
--- a/app/lib/workspaces/postgres-runtime.ts
+++ b/app/lib/workspaces/postgres-runtime.ts
@@ -1293,10 +1293,6 @@ export async function ensurePostgresOrganizationBootstrapForUser(
   const ownerUser = await findPostgresUserById(database, organization.owner_user_id) || targetUser;
   await database.run('UPDATE "user" SET role = ?, updated_at = ? WHERE id = ?', ['admin', now, ownerUser.id]);
   const ownerPermission = await ensurePermissionRow(database, organization.organization_id, ownerUser.id, 'owner');
-  if (targetUser.id !== ownerUser.id) {
-    await database.run('UPDATE "user" SET role = ?, updated_at = ? WHERE id = ?', ['admin', now, targetUser.id]);
-    await ensurePermissionRow(database, organization.organization_id, targetUser.id, 'admin');
-  }
 
   await ensureWorkspaceRecord(database, {
     organizationId: organization.organization_id,

--- a/server.js
+++ b/server.js
@@ -808,7 +808,7 @@ async function startServer() {
   ]);
   console.log('[Startup] Next.js app prepared');
 
-  server.listen(port, (err) => {
+  server.listen(port, hostname, (err) => {
     if (err) throw err;
     console.log(`> Ready on http://localhost:${port}`);
     scheduleBackgroundMaintenance();

--- a/tests/memory-personal-ui.spec.ts
+++ b/tests/memory-personal-ui.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+
+const EMAIL = process.env.TEST_LOGIN_EMAIL || process.env.BOOTSTRAP_ADMIN_EMAIL;
+const PASSWORD = process.env.TEST_LOGIN_PASSWORD || process.env.BOOTSTRAP_ADMIN_PASSWORD;
+const enabled = process.env.E2E_MEMORY_UI === '1' && Boolean(EMAIL && PASSWORD);
+
+test.describe('Memory Manager settings', () => {
+  test.skip(!enabled, 'Requires an explicitly enabled local server and login credentials.');
+
+  test('renders private memory and the dedicated review configuration without mutation', async ({ page }, testInfo) => {
+    await page.goto('/en/login');
+    await page.getByRole('textbox', { name: /email/i }).fill(EMAIL!);
+    await page.getByRole('textbox', { name: 'Password', exact: true }).fill(PASSWORD!);
+    await Promise.all([
+      page.waitForURL((url) => !url.pathname.includes('/login'), { waitUntil: 'domcontentloaded' }),
+      page.locator('button[type="submit"]').click(),
+    ]);
+
+    await page.goto('/en/settings?tab=memory&scope=user', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Memory Manager', { exact: true })).toBeVisible();
+    await expect(page.getByText(/dedicated memory-manager worker/i)).toBeVisible();
+    const scopeTabs = page.getByRole('tablist', { name: 'Memory scope' });
+    await expect(scopeTabs).toBeVisible();
+    await expect(scopeTabs.getByRole('button', { name: 'My memory' })).toBeVisible();
+    await expect(scopeTabs.getByRole('button', { name: 'Agent memory' })).toBeVisible();
+    await expect(scopeTabs.getByRole('button', { name: 'Workspace' })).toBeDisabled();
+    await expect(scopeTabs.getByRole('button', { name: 'Organization' })).toBeVisible();
+    await expect(page.getByText('Memory review runtime', { exact: true })).toBeVisible();
+    await expect(page.getByRole('switch', { name: 'Automatic memory' })).toBeVisible();
+    await expect(page.getByLabel('Provider installation')).toBeVisible();
+    await expect(page.getByLabel('Lightweight review model')).toBeDisabled();
+    await expect(page.getByLabel('Prompt budget (tokens)')).toHaveValue('2000');
+    await expect(page.getByRole('button', { name: 'Save review settings' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Import JSON' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Delete all private memory' })).toBeVisible();
+    await expect(page.getByText('Loading memory…')).not.toBeVisible();
+
+    await scopeTabs.getByRole('button', { name: 'Agent memory' }).click();
+    await expect(page.getByText('Private agent context. Published shared memory is visible to readers; pending suggestions need a manager’s approval.')).toBeVisible();
+    await expect(page.getByText('Loading memory…')).not.toBeVisible();
+
+    await page.screenshot({ path: testInfo.outputPath('memory-manager.png'), fullPage: true });
+  });
+});

--- a/tests/memory-team-governance.spec.ts
+++ b/tests/memory-team-governance.spec.ts
@@ -85,7 +85,8 @@ test.describe('Memory team governance', () => {
       const writerPage = await writerContext.newPage();
       await login(writerPage, WRITER_EMAIL!, WRITER_PASSWORD!);
       await writerPage.goto(`/en/settings?tab=memory&scope=workspace&workspaceId=${encodeURIComponent(workspaceId!)}`);
-      await writerPage.getByRole('textbox', { name: /prefers short, decisive/i }).fill('Writer suggestions are reviewed before publication.');
+      await expect(writerPage.getByText('The team uses approved terminology in customer-facing material.')).toBeVisible();
+      await writerPage.getByPlaceholder('e.g. Prefers short, decisive weekly updates.').fill('Writer suggestions are reviewed before publication.');
       await writerPage.getByRole('button', { name: 'Suggest memory' }).click();
       await expect(writerPage.getByText('Memory suggestion created for review.')).toBeVisible();
       await expect(writerPage.getByRole('button', { name: 'Publish' })).toHaveCount(0);


### PR DESCRIPTION
## Summary
- prevent member workspace bootstrap from promoting users to organization administrators
- add a focused Memory Manager UI smoke test
- stabilize the team memory governance test selector

## Verification
- npm run build
- npm run test:memory:contract
- npm run test:memory:schema
- npm run test:memory:service
- npm run test:memory:legacy
- npm run test:agent:memory
- Team memory governance E2E passed on the local licensed team-seat environment before rebase; the rebased code passed build and the complete memory test suite.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the PostgreSQL bootstrap behavior that promoted non-owner users to organization administrators, adds an opt-in Memory Manager UI smoke test, and stabilizes the team-governance writer selector.
- Stops non-owner bootstrap users from receiving global and organization administrator privileges.
- Adds coverage for personal and agent memory settings.
- Changes the main server to bind to the configured hostname.
- Uses published memory content as a readiness gate before submitting a writer suggestion.

<h3>Confidence Score: 4/5</h3>

The server binding regression should be fixed before merging because the documented direct-start path can fail its loopback health check or lose external reachability.

The new `server.listen` hostname argument consumes an inherited OS hostname without normalization, while the startup script probes a fixed loopback address; the new UI test also uses credentials contrary to the repository's prescribed administrator-login convention.

**Files Needing Attention:** server.js; tests/memory-personal-ui.spec.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/workspaces/postgres-runtime.ts | Removes the bootstrap-time promotion and administrator permission grant for non-owner users; no concrete regression was established in provisioned member paths. |
| server.js | Explicit hostname binding can break the documented direct-start path when the inherited hostname does not bind loopback and all required interfaces. |
| tests/memory-personal-ui.spec.ts | Adds an opt-in Memory Manager smoke test, but its credential precedence conflicts with the repository's required bootstrap-admin login convention. |
| tests/memory-team-governance.spec.ts | Replaces a fragile accessible-name selector with a matching placeholder and adds a published-memory readiness assertion. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[npm start] --> B[start-services.sh]
  B --> C[server.js reads HOSTNAME]
  C --> D[server.listen on resolved interface]
  B --> E[Health check on 127.0.0.1]
  D --> F{Bound interface accepts loopback?}
  F -->|Yes| G[Startup succeeds]
  F -->|No| H[Health check fails and startup exits]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix team member bootstrap permissions"](https://github.com/canvascoding/canvas-notebook/commit/fc57661bf2375473f8e0833ab50f777d97ef9589) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58625565)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/canvascoding/canvas-notebook/blob/main/AGENTS.md))

<!-- /greptile_comment -->