### PR TITLE
Add secure MCP binary uploads

### DIFF
--- a/app/lib/mcp/server/binary-upload.ts
+++ b/app/lib/mcp/server/binary-upload.ts
@@ -507,14 +507,12 @@ export async function completeDirectMcpBinaryUpload(input: {
     if (!afterRevision || afterRevision.sha256 !== handle.contentSha256) {
       throw new DirectMcpBinaryUploadError('The uploaded file could not be verified after it was saved.');
     }
-    if (!completed.alreadyCompleted) {
-      await syncPublicSharesAfterWrite([handle.targetPath], input.workspace);
-      publishWorkspaceFileMutation({
-        workspace: input.workspace,
-        type: handle.beforeSha256 ? 'change' : 'add',
-        relativePath: handle.targetPath,
-      });
-    }
+    await syncPublicSharesAfterWrite([handle.targetPath], input.workspace);
+    publishWorkspaceFileMutation({
+      workspace: input.workspace,
+      type: handle.beforeSha256 ? 'change' : 'add',
+      relativePath: handle.targetPath,
+    });
     untrackUpload(principalBinding(input.principal), handle.sessionId);
     return {
       path: handle.targetPath,

--- a/app/lib/mcp/server/binary-upload.ts
+++ b/app/lib/mcp/server/binary-upload.ts
@@ -1,0 +1,570 @@
+import 'server-only';
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { fileTypeFromBuffer } from 'file-type';
+
+import { replaceWorkspaceFileFromPath } from '@/app/lib/filesystem/workspace-files';
+import { publishWorkspaceFileMutation } from '@/app/lib/filesystem/file-watcher';
+import { runWorkspaceUploadWrite } from '@/app/lib/files/workspace-upload-flow';
+import {
+  cancelWorkspaceUploadSession,
+  completeWorkspaceUploadFile,
+  createWorkspaceUploadSession,
+  writeWorkspaceUploadChunk,
+  WorkspaceUploadServiceError,
+} from '@/app/lib/files/workspace-upload-service';
+import {
+  getWorkspaceFileRevision,
+  sha256Buffer,
+} from '@/app/lib/files/revision-guard';
+import type { DirectMcpAccessPrincipal } from '@/app/lib/mcp/server/access-token-verifier';
+import { DIRECT_MCP_ASSET_MAX_BYTES } from '@/app/lib/mcp/server/asset-reader';
+import { syncPublicSharesAfterWrite } from '@/app/lib/public-sharing/public-file-shares';
+import { resolveAuthSecret } from '@/app/lib/security/auth-secret';
+import type { WorkspaceContext } from '@/app/lib/workspaces/types';
+
+export const DIRECT_MCP_UPLOAD_MAX_BYTES = DIRECT_MCP_ASSET_MAX_BYTES;
+export const DIRECT_MCP_UPLOAD_MAX_CHUNK_BYTES = 512 * 1024;
+export const DIRECT_MCP_UPLOAD_MAX_BASE64_CHARACTERS = Math.ceil(
+  DIRECT_MCP_UPLOAD_MAX_CHUNK_BYTES / 3,
+) * 4;
+export const DIRECT_MCP_UPLOAD_HANDLE_TTL_MS = 15 * 60 * 1000;
+
+const MAX_UPLOAD_HANDLE_LENGTH = 4096;
+const MAX_ACTIVE_UPLOADS_PER_CLIENT = 4;
+const HANDLE_VERSION = 1;
+const HANDLE_IV_BYTES = 12;
+const HANDLE_AUTH_TAG_BYTES = 16;
+const MIME_TYPE_PATTERN = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/u;
+const TEXT_MIME_TYPES = new Set([
+  'application/javascript',
+  'application/json',
+  'application/ld+json',
+  'application/toml',
+  'application/xml',
+  'application/yaml',
+]);
+const TEXT_FILE_EXTENSIONS = new Set([
+  '.c', '.cc', '.conf', '.cpp', '.css', '.csv', '.env', '.go', '.h', '.hpp', '.html', '.ini', '.java',
+  '.js', '.json', '.jsx', '.kt', '.log', '.lua', '.md', '.mdx', '.mjs', '.php', '.properties', '.py',
+  '.rb', '.rs', '.rst', '.sh', '.sql', '.svg', '.swift', '.text', '.toml', '.ts', '.tsx', '.tsv', '.txt',
+  '.xml', '.yaml', '.yml',
+]);
+const activeUploadsByPrincipal = new Map<string, Map<string, number>>();
+
+type DirectMcpUploadHandle = {
+  version: 1;
+  sessionId: string;
+  fileId: string;
+  workspaceId: string;
+  principalBinding: string;
+  targetPath: string;
+  size: number;
+  mimeType: string;
+  contentSha256: string;
+  beforeSha256: string | null;
+  expiresAt: number;
+};
+
+export class DirectMcpBinaryUploadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DirectMcpBinaryUploadError';
+  }
+}
+
+function uploadSignature(value: string): string {
+  return createHmac(
+    'sha256',
+    resolveAuthSecret(process.env, { allowProductionBuildFallback: true }),
+  ).update(value).digest('base64url');
+}
+
+function uploadEncryptionKey(): Buffer {
+  return createHash('sha256')
+    .update('canvas-direct-mcp-upload-handle\0', 'utf8')
+    .update(resolveAuthSecret(process.env, { allowProductionBuildFallback: true }), 'utf8')
+    .digest();
+}
+
+function principalBinding(principal: DirectMcpAccessPrincipal): string {
+  return uploadSignature(
+    `direct-mcp-upload:${principal.clientId}:${principal.userId}:${principal.sessionId}`,
+  );
+}
+
+function safeEqual(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  return actualBuffer.length === expectedBuffer.length
+    && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function encodeUploadHandle(payload: DirectMcpUploadHandle): string {
+  const iv = randomBytes(HANDLE_IV_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', uploadEncryptionKey(), iv);
+  const encrypted = Buffer.concat([
+    cipher.update(JSON.stringify(payload), 'utf8'),
+    cipher.final(),
+  ]);
+  return Buffer.concat([iv, cipher.getAuthTag(), encrypted]).toString('base64url');
+}
+
+function isUploadHandle(value: unknown): value is DirectMcpUploadHandle {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const payload = value as Partial<DirectMcpUploadHandle>;
+  return payload.version === HANDLE_VERSION
+    && typeof payload.sessionId === 'string'
+    && /^[a-f0-9-]{36}$/iu.test(payload.sessionId)
+    && typeof payload.fileId === 'string'
+    && /^[a-f0-9-]{36}$/iu.test(payload.fileId)
+    && typeof payload.workspaceId === 'string'
+    && Boolean(payload.workspaceId)
+    && typeof payload.principalBinding === 'string'
+    && /^[A-Za-z0-9_-]{40,64}$/u.test(payload.principalBinding)
+    && typeof payload.targetPath === 'string'
+    && Boolean(payload.targetPath)
+    && typeof payload.size === 'number'
+    && Number.isSafeInteger(payload.size)
+    && payload.size > 0
+    && payload.size <= DIRECT_MCP_UPLOAD_MAX_BYTES
+    && typeof payload.mimeType === 'string'
+    && MIME_TYPE_PATTERN.test(payload.mimeType)
+    && typeof payload.contentSha256 === 'string'
+    && /^[a-f0-9]{64}$/u.test(payload.contentSha256)
+    && (payload.beforeSha256 === null
+      || (typeof payload.beforeSha256 === 'string' && /^[a-f0-9]{64}$/u.test(payload.beforeSha256)))
+    && typeof payload.expiresAt === 'number'
+    && Number.isSafeInteger(payload.expiresAt);
+}
+
+function decodeUploadHandle(input: {
+  uploadId: string;
+  principal: DirectMcpAccessPrincipal;
+  workspaceId: string;
+  now?: number;
+}): DirectMcpUploadHandle {
+  const invalid = (): never => {
+    throw new DirectMcpBinaryUploadError('The upload session is invalid or expired. Start the upload again.');
+  };
+  if (!input.uploadId || input.uploadId.length > MAX_UPLOAD_HANDLE_LENGTH) invalid();
+  if (!/^[A-Za-z0-9_-]+$/u.test(input.uploadId)) invalid();
+
+  try {
+    const decoded = Buffer.from(input.uploadId, 'base64url');
+    if (
+      decoded.length <= HANDLE_IV_BYTES + HANDLE_AUTH_TAG_BYTES
+      || decoded.toString('base64url') !== input.uploadId
+    ) {
+      invalid();
+    }
+    const iv = decoded.subarray(0, HANDLE_IV_BYTES);
+    const authTag = decoded.subarray(HANDLE_IV_BYTES, HANDLE_IV_BYTES + HANDLE_AUTH_TAG_BYTES);
+    const encrypted = decoded.subarray(HANDLE_IV_BYTES + HANDLE_AUTH_TAG_BYTES);
+    const decipher = createDecipheriv('aes-256-gcm', uploadEncryptionKey(), iv);
+    decipher.setAuthTag(authTag);
+    const plaintext = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    const payload = JSON.parse(plaintext.toString('utf8')) as unknown;
+    if (!isUploadHandle(payload)) return invalid();
+    if (
+      payload.workspaceId !== input.workspaceId
+      || !safeEqual(payload.principalBinding, principalBinding(input.principal))
+      || payload.expiresAt <= (input.now ?? Date.now())
+    ) {
+      invalid();
+    }
+    return payload;
+  } catch (error) {
+    if (error instanceof DirectMcpBinaryUploadError) throw error;
+    return invalid();
+  }
+}
+
+function pruneTrackedUploads(now = Date.now()): void {
+  for (const [trackingKey, uploads] of activeUploadsByPrincipal) {
+    for (const [sessionId, expiresAt] of uploads) {
+      if (expiresAt <= now) uploads.delete(sessionId);
+    }
+    if (uploads.size === 0) activeUploadsByPrincipal.delete(trackingKey);
+  }
+}
+
+function assertUploadCapacity(trackingKey: string): void {
+  pruneTrackedUploads();
+  if ((activeUploadsByPrincipal.get(trackingKey)?.size ?? 0) >= MAX_ACTIVE_UPLOADS_PER_CLIENT) {
+    throw new DirectMcpBinaryUploadError(
+      `At most ${MAX_ACTIVE_UPLOADS_PER_CLIENT} binary uploads may be active for one MCP connection. Complete or abort an upload before starting another.`,
+    );
+  }
+}
+
+function trackUpload(trackingKey: string, sessionId: string, expiresAt: number): void {
+  const uploads = activeUploadsByPrincipal.get(trackingKey) ?? new Map<string, number>();
+  uploads.set(sessionId, expiresAt);
+  activeUploadsByPrincipal.set(trackingKey, uploads);
+}
+
+function untrackUpload(trackingKey: string, sessionId: string): void {
+  const uploads = activeUploadsByPrincipal.get(trackingKey);
+  uploads?.delete(sessionId);
+  if (uploads?.size === 0) activeUploadsByPrincipal.delete(trackingKey);
+}
+
+export function normalizeDirectMcpUploadMimeType(value: string | undefined): string {
+  const normalized = value?.trim().toLowerCase() || 'application/octet-stream';
+  if (normalized.length > 200 || !MIME_TYPE_PATTERN.test(normalized)) {
+    throw new DirectMcpBinaryUploadError('mime_type must be a valid MIME type without parameters.');
+  }
+  if (normalized.startsWith('text/') || TEXT_MIME_TYPES.has(normalized)) {
+    throw new DirectMcpBinaryUploadError(
+      'This tool accepts binary files only. Use edit_knowledge_source for visible text documents.',
+    );
+  }
+  return normalized;
+}
+
+function assertBinaryDestinationPath(targetPath: string): void {
+  if (TEXT_FILE_EXTENSIONS.has(path.posix.extname(targetPath).toLowerCase())) {
+    throw new DirectMcpBinaryUploadError(
+      'This tool accepts binary file paths only. Use edit_knowledge_source for visible text documents.',
+    );
+  }
+}
+
+export function decodeDirectMcpUploadChunk(value: string): Buffer {
+  if (!value || value.length > DIRECT_MCP_UPLOAD_MAX_BASE64_CHARACTERS) {
+    throw new DirectMcpBinaryUploadError(
+      `data_base64 must contain at most ${DIRECT_MCP_UPLOAD_MAX_CHUNK_BYTES} decoded bytes.`,
+    );
+  }
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(value)) {
+    throw new DirectMcpBinaryUploadError('data_base64 must be canonical standard Base64 without whitespace.');
+  }
+  const decoded = Buffer.from(value, 'base64');
+  if (decoded.length === 0 || decoded.length > DIRECT_MCP_UPLOAD_MAX_CHUNK_BYTES) {
+    throw new DirectMcpBinaryUploadError(
+      `data_base64 must contain between 1 and ${DIRECT_MCP_UPLOAD_MAX_CHUNK_BYTES} decoded bytes.`,
+    );
+  }
+  if (decoded.toString('base64') !== value) {
+    throw new DirectMcpBinaryUploadError('data_base64 must be canonical standard Base64 without whitespace.');
+  }
+  return decoded;
+}
+
+async function assertDestinationRevision(input: {
+  workspace: WorkspaceContext;
+  path: string;
+  beforeSha256: string | null;
+}): Promise<void> {
+  const current = await getWorkspaceFileRevision(input.path, { workspace: input.workspace });
+  if ((current?.sha256 ?? null) === input.beforeSha256) return;
+  throw new DirectMcpBinaryUploadError(
+    'The destination changed while the upload was in progress. Read the current file and start the upload again.',
+  );
+}
+
+async function inspectUploadedMimeType(buffer: Buffer, declaredMimeType: string): Promise<string | null> {
+  const detected = await fileTypeFromBuffer(buffer).catch(() => undefined);
+  if (
+    detected
+    && declaredMimeType !== 'application/octet-stream'
+    && detected.mime !== declaredMimeType
+  ) {
+    throw new DirectMcpBinaryUploadError(
+      `The uploaded bytes are ${detected.mime}, not the declared ${declaredMimeType}.`,
+    );
+  }
+  if (!detected && !buffer.subarray(0, 8192).includes(0)) {
+    try {
+      const text = new TextDecoder('utf-8', { fatal: true }).decode(buffer.subarray(0, 8192));
+      if (![...text].some((character) => {
+        const code = character.codePointAt(0) ?? 0;
+        return code < 32 && ![9, 10, 13].includes(code);
+      })) {
+        throw new DirectMcpBinaryUploadError(
+          'The uploaded content appears to be text. Use edit_knowledge_source for visible text documents.',
+        );
+      }
+    } catch (error) {
+      if (error instanceof DirectMcpBinaryUploadError) throw error;
+      // Invalid UTF-8 is expected for an unrecognized binary format.
+    }
+  }
+  return detected?.mime ?? null;
+}
+
+export async function beginDirectMcpBinaryUpload(input: {
+  principal: DirectMcpAccessPrincipal;
+  workspace: WorkspaceContext;
+  path: string;
+  size: number;
+  mimeType: string;
+  contentSha256: string;
+  overwrite: boolean;
+  expectedSha256: string | null;
+}): Promise<{
+  uploadId: string;
+  nextOffset: number;
+  maxChunkBytes: number;
+  expiresAt: string;
+  beforeSha256: string | null;
+}> {
+  const trackingKey = principalBinding(input.principal);
+  assertUploadCapacity(trackingKey);
+  assertBinaryDestinationPath(input.path);
+  if (!Number.isSafeInteger(input.size) || input.size < 1 || input.size > DIRECT_MCP_UPLOAD_MAX_BYTES) {
+    throw new DirectMcpBinaryUploadError(
+      `size must be an integer between 1 and ${DIRECT_MCP_UPLOAD_MAX_BYTES} bytes.`,
+    );
+  }
+  if (!/^[a-f0-9]{64}$/u.test(input.contentSha256)) {
+    throw new DirectMcpBinaryUploadError('sha256 must be the lowercase SHA-256 hash of the complete file.');
+  }
+
+  const currentRevision = await getWorkspaceFileRevision(input.path, { workspace: input.workspace });
+  if (currentRevision) {
+    if (!input.overwrite) {
+      throw new DirectMcpBinaryUploadError(
+        'The destination already exists. Set overwrite to true and provide its current expected_sha256 to replace it.',
+      );
+    }
+    if (!input.expectedSha256 || input.expectedSha256 !== currentRevision.sha256) {
+      throw new DirectMcpBinaryUploadError(
+        'The destination changed or expected_sha256 is missing. Read the current file and start the upload again.',
+      );
+    }
+  } else if (input.expectedSha256) {
+    throw new DirectMcpBinaryUploadError(
+      'The destination no longer exists. Start a new upload without expected_sha256.',
+    );
+  }
+
+  const targetDir = path.posix.dirname(input.path);
+  const session = await createWorkspaceUploadSession({
+    userId: input.principal.userId,
+    workspace: input.workspace,
+    targetDir,
+    files: [{
+      path: path.posix.basename(input.path),
+      size: input.size,
+      mimeType: input.mimeType,
+    }],
+  });
+  const file = session.files[0];
+  if (!file || file.targetPath !== input.path) {
+    await cancelWorkspaceUploadSession({
+      sessionId: session.id,
+      userId: input.principal.userId,
+      workspace: input.workspace,
+    }).catch(() => undefined);
+    throw new DirectMcpBinaryUploadError('Could not create a safe upload destination.');
+  }
+
+  const expiresAt = Math.min(
+    Date.now() + DIRECT_MCP_UPLOAD_HANDLE_TTL_MS,
+    new Date(session.expiresAt).getTime(),
+  );
+  const payload: DirectMcpUploadHandle = {
+    version: HANDLE_VERSION,
+    sessionId: session.id,
+    fileId: file.id,
+    workspaceId: input.workspace.workspaceId,
+    principalBinding: principalBinding(input.principal),
+    targetPath: input.path,
+    size: input.size,
+    mimeType: input.mimeType,
+    contentSha256: input.contentSha256,
+    beforeSha256: currentRevision?.sha256 ?? null,
+    expiresAt,
+  };
+  trackUpload(trackingKey, session.id, expiresAt);
+  return {
+    uploadId: encodeUploadHandle(payload),
+    nextOffset: 0,
+    maxChunkBytes: DIRECT_MCP_UPLOAD_MAX_CHUNK_BYTES,
+    expiresAt: new Date(expiresAt).toISOString(),
+    beforeSha256: payload.beforeSha256,
+  };
+}
+
+export async function writeDirectMcpBinaryUploadChunk(input: {
+  principal: DirectMcpAccessPrincipal;
+  workspace: WorkspaceContext;
+  uploadId: string;
+  offset: number;
+  buffer: Buffer;
+}): Promise<{
+  path: string;
+  nextOffset: number;
+  totalBytes: number;
+  alreadyReceived: boolean;
+}> {
+  const handle = decodeUploadHandle({
+    uploadId: input.uploadId,
+    principal: input.principal,
+    workspaceId: input.workspace.workspaceId,
+  });
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(input.buffer);
+      controller.close();
+    },
+  });
+  const written = await writeWorkspaceUploadChunk({
+    sessionId: handle.sessionId,
+    fileId: handle.fileId,
+    userId: input.principal.userId,
+    workspace: input.workspace,
+    offset: input.offset,
+    expectedBytes: input.buffer.length,
+    body,
+  });
+  return {
+    path: handle.targetPath,
+    nextOffset: written.file.uploadedBytes,
+    totalBytes: handle.size,
+    alreadyReceived: written.alreadyReceived,
+  };
+}
+
+export async function completeDirectMcpBinaryUpload(input: {
+  principal: DirectMcpAccessPrincipal;
+  workspace: WorkspaceContext;
+  uploadId: string;
+}): Promise<{
+  path: string;
+  size: number;
+  mimeType: string;
+  detectedMimeType: string | null;
+  beforeSha256: string | null;
+  afterSha256: string;
+  modifiedAt: number | undefined;
+  alreadyCompleted: boolean;
+}> {
+  const handle = decodeUploadHandle({
+    uploadId: input.uploadId,
+    principal: input.principal,
+    workspaceId: input.workspace.workspaceId,
+  });
+  let detectedMimeType: string | null = null;
+
+  try {
+    const completed = await completeWorkspaceUploadFile({
+      sessionId: handle.sessionId,
+      fileId: handle.fileId,
+      userId: input.principal.userId,
+      workspace: input.workspace,
+      commit: async ({ file, sourcePath }) => {
+        if (file.targetPath !== handle.targetPath || file.size !== handle.size) {
+          throw new DirectMcpBinaryUploadError('The upload session no longer matches the requested file.');
+        }
+        const buffer = await fs.readFile(sourcePath);
+        if (buffer.length !== handle.size || sha256Buffer(buffer) !== handle.contentSha256) {
+          throw new DirectMcpBinaryUploadError(
+            'The uploaded file does not match the declared size or SHA-256 hash. Start the upload again.',
+          );
+        }
+        detectedMimeType = await inspectUploadedMimeType(buffer, handle.mimeType);
+        await assertDestinationRevision({
+          workspace: input.workspace,
+          path: handle.targetPath,
+          beforeSha256: handle.beforeSha256,
+        });
+        await runWorkspaceUploadWrite({
+          workspace: input.workspace,
+          fileOptions: { workspace: input.workspace },
+          actorUserId: input.principal.userId,
+          targetPath: handle.targetPath,
+          write: (onBeforeReplace) => replaceWorkspaceFileFromPath(
+            sourcePath,
+            handle.targetPath,
+            { workspace: input.workspace },
+            async () => {
+              await assertDestinationRevision({
+                workspace: input.workspace,
+                path: handle.targetPath,
+                beforeSha256: handle.beforeSha256,
+              });
+              await onBeforeReplace();
+            },
+          ),
+        });
+      },
+    });
+
+    const afterRevision = await getWorkspaceFileRevision(handle.targetPath, { workspace: input.workspace });
+    if (!afterRevision || afterRevision.sha256 !== handle.contentSha256) {
+      throw new DirectMcpBinaryUploadError('The uploaded file could not be verified after it was saved.');
+    }
+    if (!completed.alreadyCompleted) {
+      await syncPublicSharesAfterWrite([handle.targetPath], input.workspace);
+      publishWorkspaceFileMutation({
+        workspace: input.workspace,
+        type: handle.beforeSha256 ? 'change' : 'add',
+        relativePath: handle.targetPath,
+      });
+    }
+    untrackUpload(principalBinding(input.principal), handle.sessionId);
+    return {
+      path: handle.targetPath,
+      size: handle.size,
+      mimeType: handle.mimeType,
+      detectedMimeType,
+      beforeSha256: handle.beforeSha256,
+      afterSha256: afterRevision.sha256,
+      modifiedAt: afterRevision.stats.modified,
+      alreadyCompleted: completed.alreadyCompleted,
+    };
+  } catch (error) {
+    if (error instanceof DirectMcpBinaryUploadError) {
+      await cancelWorkspaceUploadSession({
+        sessionId: handle.sessionId,
+        userId: input.principal.userId,
+        workspace: input.workspace,
+      }).catch(() => undefined);
+      untrackUpload(principalBinding(input.principal), handle.sessionId);
+    }
+    throw error;
+  }
+}
+
+export async function abortDirectMcpBinaryUpload(input: {
+  principal: DirectMcpAccessPrincipal;
+  workspace: WorkspaceContext;
+  uploadId: string;
+}): Promise<{ path: string }> {
+  const handle = decodeUploadHandle({
+    uploadId: input.uploadId,
+    principal: input.principal,
+    workspaceId: input.workspace.workspaceId,
+  });
+  await cancelWorkspaceUploadSession({
+    sessionId: handle.sessionId,
+    userId: input.principal.userId,
+    workspace: input.workspace,
+  });
+  untrackUpload(principalBinding(input.principal), handle.sessionId);
+  return { path: handle.targetPath };
+}
+
+export function directMcpBinaryUploadErrorMessage(error: unknown): string {
+  if (error instanceof DirectMcpBinaryUploadError) return error.message;
+  if (error instanceof WorkspaceUploadServiceError) {
+    if (['UPLOAD_NOT_FOUND', 'UPLOAD_FILE_NOT_FOUND', 'UPLOAD_FORBIDDEN', 'UPLOAD_EXPIRED'].includes(error.code)) {
+      return 'The upload session is invalid or expired. Start the upload again.';
+    }
+    return error.message;
+  }
+  return 'Could not safely upload the binary file to the Canvas workspace.';
+}

