### PR TITLE
feat(mobile): expose profile avatar contract

### DIFF
--- a/app/api/mobile/v1/account/profile/avatar/route.ts
+++ b/app/api/mobile/v1/account/profile/avatar/route.ts
@@ -1,0 +1,161 @@
+import { createHash } from 'node:crypto';
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { parseMultipartFormData } from '@/app/lib/api/form-data';
+import { auth } from '@/app/lib/auth';
+import { resolveMobileUserProfile } from '@/app/lib/mobile/user-profile';
+import {
+  readUserProfileImage,
+  saveUserProfileImage,
+  selectUserProfileInitials,
+  UserProfileError,
+} from '@/app/lib/user-profile/service';
+import {
+  normalizeUserProfileUpload,
+  USER_PROFILE_AVATAR_MAX_UPLOAD_BYTES,
+  UserProfileUploadError,
+} from '@/app/lib/user-profile/upload';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+const MULTIPART_OVERHEAD_ALLOWANCE_BYTES = 64 * 1024;
+
+const responseHeaders = {
+  'Cache-Control': 'no-store, max-age=0',
+  Vary: 'Cookie',
+  'X-Content-Type-Options': 'nosniff',
+};
+
+function errorResponse(error: string, code: string, status: number) {
+  return NextResponse.json(
+    { success: false, error, code },
+    { status, headers: responseHeaders },
+  );
+}
+
+async function profileResponse(user: { id: string; name?: string | null; email?: string | null }) {
+  const data = await resolveMobileUserProfile({
+    userId: user.id,
+    name: user.name,
+    email: user.email,
+  });
+  return NextResponse.json({ success: true, data }, { headers: responseHeaders });
+}
+
+function mutationLimit(request: NextRequest) {
+  return rateLimit(request, {
+    limit: 10,
+    windowMs: 60_000,
+    keyPrefix: 'mobile-user-profile-avatar-mutation',
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return errorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+
+  try {
+    const image = await readUserProfileImage(session.user.id);
+    if (!image) return errorResponse('Profile image not found.', 'PROFILE_IMAGE_NOT_FOUND', 404);
+
+    const etag = `"${createHash('sha256').update(image.buffer).digest('base64url')}"`;
+    if (request.headers.get('if-none-match') === etag) {
+      return new NextResponse(null, {
+        status: 304,
+        headers: {
+          ETag: etag,
+          'Cache-Control': 'private, max-age=31536000, immutable',
+          Vary: 'Cookie',
+        },
+      });
+    }
+
+    return new NextResponse(new Uint8Array(image.buffer), {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/webp',
+        'Content-Length': String(image.buffer.length),
+        'Cache-Control': 'private, max-age=31536000, immutable',
+        ETag: etag,
+        ...(image.updatedAt ? { 'Last-Modified': new Date(image.updatedAt).toUTCString() } : {}),
+        'X-Content-Type-Options': 'nosniff',
+        'Cross-Origin-Resource-Policy': 'same-origin',
+        Vary: 'Cookie',
+      },
+    });
+  } catch (error) {
+    console.error('[MobileUserProfile] Failed to read the current user avatar.', error);
+    return errorResponse('Could not load the profile image.', 'PROFILE_IMAGE_UNAVAILABLE', 500);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return errorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+  const limited = mutationLimit(request);
+  if (!limited.ok) return limited.response;
+
+  const contentLength = Number(request.headers.get('content-length'));
+  if (
+    Number.isFinite(contentLength)
+    && contentLength > USER_PROFILE_AVATAR_MAX_UPLOAD_BYTES + MULTIPART_OVERHEAD_ALLOWANCE_BYTES
+  ) {
+    return errorResponse(
+      'Profile image is too large. Maximum size is 5 MB.',
+      'PROFILE_IMAGE_TOO_LARGE',
+      413,
+    );
+  }
+
+  try {
+    const parsed = await parseMultipartFormData(request);
+    if (!parsed.ok) return parsed.response;
+    const files = parsed.formData.getAll('avatar').filter((value): value is File => value instanceof File);
+    if (files.length !== 1) {
+      return errorResponse('Upload exactly one profile image.', 'INVALID_PROFILE_IMAGE', 400);
+    }
+    if (files[0].size > USER_PROFILE_AVATAR_MAX_UPLOAD_BYTES) {
+      return errorResponse(
+        'Profile image is too large. Maximum size is 5 MB.',
+        'PROFILE_IMAGE_TOO_LARGE',
+        413,
+      );
+    }
+
+    const normalized = await normalizeUserProfileUpload(Buffer.from(await files[0].arrayBuffer()));
+    await saveUserProfileImage({ userId: session.user.id, buffer: normalized });
+    return await profileResponse(session.user);
+  } catch (error) {
+    if (error instanceof UserProfileUploadError || error instanceof UserProfileError) {
+      return errorResponse(error.message, 'INVALID_PROFILE_IMAGE', error.status);
+    }
+    console.error('[MobileUserProfile] Failed to upload the current user avatar.', error);
+    return errorResponse(
+      'Could not upload the profile image.',
+      'PROFILE_IMAGE_UPLOAD_FAILED',
+      500,
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return errorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+  const limited = mutationLimit(request);
+  if (!limited.ok) return limited.response;
+
+  try {
+    await selectUserProfileInitials(session.user.id);
+    return await profileResponse(session.user);
+  } catch (error) {
+    if (error instanceof UserProfileError) {
+      return errorResponse(error.message, 'PROFILE_IMAGE_REMOVE_FAILED', error.status);
+    }
+    console.error('[MobileUserProfile] Failed to remove the current user avatar.', error);
+    return errorResponse(
+      'Could not remove the profile image.',
+      'PROFILE_IMAGE_REMOVE_FAILED',
+      500,
+    );
+  }
+}

--- a/app/api/mobile/v1/account/profile/route.ts
+++ b/app/api/mobile/v1/account/profile/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@/app/lib/auth';
+import { resolveMobileUserProfile } from '@/app/lib/mobile/user-profile';
+import {
+  selectUserProfileIcon,
+  selectUserProfileInitials,
+  UserProfileError,
+} from '@/app/lib/user-profile/service';
+import { rateLimit } from '@/app/lib/utils/rate-limit';
+
+const responseHeaders = {
+  'Cache-Control': 'no-store, max-age=0',
+  Vary: 'Cookie',
+  'X-Content-Type-Options': 'nosniff',
+};
+
+function errorResponse(error: string, code: string, status: number) {
+  return NextResponse.json(
+    { success: false, error, code },
+    { status, headers: responseHeaders },
+  );
+}
+
+async function profileResponse(user: { id: string; name?: string | null; email?: string | null }) {
+  const data = await resolveMobileUserProfile({
+    userId: user.id,
+    name: user.name,
+    email: user.email,
+  });
+  return NextResponse.json({ success: true, data }, { headers: responseHeaders });
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return errorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+
+  try {
+    return await profileResponse(session.user);
+  } catch (error) {
+    console.error('[MobileUserProfile] Failed to read the current user profile.', error);
+    return errorResponse(
+      'Could not load the user profile.',
+      'ACCOUNT_PROFILE_UNAVAILABLE',
+      500,
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return errorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+
+  const limited = rateLimit(request, {
+    limit: 10,
+    windowMs: 60_000,
+    keyPrefix: 'mobile-user-profile-update',
+  });
+  if (!limited.ok) return limited.response;
+
+  const payload = await request.json().catch(() => null) as Record<string, unknown> | null;
+  if (!payload || Array.isArray(payload)) {
+    return errorResponse('Invalid profile update.', 'INVALID_PROFILE_UPDATE', 400);
+  }
+
+  try {
+    if (payload.avatarKind === 'icon') {
+      await selectUserProfileIcon({ userId: session.user.id, iconId: payload.iconId });
+    } else if (payload.avatarKind === 'initials') {
+      await selectUserProfileInitials(session.user.id);
+    } else {
+      return errorResponse(
+        'Choose a supported icon or the initials fallback.',
+        'INVALID_PROFILE_CHOICE',
+        400,
+      );
+    }
+    return await profileResponse(session.user);
+  } catch (error) {
+    if (error instanceof UserProfileError) {
+      return errorResponse(error.message, 'INVALID_PROFILE_CHOICE', error.status);
+    }
+    console.error('[MobileUserProfile] Failed to update the current user profile.', error);
+    return errorResponse(
+      'Could not update the user profile.',
+      'ACCOUNT_PROFILE_UPDATE_FAILED',
+      500,
+    );
+  }
+}

--- a/app/api/mobile/v1/bootstrap/route.ts
+++ b/app/api/mobile/v1/bootstrap/route.ts
@@ -13,6 +13,7 @@ import {
 } from '@/app/lib/license/seat-limit';
 import { createMobileBootstrap } from '@/app/lib/mobile/bootstrap';
 import { createMobileCompatibility } from '@/app/lib/mobile/compatibility';
+import { resolveMobileUserProfile } from '@/app/lib/mobile/user-profile';
 import { getCurrentAppVersion } from '@/app/lib/migration/app-version';
 import { getDeploymentMode } from '@/app/lib/organization/bootstrap';
 import { resolveWorkspaceActor } from '@/app/lib/workspaces/context';
@@ -52,9 +53,14 @@ export async function GET(request: Request) {
       serverVersion: getCurrentAppVersion(),
       deploymentMode: getDeploymentMode(),
     });
+    const profile = await resolveMobileUserProfile({
+      userId: session.user.id,
+      name: session.user.name,
+      email: session.user.email,
+    });
 
     return NextResponse.json(
-      createMobileBootstrap({ compatibility, request, user: session.user, listing }),
+      createMobileBootstrap({ compatibility, request, user: session.user, profile, listing }),
       { headers: responseHeaders },
     );
   } catch (error) {

--- a/app/lib/mobile/bootstrap.ts
+++ b/app/lib/mobile/bootstrap.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import type { MobileCompatibility } from './compatibility';
+import type { MobileUserProfile } from './user-profile';
 import type { WorkspaceListing } from '@/app/lib/workspaces/listing-action';
 import type { WorkspaceContext, WorkspacePermissions, WorkspaceUserRole } from '@/app/lib/workspaces/types';
 import { buildPublicRequestUrl } from '@/app/lib/utils/request-origin';
@@ -32,6 +33,7 @@ export type MobileBootstrap = {
     name: string;
     email: string;
     image: string | null;
+    profile: MobileUserProfile;
     role: WorkspaceUserRole;
   };
   workspace: {
@@ -83,10 +85,14 @@ export function createMobileBootstrap(input: {
     image?: string | null;
     role?: string | null;
   };
+  profile: MobileUserProfile;
   listing: WorkspaceListing;
 }): MobileBootstrap {
   const capabilities = [
     'account.preferences',
+    'account.profile.read',
+    'account.profile.update',
+    'account.profile.avatar',
     'workspace.read',
     'workspace.switch',
     'workspace.update',
@@ -176,6 +182,7 @@ export function createMobileBootstrap(input: {
       name: input.user.name?.trim() || input.user.email,
       email: input.user.email,
       image: resolveMobileUserImageUrl(input.user.image, input.request),
+      profile: input.profile,
       role: normalizeRole(input.user.role),
     },
     workspace: {

--- a/app/lib/mobile/compatibility.ts
+++ b/app/lib/mobile/compatibility.ts
@@ -20,6 +20,9 @@ export type MobileCompatibility = {
     capabilities: [
       'auth.email_password',
       'account.preferences',
+      'account.profile.read',
+      'account.profile.update',
+      'account.profile.avatar',
       'workspace.bootstrap',
       'license.status',
       'license.register',
@@ -127,6 +130,9 @@ export function createMobileCompatibility(input: {
       capabilities: [
         'auth.email_password',
         'account.preferences',
+        'account.profile.read',
+        'account.profile.update',
+        'account.profile.avatar',
         'workspace.bootstrap',
         'license.status',
         'license.register',

--- a/app/lib/mobile/user-profile.ts
+++ b/app/lib/mobile/user-profile.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+import { resolveUserProfile } from '@/app/lib/user-profile/service';
+import type { ResolvedUserProfile } from '@/app/lib/user-profile/types';
+
+export const MOBILE_ACCOUNT_PROFILE_PATH = '/api/mobile/v1/account/profile' as const;
+export const MOBILE_ACCOUNT_PROFILE_AVATAR_PATH = '/api/mobile/v1/account/profile/avatar' as const;
+
+export type MobileUserProfile = Omit<ResolvedUserProfile, 'imageUrl'> & {
+  imagePath: string | null;
+};
+
+export function mobileUserProfileAvatarPath(revision: number): string {
+  return `${MOBILE_ACCOUNT_PROFILE_AVATAR_PATH}?v=${revision}`;
+}
+
+export function serializeMobileUserProfile(profile: ResolvedUserProfile): MobileUserProfile {
+  return {
+    name: profile.name,
+    avatarKind: profile.avatarKind,
+    iconId: profile.iconId,
+    initials: profile.initials,
+    imagePath: profile.avatarKind === 'image'
+      ? mobileUserProfileAvatarPath(profile.revision)
+      : null,
+    revision: profile.revision,
+  };
+}
+
+export async function resolveMobileUserProfile(input: {
+  userId: string;
+  name?: string | null;
+  email?: string | null;
+  locale?: string;
+}): Promise<MobileUserProfile> {
+  return serializeMobileUserProfile(await resolveUserProfile(input));
+}

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "test:auth:seat-limit": "tsx --conditions react-server scripts/auth-seat-limit-test.ts",
     "test:mobile:compatibility": "tsx --conditions react-server scripts/mobile-compatibility-test.ts && tsx --conditions react-server scripts/mobile-compatibility-route-test.ts",
     "test:mobile:bootstrap": "tsx --conditions react-server scripts/mobile-bootstrap-test.ts && tsx --conditions react-server scripts/mobile-bootstrap-route-test.ts",
-    "test:mobile:account": "tsx --conditions react-server scripts/mobile-account-preferences-test.ts",
+    "test:mobile:account": "tsx --conditions react-server scripts/mobile-account-preferences-test.ts && tsx --conditions react-server scripts/mobile-account-profile-test.ts",
     "test:mobile:brand": "tsx --conditions react-server scripts/mobile-workspace-brand-route-test.ts",
     "test:mobile:license": "tsx --conditions react-server scripts/mobile-license-test.ts",
     "test:license-email-activation": "CANVAS_DATABASE_PROVIDER=sqlite tsx --conditions react-server scripts/license-email-activation-test.ts && CANVAS_DATABASE_PROVIDER=postgres DATABASE_URL=postgresql://canvas:canvas@127.0.0.1:1/canvas tsx --conditions react-server scripts/license-email-activation-test.ts",

--- a/scripts/mobile-account-profile-test.ts
+++ b/scripts/mobile-account-profile-test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import Module from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { NextRequest } from 'next/server';
+
+type RouteSession = {
+  user: { id: string; email: string; name: string; image: string | null; role: string };
+  session: { id: string };
+};
+
+async function importServerModule<T>(specifier: string): Promise<T> {
+  const moduleInternals = Module as typeof Module & {
+    _load: (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+  };
+  const originalLoad = moduleInternals._load;
+  moduleInternals._load = (request, parent, isMain) => (
+    request === 'server-only' ? {} : originalLoad(request, parent, isMain)
+  );
+  try {
+    return await import(specifier) as T;
+  } finally {
+    moduleInternals._load = originalLoad;
+  }
+}
+
+function request(url: string, init?: { body?: BodyInit | null; headers?: HeadersInit; method?: string }) {
+  return new NextRequest(url, init);
+}
+
+async function main() {
+  const dataRoot = await mkdtemp(path.join(os.tmpdir(), 'canvas-mobile-account-profile-'));
+  process.env.DATA = dataRoot;
+  process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
+
+  try {
+    const { runMigrations } = await import('../app/lib/db/migrate');
+    const sqlite = new Database(path.join(dataRoot, 'sqlite.db'));
+    runMigrations(sqlite);
+    const now = Date.now();
+    sqlite.prepare(`
+      INSERT INTO user (id, name, email, email_verified, image, role, created_at, updated_at)
+      VALUES (?, ?, ?, 1, NULL, 'user', ?, ?)
+    `).run('mobile-profile-a', 'Alex Weber', 'alex@example.test', now, now);
+    sqlite.close();
+
+    const { auth } = await import('../app/lib/auth');
+    let currentSession: RouteSession | null = null;
+    const originalGetSession = auth.api.getSession;
+    assert.equal(Reflect.set(auth.api, 'getSession', async () => currentSession), true);
+
+    try {
+      const route = await importServerModule<typeof import('../app/api/mobile/v1/account/profile/route')>(
+        '../app/api/mobile/v1/account/profile/route',
+      );
+
+      assert.equal((await route.GET(request('http://localhost/api/mobile/v1/account/profile'))).status, 401);
+      currentSession = {
+        user: {
+          id: 'mobile-profile-a',
+          email: 'alex@example.test',
+          name: 'Alex Weber',
+          image: null,
+          role: 'user',
+        },
+        session: { id: 'mobile-profile-session-a' },
+      };
+
+      const initial = await route.GET(request('http://localhost/api/mobile/v1/account/profile'));
+      assert.equal(initial.status, 200);
+      assert.deepEqual((await initial.json() as { data: unknown }).data, {
+        name: 'Alex Weber',
+        avatarKind: 'initials',
+        iconId: null,
+        initials: 'AW',
+        imagePath: null,
+        revision: 0,
+      });
+
+      const icon = await route.PATCH(request('http://localhost/api/mobile/v1/account/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ avatarKind: 'icon', iconId: 'rocket' }),
+      }));
+      assert.equal(icon.status, 200);
+      assert.deepEqual((await icon.json() as { data: unknown }).data, {
+        name: 'Alex Weber',
+        avatarKind: 'icon',
+        iconId: 'rocket',
+        initials: 'AW',
+        imagePath: null,
+        revision: 1,
+      });
+
+      const invalid = await route.PATCH(request('http://localhost/api/mobile/v1/account/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ avatarKind: 'icon', iconId: '../escape' }),
+      }));
+      assert.equal(invalid.status, 400);
+    } finally {
+      Reflect.set(auth.api, 'getSession', originalGetSession);
+    }
+    console.log('mobile-account-profile-test: ok');
+  } finally {
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/mobile-bootstrap-route-test.ts
+++ b/scripts/mobile-bootstrap-route-test.ts
@@ -81,6 +81,14 @@ async function main() {
   assert.equal(payload.product, 'canvas-notebook');
   const user = payload.user as Record<string, unknown>;
   assert.equal(user.email, 'mobile@example.test');
+  assert.deepEqual(user.profile, {
+    name: 'Mobile User',
+    avatarKind: 'initials',
+    iconId: null,
+    initials: 'MU',
+    imagePath: null,
+    revision: 0,
+  });
   const workspace = payload.workspace as Record<string, unknown>;
   assert.equal(typeof workspace.activeWorkspaceId, 'string');
   assert.equal(Array.isArray(workspace.items), true);

--- a/scripts/mobile-bootstrap-test.ts
+++ b/scripts/mobile-bootstrap-test.ts
@@ -62,6 +62,14 @@ const bootstrap = createMobileBootstrap({
     image: '/api/account/profile/avatar?v=3',
     role: 'admin',
   },
+  profile: {
+    name: 'Mobile User',
+    avatarKind: 'icon',
+    iconId: 'rocket',
+    initials: 'MU',
+    imagePath: null,
+    revision: 3,
+  },
   listing,
 });
 
@@ -72,6 +80,9 @@ assert.equal(
 );
 assert.deepEqual(bootstrap.mobileApi.capabilities, [
   'account.preferences',
+  'account.profile.read',
+  'account.profile.update',
+  'account.profile.avatar',
   'workspace.read',
   'workspace.switch',
   'workspace.update',
@@ -148,6 +159,14 @@ assert.deepEqual(bootstrap.mobileApi.capabilities, [
   'integrations.composio_mobile_auth',
   'workspace.create',
 ]);
+assert.deepEqual(bootstrap.user.profile, {
+  name: 'Mobile User',
+  avatarKind: 'icon',
+  iconId: 'rocket',
+  initials: 'MU',
+  imagePath: null,
+  revision: 3,
+});
 assert.equal(bootstrap.user.role, 'admin');
 assert.equal(bootstrap.workspace.activeWorkspaceId, workspace.workspaceId);
 assert.equal(bootstrap.workspace.items[0]?.access, 'manage');

--- a/scripts/mobile-compatibility-test.ts
+++ b/scripts/mobile-compatibility-test.ts
@@ -34,6 +34,9 @@ assert.deepEqual(compatibility, {
     capabilities: [
       'auth.email_password',
       'account.preferences',
+      'account.profile.read',
+      'account.profile.update',
+      'account.profile.avatar',
       'workspace.bootstrap',
       'license.status',
       'license.register',


### PR DESCRIPTION
## Summary
- include the resolved user profile in the versioned mobile bootstrap contract
- add self-only mobile profile and avatar endpoints with icon, initials, and image support
- advertise the profile capabilities to mobile clients

## Validation
- npm run test:mobile:compatibility
- npm run test:mobile:bootstrap
- npm run test:mobile:account
- CANVAS_DATABASE_PROVIDER=sqlite DATA=/private/tmp/canvas-profile-build.EfBMw9 npm run build

## Notes
- npm run lint remains blocked by existing generated dist-linux-cli lint errors unrelated to this change.