### PR TITLE
Fix PDF browser profile contention

### DIFF
--- a/app/lib/pdf/browser.ts
+++ b/app/lib/pdf/browser.ts
@@ -29,6 +29,15 @@ export function findChromiumExecutable(): string {
   return resolveChromiumExecutable().executablePath;
 }
 
+/**
+ * PDF rendering does not need browser state to survive a Node.js process.
+ * Keeping the profile process-scoped prevents multiple app workers from
+ * attempting to open Chromium with the same profile directory.
+ */
+export function getPdfBrowserProfileId(pid: number = process.pid): string {
+  return `${PDF_EXPORT_PROFILE_ID}-${pid}`;
+}
+
 export async function getBrowser(): Promise<Browser> {
   if (browser?.connected) return browser;
 
@@ -46,7 +55,7 @@ export async function getBrowser(): Promise<Browser> {
 }
 
 async function launchPdfBrowser(): Promise<Browser> {
-  const userDataDir = resolveBrowserUserDataDir(process.env, nodeFs.existsSync, PDF_EXPORT_PROFILE_ID);
+  const userDataDir = resolveBrowserUserDataDir(process.env, nodeFs.existsSync, getPdfBrowserProfileId());
   const launchSpec = buildBrowserLaunchSpec({ forceHeadless: true, userDataDir });
   await fs.mkdir(launchSpec.userDataDir, { recursive: true });
   const preparation = await prepareBrowserProfileForLaunch(launchSpec.userDataDir);

--- a/app/lib/pdf/browser.ts
+++ b/app/lib/pdf/browser.ts
@@ -1,6 +1,7 @@
 import puppeteer, { Browser, Page } from 'puppeteer-core';
 import nodeFs from 'node:fs';
 import fs from 'node:fs/promises';
+import path from 'node:path';
 
 import {
   buildBrowserLaunchSpec,
@@ -38,6 +39,50 @@ export function getPdfBrowserProfileId(pid: number = process.pid): string {
   return `${PDF_EXPORT_PROFILE_ID}-${pid}`;
 }
 
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'EPERM');
+  }
+}
+
+export function buildPdfBrowserLaunchSpec({
+  env = process.env,
+  existsSync = nodeFs.existsSync,
+  pid = process.pid,
+}: {
+  env?: NodeJS.ProcessEnv;
+  existsSync?: (path: string) => boolean;
+  pid?: number;
+} = {}) {
+  const userDataDir = resolveBrowserUserDataDir(env, existsSync, getPdfBrowserProfileId(pid));
+  return buildBrowserLaunchSpec({ env, existsSync, forceHeadless: true, userDataDir });
+}
+
+export async function removeStalePdfBrowserProfiles(
+  profileRoot: string,
+  currentPid: number = process.pid,
+  processRunning: (pid: number) => boolean = isProcessRunning,
+): Promise<string[]> {
+  const entries = await fs.readdir(profileRoot, { withFileTypes: true });
+  const removedProfiles: string[] = [];
+
+  for (const entry of entries) {
+    const match = new RegExp(`^${PDF_EXPORT_PROFILE_ID}-(\\d+)$`).exec(entry.name);
+    if (!match || !entry.isDirectory()) continue;
+
+    const pid = Number(match[1]);
+    if (pid === currentPid || processRunning(pid)) continue;
+
+    await fs.rm(path.join(profileRoot, entry.name), { recursive: true, force: true });
+    removedProfiles.push(entry.name);
+  }
+
+  return removedProfiles;
+}
+
 export async function getBrowser(): Promise<Browser> {
   if (browser?.connected) return browser;
 
@@ -55,9 +100,12 @@ export async function getBrowser(): Promise<Browser> {
 }
 
 async function launchPdfBrowser(): Promise<Browser> {
-  const userDataDir = resolveBrowserUserDataDir(process.env, nodeFs.existsSync, getPdfBrowserProfileId());
-  const launchSpec = buildBrowserLaunchSpec({ forceHeadless: true, userDataDir });
+  const launchSpec = buildPdfBrowserLaunchSpec();
   await fs.mkdir(launchSpec.userDataDir, { recursive: true });
+  const removedProfiles = await removeStalePdfBrowserProfiles(path.dirname(launchSpec.userDataDir));
+  if (removedProfiles.length > 0) {
+    console.info('[PDF Browser] Removed stale Chromium profiles before launch:', { removedProfiles });
+  }
   const preparation = await prepareBrowserProfileForLaunch(launchSpec.userDataDir);
   if (preparation.removedArtifacts.length > 0) {
     console.info('[PDF Browser] Removed stale Chromium profile startup artifacts before launch:', {

--- a/scripts/browser-runtime-test.ts
+++ b/scripts/browser-runtime-test.ts
@@ -305,8 +305,14 @@ async function testActiveProfileLockIsPreserved() {
 }
 
 async function testPdfRendererClosedErrorsAreClassified() {
-  const { getPdfRendererClosedMessage, isPdfRendererClosedError } = await importPdfBrowser();
+  const {
+    getPdfBrowserProfileId,
+    getPdfRendererClosedMessage,
+    isPdfRendererClosedError,
+  } = await importPdfBrowser();
 
+  assert.equal(getPdfBrowserProfileId(1234), 'pdf-export-1234');
+  assert.notEqual(getPdfBrowserProfileId(1234), getPdfBrowserProfileId(5678));
   assert.equal(
     isPdfRendererClosedError(new Error('Protocol error (Target.setDiscoverTargets): Target closed')),
     true,

--- a/scripts/browser-runtime-test.ts
+++ b/scripts/browser-runtime-test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { lstat, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import Module from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
@@ -306,13 +306,45 @@ async function testActiveProfileLockIsPreserved() {
 
 async function testPdfRendererClosedErrorsAreClassified() {
   const {
+    buildPdfBrowserLaunchSpec,
     getPdfBrowserProfileId,
     getPdfRendererClosedMessage,
     isPdfRendererClosedError,
+    removeStalePdfBrowserProfiles,
   } = await importPdfBrowser();
 
   assert.equal(getPdfBrowserProfileId(1234), 'pdf-export-1234');
   assert.notEqual(getPdfBrowserProfileId(1234), getPdfBrowserProfileId(5678));
+  const launchSpec = buildPdfBrowserLaunchSpec({
+    env: makeEnv({
+      CANVAS_RUNTIME_ENV: 'docker',
+      CHROMIUM_PATH: '/usr/bin/chromium',
+      DATA: '/data',
+    }),
+    existsSync: makeExistsSync(['/usr/bin/chromium']),
+    pid: 1234,
+  });
+  assert.equal(launchSpec.userDataDir, '/data/cache/browser-runtime/pdf-export-1234');
+  assert.ok(launchSpec.args.includes('--user-data-dir=/data/cache/browser-runtime/pdf-export-1234'));
+
+  const profileRoot = await mkdtemp(path.join(os.tmpdir(), 'canvas-pdf-profile-test-'));
+  try {
+    await Promise.all([
+      mkdir(path.join(profileRoot, 'pdf-export-1234')),
+      mkdir(path.join(profileRoot, 'pdf-export-5678')),
+      mkdir(path.join(profileRoot, 'pdf-export-9999')),
+      mkdir(path.join(profileRoot, 'unrelated-profile')),
+    ]);
+    const removedProfiles = await removeStalePdfBrowserProfiles(profileRoot, 1234, (pid) => pid === 5678);
+    assert.deepEqual(removedProfiles, ['pdf-export-9999']);
+    assert.equal(existsSync(path.join(profileRoot, 'pdf-export-1234')), true);
+    assert.equal(existsSync(path.join(profileRoot, 'pdf-export-5678')), true);
+    assert.equal(existsSync(path.join(profileRoot, 'pdf-export-9999')), false);
+    assert.equal(existsSync(path.join(profileRoot, 'unrelated-profile')), true);
+  } finally {
+    await rm(profileRoot, { recursive: true, force: true });
+  }
+
   assert.equal(
     isPdfRendererClosedError(new Error('Protocol error (Target.setDiscoverTargets): Target closed')),
     true,


### PR DESCRIPTION
## Summary
- use a process-scoped Chromium profile for PDF exports
- prevent concurrent app workers from sharing a locked browser profile
- cover profile isolation with the browser runtime test

## Verification
- npm run test:browser-start
- npm run build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gives each Node.js process a separate Chromium profile for PDF rendering and adds a browser-runtime assertion for profile-ID isolation.
- Derives the PDF profile identifier from `process.pid`.
- Passes the process-scoped identifier into browser user-data-directory resolution.
- Tests deterministic and distinct identifiers for different supplied PIDs.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with non-blocking cleanup and regression-test gaps around process-scoped profile directories.

Process isolation is correctly wired into the current launch path, but old PID-specific Chromium profiles are not reclaimed and the new test would not detect the launch path reverting to a shared profile.

**Files Needing Attention:** app/lib/pdf/browser.ts; scripts/browser-runtime-test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/pdf/browser.ts | Adds process-scoped PDF profiles, preventing ordinary cross-process contention but leaving one persistent profile behind for each distinct PID. |
| scripts/browser-runtime-test.ts | Verifies profile-ID formatting and inequality but does not exercise the launch integration responsible for effective directory isolation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    P[Node.js process PID] --> I[pdf-export-PID]
    I --> R[Resolve persistent browser-runtime directory]
    R --> C[Create Chromium profile]
    C --> L[Launch PDF browser]
    C -. process exits without profile removal .-> O[Orphaned profile remains]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Isolate PDF browser profiles per process"](https://github.com/canvascoding/canvas-notebook/commit/43f2a52d1517692c479c59e771f4e0ffe1177b71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58679515)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->