--- a/app/lib/mcp/server/config.ts
+++ b/app/lib/mcp/server/config.ts
@@ -14,6 +14,7 @@ export const DIRECT_MCP_TOOL_IDS = [
   'read_knowledge_source',
   'edit_knowledge_source',
   'read_knowledge_asset',
+  'upload_knowledge_asset',
 ] as const;
 export type DirectMcpToolId = (typeof DIRECT_MCP_TOOL_IDS)[number];
 

--- a/app/lib/mcp/server/direct-server.ts
+++ b/app/lib/mcp/server/direct-server.ts
@@ -55,10 +55,12 @@ export function createDirectMcpServer(
     });
   }
   const toolsById = new Map(tools.map((tool) => [tool.id, tool]));
+  const hasWriteTool = enabledTools.has('edit_knowledge_source')
+    || enabledTools.has('upload_knowledge_asset');
   const instructions = tools.length === 0
     ? 'No MCP tools are currently enabled for this Canvas Notebook instance.'
-    : enabledTools.has('edit_knowledge_source')
-      ? 'Canvas Notebook provides read access and exact, conflict-protected text edits only for workspaces the signed-in user explicitly allows for this MCP connection.'
+    : hasWriteTool
+      ? 'Canvas Notebook provides bounded reads and explicitly enabled, conflict-protected writes only for workspaces the signed-in user allows for this MCP connection.'
       : 'Canvas Notebook provides read-only access only to workspaces the signed-in user explicitly allows for this MCP connection.';
 
   const server = new Server(

--- a/app/lib/mcp/server/request-history.ts
+++ b/app/lib/mcp/server/request-history.ts
@@ -35,6 +35,7 @@ const TOOL_NAMES = new Set([
   'read_knowledge_source',
   'edit_knowledge_source',
   'read_knowledge_asset',
+  'upload_knowledge_asset',
 ]);
 
 export type DirectMcpRequestHistoryInput = {

--- a/app/lib/mcp/server/settings-status.ts
+++ b/app/lib/mcp/server/settings-status.ts
@@ -5,7 +5,6 @@ import {
   DIRECT_MCP_DEFAULT_TOOL_IDS,
   DIRECT_MCP_PROTOCOL_VERSION,
   DIRECT_MCP_SETTINGS_SOURCE_ENV,
-  DIRECT_MCP_TOOL_IDS,
   DIRECT_MCP_TOOLS_ENV,
   DIRECT_MCP_TOOLS_SOURCE_ENV,
   getDirectMcpEnabledTools,
@@ -57,6 +56,7 @@ const DIRECT_MCP_CAPABILITIES: ReadonlyArray<Omit<DirectMcpCapabilityStatus, 'en
   { id: 'read_knowledge_source', available: true, scopes: ['knowledge:read'] },
   { id: 'edit_knowledge_source', available: true, scopes: ['knowledge:write'] },
   { id: 'read_knowledge_asset', available: true, scopes: ['knowledge:assets'] },
+  { id: 'upload_knowledge_asset', available: true, scopes: ['knowledge:write'] },
 ];
 
 function settingsSource(

--- a/app/lib/mcp/server/workspace-tools.ts
+++ b/app/lib/mcp/server/workspace-tools.ts
@@ -61,6 +61,18 @@ import {
   readDirectMcpAsset,
 } from '@/app/lib/mcp/server/asset-reader';
 import {
+  abortDirectMcpBinaryUpload,
+  beginDirectMcpBinaryUpload,
+  completeDirectMcpBinaryUpload,
+  decodeDirectMcpUploadChunk,
+  directMcpBinaryUploadErrorMessage,
+  DIRECT_MCP_UPLOAD_MAX_BASE64_CHARACTERS,
+  DIRECT_MCP_UPLOAD_MAX_BYTES,
+  DIRECT_MCP_UPLOAD_MAX_CHUNK_BYTES,
+  normalizeDirectMcpUploadMimeType,
+  writeDirectMcpBinaryUploadChunk,
+} from '@/app/lib/mcp/server/binary-upload';
+import {
   type DirectMcpResourceScope,
   type DirectMcpToolId,
 } from '@/app/lib/mcp/server/config';
@@ -82,6 +94,7 @@ export const DIRECT_MCP_WORKSPACE_TOOL_IDS = [
   'read_knowledge_source',
   'edit_knowledge_source',
   'read_knowledge_asset',
+  'upload_knowledge_asset',
 ] as const satisfies readonly DirectMcpToolId[];
 
 const MAX_WORKSPACE_ID_LENGTH = 200;
@@ -164,6 +177,14 @@ function optionalInteger(
 ): number {
   const value = args[name];
   if (value === undefined) return defaultValue;
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    invalidParams(`${name} must be an integer between ${minimum} and ${maximum}.`);
+  }
+  return value;
+}
+
+function requiredInteger(args: JsonObject, name: string, minimum: number, maximum: number): number {
+  const value = args[name];
   if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < minimum || value > maximum) {
     invalidParams(`${name} must be an integer between ${minimum} and ${maximum}.`);
   }
@@ -475,6 +496,79 @@ export function getDirectMcpWorkspaceToolDescriptor(tool: WorkspaceToolName): Di
     };
   }
 
