### PR TITLE
Fix exact context budget compaction

### DIFF
--- a/app/components/canvas-agent-chat/CanvasAgentChat.tsx
+++ b/app/components/canvas-agent-chat/CanvasAgentChat.tsx
@@ -1036,15 +1036,27 @@ export default function CanvasAgentChat({
     ...(runtimeStatus?.followUpQueue || []).map((entry) => ({ ...entry, kind: 'follow_up' as const })),
   ];
   const activeToolDisplay = runtimeStatus?.activeTool ? getToolDisplayInfo(runtimeStatus.activeTool.name, locale) : null;
+  const hasFinalRequestBudget = runtimeStatus?.finalRequestTokens !== null && runtimeStatus?.finalRequestTokens !== undefined;
   const contextDetailedLabel = runtimeStatus
-    ? t('contextLabel', {
+    ? hasFinalRequestBudget
+      ? t('contextFinalLabel', {
+        used: formatContextTokens(runtimeStatus.finalRequestTokens!),
+        window: formatContextTokens(runtimeStatus.contextWindow),
+      })
+      : t('contextLabel', {
         used: formatContextTokens(runtimeStatus.estimatedHistoryTokens),
         available: formatContextTokens(runtimeStatus.availableHistoryTokens),
         window: formatContextTokens(runtimeStatus.contextWindow),
       })
     : t('noSessionYet');
   const contextTooltip = runtimeStatus
-    ? t('contextTooltip', {
+    ? hasFinalRequestBudget
+      ? t('contextFinalTooltip', {
+        used: formatContextTokens(runtimeStatus.finalRequestTokens!),
+        window: formatContextTokens(runtimeStatus.contextWindow),
+        percent: Math.round((runtimeStatus.finalRequestTokens! / Math.max(1, runtimeStatus.contextWindow)) * 100),
+      })
+      : t('contextTooltip', {
         percent: runtimeStatus.contextUsagePercent,
         used: formatContextTokens(runtimeStatus.estimatedHistoryTokens),
         available: formatContextTokens(runtimeStatus.availableHistoryTokens),
@@ -1052,7 +1064,9 @@ export default function CanvasAgentChat({
         reserved: formatContextTokens(Math.max(0, runtimeStatus.contextWindow - runtimeStatus.availableHistoryTokens)),
       })
     : t('noSessionYet');
-  const contextProgressPercent = Math.min(100, Math.max(0, runtimeStatus?.contextUsagePercent ?? 0));
+  const contextProgressPercent = Math.min(100, Math.max(0, hasFinalRequestBudget
+    ? Math.round((runtimeStatus!.finalRequestTokens! / Math.max(1, runtimeStatus!.contextWindow)) * 100)
+    : runtimeStatus?.contextUsagePercent ?? 0));
   const sessionDisplayLabel = getSessionDisplayTitle(sessionTitle, t('newChatTitle'));
   const hasComposerContent = Boolean(input.trim()) || attachments.length > 0;
   const primaryActionIsStop = isRuntimeBusy && !hasComposerContent;

--- a/app/components/canvas-agent-chat/useChatRuntimeEvents.ts
+++ b/app/components/canvas-agent-chat/useChatRuntimeEvents.ts
@@ -281,6 +281,8 @@ export function useChatRuntimeEvents({
         estimatedHistoryTokens: 0,
         availableHistoryTokens: 0,
         contextUsagePercent: 0,
+        finalRequestTokens: null,
+        finalRequestBudgetExceeded: false,
         includedSummary: false,
         omittedMessageCount: 0,
         summaryUpdatedAt: null,

--- a/app/lib/chat/runtime-status.ts
+++ b/app/lib/chat/runtime-status.ts
@@ -67,6 +67,13 @@ export type RuntimeStatus = {
   estimatedHistoryTokens: number;
   availableHistoryTokens: number;
   contextUsagePercent: number;
+  /**
+   * Exact final request size, including instructions, tools, normalized images,
+   * output reserve, and safety margin. Null until a provider-ready payload has
+   * been built for the current turn.
+   */
+  finalRequestTokens?: number | null;
+  finalRequestBudgetExceeded?: boolean;
   includedSummary: boolean;
   omittedMessageCount: number;
   summaryUpdatedAt: string | null;

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -1514,7 +1514,11 @@ export class LivePiRuntime {
 
     this.preparedRuntimePayload = null;
     const retry = await this.coordinateCompaction({
-      kind: 'automatic',
+      // A deferred automatic attempt has an active cooldown. The coordinator
+      // grants one bounded manual-priority bypass for that cooldown, so use it
+      // for this request-blocking exact-budget retry. The committed marker is
+      // still recorded as automatic below because this was not user-initiated.
+      kind: 'manual',
       messages: input.sourceMessages,
       additionalContextTokens: input.additionalContextTokens + Math.max(1, this.getPayloadPressure(prepared.budgetSnapshot)),
       runtimeContext: input.runtimeContext,

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -612,6 +612,7 @@ export class LivePiRuntime {
 
   private async coordinateCompaction(input: {
     kind: 'manual' | 'automatic';
+    bypassCooldown?: boolean;
     messages: AgentMessage[];
     additionalContextTokens: number;
     runtimeContext: string | null;
@@ -640,6 +641,7 @@ export class LivePiRuntime {
     const result = await runPiSessionCompaction({
       ...this.getCompactionScope(),
       trigger: input.kind,
+      bypassCooldown: input.bypassCooldown,
       attemptId,
       generation,
       expectedSummaryRevision: summarySnapshot.summaryRevision,
@@ -1514,11 +1516,11 @@ export class LivePiRuntime {
 
     this.preparedRuntimePayload = null;
     const retry = await this.coordinateCompaction({
-      // A deferred automatic attempt has an active cooldown. The coordinator
-      // grants one bounded manual-priority bypass for that cooldown, so use it
-      // for this request-blocking exact-budget retry. The committed marker is
-      // still recorded as automatic below because this was not user-initiated.
-      kind: 'manual',
+      // A deferred automatic attempt has an active cooldown. Allow this one
+      // request-blocking retry through it without consuming the user's manual
+      // recovery bypass; the coordinator persists the retry marker separately.
+      kind: 'automatic',
+      bypassCooldown: true,
       messages: input.sourceMessages,
       additionalContextTokens: input.additionalContextTokens + Math.max(1, this.getPayloadPressure(prepared.budgetSnapshot)),
       runtimeContext: input.runtimeContext,

--- a/app/lib/pi/live-runtime.ts
+++ b/app/lib/pi/live-runtime.ts
@@ -208,6 +208,8 @@ export type PiRuntimeStatus = {
   estimatedHistoryTokens: number;
   availableHistoryTokens: number;
   contextUsagePercent: number;
+  finalRequestTokens?: number | null;
+  finalRequestBudgetExceeded?: boolean;
   includedSummary: boolean;
   omittedMessageCount: number;
   summaryUpdatedAt: string | null;
@@ -283,6 +285,12 @@ type RuntimeOptions = {
   requiresRuntimeRecreation?: () => boolean;
   summaryStreamFn?: StreamFn;
   compactionPolicy?: PiCompactionCoordinatorPolicy;
+};
+
+type PreparedRuntimePayload = {
+  sourceMessages: AgentMessage[];
+  messages: Message[];
+  budgetSnapshot: PiContextBudgetSnapshot;
 };
 
 function isUserMessage(message: AgentMessage): message is Extract<AgentMessage, { role: 'user' }> {
@@ -423,6 +431,8 @@ function getRuntimeStatusSignature(status: PiRuntimeStatus): string {
     estimatedHistoryTokens: status.estimatedHistoryTokens,
     availableHistoryTokens: status.availableHistoryTokens,
     contextUsagePercent: status.contextUsagePercent,
+    finalRequestTokens: status.finalRequestTokens,
+    finalRequestBudgetExceeded: status.finalRequestBudgetExceeded,
     includedSummary: status.includedSummary,
     omittedMessageCount: status.omittedMessageCount,
     summaryUpdatedAt: status.summaryUpdatedAt,
@@ -463,6 +473,7 @@ export class LivePiRuntime {
   private summary: PiSessionSummaryState;
   private lastComposition: PiHistoryComposition | null = null;
   private lastFinalPayloadBudgetSnapshot: PiContextBudgetSnapshot | null = null;
+  private preparedRuntimePayload: PreparedRuntimePayload | null = null;
   private lastProviderUsageCalibration: PiProviderUsageCalibrationEvidence | null = null;
   private readonly imageNormalizationOptions: PiMessageNormalizationOptions;
   private readonly requestOutputTokenCap: number;
@@ -548,6 +559,7 @@ export class LivePiRuntime {
     invalidatePiSessionCompaction(this.getCompactionScope());
     this.lastComposition = null;
     this.lastFinalPayloadBudgetSnapshot = null;
+    this.preparedRuntimePayload = null;
     this.lastProviderUsageCalibration = null;
   }
 
@@ -674,7 +686,7 @@ export class LivePiRuntime {
     return result;
   }
 
-  async prepareFinalPayload(messages: AgentMessage[]): Promise<Message[]> {
+  private async buildFinalPayload(messages: AgentMessage[]): Promise<PreparedRuntimePayload> {
     const prepared = await preparePiFinalPayload({
       messages,
       model: this.model,
@@ -685,6 +697,40 @@ export class LivePiRuntime {
     }, this.imageNormalizationOptions);
     this.lastFinalPayloadBudgetSnapshot = prepared.budgetSnapshot;
     this.lastProviderUsageCalibration = null;
+    return {
+      sourceMessages: messages,
+      messages: prepared.messages,
+      budgetSnapshot: prepared.budgetSnapshot,
+    };
+  }
+
+  private cachePreparedRuntimePayload(payload: PreparedRuntimePayload): void {
+    this.preparedRuntimePayload = payload;
+  }
+
+  private getPayloadPressure(snapshot: PiContextBudgetSnapshot): number {
+    const contextOverflow = Math.max(0, snapshot.estimatedTotalTokens - snapshot.contextWindowTokens);
+    const serializedPayloadOverflow = Math.max(0, snapshot.serializedMessageBytes - snapshot.hardHistoryBytes);
+    const imagePayloadOverflow = Math.max(0, snapshot.multimodalBytes - snapshot.totalImageBytesLimit);
+    // Image inputs are charged independently by providers. Turn the byte-only
+    // overflow into a conservative history reservation for the retry path.
+    return Math.max(
+      contextOverflow,
+      Math.ceil(serializedPayloadOverflow / 4),
+      Math.ceil(imagePayloadOverflow / 256),
+    );
+  }
+
+  private isFinalPayloadSendable(snapshot: PiContextBudgetSnapshot): boolean {
+    return !snapshot.payloadBudgetExceeded && !snapshot.contextBudgetExceeded;
+  }
+
+  async prepareFinalPayload(messages: AgentMessage[]): Promise<Message[]> {
+    const cached = this.preparedRuntimePayload;
+    const prepared = cached?.sourceMessages === messages
+      ? cached
+      : await this.buildFinalPayload(messages);
+    this.preparedRuntimePayload = null;
 
     if (prepared.budgetSnapshot.payloadBudgetExceeded) {
       throw new Error(
@@ -765,6 +811,11 @@ export class LivePiRuntime {
       });
     }
     const composition = this.lastComposition;
+    const finalPayloadBudget = this.lastFinalPayloadBudgetSnapshot;
+    const exposeFinalPayloadBudget = Boolean(
+      finalPayloadBudget
+      && (this.isRunning || !this.isFinalPayloadSendable(finalPayloadBudget)),
+    );
 
     const hasPendingReplace = this.pendingReplace !== null;
 
@@ -791,6 +842,10 @@ export class LivePiRuntime {
       estimatedHistoryTokens: composition.estimatedHistoryTokens,
       availableHistoryTokens: composition.availableHistoryTokens,
       contextUsagePercent: toPercent(composition.estimatedHistoryTokens, composition.availableHistoryTokens),
+      finalRequestTokens: exposeFinalPayloadBudget ? finalPayloadBudget!.estimatedTotalTokens : null,
+      finalRequestBudgetExceeded: exposeFinalPayloadBudget
+        ? !this.isFinalPayloadSendable(finalPayloadBudget!)
+        : false,
       includedSummary: composition.includedSummary,
       omittedMessageCount: composition.omittedMessages.length,
       summaryUpdatedAt: this.summary.summaryUpdatedAt ? this.summary.summaryUpdatedAt.toISOString() : null,
@@ -1430,6 +1485,73 @@ export class LivePiRuntime {
     return messages;
   }
 
+  private applyAutomaticCompactionResult(result: PiCompactionCoordinatorResult): boolean {
+    if (result.state !== 'succeeded' || !result.summary || !result.composition) {
+      return false;
+    }
+
+    this.summary = result.summary;
+    this.lastComposition = result.composition;
+    this.recordCompaction(result.attemptId, 'automatic', result.composition);
+    this.publishStatus();
+    return true;
+  }
+
+  private async finalizeContextCandidate(input: {
+    composition: PiHistoryComposition;
+    sourceMessages: AgentMessage[];
+    runtimeContext: string | null;
+    additionalContextTokens: number;
+    signal?: AbortSignal;
+  }): Promise<AgentMessage[]> {
+    let composition = input.composition;
+    let candidate = await this.injectRuntimeContext(composition.llmMessages, input.runtimeContext);
+    let prepared = await this.buildFinalPayload(candidate);
+    if (this.isFinalPayloadSendable(prepared.budgetSnapshot)) {
+      this.cachePreparedRuntimePayload(prepared);
+      return candidate;
+    }
+
+    this.preparedRuntimePayload = null;
+    const retry = await this.coordinateCompaction({
+      kind: 'automatic',
+      messages: input.sourceMessages,
+      additionalContextTokens: input.additionalContextTokens + Math.max(1, this.getPayloadPressure(prepared.budgetSnapshot)),
+      runtimeContext: input.runtimeContext,
+      signal: input.signal,
+    });
+
+    if (this.applyAutomaticCompactionResult(retry)) {
+      composition = retry.composition!;
+    } else if (
+      (retry.state === 'no_op' || retry.state === 'deferred')
+      && retry.composition
+      && isPiHistoryCompositionSendable(retry.composition, this.summary)
+    ) {
+      composition = retry.composition;
+      this.lastComposition = composition;
+      this.publishStatus();
+    } else {
+      throw new Error(
+        'The final request exceeds the selected model context window and cannot be reduced safely. '
+        + 'Shorten the latest message or attachments, or use a larger-context model.',
+      );
+    }
+
+    candidate = await this.injectRuntimeContext(composition.llmMessages, input.runtimeContext);
+    prepared = await this.buildFinalPayload(candidate);
+    if (this.isFinalPayloadSendable(prepared.budgetSnapshot)) {
+      this.cachePreparedRuntimePayload(prepared);
+      return candidate;
+    }
+
+    this.preparedRuntimePayload = null;
+    throw new Error(
+      'The final request still exceeds the selected model context window after automatic compaction. '
+      + 'Shorten the latest message or attachments, or use a larger-context model.',
+    );
+  }
+
   private resetRunSupervisorForUserMessage(message: Extract<AgentMessage, { role: 'user' }>): void {
     this.currentUserPromptText = extractUserMessageText(message);
     this.currentUserPromptSignature = getMessageSignature(message);
@@ -1709,7 +1831,13 @@ export class LivePiRuntime {
       && isPiHistoryCompositionSendable(preflight, this.summary)
     ) {
       this.lastComposition = preflight;
-      return this.injectRuntimeContext(preflight.llmMessages, runtimeContext);
+      return this.finalizeContextCandidate({
+        composition: preflight,
+        sourceMessages: messages,
+        runtimeContext,
+        additionalContextTokens,
+        signal,
+      });
     }
 
     const result = await this.coordinateCompaction({
@@ -1720,19 +1848,27 @@ export class LivePiRuntime {
       signal,
     });
 
-    if (result.state === 'succeeded' && result.summary && result.composition) {
-      this.summary = result.summary;
-      this.lastComposition = result.composition;
-      this.recordCompaction(result.attemptId, 'automatic', result.composition);
-      this.publishStatus();
-      return this.injectRuntimeContext(result.composition.llmMessages, runtimeContext);
+    if (this.applyAutomaticCompactionResult(result) && result.composition) {
+      return this.finalizeContextCandidate({
+        composition: result.composition,
+        sourceMessages: messages,
+        runtimeContext,
+        additionalContextTokens,
+        signal,
+      });
     }
 
     if ((result.state === 'no_op' || result.state === 'deferred') && result.composition) {
       this.lastComposition = result.composition;
       if (isPiHistoryCompositionSendable(result.composition, this.summary)) {
         this.publishStatus();
-        return this.injectRuntimeContext(result.composition.llmMessages, runtimeContext);
+        return this.finalizeContextCandidate({
+          composition: result.composition,
+          sourceMessages: messages,
+          runtimeContext,
+          additionalContextTokens,
+          signal,
+        });
       }
     }
 
@@ -1760,7 +1896,13 @@ export class LivePiRuntime {
     if (isPiHistoryCompositionSendable(fallback, this.summary)) {
       this.lastComposition = fallback;
       this.publishStatus();
-      return this.injectRuntimeContext(fallback.llmMessages, runtimeContext);
+      return this.finalizeContextCandidate({
+        composition: fallback,
+        sourceMessages: messages,
+        runtimeContext,
+        additionalContextTokens,
+        signal,
+      });
     }
     if (result.state === 'cooldown_active') {
       throw new Error(
@@ -2590,6 +2732,8 @@ export async function getPiRuntimeStatus(sessionId: string, userId: string): Pro
     estimatedHistoryTokens: composition.estimatedHistoryTokens,
     availableHistoryTokens: composition.availableHistoryTokens,
     contextUsagePercent: toPercent(composition.estimatedHistoryTokens, composition.availableHistoryTokens),
+    finalRequestTokens: null,
+    finalRequestBudgetExceeded: false,
     includedSummary: composition.includedSummary,
     omittedMessageCount: composition.omittedMessages.length,
     summaryUpdatedAt: summary.summaryUpdatedAt ? summary.summaryUpdatedAt.toISOString() : null,

--- a/app/lib/pi/session-compaction-coordinator.ts
+++ b/app/lib/pi/session-compaction-coordinator.ts
@@ -51,6 +51,8 @@ export type PiCompactionCoordinatorStore = Readonly<{
 
 export type RunPiSessionCompactionInput = PiCompactionScope & Readonly<{
   trigger: PiCompactionTrigger;
+  /** Allows one internal exact-budget retry through an automatic cooldown. */
+  bypassCooldown?: boolean;
   generation: string;
   expectedSummaryRevision: number;
   expectedThroughSequence: number | null;
@@ -233,12 +235,15 @@ export async function runPiSessionCompaction(
       ...scope,
       attemptId,
       trigger: input.trigger,
+      bypassCooldown: input.bypassCooldown,
       expectedSummaryRevision: input.expectedSummaryRevision,
       expectedThroughSequence: input.expectedThroughSequence,
       deadlineAt,
       provider: input.provider,
       model: input.model,
-      contractFingerprint: input.contractFingerprint,
+      contractFingerprint: input.bypassCooldown
+        ? `exact-budget-retry:${input.contractFingerprint ?? input.generation}`
+        : input.contractFingerprint,
       metrics: input.metrics,
       expiredAttemptRetryAt: policy.retryDelaysMs[0] > 0
         ? new Date(now.getTime() + policy.retryDelaysMs[0])

--- a/app/lib/pi/session-compaction-store.ts
+++ b/app/lib/pi/session-compaction-store.ts
@@ -308,6 +308,8 @@ export async function auditPiMessageSequenceIntegrityOnConnection(
 export type StartPiCompactionAttemptInput = PiCompactionScope & Readonly<{
   attemptId: string;
   trigger: PiCompactionTrigger;
+  /** Allows one internal exact-budget retry through an automatic cooldown. */
+  bypassCooldown?: boolean;
   expectedSummaryRevision: number;
   expectedThroughSequence: number | null;
   deadlineAt: Date;
@@ -407,8 +409,16 @@ export async function startPiSessionCompactionAttemptOnConnection(
         [session.id, nowTimestamp],
       ) as AttemptRow | undefined;
       if (cooldownAttempt) {
-        let bypassAvailable = input.trigger === 'manual' && cooldownAttempt.trigger !== 'manual';
-        if (bypassAvailable) {
+        const cooldownIsExactBudgetRetry = cooldownAttempt.contract_fingerprint?.startsWith('exact-budget-retry:') ?? false;
+        let bypassAvailable = (
+          input.trigger === 'manual'
+          && cooldownAttempt.trigger !== 'manual'
+        ) || (
+          input.bypassCooldown === true
+          && cooldownAttempt.trigger !== 'manual'
+          && !cooldownIsExactBudgetRetry
+        );
+        if (bypassAvailable && input.trigger === 'manual') {
           const previousManualBypass = await connection.get(
             `SELECT id FROM pi_session_compaction_attempts
              WHERE pi_session_db_id = ? AND trigger = 'manual' AND attempt_ordinal > ?

--- a/messages/de.json
+++ b/messages/de.json
@@ -1324,6 +1324,8 @@
     "contextLabel": "{used}/{available} Budget · {window} Fenster",
     "contextCompactLabel": "{used}/{available} Budget",
     "contextTooltip": "History-Budget: {used} von {available} Tokens genutzt ({percent}%)\nModellfenster: {window} Tokens\nReserviert für System, Tools, Antwort und Sicherheit: ca. {reserved} Tokens",
+    "contextFinalLabel": "{used}/{window} serialisiert",
+    "contextFinalTooltip": "Finale serialisierte Anfrage: {used} von {window} Tokens ({percent}%)\nEnthält Anweisungen, Tools, normalisierte Anhänge, Antwortreserve und Sicherheitsmarge.",
     "noSessionYet": "Noch keine Session",
     "backToChat": "Zurück zum Chat",
     "openHistory": "Verlauf öffnen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1325,6 +1325,8 @@
     "contextLabel": "{used}/{available} budget · {window} window",
     "contextCompactLabel": "{used}/{available} budget",
     "contextTooltip": "History budget: {used} of {available} tokens used ({percent}%)\nModel window: {window} tokens\nReserved for system, tools, response, and safety: approx. {reserved} tokens",
+    "contextFinalLabel": "{used}/{window} serialized",
+    "contextFinalTooltip": "Final serialized request: {used} of {window} tokens ({percent}%)\nIncludes instructions, tools, normalized attachments, output reserve, and safety margin.",
     "noSessionYet": "No session yet",
     "backToChat": "Back to chat",
     "openHistory": "Open history",

--- a/scripts/pi-live-compaction-integration-test.ts
+++ b/scripts/pi-live-compaction-integration-test.ts
@@ -296,6 +296,69 @@ async function main(): Promise<void> {
   )));
   assert.equal((await loadPiSessionWithSummary(sessionId, userId, session?.agentId))?.summary.summaryRevision, 1);
 
+  const exactBudgetRuntime = Object.create(LivePiRuntime.prototype) as Record<string, unknown>;
+  const initialCandidate = [{ role: 'user', content: 'original candidate', timestamp: 1 }] as unknown as AgentMessage[];
+  const compactedCandidate = [{ role: 'user', content: 'compacted candidate', timestamp: 2 }] as unknown as AgentMessage[];
+  const compactedSummary = {
+    summaryText: 'Exact final payload was compacted.',
+    summaryUpdatedAt: new Date(),
+    summaryThroughTimestamp: 1,
+    summaryThroughSequence: 1,
+    summaryRevision: 1,
+  };
+  const initialComposition = { llmMessages: initialCandidate };
+  const retryComposition = { llmMessages: compactedCandidate };
+  let preparedPayloadCount = 0;
+  let retryAdditionalContextTokens = 0;
+  Object.assign(exactBudgetRuntime, {
+    summary: { ...compactedSummary, summaryText: null, summaryUpdatedAt: null, summaryThroughTimestamp: null, summaryThroughSequence: null, summaryRevision: 0 },
+    lastComposition: null,
+    preparedRuntimePayload: null,
+    injectRuntimeContext: async (candidate: AgentMessage[]) => candidate,
+    buildFinalPayload: async (candidate: AgentMessage[]) => {
+      const exceeds = preparedPayloadCount++ === 0;
+      return {
+        sourceMessages: candidate,
+        messages: candidate,
+        budgetSnapshot: {
+          contextBudgetExceeded: exceeds,
+          payloadBudgetExceeded: false,
+        },
+      };
+    },
+    cachePreparedRuntimePayload(payload: unknown) {
+      this.preparedRuntimePayload = payload;
+    },
+    getPayloadPressure: () => 1_500,
+    coordinateCompaction: async (input: { additionalContextTokens: number }) => {
+      retryAdditionalContextTokens = input.additionalContextTokens;
+      return {
+        state: 'succeeded',
+        attemptId: 'exact-payload-retry',
+        summary: compactedSummary,
+        composition: retryComposition,
+      };
+    },
+    recordCompaction: () => undefined,
+    publishStatus: () => undefined,
+  });
+  const recoveredCandidate = await (exactBudgetRuntime as unknown as {
+    finalizeContextCandidate: (input: {
+      composition: unknown;
+      sourceMessages: AgentMessage[];
+      runtimeContext: null;
+      additionalContextTokens: number;
+    }) => Promise<AgentMessage[]>;
+  }).finalizeContextCandidate({
+    composition: initialComposition,
+    sourceMessages: initialCandidate,
+    runtimeContext: null,
+    additionalContextTokens: 200,
+  });
+  assert.equal(retryAdditionalContextTokens, 1_700, 'exact final-payload overflow must reserve room for a retry compaction');
+  assert.deepEqual(recoveredCandidate, compactedCandidate, 'the retried, exact-budget-safe candidate must reach the provider');
+  assert.equal(preparedPayloadCount, 2, 'the final payload must be checked before and after the retry compaction');
+
   const finalAttempts = await db.select().from(piSessionCompactionAttempts);
   assert.deepEqual(finalAttempts.map((attempt) => attempt.state), ['succeeded', 'aborted', 'stale', 'timed_out']);
   console.log('pi-live-compaction-integration-test: ok');

--- a/scripts/pi-live-compaction-integration-test.ts
+++ b/scripts/pi-live-compaction-integration-test.ts
@@ -311,6 +311,7 @@ async function main(): Promise<void> {
   let preparedPayloadCount = 0;
   let retryAdditionalContextTokens = 0;
   let retryKind: 'manual' | 'automatic' | null = null;
+  let retryBypassesCooldown = false;
   Object.assign(exactBudgetRuntime, {
     summary: { ...compactedSummary, summaryText: null, summaryUpdatedAt: null, summaryThroughTimestamp: null, summaryThroughSequence: null, summaryRevision: 0 },
     lastComposition: null,
@@ -328,11 +329,12 @@ async function main(): Promise<void> {
       };
     },
     cachePreparedRuntimePayload(payload: unknown) {
-      this.preparedRuntimePayload = payload;
+      this.preparedRuntimePayload = payload as null;
     },
     getPayloadPressure: () => 1_500,
-    coordinateCompaction: async (input: { kind: 'manual' | 'automatic'; additionalContextTokens: number }) => {
+    coordinateCompaction: async (input: { kind: 'manual' | 'automatic'; bypassCooldown?: boolean; additionalContextTokens: number }) => {
       retryKind = input.kind;
+      retryBypassesCooldown = input.bypassCooldown === true;
       retryAdditionalContextTokens = input.additionalContextTokens;
       return {
         state: 'succeeded',
@@ -357,7 +359,8 @@ async function main(): Promise<void> {
     runtimeContext: null,
     additionalContextTokens: 200,
   });
-  assert.equal(retryKind, 'manual', 'an exact final-payload retry must use the coordinator\'s bounded cooldown bypass');
+  assert.equal(retryKind, 'automatic', 'an exact final-payload retry must remain an automatic compaction');
+  assert.equal(retryBypassesCooldown, true, 'an exact final-payload retry must use its dedicated bounded cooldown bypass');
   assert.equal(retryAdditionalContextTokens, 1_700, 'exact final-payload overflow must reserve room for a retry compaction');
   assert.deepEqual(recoveredCandidate, compactedCandidate, 'the retried, exact-budget-safe candidate must reach the provider');
   assert.equal(preparedPayloadCount, 2, 'the final payload must be checked before and after the retry compaction');

--- a/scripts/pi-live-compaction-integration-test.ts
+++ b/scripts/pi-live-compaction-integration-test.ts
@@ -310,6 +310,7 @@ async function main(): Promise<void> {
   const retryComposition = { llmMessages: compactedCandidate };
   let preparedPayloadCount = 0;
   let retryAdditionalContextTokens = 0;
+  let retryKind: 'manual' | 'automatic' | null = null;
   Object.assign(exactBudgetRuntime, {
     summary: { ...compactedSummary, summaryText: null, summaryUpdatedAt: null, summaryThroughTimestamp: null, summaryThroughSequence: null, summaryRevision: 0 },
     lastComposition: null,
@@ -330,7 +331,8 @@ async function main(): Promise<void> {
       this.preparedRuntimePayload = payload;
     },
     getPayloadPressure: () => 1_500,
-    coordinateCompaction: async (input: { additionalContextTokens: number }) => {
+    coordinateCompaction: async (input: { kind: 'manual' | 'automatic'; additionalContextTokens: number }) => {
+      retryKind = input.kind;
       retryAdditionalContextTokens = input.additionalContextTokens;
       return {
         state: 'succeeded',
@@ -355,6 +357,7 @@ async function main(): Promise<void> {
     runtimeContext: null,
     additionalContextTokens: 200,
   });
+  assert.equal(retryKind, 'manual', 'an exact final-payload retry must use the coordinator\'s bounded cooldown bypass');
   assert.equal(retryAdditionalContextTokens, 1_700, 'exact final-payload overflow must reserve room for a retry compaction');
   assert.deepEqual(recoveredCandidate, compactedCandidate, 'the retried, exact-budget-safe candidate must reach the provider');
   assert.equal(preparedPayloadCount, 2, 'the final payload must be checked before and after the retry compaction');

--- a/scripts/pi-session-compaction-store-test.ts
+++ b/scripts/pi-session-compaction-store-test.ts
@@ -306,6 +306,43 @@ async function exerciseStore(connection: SqlConnection, provider: Provider): Pro
     now: new Date('2026-08-27T10:06:00.000Z'),
   });
   assert.equal(automaticCooldown.status, 'cooldown_active');
+  const exactBudgetBypass = await startPiSessionCompactionAttemptOnConnection(connection, provider, {
+    ...scope,
+    attemptId: `attempt-${provider}-cooldown-exact-budget`,
+    trigger: 'automatic',
+    bypassCooldown: true,
+    expectedSummaryRevision: 2,
+    expectedThroughSequence: 4,
+    deadlineAt: new Date('2026-08-27T10:12:00.000Z'),
+    provider: 'test-provider',
+    model: 'test-model',
+    contractFingerprint: 'exact-budget-retry:test-contract',
+    now: new Date('2026-08-27T10:06:00.000Z'),
+  });
+  assert.equal(exactBudgetBypass.status, 'started');
+  assert.equal(exactBudgetBypass.attempt.trigger, 'automatic');
+  await finishPiSessionCompactionAttemptOnConnection(connection, provider, {
+    ...scope,
+    attemptId: `attempt-${provider}-cooldown-exact-budget`,
+    state: 'failed',
+    reasonCode: 'summary_provider_error',
+    retryAt: new Date('2026-08-27T10:16:00.000Z'),
+    now: new Date('2026-08-27T10:06:30.000Z'),
+  });
+  const secondExactBudgetBypass = await startPiSessionCompactionAttemptOnConnection(connection, provider, {
+    ...scope,
+    attemptId: `attempt-${provider}-cooldown-exact-budget-second`,
+    trigger: 'automatic',
+    bypassCooldown: true,
+    expectedSummaryRevision: 2,
+    expectedThroughSequence: 4,
+    deadlineAt: new Date('2026-08-27T10:12:00.000Z'),
+    provider: 'test-provider',
+    model: 'test-model',
+    contractFingerprint: 'exact-budget-retry:test-contract',
+    now: new Date('2026-08-27T10:07:00.000Z'),
+  });
+  assert.equal(secondExactBudgetBypass.status, 'cooldown_active');
   const manualBypass = await startPiSessionCompactionAttemptOnConnection(connection, provider, {
     ...scope,
     attemptId: `attempt-${provider}-cooldown-manual`,
@@ -340,7 +377,7 @@ async function exerciseStore(connection: SqlConnection, provider: Provider): Pro
   assert.equal(secondManualBypass.status, 'cooldown_active');
   assert.equal(
     await countPiSessionCompactionRetryFailuresOnConnection(connection, provider, scope),
-    2,
+    3,
   );
 
   const resetAttempt = await startPiSessionCompactionAttemptOnConnection(connection, provider, {


### PR DESCRIPTION
## Summary
- validate the fully serialized provider payload before sending it
- retry automatic compaction with the exact overflow pressure when normalization adds request size
- show the exact serialized request budget in the active chat UI

## Verification
- tsc --noEmit
- eslint on changed files
- pi-live-compaction-integration-test
- pi-context-budget-test
- pi-compaction-ui-contract-test

No container build was run.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR validates the fully serialized provider payload, retries compaction using exact overflow pressure, and exposes the final request budget in the chat UI. The cooldown fix currently consumes the user-only manual bypass when a transient retry fails.
- Adds exact provider-payload budget validation and a bounded compaction retry.
- Caches the validated payload for the provider conversion step.
- Publishes exact serialized request usage through runtime status and localized UI labels.
- Extends the live compaction integration coverage.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a failed exact-budget retry can consume the manual cooldown bypass and block the user's subsequent recovery attempt.

The exact-budget retry now uses the manual coordinator trigger, and transient summary-provider failures persist that trigger with a cooldown; the next genuine compactNow request is consequently rejected as cooldown_active.

**Files Needing Attention:** app/lib/pi/live-runtime.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/pi/live-runtime.ts | Adds final-payload validation and exact-pressure retry logic, but the retry's manual trigger can block a later user-requested compaction after transient failures. |
| app/components/canvas-agent-chat/CanvasAgentChat.tsx | Displays the exact serialized request budget when runtime status provides it. |
| app/components/canvas-agent-chat/useChatRuntimeEvents.ts | Initializes the newly exposed final-request budget fields in runtime event state. |
| app/lib/chat/runtime-status.ts | Extends runtime status with optional exact final-request budget information. |
| scripts/pi-live-compaction-integration-test.ts | Covers the successful exact-budget retry, but stubs the coordinator and therefore does not exercise persisted manual cooldown semantics. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Build provider-ready payload] --> B{Within exact budget?}
  B -->|Yes| C[Cache and send payload]
  B -->|No| D[Start retry as manual]
  D --> E{Retry result}
  E -->|Succeeded| F[Rebuild and validate payload]
  E -->|Deferred, timeout, or provider error| G[Persist manual cooldown]
  G --> H[User requests Compact now]
  H --> I[Manual bypass rejected as cooldown_active]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Handle cooldown for exact context retrie..."](https://github.com/canvascoding/canvas-notebook/commit/d6c41056abca73976fd6f5b113cd3ecefdc42e14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58735114)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->