+  if (tool === 'upload_knowledge_asset') {
+    return {
+      name: tool,
+      title: 'Upload a binary workspace file',
+      description: 'Uploads one binary file in a short-lived, conflict-protected session. Call begin, send ordered Base64 chunks, then call complete; call abort to discard an unfinished upload.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          operation: { type: 'string', enum: ['begin', 'chunk', 'complete', 'abort'], description: 'Upload operation to perform.' },
+          workspace_id: { type: 'string', description: 'Workspace ID from list_workspaces.' },
+          path: { type: 'string', description: 'For begin, the visible workspace-relative destination path.' },
+          size: { type: 'integer', minimum: 1, maximum: DIRECT_MCP_UPLOAD_MAX_BYTES, description: 'For begin, exact file size in bytes.' },
+          mime_type: { type: 'string', description: 'For begin, MIME type without parameters. Defaults to application/octet-stream.' },
+          sha256: { type: 'string', description: 'For begin, lowercase SHA-256 of the complete file.' },
+          overwrite: { type: 'boolean', description: 'For begin, allow replacing an existing file. Defaults to false.' },
+          expected_sha256: { type: 'string', description: 'For overwrite, the current destination SHA-256 returned by a read tool.' },
+          upload_id: { type: 'string', description: 'Short-lived opaque upload handle returned by begin.' },
+          offset: { type: 'integer', minimum: 0, description: 'For chunk, zero-based byte offset. Chunks must be sent in order.' },
+          data_base64: { type: 'string', maxLength: DIRECT_MCP_UPLOAD_MAX_BASE64_CHARACTERS, description: `For chunk, canonical standard Base64 encoding of 1 to ${DIRECT_MCP_UPLOAD_MAX_CHUNK_BYTES} bytes.` },
+        },
+        required: ['operation', 'workspace_id'],
+        oneOf: [
+          {
+            properties: { operation: { const: 'begin' } },
+            required: ['path', 'size', 'sha256'],
+          },
+          {
+            properties: { operation: { const: 'chunk' } },
+            required: ['upload_id', 'offset', 'data_base64'],
+          },
+          {
+            properties: { operation: { const: 'complete' } },
+            required: ['upload_id'],
+          },
+          {
+            properties: { operation: { const: 'abort' } },
+            required: ['upload_id'],
+          },
+        ],
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: 'object' as const,
+        properties: {
+          operation: { type: 'string', enum: ['begin', 'chunk', 'complete', 'abort'] },
+          workspace_id: { type: 'string' },
+          path: { type: 'string' },
+          upload_id: { type: 'string' },
+          next_offset: { type: 'integer' },
+          total_size: { type: 'integer' },
+          max_chunk_bytes: { type: 'integer' },
+          expires_at: { type: 'string' },
+          already_received: { type: 'boolean' },
+          already_completed: { type: 'boolean' },
+          mime_type: { type: 'string' },
+          detected_mime_type: { type: ['string', 'null'] },
+          before_sha256: { type: ['string', 'null'] },
+          after_sha256: { type: 'string' },
+          modified_at: { type: ['string', 'null'] },
+        },
+        required: ['operation', 'workspace_id', 'path'],
+        additionalProperties: false,
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      ...getToolSecurity('knowledge:write'),
+    };
+  }
+
   return {
     name: tool,
     title: 'Read workspace document',
@@ -714,6 +808,7 @@ async function auditWorkspaceToolCall(input: {
   mimeType?: string;
   sizeBytes?: number;
   pageCount?: number;
+  uploadOperation?: 'begin' | 'chunk' | 'complete' | 'abort';
 }): Promise<void> {
   await recordAuditEvent({
     organizationId: input.workspace?.organizationId ?? null,
@@ -739,6 +834,7 @@ async function auditWorkspaceToolCall(input: {
       mimeType: input.mimeType ?? null,
       sizeBytes: input.sizeBytes ?? null,
       pageCount: input.pageCount ?? null,
+      uploadOperation: input.uploadOperation ?? null,
     },
   });
 }
@@ -1094,6 +1190,178 @@ async function executeReadKnowledgeAsset(
   }
 }
 
+async function executeUploadKnowledgeAsset(
+  args: unknown,
+  authInfo?: AuthInfo,
+): Promise<CallToolResult> {
+  const parsed = parseArgs(args);
+  const operation = requiredString(parsed, 'operation', 20);
+  if (!['begin', 'chunk', 'complete', 'abort'].includes(operation)) {
+    invalidParams('operation must be begin, chunk, complete, or abort.');
+  }
+  const uploadOperation = operation as 'begin' | 'chunk' | 'complete' | 'abort';
+  const workspaceId = requiredString(parsed, 'workspace_id', MAX_WORKSPACE_ID_LENGTH);
+  const authorization = await authenticateForTool(authInfo, 'knowledge:write');
+  if ('result' in authorization) return authorization.result;
+
+  try {
+    const workspace = await writableWorkspace(authorization.principal, workspaceId);
+
+    if (uploadOperation === 'begin') {
+      const filePath = requiredString(parsed, 'path', MAX_PATH_LENGTH);
+      assertVisibleWorkspacePath(filePath);
+      const size = requiredInteger(parsed, 'size', 1, DIRECT_MCP_UPLOAD_MAX_BYTES);
+      const contentSha256 = normalizeExpectedSha256(requiredString(parsed, 'sha256', 80));
+      if (!contentSha256) invalidParams('sha256 must be a valid SHA-256 hash of the complete file.');
+      const expectedSha256 = parsed.expected_sha256 === undefined
+        ? null
+        : normalizeExpectedSha256(requiredString(parsed, 'expected_sha256', 80));
+      if (parsed.expected_sha256 !== undefined && !expectedSha256) {
+        invalidParams('expected_sha256 must be a valid SHA-256 hash returned by a read tool.');
+      }
+      const mimeType = normalizeDirectMcpUploadMimeType(
+        optionalString(parsed, 'mime_type', 'application/octet-stream', 200),
+      );
+      const upload = await beginDirectMcpBinaryUpload({
+        principal: authorization.principal,
+        workspace,
+        path: filePath,
+        size,
+        mimeType,
+        contentSha256,
+        overwrite: optionalBoolean(parsed, 'overwrite') ?? false,
+        expectedSha256,
+      });
+      const structuredContent = {
+        operation: uploadOperation,
+        workspace_id: workspace.workspaceId,
+        path: filePath,
+        upload_id: upload.uploadId,
+        next_offset: upload.nextOffset,
+        total_size: size,
+        max_chunk_bytes: upload.maxChunkBytes,
+        expires_at: upload.expiresAt,
+        mime_type: mimeType,
+        before_sha256: upload.beforeSha256,
+      };
+      await auditWorkspaceToolCall({
+        principal: authorization.principal,
+        tool: 'upload_knowledge_asset',
+        workspace,
+        path: filePath,
+        beforeSha256: upload.beforeSha256 ?? undefined,
+        changed: false,
+        mimeType,
+        sizeBytes: size,
+        uploadOperation,
+      });
+      return result(structuredContent, `Binary upload started for ${filePath}. Send chunks beginning at byte 0.`);
+    }
+
+    const uploadId = requiredString(parsed, 'upload_id', 4096);
+    if (uploadOperation === 'chunk') {
+      const offset = requiredInteger(parsed, 'offset', 0, DIRECT_MCP_UPLOAD_MAX_BYTES);
+      const encodedData = requiredText(
+        parsed,
+        'data_base64',
+        DIRECT_MCP_UPLOAD_MAX_BASE64_CHARACTERS,
+      );
+      const buffer = decodeDirectMcpUploadChunk(encodedData);
+      const upload = await writeDirectMcpBinaryUploadChunk({
+        principal: authorization.principal,
+        workspace,
+        uploadId,
+        offset,
+        buffer,
+      });
+      const structuredContent = {
+        operation: uploadOperation,
+        workspace_id: workspace.workspaceId,
+        path: upload.path,
+        next_offset: upload.nextOffset,
+        total_size: upload.totalBytes,
+        already_received: upload.alreadyReceived,
+      };
+      await auditWorkspaceToolCall({
+        principal: authorization.principal,
+        tool: 'upload_knowledge_asset',
+        workspace,
+        path: upload.path,
+        resultCount: buffer.length,
+        changed: false,
+        sizeBytes: buffer.length,
+        uploadOperation,
+      });
+      return result(
+        structuredContent,
+        upload.nextOffset === upload.totalBytes
+          ? `All bytes for ${upload.path} were received. Call complete to verify and save the file.`
+          : `Received ${buffer.length} bytes for ${upload.path}. Continue at byte ${upload.nextOffset}.`,
+      );
+    }
+
+    if (uploadOperation === 'complete') {
+      const upload = await completeDirectMcpBinaryUpload({
+        principal: authorization.principal,
+        workspace,
+        uploadId,
+      });
+      const structuredContent = {
+        operation: uploadOperation,
+        workspace_id: workspace.workspaceId,
+        path: upload.path,
+        total_size: upload.size,
+        already_completed: upload.alreadyCompleted,
+        mime_type: upload.mimeType,
+        detected_mime_type: upload.detectedMimeType,
+        before_sha256: upload.beforeSha256,
+        after_sha256: upload.afterSha256,
+        modified_at: toIsoDate(upload.modifiedAt),
+      };
+      await auditWorkspaceToolCall({
+        principal: authorization.principal,
+        tool: 'upload_knowledge_asset',
+        workspace,
+        path: upload.path,
+        beforeSha256: upload.beforeSha256 ?? undefined,
+        afterSha256: upload.afterSha256,
+        changed: !upload.alreadyCompleted,
+        mimeType: upload.mimeType,
+        sizeBytes: upload.size,
+        uploadOperation,
+      });
+      return result(
+        structuredContent,
+        upload.alreadyCompleted
+          ? `The binary upload for ${upload.path} was already completed.`
+          : `Uploaded ${upload.path} and verified its SHA-256 hash.`,
+      );
+    }
+
+    const upload = await abortDirectMcpBinaryUpload({
+      principal: authorization.principal,
+      workspace,
+      uploadId,
+    });
+    const structuredContent = {
+      operation: uploadOperation,
+      workspace_id: workspace.workspaceId,
+      path: upload.path,
+    };
+    await auditWorkspaceToolCall({
+      principal: authorization.principal,
+      tool: 'upload_knowledge_asset',
+      workspace,
+      path: upload.path,
+      changed: false,
+      uploadOperation,
+    });
+    return result(structuredContent, `Discarded the unfinished binary upload for ${upload.path}.`);
+  } catch (error) {
+    return errorResult(directMcpBinaryUploadErrorMessage(error));
+  }
+}
+
 function editErrorResult(error: unknown): CallToolResult {
   if (error instanceof WorkspaceFileRevisionError) {
     return errorResult('The workspace file changed since it was read. Read the current file content again before retrying.');
@@ -1360,6 +1628,11 @@ export function getDirectMcpWorkspaceToolDefinitions(): DirectMcpWorkspaceToolDe
       id: 'read_knowledge_asset',
       descriptor: getDirectMcpWorkspaceToolDescriptor('read_knowledge_asset'),
       execute: executeReadKnowledgeAsset,
+    },
+    {
+      id: 'upload_knowledge_asset',
+      descriptor: getDirectMcpWorkspaceToolDescriptor('upload_knowledge_asset'),
+      execute: executeUploadKnowledgeAsset,
     },
   ];
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -3512,6 +3512,10 @@
           "read_knowledge_asset": {
             "title": "Bilder und PDFs lesen",
             "description": "Stellt begrenzten visuellen und Textkontext aus sichtbaren Bildern und PDF-Dokumenten nach einer ausdrücklichen Freigabe durch die Administration bereit."
+          },
+          "upload_knowledge_asset": {
+            "title": "Binärdateien hochladen",
+            "description": "Erlaubt größenbegrenzte und per Hash geprüfte Uploads in sichtbare Workspace-Pfade nach einer ausdrücklichen Freigabe durch die Administration."
           }
         }
       },

--- a/messages/en.json
+++ b/messages/en.json
@@ -3513,6 +3513,10 @@
           "read_knowledge_asset": {
             "title": "Read images and PDFs",
             "description": "Provides bounded visual and text context from visible images and PDF documents after an explicit administrator enablement."
+          },
+          "upload_knowledge_asset": {
+            "title": "Upload binary files",
+            "description": "Allows size-limited, hash-verified uploads to visible workspace paths after an explicit administrator enablement."
           }
         }
       },

--- a/scripts/mcp-server-auth-probe-test.ts
+++ b/scripts/mcp-server-auth-probe-test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -24,6 +25,7 @@ const DIRECT_MCP_TOOL_NAMES = [
   'read_knowledge_source',
   'edit_knowledge_source',
   'read_knowledge_asset',
+  'upload_knowledge_asset',
 ] as const;
 const DIRECT_MCP_RESOURCE_SCOPES = [
   'workspace:list',
@@ -442,10 +444,18 @@ async function main(): Promise<void> {
       scopes: ['knowledge:assets'],
     }]);
     assert.equal((assetTool.annotations as JsonRecord).readOnlyHint, true);
+    const uploadTool = tools.find((tool) => tool.name === 'upload_knowledge_asset');
+    assert.ok(uploadTool);
+    assert.deepEqual(uploadTool.securitySchemes, [{
+      type: 'oauth2',
+      scopes: ['knowledge:write'],
+    }]);
+    assert.equal((uploadTool.annotations as JsonRecord).readOnlyHint, false);
+    assert.equal((uploadTool.annotations as JsonRecord).destructiveHint, true);
 
     const { loadWorkspaceListingForActor } = await import('../app/lib/workspaces/listing-action');
     const { resolveWorkspaceActor } = await import('../app/lib/workspaces/context');
-    const { writeFile } = await import('../app/lib/filesystem/workspace-files');
+    const { readFile, writeFile } = await import('../app/lib/filesystem/workspace-files');
     const {
       grantDirectMcpDefaultWorkspaces,
       setDirectMcpWorkspaceEnabled,
@@ -715,6 +725,510 @@ async function main(): Promise<void> {
     assert.match(
       String((unsupportedAssetResult.content as Array<{ text?: string }>)[0]?.text),
       /Only PNG, JPEG, GIF, WebP images, and PDF documents/u,
+    );
+
+    const uploadedAssetBytes = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9JH8sAAAAASUVORK5CYII=',
+      'base64',
+    );
+    const uploadedAssetSha256 = createHash('sha256').update(uploadedAssetBytes).digest('hex');
+    const missingUploadScope = await rpcRequest({
+      post: mcpRoute.POST,
+      token: noProbeScopeToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 36,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'begin',
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-upload.png',
+            size: uploadedAssetBytes.length,
+            mime_type: 'image/png',
+            sha256: uploadedAssetSha256,
+          },
+        },
+      },
+    });
+    const missingUploadScopeResult = resultFromRpc(await readJson(missingUploadScope));
+    assert.equal(missingUploadScopeResult.isError, true);
+    const uploadScopeChallenge = (
+      missingUploadScopeResult._meta as JsonRecord
+    )['mcp/www_authenticate'] as string[];
+    assert.ok(uploadScopeChallenge[0].includes('error="insufficient_scope"'));
+    assert.ok(uploadScopeChallenge[0].includes('scope="knowledge:write"'));
+
+    const beginUpload = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 37,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'begin',
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-upload.png',
+            size: uploadedAssetBytes.length,
+            mime_type: 'image/png',
+            sha256: uploadedAssetSha256,
+          },
+        },
+      },
+    });
+    const beginUploadResult = resultFromRpc(await readJson(beginUpload));
+    assert.notEqual(beginUploadResult.isError, true);
+    const beginUploadContent = beginUploadResult.structuredContent as JsonRecord;
+    assert.equal(beginUploadContent.operation, 'begin');
+    assert.equal(beginUploadContent.next_offset, 0);
+    assert.equal(beginUploadContent.before_sha256, null);
+    assert.equal(beginUploadContent.total_size, uploadedAssetBytes.length);
+    assert.equal(typeof beginUploadContent.upload_id, 'string');
+    assert.ok(Number(beginUploadContent.max_chunk_bytes) >= uploadedAssetBytes.length);
+    const uploadId = String(beginUploadContent.upload_id);
+
+    const tamperedUpload = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 38,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'chunk',
+            workspace_id: workspace.workspaceId,
+            upload_id: `${uploadId.slice(0, -1)}${uploadId.endsWith('A') ? 'B' : 'A'}`,
+            offset: 0,
+            data_base64: uploadedAssetBytes.toString('base64'),
+          },
+        },
+      },
+    });
+    const tamperedUploadResult = resultFromRpc(await readJson(tamperedUpload));
+    assert.equal(tamperedUploadResult.isError, true);
+    assert.match(
+      String((tamperedUploadResult.content as Array<{ text?: string }>)[0]?.text),
+      /invalid or expired/u,
+    );
+
+    const malformedChunk = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 39,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'chunk',
+            workspace_id: workspace.workspaceId,
+            upload_id: uploadId,
+            offset: 0,
+            data_base64: `${uploadedAssetBytes.toString('base64')}\n`,
+          },
+        },
+      },
+    });
+    const malformedChunkResult = resultFromRpc(await readJson(malformedChunk));
+    assert.equal(malformedChunkResult.isError, true);
+    assert.match(
+      String((malformedChunkResult.content as Array<{ text?: string }>)[0]?.text),
+      /canonical standard Base64/u,
+    );
+
+    const splitOffset = Math.floor(uploadedAssetBytes.length / 2);
+    const offsetMismatch = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 40,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'chunk',
+            workspace_id: workspace.workspaceId,
+            upload_id: uploadId,
+            offset: 1,
+            data_base64: uploadedAssetBytes.subarray(0, splitOffset).toString('base64'),
+          },
+        },
+      },
+    });
+    const offsetMismatchResult = resultFromRpc(await readJson(offsetMismatch));
+    assert.equal(offsetMismatchResult.isError, true);
+    assert.match(
+      String((offsetMismatchResult.content as Array<{ text?: string }>)[0]?.text),
+      /expects byte 0/u,
+    );
+
+    const firstChunk = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 41,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'chunk',
+            workspace_id: workspace.workspaceId,
+            upload_id: uploadId,
+            offset: 0,
+            data_base64: uploadedAssetBytes.subarray(0, splitOffset).toString('base64'),
+          },
+        },
+      },
+    });
+    const firstChunkResult = resultFromRpc(await readJson(firstChunk));
+    assert.equal((firstChunkResult.structuredContent as JsonRecord).next_offset, splitOffset);
+
+    const duplicateChunk = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 42,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'chunk',
+            workspace_id: workspace.workspaceId,
+            upload_id: uploadId,
+            offset: 0,
+            data_base64: uploadedAssetBytes.subarray(0, splitOffset).toString('base64'),
+          },
+        },
+      },
+    });
+    const duplicateChunkResult = resultFromRpc(await readJson(duplicateChunk));
+    assert.equal((duplicateChunkResult.structuredContent as JsonRecord).already_received, true);
+    assert.equal((duplicateChunkResult.structuredContent as JsonRecord).next_offset, splitOffset);
+
+    const finalChunk = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 43,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'chunk',
+            workspace_id: workspace.workspaceId,
+            upload_id: uploadId,
+            offset: splitOffset,
+            data_base64: uploadedAssetBytes.subarray(splitOffset).toString('base64'),
+          },
+        },
+      },
+    });
+    const finalChunkResult = resultFromRpc(await readJson(finalChunk));
+    assert.equal(
+      (finalChunkResult.structuredContent as JsonRecord).next_offset,
+      uploadedAssetBytes.length,
+    );
+
+    const completeUpload = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 44,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'complete',
+            workspace_id: workspace.workspaceId,
+            upload_id: uploadId,
+          },
+        },
+      },
+    });
+    const completeUploadResult = resultFromRpc(await readJson(completeUpload));
+    assert.notEqual(
+      completeUploadResult.isError,
+      true,
+      JSON.stringify(completeUploadResult),
+    );
+    const completeUploadContent = completeUploadResult.structuredContent as JsonRecord;
+    assert.equal(completeUploadContent.path, 'mcp-server-upload.png');
+    assert.equal(completeUploadContent.after_sha256, uploadedAssetSha256);
+    assert.equal(completeUploadContent.mime_type, 'image/png');
+    assert.equal(completeUploadContent.detected_mime_type, 'image/png');
+    assert.equal(completeUploadContent.already_completed, false);
+
+    const readUploadedAsset = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 45,
+        method: 'tools/call',
+        params: {
+          name: 'read_knowledge_asset',
+          arguments: { workspace_id: workspace.workspaceId, path: 'mcp-server-upload.png' },
+        },
+      },
+    });
+    const readUploadedAssetResult = resultFromRpc(await readJson(readUploadedAsset));
+    assert.equal(
+      (readUploadedAssetResult.structuredContent as JsonRecord).sha256,
+      uploadedAssetSha256,
+    );
+
+    const overwriteWithoutRevision = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 46,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'begin',
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-upload.png',
+            size: uploadedAssetBytes.length,
+            mime_type: 'image/png',
+            sha256: uploadedAssetSha256,
+            overwrite: true,
+          },
+        },
+      },
+    });
+    const overwriteWithoutRevisionResult = resultFromRpc(await readJson(overwriteWithoutRevision));
+    assert.equal(overwriteWithoutRevisionResult.isError, true);
+    assert.match(
+      String((overwriteWithoutRevisionResult.content as Array<{ text?: string }>)[0]?.text),
+      /expected_sha256 is missing/u,
+    );
+
+    const badHashBytes = Buffer.from([0, 1, 2, 3]);
+    const beginBadHashUpload = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 47,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'begin',
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-bad-hash.bin',
+            size: badHashBytes.length,
+            sha256: '0'.repeat(64),
+          },
+        },
+      },
+    });
+    const beginBadHashResult = resultFromRpc(await readJson(beginBadHashUpload));
+    const badHashUploadId = String(
+      (beginBadHashResult.structuredContent as JsonRecord).upload_id,
+    );
+    const badHashChunk = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 48,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'chunk',
+            workspace_id: workspace.workspaceId,
+            upload_id: badHashUploadId,
+            offset: 0,
+            data_base64: badHashBytes.toString('base64'),
+          },
+        },
+      },
+    });
+    assert.notEqual(resultFromRpc(await readJson(badHashChunk)).isError, true);
+    const completeBadHash = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 49,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'complete',
+            workspace_id: workspace.workspaceId,
+            upload_id: badHashUploadId,
+          },
+        },
+      },
+    });
+    const completeBadHashResult = resultFromRpc(await readJson(completeBadHash));
+    assert.equal(completeBadHashResult.isError, true);
+    assert.match(
+      String((completeBadHashResult.content as Array<{ text?: string }>)[0]?.text),
+      /does not match the declared size or SHA-256 hash/u,
+    );
+
+    const abortedBytes = Buffer.from([0, 7]);
+    const beginAbortedUpload = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 50,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'begin',
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-aborted.bin',
+            size: abortedBytes.length,
+            sha256: createHash('sha256').update(abortedBytes).digest('hex'),
+          },
+        },
+      },
+    });
+    const abortedUploadId = String(
+      (resultFromRpc(await readJson(beginAbortedUpload)).structuredContent as JsonRecord).upload_id,
+    );
+    const abortUpload = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 52,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'abort',
+            workspace_id: workspace.workspaceId,
+            upload_id: abortedUploadId,
+          },
+        },
+      },
+    });
+    assert.equal(
+      (resultFromRpc(await readJson(abortUpload)).structuredContent as JsonRecord).operation,
+      'abort',
+    );
+    const chunkAfterAbort = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 53,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'chunk',
+            workspace_id: workspace.workspaceId,
+            upload_id: abortedUploadId,
+            offset: 0,
+            data_base64: abortedBytes.toString('base64'),
+          },
+        },
+      },
+    });
+    assert.match(
+      String((resultFromRpc(await readJson(chunkAfterAbort)).content as Array<{ text?: string }>)[0]?.text),
+      /invalid or expired/u,
+    );
+
+    const initialConflictBytes = Buffer.from([0, 1]);
+    const replacementConflictBytes = Buffer.from([0, 2]);
+    const concurrentConflictBytes = Buffer.from([0, 9]);
+    await writeFile('mcp-server-upload-conflict.bin', initialConflictBytes, { workspace });
+    const initialConflictSha256 = createHash('sha256').update(initialConflictBytes).digest('hex');
+    const beginConflictUpload = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 54,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'begin',
+            workspace_id: workspace.workspaceId,
+            path: 'mcp-server-upload-conflict.bin',
+            size: replacementConflictBytes.length,
+            sha256: createHash('sha256').update(replacementConflictBytes).digest('hex'),
+            overwrite: true,
+            expected_sha256: initialConflictSha256,
+          },
+        },
+      },
+    });
+    const conflictUploadId = String(
+      (resultFromRpc(await readJson(beginConflictUpload)).structuredContent as JsonRecord).upload_id,
+    );
+    const conflictChunk = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 55,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'chunk',
+            workspace_id: workspace.workspaceId,
+            upload_id: conflictUploadId,
+            offset: 0,
+            data_base64: replacementConflictBytes.toString('base64'),
+          },
+        },
+      },
+    });
+    assert.notEqual(resultFromRpc(await readJson(conflictChunk)).isError, true);
+    await writeFile('mcp-server-upload-conflict.bin', concurrentConflictBytes, { workspace });
+    const completeConflictUpload = await rpcRequest({
+      post: mcpRoute.POST,
+      token: workspaceToolsToken,
+      body: {
+        jsonrpc: '2.0',
+        id: 56,
+        method: 'tools/call',
+        params: {
+          name: 'upload_knowledge_asset',
+          arguments: {
+            operation: 'complete',
+            workspace_id: workspace.workspaceId,
+            upload_id: conflictUploadId,
+          },
+        },
+      },
+    });
+    const completeConflictResult = resultFromRpc(await readJson(completeConflictUpload));
+    assert.equal(completeConflictResult.isError, true);
+    assert.match(
+      String((completeConflictResult.content as Array<{ text?: string }>)[0]?.text),
+      /destination changed while the upload was in progress/u,
+    );
+    assert.deepEqual(
+      await readFile('mcp-server-upload-conflict.bin', { workspace }),
+      concurrentConflictBytes,
     );
 
     const staleEdit = await rpcRequest({

--- a/scripts/mcp-server-auth-probe-test.ts
+++ b/scripts/mcp-server-auth-probe-test.ts
@@ -970,6 +970,89 @@ async function main(): Promise<void> {
     assert.equal(completeUploadContent.detected_mime_type, 'image/png');
     assert.equal(completeUploadContent.already_completed, false);
 
+    const { createPublicFileShares } = await import(
+      '../app/lib/public-sharing/public-file-shares'
+    );
+    const createdUploadShare = await createPublicFileShares({
+      paths: ['mcp-server-upload.png'],
+      createdByUserId: userId,
+      workspace,
+    });
+    assert.equal(createdUploadShare.shares.length, 1);
+    const uploadShare = createdUploadShare.shares[0];
+    assert.ok(uploadShare);
+    assert.ok(uploadShare.lastKnownRevision);
+    const staleShareDatabase = await openDb();
+    try {
+      await staleShareDatabase.run(
+        'UPDATE public_file_shares SET last_known_revision = ? WHERE id = ?',
+        ['stale-upload-revision', uploadShare.id],
+      );
+    } finally {
+      await staleShareDatabase.close();
+    }
+
+    const { getFileWatcher } = await import('../app/lib/filesystem/file-watcher');
+    const uploadRetryEvents: Array<{ relativePath: string; type: string }> = [];
+    const fileWatcher = getFileWatcher();
+    const unsubscribeUploadRetry = fileWatcher.subscribe({
+      id: 'mcp-upload-retry-test',
+      workspaceId: workspace.workspaceId,
+      workspace,
+      send: (event) => uploadRetryEvents.push(event),
+    });
+    try {
+      const completeUploadRetry = await rpcRequest({
+        post: mcpRoute.POST,
+        token: workspaceToolsToken,
+        body: {
+          jsonrpc: '2.0',
+          id: 440,
+          method: 'tools/call',
+          params: {
+            name: 'upload_knowledge_asset',
+            arguments: {
+              operation: 'complete',
+              workspace_id: workspace.workspaceId,
+              upload_id: uploadId,
+            },
+          },
+        },
+      });
+      const completeUploadRetryResult = resultFromRpc(await readJson(completeUploadRetry));
+      assert.notEqual(
+        completeUploadRetryResult.isError,
+        true,
+        JSON.stringify(completeUploadRetryResult),
+      );
+      assert.equal(
+        (completeUploadRetryResult.structuredContent as JsonRecord).already_completed,
+        true,
+      );
+      assert.equal(
+        uploadRetryEvents.some((event) => (
+          event.relativePath === 'mcp-server-upload.png'
+          && event.type === 'add'
+        )),
+        true,
+        'Idempotent completion retries should republish the committed file mutation.',
+      );
+    } finally {
+      unsubscribeUploadRetry();
+      fileWatcher.stop();
+    }
+
+    const reconciledShareDatabase = await openDb();
+    try {
+      const reconciledShare = await reconciledShareDatabase.get(
+        'SELECT last_known_revision AS lastKnownRevision FROM public_file_shares WHERE id = ?',
+        [uploadShare.id],
+      ) as { lastKnownRevision: string | null } | undefined;
+      assert.equal(reconciledShare?.lastKnownRevision, uploadShare.lastKnownRevision);
+    } finally {
+      await reconciledShareDatabase.close();
+    }
+
     const readUploadedAsset = await rpcRequest({
       post: mcpRoute.POST,
       token: workspaceToolsToken,

--- a/scripts/mcp-server-request-history-test.ts
+++ b/scripts/mcp-server-request-history-test.ts
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
       phase: 'oauth.registration',
       httpMethod: 'POST',
       operation: 'tools/call',
-      toolName: 'read_knowledge_asset',
+      toolName: 'upload_knowledge_asset',
       outcome: 'succeeded',
       statusCode: 201,
       code: 'OAUTH_REQUEST_COMPLETED',
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
     assert.equal(entries[0].phase, 'oauth.registration');
     assert.equal(entries[0].httpMethod, 'POST');
     assert.equal(entries[0].operation, 'tools/call');
-    assert.equal(entries[0].toolName, 'read_knowledge_asset');
+    assert.equal(entries[0].toolName, 'upload_knowledge_asset');
     assert.equal(entries[0].outcome, 'succeeded');
     assert.equal(entries[0].statusCode, 201);
     assert.equal(entries[0].code, 'OAUTH_REQUEST_COMPLETED');

--- a/scripts/mcp-server-settings-test.ts
+++ b/scripts/mcp-server-settings-test.ts
@@ -158,6 +158,7 @@ async function main(): Promise<void> {
         { id: 'read_knowledge_source', available: true, enabled: true, scopes: ['knowledge:read'] },
         { id: 'edit_knowledge_source', available: true, enabled: true, scopes: ['knowledge:write'] },
         { id: 'read_knowledge_asset', available: true, enabled: true, scopes: ['knowledge:assets'] },
+        { id: 'upload_knowledge_asset', available: true, enabled: true, scopes: ['knowledge:write'] },
       ],
     );
     assert.equal(
@@ -177,11 +178,10 @@ async function main(): Promise<void> {
     assert.deepEqual(
       missingScopesForEnabledCapabilities({
         grantedScopes: ['workspace:list'],
-        capabilities: status.capabilities.map((capability) => (
-          capability.id === 'read_knowledge_asset'
-            ? { ...capability, enabled: true }
-            : capability
-        )),
+        capabilities: status.capabilities.map((capability) => ({
+          ...capability,
+          enabled: capability.id === 'read_knowledge_asset',
+        })),
       }),
       ['knowledge:assets'],
     );


### PR DESCRIPTION
## Summary

- add the opt-in `upload_knowledge_asset` MCP tool with begin, chunk, complete, and abort operations
- bind encrypted short-lived upload handles to the OAuth principal and workspace
- verify write permission, size, Base64 chunks, SHA-256, MIME type, and destination revision before the atomic commit
- expose the capability in MCP settings and request history with German and English UI copy
- keep text writes on `edit_knowledge_source`

## Verification

- `npx tsc --noEmit --pretty false`
- `npm run lint` (passes with two pre-existing React hook warnings)
- `npm run test:mcp:server-settings`
- `npm run test:mcp:server-request-history`
- `npm run test:mcp:server-auth-probe`
- `node --disable-warning=DEP0205 ./node_modules/next/dist/bin/next build`

## Known repository check

- `npm run build` currently stops in the existing third-party inventory check because generated compliance metadata differs from the installed `@swc/helpers` license state. This PR changes no dependencies; the underlying Next.js production build succeeds.

## UI verification

- No browser or Playwright test was run because repository rules require explicit approval. The settings view renders the new capability through the existing generic capability list.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an opt-in MCP tool for authenticated, chunked binary uploads with encrypted short-lived handles, revision protection, content validation, settings exposure, request-history support, and localized UI copy.

- Adds begin, chunk, complete, and abort operations for binary workspace uploads.
- Binds handles to the OAuth principal and workspace and verifies size, hash, MIME type, permissions, and destination revision.
- Extends MCP configuration, capability status, diagnostics, translations, and integration tests.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until retried upload completion reliably performs public-share and watcher reconciliation after a post-commit failure.

A successful file commit can be followed by a synchronization failure, after which completion retries treat the session as already completed and permanently skip the required reconciliation side effects.

**Files Needing Attention:** app/lib/mcp/server/binary-upload.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/mcp/server/binary-upload.ts | Implements secure upload handles and staged completion, but retried completion can permanently skip post-commit share and watcher reconciliation. |
| app/lib/mcp/server/workspace-tools.ts | Adds the upload tool schema, authorization, operation dispatch, structured responses, and audit metadata. |
| app/lib/mcp/server/config.ts | Registers upload_knowledge_asset as an opt-in Direct MCP tool without changing the default read-only set. |
| app/lib/mcp/server/settings-status.ts | Exposes the new write-scoped capability in MCP settings status. |
| app/lib/mcp/server/request-history.ts | Allows request-history records to retain the new tool name. |
| scripts/mcp-server-auth-probe-test.ts | Extends MCP integration coverage for upload discovery, authorization, validation, chunking, completion, and overwrite behavior. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client as MCP Client
  participant Tool as upload_knowledge_asset
  participant Session as Upload Session Service
  participant Workspace as Workspace Storage
  participant Shares as Share/Watcher Reconciliation
  Client->>Tool: begin(path, size, sha256)
  Tool->>Session: create session
  Session-->>Tool: session and file IDs
  Tool-->>Client: encrypted upload_id
  loop Ordered chunks
    Client->>Tool: chunk(upload_id, offset, base64)
    Tool->>Session: append validated bytes
  end
  Client->>Tool: complete(upload_id)
  Tool->>Session: verify and commit
  Session->>Workspace: atomic replacement
  Session-->>Tool: completed
  Tool->>Shares: synchronize shares and publish mutation
  Tool-->>Client: verified result
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add secure MCP binary uploads"](https://github.com/canvascoding/canvas-notebook/commit/c61e50b7d79a0e152651e6fc2885097cb1d4a2fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58659231)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->