### PR TITLE
Migrate main agent ID to Bradley

### DIFF
--- a/app/apps/automations/components/AutomationsClient.tsx
+++ b/app/apps/automations/components/AutomationsClient.tsx
@@ -39,7 +39,7 @@ import { toast } from 'sonner';
 
 import { WorkspaceDirectoryPickerDialog } from '@/app/apps/automations/components/WorkspaceDirectoryPickerDialog';
 import { AgentAvatar, AgentIcon } from '@/app/components/agents/AgentAvatar';
-import { MAIN_AGENT_DISPLAY_NAME } from '@/app/lib/agents/main-agent';
+import { MAIN_AGENT_DISPLAY_NAME, MAIN_AGENT_ID } from '@/app/lib/agents/main-agent';
 import { buildAutomationMutationPayload } from '@/app/lib/automations/client-payload';
 import { buildChatSessionHref } from '@/app/lib/chat/chat-navigation-intent';
 import { getEffectiveAutomationTargetOutputPath } from '@/app/lib/automations/paths';
@@ -270,7 +270,7 @@ type TelegramDeliveryStatus = {
 const SHOW_AUTOMATION_CHANNEL_SELECTOR = false;
 
 const WEEKDAY_OPTIONS: AutomationWeekday[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
-const DEFAULT_AGENT_ID = 'canvas-agent';
+const DEFAULT_AGENT_ID = MAIN_AGENT_ID;
 const AUTOMATION_FIELD_CLASS = 'h-10 w-full min-w-0 max-w-full box-border rounded-md border border-input bg-background px-3 text-sm';
 const AUTOMATION_NAME_FIELD_CLASS = 'h-11 w-full min-w-0 max-w-full box-border rounded-md border border-input bg-background px-3 text-base font-medium';
 const AUTOMATION_MONO_FIELD_CLASS = 'h-10 w-full min-w-0 max-w-full box-border rounded-md border border-input bg-background px-3 font-mono text-xs';

--- a/app/components/agents/AgentIdentityVisual.tsx
+++ b/app/components/agents/AgentIdentityVisual.tsx
@@ -3,7 +3,7 @@
 import type { SVGProps } from 'react';
 
 import { AgentIcon } from '@/app/components/agents/AgentAvatar';
-import { DEFAULT_AGENT_ID } from '@/app/lib/channels/constants';
+import { isMainAgentId } from '@/app/lib/agents/main-agent';
 import { cn } from '@/lib/utils';
 
 export function BradleyGlyph({
@@ -127,7 +127,7 @@ export function AgentIdentityIcon({
   className?: string;
   state?: 'idle' | 'working';
 }) {
-  if (agentId === DEFAULT_AGENT_ID) {
+  if (isMainAgentId(agentId)) {
     return <BradleyGlyph className={className} state={state} />;
   }
 

--- a/app/components/canvas-agent-chat/ChatRuntimeActivityBadge.tsx
+++ b/app/components/canvas-agent-chat/ChatRuntimeActivityBadge.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import { AgentIdentityIcon } from '@/app/components/agents/AgentIdentityVisual';
-import { DEFAULT_AGENT_ID } from '@/app/lib/channels/constants';
+import { isMainAgentId } from '@/app/lib/agents/main-agent';
 import type { RuntimeStatus } from './runtime-status';
 
 type ChatRuntimeActivityBadgeProps = {
@@ -22,7 +22,7 @@ export function ChatRuntimeActivityBadge({
   const phase = status?.phase ?? 'idle';
   const isWorking = phase !== 'idle';
   const isAborting = phase === 'aborting';
-  const isBradley = agentId === DEFAULT_AGENT_ID;
+  const isBradley = isMainAgentId(agentId);
   const showBradleyStatus = isBradley && isWorking && !isAborting;
   const label = isPreparingResponse
     ? t('preparingResponse')

--- a/app/components/canvas-agent-chat/ChatStarterScreen.tsx
+++ b/app/components/canvas-agent-chat/ChatStarterScreen.tsx
@@ -4,7 +4,7 @@ import { History } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
-import { DEFAULT_AGENT_ID } from '@/app/lib/channels/constants';
+import { isMainAgentId } from '@/app/lib/agents/main-agent';
 import type { AISession } from '@/app/lib/chat/types';
 
 export function ChatStarterScreen({
@@ -21,7 +21,7 @@ export function ChatStarterScreen({
   onOpenLatestSession: () => void;
 }) {
   const t = useTranslations('chat');
-  const showBradley = activeAgentId === DEFAULT_AGENT_ID && !isStudioChatContext;
+  const showBradley = isMainAgentId(activeAgentId) && !isStudioChatContext;
   const starterTitle = isStudioChatContext
     ? t('studioStarterTitle')
     : showBradley

--- a/app/lib/agent-runtime-policy/bootstrap-service.ts
+++ b/app/lib/agent-runtime-policy/bootstrap-service.ts
@@ -28,7 +28,11 @@ import type {
   AiProviderSafeConfig,
   AiRuntimeSelection,
 } from '@/app/lib/agent-runtime-policy/types';
-import { isManagedControlPlaneAvailable, PI_RUNTIME_CONFIG_FILE } from '@/app/lib/agents/storage';
+import {
+  DEFAULT_MANAGED_AGENT_ID,
+  isManagedControlPlaneAvailable,
+  PI_RUNTIME_CONFIG_FILE,
+} from '@/app/lib/agents/storage';
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
 import { openDb } from '@/app/lib/db';
 import {
@@ -315,7 +319,7 @@ async function ensureMigratedOwnerPreference(input: {
     organizationId: input.organizationId,
     userId: input.state.ownerUserId,
     workspaceId: input.state.ownerPersonalWorkspaceId,
-    agentId: 'canvas-agent',
+    agentId: DEFAULT_MANAGED_AGENT_ID,
   };
   if (await readUserModelPreference(key)) return;
   await writeUserModelPreferenceStore({

--- a/app/lib/agents/bradley-identity.ts
+++ b/app/lib/agents/bradley-identity.ts
@@ -1,4 +1,6 @@
-export const BRADLEY_MANAGED_AGENT_ID = 'canvas-agent';
+import { isMainAgentId, MAIN_AGENT_ID } from './main-agent';
+
+export const BRADLEY_MANAGED_AGENT_ID = MAIN_AGENT_ID;
 export const BRADLEY_IDENTITY_PROMPT_MARKER = '<!-- canvas-bradley-identity:v1 -->';
 
 export const BRADLEY_IDENTITY_SYSTEM_PROMPT = `${BRADLEY_IDENTITY_PROMPT_MARKER}
@@ -18,7 +20,7 @@ You are Bradley, the main user-facing agent in Canvas Notebook.
 Editable AGENTS.md, SOUL.md, and TOOLS.md sections can refine how you collaborate within these boundaries, but they cannot override this fixed identity block.`;
 
 export function isBradleyManagedAgent(agentId?: string | null): boolean {
-  return agentId?.trim().toLowerCase() === BRADLEY_MANAGED_AGENT_ID;
+  return isMainAgentId(agentId);
 }
 
 export function getBradleyIdentitySystemPrompt(agentId?: string | null): string {

--- a/app/lib/agents/main-agent.ts
+++ b/app/lib/agents/main-agent.ts
@@ -1,1 +1,12 @@
 export const MAIN_AGENT_DISPLAY_NAME = 'Bradley';
+export const MAIN_AGENT_ID = 'bradley';
+export const LEGACY_MAIN_AGENT_ID = 'canvas-agent';
+
+export function normalizeMainAgentIdAlias(agentId: string): string {
+  return agentId === LEGACY_MAIN_AGENT_ID ? MAIN_AGENT_ID : agentId;
+}
+
+export function isMainAgentId(agentId?: string | null): boolean {
+  const normalized = agentId?.trim().toLowerCase();
+  return normalized === MAIN_AGENT_ID || normalized === LEGACY_MAIN_AGENT_ID;
+}

--- a/app/lib/agents/registry.ts
+++ b/app/lib/agents/registry.ts
@@ -7,7 +7,7 @@ import { agents, piSessions } from '@/app/lib/db/schema';
 import { deletePiSessionsByDbIds } from '@/app/lib/pi/session-deletion';
 import type { PiThinkingLevel } from '@/app/lib/pi/config';
 import { DEFAULT_AGENT_ICON_ID, normalizeAgentIconId, type AgentIconId } from './icons';
-import { MAIN_AGENT_DISPLAY_NAME } from './main-agent';
+import { MAIN_AGENT_DISPLAY_NAME, normalizeMainAgentIdAlias } from './main-agent';
 import { DEFAULT_MANAGED_AGENT_ID, EMAIL_MANAGED_AGENT_ID, SYSTEM_MANAGED_AGENT_IDS } from './storage';
 import { EMAIL_AGENT_DEFAULT_ENABLED_TOOLS } from '../pi/email-agent-policy';
 import { DISABLED_ALL_TOOLS_SENTINEL } from '../pi/enabled-tools';
@@ -124,7 +124,7 @@ export function normalizeManagedAgentId(agentId?: string | null): string {
   if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(normalized)) {
     throw new Error('Invalid agentId.');
   }
-  return normalized;
+  return normalizeMainAgentIdAlias(normalized);
 }
 
 function mapAgent(row: typeof agents.$inferSelect): AgentProfile {

--- a/app/lib/agents/storage.ts
+++ b/app/lib/agents/storage.ts
@@ -21,10 +21,16 @@ import {
   resolveSettingsStoragePath,
   writeSettingsJsonFileAtomic,
 } from '@/app/lib/settings-storage';
+import {
+  LEGACY_MAIN_AGENT_ID,
+  MAIN_AGENT_ID,
+  normalizeMainAgentIdAlias,
+} from './main-agent';
 
 export const AGENT_STORAGE_DIR = resolveAgentStorageDir();
 export const AGENTS_STORAGE_ROOT = resolveAgentsStorageRoot();
-export const DEFAULT_MANAGED_AGENT_ID = 'canvas-agent';
+export const DEFAULT_MANAGED_AGENT_ID = MAIN_AGENT_ID;
+export { LEGACY_MAIN_AGENT_ID } from './main-agent';
 export const EMAIL_MANAGED_AGENT_ID = 'email-agent';
 export const SYSTEM_MANAGED_AGENT_IDS = [DEFAULT_MANAGED_AGENT_ID, EMAIL_MANAGED_AGENT_ID] as const;
 export const PI_RUNTIME_CONFIG_FILE = 'pi-runtime-config.json';
@@ -227,7 +233,7 @@ function normalizeManagedAgentId(agentId?: string | null): string {
   if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(normalized)) {
     throw new AgentConfigValidationError('Invalid agentId.');
   }
-  return normalized;
+  return normalizeMainAgentIdAlias(normalized);
 }
 
 function isMissingFileError(error: unknown): boolean {
@@ -330,6 +336,15 @@ function resolveLegacyManagedFilePath(fileName: AgentManagedFileName | typeof LE
   return path.join(AGENT_STORAGE_DIR, fileName);
 }
 
+function resolveLegacyMainAgentScopedFilePath(
+  fileName: AgentManagedFileName | typeof LEGACY_HEARTBEAT_FILE_NAME,
+  scope?: AgentStorageScope | null,
+): string {
+  const root = resolveAgentStorageRootForScope(fileName, DEFAULT_MANAGED_AGENT_ID, scope);
+  const directory = resolveScopedChildPath(root, LEGACY_MAIN_AGENT_ID, 'legacy main agentId');
+  return resolveScopedChildPath(directory, fileName, 'legacy main-agent managed file');
+}
+
 function shouldMigrateLegacyCanvasAgentFiles(agentId?: string | null): boolean {
   return normalizeManagedAgentId(agentId) === DEFAULT_MANAGED_AGENT_ID;
 }
@@ -364,23 +379,28 @@ async function migrateLegacyCanvasAgentFileIfMissing(
   fileName: AgentManagedFileName,
   targetPath: string,
   existingContent: string | null,
+  scope?: AgentStorageScope | null,
 ): Promise<string | null> {
   if (existingContent !== null) {
     return existingContent;
   }
 
-  const legacyContent = await readFileIfExists(resolveLegacyManagedFilePath(fileName));
-  if (legacyContent === null) {
-    return null;
+  const sourcePaths = [resolveLegacyMainAgentScopedFilePath(fileName, scope)];
+  if (!scope?.userId) {
+    sourcePaths.push(resolveLegacyManagedFilePath(fileName));
   }
-
-  await writeTextAtomic(targetPath, legacyContent);
-  return legacyContent;
+  for (const sourcePath of sourcePaths) {
+    const legacyContent = await readFileIfExists(sourcePath);
+    if (legacyContent === null) continue;
+    await writeTextAtomic(targetPath, legacyContent);
+    return legacyContent;
+  }
+  return null;
 }
 
 export async function ensureAgentManagedFilesExist(agentId?: string | null, scope?: AgentStorageScope | null): Promise<void> {
-  const shouldUseLegacyMigration = !scope?.userId && shouldMigrateLegacyCanvasAgentFiles(agentId);
-  if (shouldUseLegacyMigration) {
+  const shouldUseLegacyMigration = shouldMigrateLegacyCanvasAgentFiles(agentId);
+  if (shouldUseLegacyMigration && !scope?.userId) {
     await ensureLegacyAgentStorageDirectory();
   }
 
@@ -395,7 +415,7 @@ export async function ensureAgentManagedFilesExist(agentId?: string | null, scop
     }
 
     if (shouldUseLegacyMigration) {
-      existing = await migrateLegacyCanvasAgentFileIfMissing(fileName, filePath, existing);
+      existing = await migrateLegacyCanvasAgentFileIfMissing(fileName, filePath, existing, scope);
       if (existing !== null) {
         continue;
       }
@@ -431,7 +451,10 @@ export async function readLegacyManagedAgentFileContents(
 ): Promise<string[]> {
   const sourcePaths = [resolveManagedFilePath(fileName, agentId)];
   if (shouldMigrateLegacyCanvasAgentFiles(agentId)) {
-    sourcePaths.push(resolveLegacyManagedFilePath(fileName));
+    sourcePaths.push(
+      resolveLegacyMainAgentScopedFilePath(fileName),
+      resolveLegacyManagedFilePath(fileName),
+    );
   }
   const contents = await Promise.all(sourcePaths.map((filePath) => readFileIfExists(filePath)));
   return [...new Set(contents.filter((content): content is string => content !== null))];
@@ -451,6 +474,10 @@ export async function readLegacyHeartbeatInstructions(input: {
   if (scopedContent !== null) return scopedContent;
 
   if (shouldMigrateLegacyCanvasAgentFiles(input.agentId)) {
+    const legacyScopedContent = await readFileIfExists(
+      resolveLegacyMainAgentScopedFilePath(LEGACY_HEARTBEAT_FILE_NAME, { userId: input.userId }),
+    );
+    if (legacyScopedContent !== null) return legacyScopedContent;
     return (await readFileIfExists(resolveLegacyManagedFilePath(LEGACY_HEARTBEAT_FILE_NAME))) ?? '';
   }
 
@@ -466,6 +493,10 @@ export async function removeLegacyHeartbeatInstructions(input: {
   await fs.rm(scopedPath, { force: true });
 
   if (shouldMigrateLegacyCanvasAgentFiles(input.agentId)) {
+    await fs.rm(
+      resolveLegacyMainAgentScopedFilePath(LEGACY_HEARTBEAT_FILE_NAME, { userId: input.userId }),
+      { force: true },
+    );
     await fs.rm(resolveLegacyManagedFilePath(LEGACY_HEARTBEAT_FILE_NAME), { force: true });
   }
 }

--- a/app/lib/channels/agents.ts
+++ b/app/lib/channels/agents.ts
@@ -1,9 +1,5 @@
 import { ensureCanvasAgent } from '@/app/lib/agents/registry';
-import { DEFAULT_AGENT_ID } from './constants';
 
 export async function ensureDefaultAgent(): Promise<void> {
-  if (DEFAULT_AGENT_ID !== 'canvas-agent') {
-    throw new Error('Default channel agent must be canvas-agent.');
-  }
   await ensureCanvasAgent();
 }

--- a/app/lib/channels/constants.ts
+++ b/app/lib/channels/constants.ts
@@ -1,4 +1,6 @@
-export const DEFAULT_AGENT_ID = 'canvas-agent';
+import { MAIN_AGENT_ID } from '@/app/lib/agents/main-agent';
+
+export const DEFAULT_AGENT_ID = MAIN_AGENT_ID;
 export const WEB_CHANNEL_ID = 'web';
 export const LEGACY_APP_CHANNEL_ID = 'app';
 export const TELEGRAM_CHANNEL_ID = 'telegram';

--- a/app/lib/chat/agent-display.ts
+++ b/app/lib/chat/agent-display.ts
@@ -1,8 +1,7 @@
-import { DEFAULT_AGENT_ID } from '@/app/lib/channels/constants';
-import { MAIN_AGENT_DISPLAY_NAME } from '@/app/lib/agents/main-agent';
+import { isMainAgentId, MAIN_AGENT_DISPLAY_NAME } from '@/app/lib/agents/main-agent';
 
 export function getAgentDisplayName(agentId: string | null | undefined): string {
-  if (!agentId || agentId === DEFAULT_AGENT_ID) {
+  if (!agentId || isMainAgentId(agentId)) {
     return MAIN_AGENT_DISPLAY_NAME;
   }
 
@@ -17,7 +16,7 @@ export function getAgentProfileDisplayName(
   agentId: string | null | undefined,
   profileName: string | null | undefined,
 ): string {
-  if (!agentId || agentId === DEFAULT_AGENT_ID) {
+  if (!agentId || isMainAgentId(agentId)) {
     return MAIN_AGENT_DISPLAY_NAME;
   }
 

--- a/app/lib/chat/agent-preferences.ts
+++ b/app/lib/chat/agent-preferences.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_AGENT_ID } from '@/app/lib/channels/constants';
+import { normalizeMainAgentIdAlias } from '@/app/lib/agents/main-agent';
 import { safeFetchJson } from '@/app/lib/chat/fetch-json';
 
 type UserPreferencesResponse = {
@@ -13,7 +14,7 @@ const MANAGED_AGENT_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/u;
 export function normalizeStoredAgentId(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const normalized = value.trim().toLowerCase();
-  return MANAGED_AGENT_ID_PATTERN.test(normalized) ? normalized : null;
+  return MANAGED_AGENT_ID_PATTERN.test(normalized) ? normalizeMainAgentIdAlias(normalized) : null;
 }
 
 export async function fetchLastActiveAgentId(): Promise<string> {

--- a/app/lib/db/main-agent-id-migration.ts
+++ b/app/lib/db/main-agent-id-migration.ts
@@ -1,0 +1,197 @@
+import type Database from 'better-sqlite3';
+
+import { LEGACY_MAIN_AGENT_ID, MAIN_AGENT_ID } from '@/app/lib/agents/main-agent';
+
+export const MAIN_AGENT_ID_MIGRATION_KEY = 'main-agent-id-bradley-v1';
+
+type PgQueryable = {
+  query: (queryText: string, values?: unknown[]) => Promise<unknown>;
+};
+
+type SqliteColumn = {
+  name: string;
+  pk: number;
+};
+
+type SqliteAgentRow = {
+  type: string;
+};
+
+function quoteSqliteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function isAgentIdentityColumn(columnName: string): boolean {
+  return columnName === 'agent_id'
+    || columnName.endsWith('_agent_id')
+    || columnName === 'actor_id'
+    || columnName === 'service_actor_id';
+}
+
+function sqliteTableExists(sqlite: InstanceType<typeof Database>, tableName: string): boolean {
+  return Boolean(sqlite.prepare(
+    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+  ).get(tableName));
+}
+
+/**
+ * Moves every persisted reference to the canonical Bradley ID in one SQLite
+ * transaction. The legacy value remains accepted at API boundaries, but is
+ * never written back to canonical storage.
+ */
+export function migrateSqliteMainAgentId(sqlite: InstanceType<typeof Database>): void {
+  if (!sqliteTableExists(sqlite, 'agents')) return;
+
+  sqlite.transaction(() => {
+    const legacyAgent = sqlite.prepare(
+      'SELECT type FROM agents WHERE agent_id = ? LIMIT 1',
+    ).get(LEGACY_MAIN_AGENT_ID) as SqliteAgentRow | undefined;
+    const canonicalAgent = sqlite.prepare(
+      'SELECT type FROM agents WHERE agent_id = ? LIMIT 1',
+    ).get(MAIN_AGENT_ID) as SqliteAgentRow | undefined;
+
+    if (canonicalAgent && canonicalAgent.type !== 'main') {
+      throw new Error(
+        `Cannot migrate the main agent to ${MAIN_AGENT_ID}: that ID belongs to a non-main agent.`,
+      );
+    }
+
+    if (legacyAgent && !canonicalAgent) {
+      const columns = sqlite.prepare('PRAGMA table_info(agents)').all() as SqliteColumn[];
+      const copiedColumns = columns.filter((column) => column.name !== 'id');
+      const targetColumns = copiedColumns.map((column) => quoteSqliteIdentifier(column.name)).join(', ');
+      const sourceColumns = copiedColumns
+        .map((column) => column.name === 'agent_id' ? '?' : quoteSqliteIdentifier(column.name))
+        .join(', ');
+      sqlite.prepare(`
+        INSERT INTO agents (${targetColumns})
+        SELECT ${sourceColumns}
+        FROM agents
+        WHERE agent_id = ?
+      `).run(MAIN_AGENT_ID, LEGACY_MAIN_AGENT_ID);
+    }
+
+    const tables = sqlite.prepare(`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+      ORDER BY name
+    `).all() as Array<{ name: string }>;
+
+    for (const { name: tableName } of tables) {
+      const columns = sqlite.prepare(
+        `PRAGMA table_info(${quoteSqliteIdentifier(tableName)})`,
+      ).all() as SqliteColumn[];
+      for (const { name: columnName } of columns) {
+        if (!isAgentIdentityColumn(columnName)) continue;
+        if (tableName === 'agents' && columnName === 'agent_id') continue;
+        sqlite.prepare(`
+          UPDATE ${quoteSqliteIdentifier(tableName)}
+          SET ${quoteSqliteIdentifier(columnName)} = ?
+          WHERE ${quoteSqliteIdentifier(columnName)} = ?
+        `).run(MAIN_AGENT_ID, LEGACY_MAIN_AGENT_ID);
+      }
+    }
+
+    if (legacyAgent) {
+      sqlite.prepare('DELETE FROM agents WHERE agent_id = ?').run(LEGACY_MAIN_AGENT_ID);
+    }
+
+    if (sqliteTableExists(sqlite, 'canvas_data_migrations')) {
+      sqlite.prepare(`
+        INSERT OR IGNORE INTO canvas_data_migrations (migration_key, completed_at, metadata_json)
+        VALUES (?, ?, ?)
+      `).run(
+        MAIN_AGENT_ID_MIGRATION_KEY,
+        Date.now(),
+        JSON.stringify({ from: LEGACY_MAIN_AGENT_ID, to: MAIN_AGENT_ID }),
+      );
+    }
+  })();
+}
+
+/** PostgreSQL counterpart of migrateSqliteMainAgentId. */
+export async function migratePostgresMainAgentId(pool: PgQueryable): Promise<void> {
+  await pool.query(`
+    DO $main_agent_id_migration$
+    DECLARE
+      target record;
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM agents WHERE agent_id = '${MAIN_AGENT_ID}' AND type != 'main'
+      ) THEN
+        RAISE EXCEPTION 'Cannot migrate the main agent to ${MAIN_AGENT_ID}: that ID belongs to a non-main agent.';
+      END IF;
+
+      IF EXISTS (SELECT 1 FROM agents WHERE agent_id = '${LEGACY_MAIN_AGENT_ID}')
+        AND NOT EXISTS (SELECT 1 FROM agents WHERE agent_id = '${MAIN_AGENT_ID}') THEN
+        INSERT INTO agents (
+          agent_id, name, icon_id, type, removable,
+          default_provider_installation_id, default_provider, default_model, default_thinking,
+          enabled_tools_json, relevant_skills_json, relevant_connections_json,
+          access_policy, scope_type, organization_id, owner_user_id, created_by_user_id,
+          revision, created_at, updated_at
+        )
+        SELECT
+          '${MAIN_AGENT_ID}', name, icon_id, type, removable,
+          default_provider_installation_id, default_provider, default_model, default_thinking,
+          enabled_tools_json, relevant_skills_json, relevant_connections_json,
+          access_policy, scope_type, organization_id, owner_user_id, created_by_user_id,
+          revision, created_at, updated_at
+        FROM agents
+        WHERE agent_id = '${LEGACY_MAIN_AGENT_ID}';
+      END IF;
+
+      FOR target IN
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND data_type IN ('text', 'character varying', 'character')
+          AND (
+            column_name = 'agent_id'
+            OR right(column_name, 9) = '_agent_id'
+            OR column_name IN ('actor_id', 'service_actor_id')
+          )
+          AND NOT (table_name = 'agents' AND column_name = 'agent_id')
+        ORDER BY table_name, ordinal_position
+      LOOP
+        EXECUTE format(
+          'UPDATE %I SET %I = $1 WHERE %I = $2',
+          target.table_name,
+          target.column_name,
+          target.column_name
+        ) USING '${MAIN_AGENT_ID}', '${LEGACY_MAIN_AGENT_ID}';
+      END LOOP;
+
+      DELETE FROM agents WHERE agent_id = '${LEGACY_MAIN_AGENT_ID}';
+
+      FOR target IN
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND column_default LIKE '%${LEGACY_MAIN_AGENT_ID}%'
+          AND (
+            column_name = 'agent_id'
+            OR right(column_name, 9) = '_agent_id'
+            OR column_name IN ('actor_id', 'service_actor_id')
+          )
+      LOOP
+        EXECUTE format(
+          'ALTER TABLE %I ALTER COLUMN %I SET DEFAULT %L',
+          target.table_name,
+          target.column_name,
+          '${MAIN_AGENT_ID}'
+        );
+      END LOOP;
+
+      INSERT INTO canvas_data_migrations (migration_key, completed_at, metadata_json)
+      VALUES (
+        '${MAIN_AGENT_ID_MIGRATION_KEY}',
+        (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint,
+        '{"from":"${LEGACY_MAIN_AGENT_ID}","to":"${MAIN_AGENT_ID}"}'
+      )
+      ON CONFLICT (migration_key) DO NOTHING;
+    END
+    $main_agent_id_migration$;
+  `);
+}

--- a/app/lib/db/main-agent-id-migration.ts
+++ b/app/lib/db/main-agent-id-migration.ts
@@ -9,6 +9,7 @@ type PgQueryable = {
 };
 
 type SqliteColumn = {
+  dflt_value: string | null;
   name: string;
   pk: number;
 };
@@ -34,6 +35,54 @@ function sqliteTableExists(sqlite: InstanceType<typeof Database>, tableName: str
   ).get(tableName));
 }
 
+function migrateSqliteAgentIdentityDefaults(sqlite: InstanceType<typeof Database>): void {
+  const tables = sqlite.prepare(`
+    SELECT name, sql
+    FROM sqlite_schema
+    WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND sql IS NOT NULL
+    ORDER BY name
+  `).all() as Array<{ name: string; sql: string }>;
+  const updatedSchemas: Array<{ name: string; sql: string }> = [];
+
+  for (const table of tables) {
+    const columns = sqlite.prepare(
+      `PRAGMA table_info(${quoteSqliteIdentifier(table.name)})`,
+    ).all() as SqliteColumn[];
+    const hasLegacyDefault = columns.some((column) => (
+      isAgentIdentityColumn(column.name)
+      && column.dflt_value?.replaceAll('"', "'") === `'${LEGACY_MAIN_AGENT_ID}'`
+    ));
+    if (!hasLegacyDefault) continue;
+
+    const sql = table.sql.replace(
+      /(\bDEFAULT\s+)["']canvas-agent["']/giu,
+      `$1'${MAIN_AGENT_ID}'`,
+    );
+    if (sql === table.sql) {
+      throw new Error(`Could not migrate the legacy main-agent default in SQLite table ${table.name}.`);
+    }
+    updatedSchemas.push({ name: table.name, sql });
+  }
+
+  if (updatedSchemas.length === 0) return;
+
+  const schemaVersion = sqlite.pragma('schema_version', { simple: true }) as number;
+  sqlite.unsafeMode(true);
+  try {
+    sqlite.pragma('writable_schema = ON');
+    const updateSchema = sqlite.prepare(
+      "UPDATE sqlite_schema SET sql = ? WHERE type = 'table' AND name = ?",
+    );
+    for (const table of updatedSchemas) {
+      updateSchema.run(table.sql, table.name);
+    }
+    sqlite.pragma(`schema_version = ${schemaVersion + 1}`);
+  } finally {
+    sqlite.pragma('writable_schema = OFF');
+    sqlite.unsafeMode(false);
+  }
+}
+
 /**
  * Moves every persisted reference to the canonical Bradley ID in one SQLite
  * transaction. The legacy value remains accepted at API boundaries, but is
@@ -41,6 +90,20 @@ function sqliteTableExists(sqlite: InstanceType<typeof Database>, tableName: str
  */
 export function migrateSqliteMainAgentId(sqlite: InstanceType<typeof Database>): void {
   if (!sqliteTableExists(sqlite, 'agents')) return;
+
+  const existingCanonicalAgent = sqlite.prepare(
+    'SELECT type FROM agents WHERE agent_id = ? LIMIT 1',
+  ).get(MAIN_AGENT_ID) as SqliteAgentRow | undefined;
+  if (existingCanonicalAgent && existingCanonicalAgent.type !== 'main') {
+    throw new Error(
+      `Cannot migrate the main agent to ${MAIN_AGENT_ID}: that ID belongs to a non-main agent.`,
+    );
+  }
+
+  // writable_schema changes are ignored inside an active transaction. Perform
+  // the guarded default rewrite first; legacy rows still remain valid if the
+  // following data transaction encounters an unrelated failure.
+  migrateSqliteAgentIdentityDefaults(sqlite);
 
   sqlite.transaction(() => {
     const legacyAgent = sqlite.prepare(

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -1,5 +1,6 @@
 import type Database from 'better-sqlite3';
 
+import { migrateSqliteMainAgentId } from './main-agent-id-migration';
 import { STUDIO_WORKSPACE_BACKFILL_STATEMENTS } from './studio-workspace-migration';
 
 export const TEAM_SEAT_LEGACY_MIGRATION_KEY = 'team-seat-memberships-v1';
@@ -1012,7 +1013,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       organization_id TEXT NOT NULL,
       user_id TEXT NOT NULL,
       workspace_id TEXT NOT NULL,
-      agent_id TEXT NOT NULL DEFAULT 'canvas-agent',
+      agent_id TEXT NOT NULL DEFAULT 'bradley',
       provider_installation_id TEXT NOT NULL,
       provider_id TEXT NOT NULL,
       model_id TEXT NOT NULL,
@@ -1063,7 +1064,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       session_id TEXT NOT NULL,
       client_request_id TEXT,
       user_id TEXT NOT NULL,
-      agent_id TEXT NOT NULL DEFAULT 'canvas-agent',
+      agent_id TEXT NOT NULL DEFAULT 'bradley',
       provider TEXT NOT NULL,
       model TEXT NOT NULL,
       thinking_level TEXT,
@@ -1199,7 +1200,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       project_id TEXT,
       workspace_id TEXT,
       workspace_type TEXT,
-      agent_id TEXT NOT NULL DEFAULT 'canvas-agent',
+      agent_id TEXT NOT NULL DEFAULT 'bradley',
       session_id TEXT NOT NULL,
       provider TEXT NOT NULL,
       model TEXT NOT NULL,
@@ -1615,7 +1616,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       last_run_at INTEGER,
       last_run_status TEXT,
       created_by_user_id TEXT NOT NULL,
-      agent_id TEXT NOT NULL DEFAULT 'canvas-agent',
+      agent_id TEXT NOT NULL DEFAULT 'bradley',
       delivery_mode TEXT NOT NULL DEFAULT 'web',
       delivery_channel_id TEXT,
       delivery_session_mode TEXT NOT NULL DEFAULT 'new_session',
@@ -2822,7 +2823,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
   `);
 
   addColumns(sqlite, 'pi_sessions', {
-    agent_id: "TEXT NOT NULL DEFAULT 'canvas-agent'",
+    agent_id: "TEXT NOT NULL DEFAULT 'bradley'",
     channel_id: "TEXT NOT NULL DEFAULT 'app'",
     channel_session_key: 'TEXT',
     system_prompt_snapshot: 'TEXT',
@@ -2964,7 +2965,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     project_id: 'TEXT',
     workspace_id: 'TEXT',
     workspace_type: 'TEXT',
-    agent_id: "TEXT NOT NULL DEFAULT 'canvas-agent'",
+    agent_id: "TEXT NOT NULL DEFAULT 'bradley'",
   });
 
   addColumns(sqlite, 'automation_jobs', {
@@ -2980,7 +2981,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     service_actor_id: 'TEXT',
     approved_by_user_id: 'TEXT',
     last_edited_by_user_id: 'TEXT',
-    agent_id: "TEXT NOT NULL DEFAULT 'canvas-agent'",
+    agent_id: "TEXT NOT NULL DEFAULT 'bradley'",
     delivery_mode: "TEXT NOT NULL DEFAULT 'web'",
     delivery_channel_id: 'TEXT',
     delivery_session_mode: "TEXT NOT NULL DEFAULT 'new_session'",
@@ -3174,7 +3175,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
           AND s.user_id = pi_usage_events.user_id
         ORDER BY s.updated_at DESC
         LIMIT 1
-      ), NULLIF(agent_id, ''), 'canvas-agent')
+      ), NULLIF(agent_id, ''), 'bradley')
     WHERE organization_id IS NULL
       OR workspace_id IS NULL
       OR workspace_type IS NULL
@@ -3385,7 +3386,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE TABLE IF NOT EXISTS channel_active_sessions (
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
       user_id TEXT NOT NULL,
-      agent_id TEXT NOT NULL DEFAULT 'canvas-agent',
+      agent_id TEXT NOT NULL DEFAULT 'bradley',
       channel_id TEXT NOT NULL,
       channel_session_key TEXT NOT NULL,
       channel_thread_key TEXT NOT NULL DEFAULT '',
@@ -3435,7 +3436,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     next_attempt_at: 'INTEGER',
   });
   addColumns(sqlite, 'channel_active_sessions', {
-    agent_id: "TEXT NOT NULL DEFAULT 'canvas-agent'",
+    agent_id: "TEXT NOT NULL DEFAULT 'bradley'",
   });
   addColumns(sqlite, 'user', {
     banned: 'INTEGER',
@@ -3447,7 +3448,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
   });
   sqlite.exec(`
     UPDATE channel_active_sessions
-    SET agent_id = 'canvas-agent'
+    SET agent_id = 'bradley'
     WHERE agent_id IS NULL OR agent_id = '';
 
     UPDATE channel_active_sessions
@@ -3492,10 +3493,12 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       ON channel_active_sessions (user_id, agent_id, channel_id, channel_session_key, channel_thread_key);
   `);
 
+  migrateSqliteMainAgentId(sqlite);
+
   const now = Date.now();
   sqlite.prepare(`
     INSERT OR IGNORE INTO agents (agent_id, name, type, removable, created_at, updated_at)
-    VALUES ('canvas-agent', 'Bradley', 'main', 0, ?, ?)
+    VALUES ('bradley', 'Bradley', 'main', 0, ?, ?)
   `).run(now, now);
 
   sqlite.prepare(`
@@ -3601,7 +3604,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     )
     SELECT
       user_id,
-      'canvas-agent',
+      'bradley',
       'telegram',
       'telegram:' || chat_id,
       '',

--- a/app/lib/db/postgres.ts
+++ b/app/lib/db/postgres.ts
@@ -8,6 +8,7 @@ import {
   TEAM_SEAT_LEGACY_MIGRATION_METADATA,
   TEAM_SEAT_LEGACY_MIGRATION_REASON,
 } from './migrate';
+import { migratePostgresMainAgentId } from './main-agent-id-migration';
 import { STUDIO_WORKSPACE_BACKFILL_STATEMENTS } from './studio-workspace-migration';
 
 const TABLE_NAME_SYMBOL = Symbol.for('drizzle:Name');
@@ -1294,12 +1295,13 @@ export async function runPostgresMigrations(pool: PgQueryable): Promise<void> {
   }
 
   await runPostgresTeamSeatLegacyBackfill(pool);
+  await migratePostgresMainAgentId(pool);
 
   const now = Math.floor(Date.now() / 1000);
   await pool.query(
     `
       INSERT INTO agents (agent_id, name, type, removable, created_at, updated_at)
-      VALUES ('canvas-agent', 'Bradley', 'main', 0, $1, $2)
+      VALUES ('bradley', 'Bradley', 'main', 0, $1, $2)
       ON CONFLICT (agent_id) DO NOTHING
     `,
     [now, now],

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -1,5 +1,6 @@
 import { desc, sql } from "drizzle-orm";
 import { sqliteTable, text, integer, real, index, uniqueIndex, primaryKey, check, customType } from "drizzle-orm/sqlite-core";
+import { MAIN_AGENT_ID } from '@/app/lib/agents/main-agent';
 
 // OAuth metadata is stored in text columns on both SQLite and PostgreSQL. A
 // plain `$type<T>()` only affects TypeScript; PostgreSQL otherwise persists
@@ -1105,7 +1106,7 @@ export const aiUserModelPreferences = sqliteTable("ai_user_model_preferences", {
   organizationId: text("organization_id").notNull().references(() => canvasOrganizationSettings.organizationId, { onDelete: 'cascade' }),
   userId: text("user_id").notNull().references(() => user.id, { onDelete: 'cascade' }),
   workspaceId: text("workspace_id").notNull().references(() => canvasWorkspaces.id, { onDelete: 'cascade' }),
-  agentId: text("agent_id").notNull().default("canvas-agent"),
+  agentId: text("agent_id").notNull().default(MAIN_AGENT_ID),
   providerInstallationId: text("provider_installation_id").notNull(),
   providerId: text("provider_id").notNull(),
   modelId: text("model_id").notNull(),
@@ -1172,7 +1173,7 @@ export const piSessions = sqliteTable("pi_sessions", {
   sessionId: text("session_id").notNull(),
   clientRequestId: text("client_request_id"),
   userId: text("user_id").notNull().references(() => user.id),
-  agentId: text("agent_id").notNull().default('canvas-agent'),
+  agentId: text("agent_id").notNull().default(MAIN_AGENT_ID),
   provider: text("provider").notNull(),
   model: text("model").notNull(),
   thinkingLevel: text("thinking_level"),
@@ -1558,7 +1559,7 @@ export const piUsageEvents = sqliteTable("pi_usage_events", {
   projectId: text("project_id"),
   workspaceId: text("workspace_id"),
   workspaceType: text("workspace_type"),
-  agentId: text("agent_id").notNull().default('canvas-agent'),
+  agentId: text("agent_id").notNull().default(MAIN_AGENT_ID),
   sessionId: text("session_id").notNull(),
   provider: text("provider").notNull(),
   model: text("model").notNull(),
@@ -1917,7 +1918,7 @@ export const automationJobs = sqliteTable("automation_jobs", {
   lastRunAt: integer("last_run_at", { mode: "timestamp" }),
   lastRunStatus: text("last_run_status"),
   createdByUserId: text("created_by_user_id").notNull().references(() => user.id),
-  agentId: text("agent_id").notNull().default('canvas-agent'),
+  agentId: text("agent_id").notNull().default(MAIN_AGENT_ID),
   deliveryMode: text("delivery_mode").notNull().default('web'),
   deliveryChannelId: text("delivery_channel_id"),
   deliverySessionMode: text("delivery_session_mode").notNull().default('new_session'),
@@ -2403,7 +2404,7 @@ export const sessionChannelLinks = sqliteTable("session_channel_links", {
 export const channelActiveSessions = sqliteTable("channel_active_sessions", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   userId: text("user_id").notNull().references(() => user.id),
-  agentId: text("agent_id").notNull().default('canvas-agent'),
+  agentId: text("agent_id").notNull().default(MAIN_AGENT_ID),
   channelId: text("channel_id").notNull(),
   channelSessionKey: text("channel_session_key").notNull(),
   channelThreadKey: text("channel_thread_key").notNull().default(''),

--- a/app/lib/pi/agent-file-operations.ts
+++ b/app/lib/pi/agent-file-operations.ts
@@ -4,6 +4,7 @@ import type { Stats } from 'node:fs';
 import path from 'node:path';
 
 import { recordAuditEvent } from '@/app/lib/audit/audit-service';
+import { DEFAULT_MANAGED_AGENT_ID } from '@/app/lib/agents/storage';
 import { getDatabaseProvider } from '@/app/lib/db/provider';
 import { logger } from '@/app/lib/logging';
 import {
@@ -592,7 +593,7 @@ function collaborativeAgentExcalidrawContext(fullPath: string): {
 function collaborationAgentIdentity(executionContext: AgentExecutionContext) {
   return {
     initiatedByUserId: executionContext.userId,
-    actorId: executionContext.agentId || 'canvas-agent',
+    actorId: executionContext.agentId || DEFAULT_MANAGED_AGENT_ID,
     actorDisplayName: getAgentDisplayName(executionContext.agentId),
     actorSessionId: executionContext.sessionId,
   };
@@ -664,7 +665,7 @@ export async function editAgentExcalidrawScene(params: {
     observedSceneSequence: params.observedSceneSequence,
     actions: params.actions,
     initiatedByUserId: collaboration.executionContext.userId,
-    actorId: collaboration.executionContext.agentId || 'canvas-agent',
+    actorId: collaboration.executionContext.agentId || DEFAULT_MANAGED_AGENT_ID,
     idempotencyKey: params.idempotencyKey,
   });
 }

--- a/app/lib/pi/session-workspace-context.ts
+++ b/app/lib/pi/session-workspace-context.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 import type { ChatRequestContext } from '@/app/lib/chat/types';
 import { requireAgentAccess } from '@/app/lib/agents/access';
+import { DEFAULT_MANAGED_AGENT_ID } from '@/app/lib/agents/storage';
 import { db } from '@/app/lib/db';
 import { getDatabaseProvider } from '@/app/lib/db/provider';
 import { piSessions } from '@/app/lib/db/schema';
@@ -405,7 +406,7 @@ export async function resolveAgentExecutionContextForSession(input: {
     agentId: input.agentId,
     permissions: input.permissions,
   });
-  await requireAgentAccess(input.userId, input.agentId || 'canvas-agent', 'canUse', {
+  await requireAgentAccess(input.userId, input.agentId || DEFAULT_MANAGED_AGENT_ID, 'canUse', {
     organizationId: workspace.organizationId,
     workspaceId: workspace.workspaceId,
     projectId: workspace.projectId,

--- a/app/lib/pi/usage-events.ts
+++ b/app/lib/pi/usage-events.ts
@@ -6,6 +6,7 @@ import { and, desc, eq, gt } from 'drizzle-orm';
 
 import { db } from '../db';
 import { piSessions, piUsageEvents } from '../db/schema';
+import { DEFAULT_MANAGED_AGENT_ID } from '../agents/storage';
 
 type PersistPiUsageEventsParams = {
   sessionId: string;
@@ -85,7 +86,7 @@ export function extractPiUsageEventValues(params: {
       organizationId: params.organizationId ?? null,
       workspaceId: params.workspaceId ?? null,
       workspaceType: params.workspaceType ?? null,
-      agentId: params.agentId ?? 'canvas-agent',
+      agentId: params.agentId ?? DEFAULT_MANAGED_AGENT_ID,
       sessionId: params.sessionId,
       provider: message.provider,
       model: message.model,
@@ -123,7 +124,7 @@ async function loadSessionUsageContext(sessionId: string, userId: string): Promi
     organizationId: session?.organizationId ?? null,
     workspaceId: session?.workspaceId ?? null,
     workspaceType: session?.workspaceType ?? null,
-    agentId: session?.agentId ?? 'canvas-agent',
+    agentId: session?.agentId ?? DEFAULT_MANAGED_AGENT_ID,
   };
 }
 

--- a/docs/architecture/canvas-notebook/agent-personality-warm-branding-plan.md
+++ b/docs/architecture/canvas-notebook/agent-personality-warm-branding-plan.md
@@ -142,8 +142,8 @@ Folgende Grundlagen sind bereits vorhanden:
 - [x] Deutsche und englische Produktstimme im
   [Bradley DE-/EN-Sprachleitfaden](./bradley-de-en-language-style-guide.md)
   vollständig dokumentiert.
-- [x] Festen, versionierten Bradley Identity Block ausschließlich für
-  `canvas-agent` in die Prompt-Architektur integriert und bestehende
+- [x] Festen, versionierten Bradley Identity Block ausschließlich für den
+  Hauptagenten (`bradley`, einschließlich Legacy-Alias `canvas-agent`) in die Prompt-Architektur integriert und bestehende
   Session-Snapshots verlustfrei ergänzt; Nachweis:
   [Bradley Prompt-Identity-Implementierung](./bradley-prompt-identity-implementation.md).
 
@@ -164,8 +164,9 @@ Es gilt:
 - UI-Name: **Bradley**
 - Keine Kurzform: **Brad** nicht verwenden
 - Frühere Arbeitsnamen: **Mo**, **Mosa** und **Mosaic Agent** nicht verwenden
-- Interne technische ID: unverändert `canvas-agent`
-- Technische Speicherpfade und API-Verträge: unverändert
+- Kanonische technische ID: `bradley`
+- Legacy-ID: `canvas-agent` bleibt an Eingabe- und Migrationsgrenzen gültig
+- Globale Infrastrukturpfade des Canvas Host Agent bleiben unverändert
 
 BRADLEY-002 hat Aussprache und Wirkung validiert. BRADLEY-003 hat Produkt-, Domain- und
 Markenrisiken dokumentiert. Bradley bleibt eine Identität innerhalb von Canvas
@@ -262,7 +263,7 @@ technische Canvas Host Agent hinzu.
 
 | Ebene | Sichtbare Identität | Regel |
 | --- | --- | --- |
-| Hauptagent `canvas-agent` | Bradley | Bradley ist die Produktidentität des Hauptagenten. |
+| Hauptagent `bradley` | Bradley | Bradley ist die Produktidentität des Hauptagenten; `canvas-agent` wird als Legacy-Alias akzeptiert. |
 | Eigene und spezialisierte Agenten | Eigener Name und eigenes Icon | Antworten dürfen nicht als Bradley beschriftet werden. |
 | E-Mail-Agent | E-Mail-Agent beziehungsweise definierter Profilname | Keine Bradley-Umbenennung. |
 | Delegierte Aufgaben | Tatsächlich verwendeter Agent | Bradley kann delegieren, ist aber nicht automatisch der ausführende Agent. |
@@ -272,10 +273,12 @@ technische Canvas Host Agent hinzu.
 
 ### Nicht verhandelbare technische Grenze
 
-Die interne ID `canvas-agent`, Datenbankbeziehungen, Session-Zuordnungen,
-Automationen, API-Parameter und Pfade wie `/data/agents/canvas-agent` werden
-nicht aus Branding-Gründen umbenannt. Bradley ist zunächst ein Display- und
-Identitätsvertrag, keine technische ID-Migration.
+Die Notebook-Hauptagent-ID wird kontrolliert auf `bradley` migriert.
+Datenbankbeziehungen, Session-Zuordnungen, Automationen und nutzerbezogene
+Agentenpfade behalten ihre Semantik; Legacy-Werte werden aliasfähig gelesen und
+rollback-sicher migriert. Der davon getrennte globale Infrastrukturpfad
+`/data/canvas-agent` und der Canvas Host Agent werden nicht umbenannt. Siehe
+[Bradley Agent-ID-Migration](./bradley-agent-id-migration.md).
 
 ## 6. Persönlichkeit und Prompt-Hierarchie
 
@@ -427,7 +430,8 @@ benötigt daher einen expliziten Migrationsvertrag.
   versioniert und nachvollziehbar auf Bradley migriert.
 - Bewusst gesetzte eigene Namen oder organisationsbezogene Anpassungen werden
   vor einer Migration erkannt und geschützt.
-- Sessions, Agent-IDs, Automationen und Speicherpfade bleiben stabil.
+- Sessions und Automationen werden auf die kanonische ID `bradley` migriert;
+  `canvas-agent` bleibt als Legacy-Alias lesbar.
 - Deutsche und englische Onboarding-Texte werden gemeinsam aktualisiert.
 
 ## 10. Marketing und Datenhoheit
@@ -460,7 +464,7 @@ Empfohlene Formulierung:
 
 ## 11. Nicht im Umfang dieses Vorhabens
 
-- Umbenennung der internen Agent-ID `canvas-agent`;
+- Entfernung des Legacy-Alias `canvas-agent` ohne gesonderte Auslaufentscheidung;
 - Änderung der Agent-, Subagent- oder Automationsarchitektur;
 - Umbenennung oder technische Änderung des Canvas Host Agent;
 - Änderung von Tool-Berechtigungen oder Sicherheitsgrenzen;
@@ -528,6 +532,7 @@ Statuslegende: `offen`, `in Arbeit`, `blockiert`, `fertig`.
 | BRADLEY-034 | fertig | UI-Fallbacks und Registry-Defaults inventarisieren und aktualisieren; Inventar: [Bradley UI-Fallbacks](./bradley-ui-fallback-inventory.md) | Kein sichtbarer Standard-Fallback zeigt unbeabsichtigt „Canvas Agent“, wenn der Hauptagent Bradley ist. |
 | BRADLEY-035 | fertig | Onboarding-, Notification-, Automation- und E-Mail-Texte inventarisieren; Inventar: [Bradley sichtbare Copy](./bradley-visible-copy-inventory.md) | Alle sichtbaren Hauptagent-Referenzen sind klassifiziert und entweder migriert oder bewusst beibehalten. |
 | BRADLEY-036 | fertig | Interne ID- und Pfadstabilität durch Regressionstests absichern; Nachweis: [Bradley Runtime-Stabilitätsregression](./bradley-runtime-stability-regression.md) | Tests belegen, dass `canvas-agent`, Sessions, Automationen, APIs und Speicherpfade unverändert funktionieren. |
+| BRADLEY-037 | fertig | Kanonische Hauptagent-ID auf `bradley` migrieren; Implementierung: [Bradley Agent-ID-Migration](./bradley-agent-id-migration.md) | Neue Daten und Clients verwenden `bradley`; SQLite, PostgreSQL, Sessions, Automationen und Agentendateien werden migriert; `canvas-agent` bleibt als Legacy-Alias gültig. |
 
 ### Phase E — UI-Pilot
 

--- a/docs/architecture/canvas-notebook/bradley-agent-id-migration.md
+++ b/docs/architecture/canvas-notebook/bradley-agent-id-migration.md
@@ -46,8 +46,9 @@ sind ein getrenntes System und werden nicht umbenannt.
 - [x] Bradley-UI, Starter, Animation, Auswahl und Display-Name funktionieren mit
   kanonischer und alter ID.
 - [x] Produktions-Build des Notebook-Repositories ist erfolgreich.
-- [ ] Mobile-App verwendet `bradley` für neue Requests und akzeptiert
-  `canvas-agent` in alten Serverantworten.
+- [x] Mobile-App verwendet `bradley` für neue Requests und akzeptiert
+  `canvas-agent` in alten Serverantworten; verifiziert im Mobile-Commit
+  `3f00792` mit vollständigem `npm run verify`.
 
 ## Bewusst unverändert
 

--- a/docs/architecture/canvas-notebook/bradley-agent-id-migration.md
+++ b/docs/architecture/canvas-notebook/bradley-agent-id-migration.md
@@ -1,0 +1,58 @@
+---
+title: Canvas Notebook — Bradley Agent-ID-Migration
+status: implemented
+todo_id: BRADLEY-037
+decision_date: 2026-09-02
+owners:
+  - Canvas Notebook
+tags:
+  - agent
+  - migration
+  - mobile
+  - database
+---
+
+# Canvas Notebook — Bradley Agent-ID-Migration
+
+## Entscheidung
+
+Die kanonische ID des Notebook-Hauptagenten lautet `bradley`. Die frühere ID
+`canvas-agent` wird als Legacy-Alias akzeptiert und beim Einlesen auf
+`bradley` normalisiert. Neue Datensätze, API-Ausgaben und Clients verwenden
+ausschließlich die kanonische ID.
+
+Der Canvas Host Agent und globale Infrastrukturpfade wie `/data/canvas-agent`
+sind ein getrenntes System und werden nicht umbenannt.
+
+## Umsetzung
+
+- Eine zentrale Konstante und Alias-Normalisierung definieren die Hauptagent-ID.
+- SQLite und PostgreSQL migrieren bestehende Agenten-, Session-, Automations-
+  und weitere Agentenreferenzen transaktional von `canvas-agent` zu `bradley`.
+- Spaltendefaults für neue Datensätze verwenden `bradley`.
+- Eine bereits belegte, nicht zum Hauptagenten gehörende ID `bradley` stoppt die
+  Migration mit einer klaren Fehlermeldung, statt Daten zusammenzuführen.
+- Nutzerbezogene Dateien unter `agents/canvas-agent` werden beim ersten Zugriff
+  nach `agents/bradley` kopiert. Die alte Kopie bleibt für Rollback und Diagnose
+  bestehen.
+- Web- und Mobile-Oberflächen erkennen während der Übergangszeit beide IDs als
+  Bradley, senden für neue Vorgänge aber `bradley`.
+
+## Abnahme
+
+- [x] Frische SQLite-Installation verwendet `bradley`.
+- [x] Bestehende SQLite-Daten und Agentendateien werden verlustfrei migriert.
+- [x] PostgreSQL-Daten und Spaltendefaults werden migriert.
+- [x] Bradley-UI, Starter, Animation, Auswahl und Display-Name funktionieren mit
+  kanonischer und alter ID.
+- [x] Produktions-Build des Notebook-Repositories ist erfolgreich.
+- [ ] Mobile-App verwendet `bradley` für neue Requests und akzeptiert
+  `canvas-agent` in alten Serverantworten.
+
+## Bewusst unverändert
+
+- Canvas Host Agent, systemd-Dienst, CLI und Control-Plane-Protokolle;
+- globaler Runtime-Pfad `/data/canvas-agent`;
+- historische Exportformate und Migrationsquellen;
+- Komponentenordner und interne Dateinamen, deren Umbenennung keinen
+  funktionalen Nutzen hat.

--- a/docs/architecture/canvas-notebook/bradley-agent-terminology-contract.md
+++ b/docs/architecture/canvas-notebook/bradley-agent-terminology-contract.md
@@ -2,7 +2,7 @@
 title: Canvas Notebook — Bradley und Canvas Host Agent Terminologievertrag
 status: decided
 todo_id: BRADLEY-006
-decision_date: 2026-08-31
+decision_date: 2026-09-02
 owners:
   - Canvas Notebook
 tags:
@@ -23,8 +23,9 @@ getrennte Namen:
 - **Bradley** ist der sichtbare Hauptagent innerhalb von Canvas Notebook.
 - **Canvas Host Agent** ist der technische Dienst auf einer verwalteten
   VM, der den Host mit der Canvas Control Plane verbindet.
-- **`canvas-agent`** bleibt die interne ID des Notebook-Hauptagenten und ein
-  Bestandteil bestehender technischer Pfade. Die ID ist kein sichtbarer Name.
+- **`bradley`** ist die kanonische interne ID des Notebook-Hauptagenten.
+- **`canvas-agent`** bleibt als Legacy-Alias und in bestehenden technischen
+  Infrastrukturpfaden erhalten, ist aber keine neue Hauptagenten-ID.
 
 Die unqualifizierte Bezeichnung **Canvas Agent** wird in neuer Produkt-,
 Support- und Architektursprache nicht mehr verwendet. Sie ist zu mehrdeutig,
@@ -40,7 +41,7 @@ bezeichnet hat.
 | Aufgabe | mit Dateien, Projekten, Tools, Modellen und Workflows arbeiten | Host- und Docker-Metriken melden sowie erlaubte Betriebsbefehle ausführen |
 | Kommunikation | Chat, Onboarding, Agent-Auswahl, Status und Deliverables | Machine-to-Machine-Verbindung, Betriebsstatus, Audit-Log und VM-Verwaltung |
 | Sichtbarer Name | Bradley | Canvas Host Agent |
-| Technische Bezeichner | Hauptagent-ID `canvas-agent` | bestehende Service-, Pfad-, Paket-, Tabellen- und Protokollnamen bleiben unverändert |
+| Technische Bezeichner | Hauptagent-ID `bradley`; Legacy-Alias `canvas-agent` | bestehende Service-, Pfad-, Paket-, Tabellen- und Protokollnamen bleiben unverändert |
 | Visuelles Zeichen | Bradley-Glyph beziehungsweise Character | neutrales technisches Infrastruktur-Icon; niemals Bradley-Glyph |
 | Verfügbarkeit | Bestandteil von Canvas Notebook | nur vorhanden, wenn die Installation durch eine Control Plane verwaltet wird |
 | Verantwortung | arbeitet innerhalb der effektiven Notebook-Fähigkeiten | führt ausschließlich erlaubte Host-/CLI-Aktionen im Control-Plane-Kontext aus |
@@ -56,7 +57,8 @@ bezeichnet hat.
 | technischer VM-Dienst in UI und Support | `Canvas Host Agent` |
 | erklärende erste Nennung | `Canvas Host Agent, der technische Verwaltungsdienst auf der VM` |
 | zentrale Verwaltungsplattform | `Canvas Control Plane` |
-| interne Hauptagent-ID | `` `canvas-agent` `` |
+| interne Hauptagent-ID | `` `bradley` `` |
+| Legacy-Hauptagent-ID | `` `canvas-agent` `` |
 
 ### Englisch
 
@@ -67,25 +69,34 @@ bezeichnet hat.
 | Technical VM service in UI and support | `Canvas Host Agent` |
 | Explanatory first mention | `Canvas Host Agent, the technical management service running on the VM` |
 | Central management platform | `Canvas Control Plane` |
-| Internal main-agent ID | `` `canvas-agent` `` |
+| Internal main-agent ID | `` `bradley` `` |
+| Legacy main-agent ID | `` `canvas-agent` `` |
 
 `Canvas Host Agent` bleibt in deutschen Texten als Produktkomponentenname
 englisch. Falls zusätzliche Erklärung nötig ist, folgt „technischer
 Host-Dienst“ oder „Verwaltungsdienst auf der VM“.
 
-## Technische Bezeichner bleiben stabil
+## Technische ID-Migration und stabile Infrastrukturbezeichner
 
-Die sprachliche Entscheidung benennt keine bestehenden technischen Verträge
-um. Dazu gehören insbesondere:
+Seit 2026-09-02 wird die Notebook-Hauptagent-ID kontrolliert von
+`canvas-agent` auf `bradley` migriert. Neue Daten, API-Ausgaben und mobile
+Requests verwenden `bradley`. Eingehende Legacy-Werte werden weiterhin
+akzeptiert und auf `bradley` normalisiert.
 
-- Notebook-Hauptagent-ID `canvas-agent`;
-- Datenbankwerte und Session-Zuordnungen mit `agent_id = 'canvas-agent'`;
-- Speicher- und Konfigurationspfade mit `canvas-agent`;
+Unverändert bleiben davon getrennte Infrastrukturverträge, insbesondere:
+
+- der Canvas-Host-Agent und seine Service-, Paket- und Protokollnamen;
+- der globale Runtime-Pfad `/data/canvas-agent`;
+- historische Exportformate und Migrationsquellen mit `canvas-agent`;
 - bestehende systemd-, Paket-, Repository-, Tabellen- und WebSocket-Bezeichner
   des Host-Dienstes;
 - Canvas CLI und ihre erlaubten Betriebsaktionen;
-- API-, Audit- und Protokollfelder, deren Umbenennung eine Migration erfordern
-  würde.
+- UI-Komponentenordner, deren Umbenennung keinen Produktnutzen erzeugt.
+
+Bestehende Notebook-Datenbankreferenzen und nutzerbezogene Agentenpfade werden
+rollback-sicher migriert. Die alte Dateikopie bleibt dabei erhalten. Details
+und Abnahmekriterien stehen in der
+[Bradley Agent-ID-Migration](./bradley-agent-id-migration.md).
 
 In technischen Dokumenten dürfen diese Literalwerte exakt genannt werden,
 wenn ihre Funktion erläutert wird. Sie werden aber nicht als sichtbarer
@@ -103,7 +114,7 @@ Canvas Host Agent.
 | --- | --- | --- |
 | Chat-Header und Agent-Auswahl | Hauptagent ausschließlich Bradley nennen | `Bradley` |
 | Onboarding | Rolle von Bradley erklären, keinen Host-Agenten erwähnen, wenn er für den Ablauf irrelevant ist | „Das ist Bradley, dein Hauptagent in Canvas Notebook.“ |
-| Agent-Einstellungen | sichtbaren Namen Bradley von interner ID trennen | `Bradley · Interne ID: canvas-agent` nur in technischer Detailansicht |
+| Agent-Einstellungen | sichtbaren Namen Bradley von interner ID trennen | `Bradley · Interne ID: bradley` nur in technischer Detailansicht |
 | Control-Plane-VM-Ansicht | Verbindungszustand dem Canvas Host Agent zuordnen | „Canvas Host Agent ist offline.“ |
 | Host-Metriken | Quelle als Canvas Host Agent oder VM kennzeichnen | „Vom Canvas Host Agent zuletzt vor 30 Sekunden gemeldet.“ |
 | Betriebsbefehl | ausführenden Infrastrukturpfad nennen | „Neustart über den Canvas Host Agent ausgeführt.“ |
@@ -162,10 +173,11 @@ klassifiziert:
 
 1. sichtbarer Hauptagent → `Bradley`;
 2. technischer VM-Dienst → `Canvas Host Agent`;
-3. interne ID, Pfad, API- oder Codebezeichner → unverändert lassen;
-4. Sammelbegriff für mehrere Agenten → präzisieren, zum Beispiel
+3. Notebook-Hauptagent-ID → kanonisch `bradley`, Legacy-Eingaben normalisieren;
+4. Host-Agent-, globaler Runtime-, Export- oder historischer Pfad → unverändert lassen;
+5. Sammelbegriff für mehrere Agenten → präzisieren, zum Beispiel
    `Canvas-Notebook-Agenten` oder `verfügbare Agenten`;
-5. historisches Zitat oder Migrationshinweis → als historisch kennzeichnen.
+6. historisches Zitat oder Migrationshinweis → als historisch kennzeichnen.
 
 Eine automatische globale Textersetzung ist unzulässig, weil `canvas-agent`
 in beiden Systemen als technischer Altbezeichner vorkommen kann. Die sichtbare
@@ -174,6 +186,7 @@ Klassifikation umgesetzt.
 
 ## Abschluss BRADLEY-006
 
-BRADLEY-006 ist abgeschlossen. Bradley, Canvas Host Agent, Canvas Control Plane
-und die interne ID `canvas-agent` besitzen getrennte Rollen, kanonische
-DE-/EN-Bezeichnungen, UI-Regeln, Statussemantik und Migrationskriterien.
+BRADLEY-006 ist abgeschlossen. Bradley, Canvas Host Agent, Canvas Control Plane,
+die kanonische ID `bradley` und der Legacy-Alias `canvas-agent` besitzen
+getrennte Rollen, kanonische DE-/EN-Bezeichnungen, UI-Regeln, Statussemantik
+und Migrationskriterien.

--- a/docs/architecture/canvas-notebook/bradley-name-contract.md
+++ b/docs/architecture/canvas-notebook/bradley-name-contract.md
@@ -2,7 +2,7 @@
 title: Canvas Notebook — Bradley Namensvertrag
 status: decided
 decision_id: BRADLEY-001
-decision_date: 2026-08-31
+decision_date: 2026-09-02
 supersedes: MO-001
 owners:
   - Canvas Notebook
@@ -25,8 +25,9 @@ UI-Namen. Die frühere Arbeitsbezeichnung Mo ist durch diese Entscheidung
 abgelöst.
 
 Diese Regel gilt für neue Texte und Implementierungen in UI, Onboarding,
-Produktdokumentation, Assets und Marketing. Bereits vorhandene technische
-Bezeichner werden dadurch nicht umbenannt.
+Produktdokumentation, Assets und Marketing. Die Notebook-Hauptagent-ID wurde
+anschließend in einer gesonderten technischen Entscheidung auf `bradley`
+migriert; Infrastrukturbezeichner des Canvas Host Agent bleiben davon getrennt.
 
 ## Vertrag pro Oberfläche
 
@@ -34,7 +35,7 @@ Bezeichner werden dadurch nicht umbenannt.
 | --- | --- | --- |
 | Agent-Auswahl und Chat-Header | `Bradley` | Nur der Hauptagent erhält diesen sichtbaren Namen. |
 | Onboarding | `Bradley` | Erste Nennung: „Bradley, der Hauptagent von Canvas Notebook“. |
-| Produktdokumentation | `Bradley` | In technischen Texten bei der ersten Nennung: „Bradley (Display-Name des Hauptagenten `canvas-agent`)“. |
+| Produktdokumentation | `Bradley` | In technischen Texten bei der ersten Nennung: „Bradley (Hauptagent-ID `bradley`)“. |
 | Marketing und Website | `Bradley` | Der Name erscheint mit einem klaren Canvas-Notebook-Absender, nicht als zweite eigenständige Produktmarke. |
 | Status- und Fehlermeldungen | `Bradley` oder kein Eigenname | Der Name wird nur verwendet, wenn tatsächlich der Hauptagent gemeint ist. |
 | Eigene und spezialisierte Agenten | jeweiliger eigener Name | Keine Umbenennung zu Bradley. |
@@ -42,18 +43,20 @@ Bezeichner werden dadurch nicht umbenannt.
 
 ## Technische Grenzen
 
-Die Namensentscheidung ändert ausschließlich den sichtbaren Display- und
-Identitätsvertrag sowie die noch nicht produktiv integrierten Brand-Assets.
-Folgende Werte bleiben stabil:
+Die kanonische Notebook-Hauptagent-ID ist `bradley`. Die frühere ID
+`canvas-agent` bleibt an Eingabegrenzen als Legacy-Alias gültig. Folgende
+getrennte Werte bleiben stabil:
 
-- interne Agent-ID `canvas-agent`;
-- Datenbankbeziehungen und Session-Zuordnungen;
-- API-Parameter und Automationsreferenzen;
-- Speicherpfade wie `/data/agents/canvas-agent`;
+- Datenbankbeziehungen und Session-Zuordnungen werden unter Beibehaltung ihrer
+  Semantik auf `bradley` migriert;
+- API-Parameter und Automationsreferenzen akzeptieren weiterhin den Legacy-Alias;
+- alte nutzerbezogene Agentenpfade werden nach `bradley` kopiert und bleiben als
+  Rollback-Kopie bestehen;
+- der globale Infrastrukturpfad `/data/canvas-agent` bleibt unverändert;
 - Namen eigener, spezialisierter und technischer Agenten.
 
-Eine technische Umbenennung von `canvas-agent` ist nicht Bestandteil dieses
-Vorhabens.
+Der vollständige Vertrag steht in der
+[Bradley Agent-ID-Migration](./bradley-agent-id-migration.md).
 
 ## Schreibweise
 
@@ -87,4 +90,5 @@ BRADLEY-001 und BRADLEY-003 werden dann mit Begründung erneut geöffnet.
 
 BRADLEY-001 ist abgeschlossen: **Bradley** ist als einziger öffentlicher Name
 für UI, Onboarding, Dokumentation, Assets und Marketing festgelegt, ohne
-Kurzform und klar getrennt von der technischen ID `canvas-agent`.
+Kurzform. Die kanonische technische Hauptagent-ID lautet ebenfalls `bradley`;
+`canvas-agent` ist nur noch Legacy-Alias beziehungsweise Infrastrukturbezeichner.

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test:agent:bradley-display-name": "tsx --conditions react-server scripts/agent-display-name-migration-test.ts",
     "test:agent:bradley-fallbacks": "tsx scripts/agent-display-fallbacks-test.ts",
     "test:agent:bradley-copy": "tsx scripts/bradley-visible-copy-test.ts",
-    "test:agent:bradley-stability": "tsx --conditions react-server scripts/bradley-runtime-stability-test.ts && tsx scripts/bradley-agent-id-postgres-migration-test.ts && npm run test:agent:tools-route && npm run test:agent:bradley-display-name",
+    "test:agent:bradley-stability": "tsx --conditions react-server scripts/bradley-runtime-stability-test.ts && tsx --conditions react-server scripts/bradley-agent-id-sqlite-migration-test.ts && tsx scripts/bradley-agent-id-postgres-migration-test.ts && npm run test:agent:tools-route && npm run test:agent:bradley-display-name",
     "test:agent:bradley-selector": "tsx scripts/bradley-agent-selector-contract-test.ts",
     "test:agent:bradley-glyph": "tsx scripts/bradley-glyph-ui-test.tsx && npm run test:agent:bradley-selector",
     "test:agent:bradley-working-state": "tsx scripts/bradley-working-state-test.tsx && tsx scripts/bradley-abort-transition-test.ts && npm run test:agent:bradley-glyph",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test:agent:bradley-display-name": "tsx --conditions react-server scripts/agent-display-name-migration-test.ts",
     "test:agent:bradley-fallbacks": "tsx scripts/agent-display-fallbacks-test.ts",
     "test:agent:bradley-copy": "tsx scripts/bradley-visible-copy-test.ts",
-    "test:agent:bradley-stability": "tsx --conditions react-server scripts/bradley-runtime-stability-test.ts && npm run test:agent:tools-route && npm run test:agent:bradley-display-name",
+    "test:agent:bradley-stability": "tsx --conditions react-server scripts/bradley-runtime-stability-test.ts && tsx scripts/bradley-agent-id-postgres-migration-test.ts && npm run test:agent:tools-route && npm run test:agent:bradley-display-name",
     "test:agent:bradley-selector": "tsx scripts/bradley-agent-selector-contract-test.ts",
     "test:agent:bradley-glyph": "tsx scripts/bradley-glyph-ui-test.tsx && npm run test:agent:bradley-selector",
     "test:agent:bradley-working-state": "tsx scripts/bradley-working-state-test.tsx && tsx scripts/bradley-abort-transition-test.ts && npm run test:agent:bradley-glyph",

--- a/scripts/agent-display-name-migration-test.ts
+++ b/scripts/agent-display-name-migration-test.ts
@@ -25,7 +25,7 @@ async function main() {
   } = await import('../app/lib/agents/registry');
 
   const fresh = await ensureCanvasAgent();
-  assert.equal(fresh.agentId, 'canvas-agent');
+  assert.equal(fresh.agentId, 'bradley');
   assert.equal(fresh.name, MAIN_AGENT_DISPLAY_NAME);
   assert.equal(fresh.name, 'Bradley');
   assert.equal(fresh.type, 'main');
@@ -36,7 +36,7 @@ async function main() {
   sqlite.prepare(`
     UPDATE agents
     SET name = 'Canvas Agent', revision = ?, updated_at = ?
-    WHERE agent_id = 'canvas-agent'
+    WHERE agent_id = 'bradley'
   `).run(legacyRevision, Date.now() - 10_000);
 
   const migrated = await ensureCanvasAgent();
@@ -53,12 +53,12 @@ async function main() {
   sqlite.prepare(`
     UPDATE agents
     SET name = 'Studio Companion', revision = ?, updated_at = ?
-    WHERE agent_id = 'canvas-agent'
+    WHERE agent_id = 'bradley'
   `).run(customRevision, customUpdatedAt);
   const beforePreservationCheck = sqlite.prepare(`
     SELECT updated_at AS updatedAt
     FROM agents
-    WHERE agent_id = 'canvas-agent'
+    WHERE agent_id = 'bradley'
   `).get() as { updatedAt: number };
 
   const preserved = await ensureCanvasAgent();
@@ -67,7 +67,7 @@ async function main() {
   const afterPreservationCheck = sqlite.prepare(`
     SELECT updated_at AS updatedAt
     FROM agents
-    WHERE agent_id = 'canvas-agent'
+    WHERE agent_id = 'bradley'
   `).get() as { updatedAt: number };
   assert.equal(afterPreservationCheck.updatedAt, beforePreservationCheck.updatedAt);
   sqlite.close();

--- a/scripts/bradley-agent-id-postgres-migration-test.ts
+++ b/scripts/bradley-agent-id-postgres-migration-test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+
+import { PGlite } from '@electric-sql/pglite';
+
+import { runPostgresMigrations } from '../app/lib/db/postgres';
+
+type PgQueryable = Parameters<typeof runPostgresMigrations>[0];
+
+async function main(): Promise<void> {
+  const postgres = new PGlite();
+  try {
+    const migrationTarget = postgres as unknown as PgQueryable;
+    await runPostgresMigrations(migrationTarget);
+    await postgres.exec(`
+      INSERT INTO "user" (id, name, email, email_verified, created_at, updated_at)
+      VALUES ('bradley-pg-user', 'Bradley Migration', 'bradley-pg@example.test', 1, 1700000000, 1700000000);
+
+      UPDATE agents SET agent_id = 'canvas-agent' WHERE agent_id = 'bradley';
+
+      INSERT INTO pi_sessions (
+        session_id, user_id, agent_id, provider, model, title, created_at, updated_at
+      ) VALUES (
+        'legacy-bradley-session', 'bradley-pg-user', 'canvas-agent',
+        'test', 'test-model', 'Legacy Bradley session', 1700000000, 1700000000
+      );
+
+      INSERT INTO automation_jobs (
+        id, name, status, owner_user_id, prompt, preferred_skill,
+        workspace_context_paths_json, schedule_kind, schedule_config_json,
+        time_zone, created_by_user_id, agent_id, delivery_mode,
+        delivery_session_mode, created_at, updated_at
+      ) VALUES (
+        'legacy-bradley-job', 'Legacy Bradley automation', 'paused', 'bradley-pg-user',
+        'Verify the canonical Bradley agent ID.', '', '[]', 'manual', '{}', 'UTC',
+        'bradley-pg-user', 'canvas-agent', 'web', 'new_session', 1700000000, 1700000000
+      );
+    `);
+
+    await runPostgresMigrations(migrationTarget);
+
+    const profiles = await postgres.query<{ agent_id: string; name: string }>(`
+      SELECT agent_id, name FROM agents WHERE type = 'main' ORDER BY agent_id
+    `);
+    assert.deepEqual(profiles.rows, [{ agent_id: 'bradley', name: 'Bradley' }]);
+
+    const sessions = await postgres.query<{ agent_id: string }>(`
+      SELECT agent_id FROM pi_sessions WHERE session_id = 'legacy-bradley-session'
+    `);
+    assert.deepEqual(sessions.rows, [{ agent_id: 'bradley' }]);
+
+    const jobs = await postgres.query<{ agent_id: string }>(`
+      SELECT agent_id FROM automation_jobs WHERE id = 'legacy-bradley-job'
+    `);
+    assert.deepEqual(jobs.rows, [{ agent_id: 'bradley' }]);
+
+    const defaults = await postgres.query<{ column_default: string | null }>(`
+      SELECT column_default
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'pi_sessions'
+        AND column_name = 'agent_id'
+    `);
+    assert.match(defaults.rows[0]?.column_default ?? '', /bradley/u);
+    assert.doesNotMatch(defaults.rows[0]?.column_default ?? '', /canvas-agent/u);
+  } finally {
+    await postgres.close();
+  }
+
+  console.log('bradley-agent-id-postgres-migration-test: ok');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/bradley-agent-id-sqlite-migration-test.ts
+++ b/scripts/bradley-agent-id-sqlite-migration-test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+
+import Database from 'better-sqlite3';
+
+import { migrateSqliteMainAgentId } from '../app/lib/db/main-agent-id-migration';
+
+function main(): void {
+  const sqlite = new Database(':memory:');
+  sqlite.pragma('foreign_keys = ON');
+  sqlite.exec(`
+    CREATE TABLE agents (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL
+    );
+    CREATE TABLE pi_sessions (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL DEFAULT 'canvas-agent' REFERENCES agents(agent_id)
+    );
+    CREATE TABLE actor_events (
+      id TEXT PRIMARY KEY,
+      actor_id TEXT NOT NULL DEFAULT 'canvas-agent'
+    );
+    INSERT INTO agents (agent_id, name, type)
+    VALUES ('canvas-agent', 'Bradley', 'main');
+    INSERT INTO pi_sessions (id) VALUES ('legacy-session');
+    INSERT INTO actor_events (id) VALUES ('legacy-event');
+  `);
+
+  migrateSqliteMainAgentId(sqlite);
+
+  assert.deepEqual(
+    sqlite.prepare('SELECT agent_id, type FROM agents').all(),
+    [{ agent_id: 'bradley', type: 'main' }],
+  );
+  assert.equal(
+    sqlite.prepare("SELECT agent_id FROM pi_sessions WHERE id = 'legacy-session'").pluck().get(),
+    'bradley',
+  );
+  assert.equal(
+    sqlite.prepare("SELECT actor_id FROM actor_events WHERE id = 'legacy-event'").pluck().get(),
+    'bradley',
+  );
+
+  for (const tableName of ['pi_sessions', 'actor_events']) {
+    const columns = sqlite.prepare(`PRAGMA table_info("${tableName}")`).all() as Array<{
+      dflt_value: string | null;
+      name: string;
+    }>;
+    const identityColumn = columns.find((column) => (
+      column.name === 'agent_id' || column.name === 'actor_id'
+    ));
+    assert.equal(identityColumn?.dflt_value, "'bradley'", `${tableName} default`);
+  }
+
+  sqlite.prepare('INSERT INTO pi_sessions (id) VALUES (?)').run('canonical-session');
+  sqlite.prepare('INSERT INTO actor_events (id) VALUES (?)').run('canonical-event');
+  assert.equal(
+    sqlite.prepare("SELECT agent_id FROM pi_sessions WHERE id = 'canonical-session'").pluck().get(),
+    'bradley',
+  );
+  assert.equal(
+    sqlite.prepare("SELECT actor_id FROM actor_events WHERE id = 'canonical-event'").pluck().get(),
+    'bradley',
+  );
+
+  const integrity = sqlite.pragma('integrity_check', { simple: true });
+  assert.equal(integrity, 'ok');
+  sqlite.close();
+  console.log('bradley-agent-id-sqlite-migration-test: ok');
+}
+
+main();

--- a/scripts/bradley-runtime-stability-test.ts
+++ b/scripts/bradley-runtime-stability-test.ts
@@ -1,10 +1,19 @@
 import assert from 'node:assert/strict';
 import Module from 'node:module';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-const dataDir = mkdtempSync(path.join(tmpdir(), 'canvas-bradley-runtime-stability-'));
+import Database from 'better-sqlite3';
+
+const dataDir = mkdtempSync(path.join(tmpdir(), 'canvas-bradley-agent-id-'));
 process.env.DATA = dataDir;
 process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
 
@@ -20,88 +29,102 @@ moduleInternals._load = (request, parent, isMain) => {
 let closeDatabaseConnections: (() => Promise<void>) | undefined;
 
 async function main(): Promise<void> {
+  const sqlitePath = path.join(dataDir, 'sqlite.db');
+  const legacyDatabase = new Database(sqlitePath);
+  const { runMigrations } = await import('../app/lib/db/migrate');
+  runMigrations(legacyDatabase);
+
+  const userId = 'bradley-agent-id-user';
+  const now = Date.now();
+  legacyDatabase.prepare(`
+    INSERT INTO user (id, name, email, email_verified, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(userId, 'Bradley Migration Test', 'bradley-migration@example.test', 1, now, now);
+  legacyDatabase.prepare("UPDATE agents SET agent_id = 'canvas-agent' WHERE agent_id = 'bradley'").run();
+  legacyDatabase.prepare(`
+    INSERT INTO pi_sessions (
+      session_id, user_id, agent_id, provider, model, title, created_at, updated_at
+    ) VALUES (?, ?, 'canvas-agent', ?, ?, ?, ?, ?)
+  `).run('legacy-main-session', userId, 'test', 'test-model', 'Legacy Bradley session', now, now);
+  legacyDatabase.prepare(`
+    INSERT INTO automation_jobs (
+      id, name, status, owner_user_id, prompt, preferred_skill,
+      workspace_context_paths_json, schedule_kind, schedule_config_json,
+      time_zone, created_by_user_id, agent_id, delivery_mode,
+      delivery_session_mode, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'canvas-agent', ?, ?, ?, ?)
+  `).run(
+    'legacy-main-automation',
+    'Legacy Bradley automation',
+    'paused',
+    userId,
+    'Verify the canonical Bradley agent ID.',
+    '',
+    '[]',
+    'manual',
+    '{}',
+    'Europe/Berlin',
+    userId,
+    'web',
+    'new_session',
+    now,
+    now,
+  );
+  legacyDatabase.close();
+
+  const legacySoulPath = path.join(dataDir, 'users', userId, 'agents', 'canvas-agent', 'SOUL.md');
+  mkdirSync(path.dirname(legacySoulPath), { recursive: true });
+  const soulContent = '# Personal collaboration preferences\n\nUse concise answers.\n';
+  writeFileSync(legacySoulPath, soulContent, 'utf8');
+
   const { DEFAULT_AGENT_ID } = await import('../app/lib/channels/constants');
   const {
     DEFAULT_MANAGED_AGENT_ID,
-    writeManagedAgentFile,
+    readManagedAgentFile,
   } = await import('../app/lib/agents/storage');
   const {
     ensureCanvasAgent,
     MAIN_AGENT_DISPLAY_NAME,
+    normalizeManagedAgentId,
   } = await import('../app/lib/agents/registry');
   const databaseModule = await import('../app/lib/db');
   closeDatabaseConnections = databaseModule.closeDatabaseConnections;
 
-  assert.equal(DEFAULT_AGENT_ID, 'canvas-agent');
-  assert.equal(DEFAULT_MANAGED_AGENT_ID, 'canvas-agent');
+  assert.equal(DEFAULT_AGENT_ID, 'bradley');
+  assert.equal(DEFAULT_MANAGED_AGENT_ID, 'bradley');
+  assert.equal(normalizeManagedAgentId('canvas-agent'), 'bradley');
+  assert.equal(normalizeManagedAgentId('bradley'), 'bradley');
   assert.equal(MAIN_AGENT_DISPLAY_NAME, 'Bradley');
 
   const profile = await ensureCanvasAgent();
-  assert.equal(profile.agentId, DEFAULT_AGENT_ID);
+  assert.equal(profile.agentId, 'bradley');
   assert.equal(profile.name, MAIN_AGENT_DISPLAY_NAME);
   assert.equal(profile.type, 'main');
 
-  const userId = 'bradley-runtime-stability-user';
-  const soulContent = '# Personal collaboration preferences\n\nUse concise answers.\n';
-  await writeManagedAgentFile('SOUL.md', soulContent, DEFAULT_MANAGED_AGENT_ID, { userId });
-
-  const expectedSoulPath = path.join(dataDir, 'users', userId, 'agents', 'canvas-agent', 'SOUL.md');
-  const displayNamePath = path.join(dataDir, 'users', userId, 'agents', 'Bradley');
-  assert.equal(readFileSync(expectedSoulPath, 'utf8'), soulContent);
-  assert.equal(existsSync(displayNamePath), false);
-
   const database = await databaseModule.openDb();
-  const now = Math.floor(Date.now() / 1_000);
-  await database.run(
-    `INSERT INTO user (id, name, email, email_verified, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [userId, 'Bradley Runtime Test', 'bradley-runtime@example.test', 1, now, now],
-  );
-
-  const sessionId = 'bradley-runtime-session';
-  await database.run(
-    `INSERT INTO pi_sessions (
-       session_id, user_id, provider, model, title, created_at, updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    [sessionId, userId, 'test', 'test-model', 'Bradley runtime stability', now, now],
-  );
+  for (const table of ['agents', 'pi_sessions', 'automation_jobs']) {
+    const legacyCount = await database.get(
+      `SELECT COUNT(*) AS count FROM ${table} WHERE agent_id = ?`,
+      ['canvas-agent'],
+    ) as { count: number };
+    assert.equal(legacyCount.count, 0, `${table} still contains the legacy main-agent ID`);
+  }
   const session = await database.get(
-    `SELECT agent_id AS agentId FROM pi_sessions WHERE user_id = ? AND session_id = ?`,
-    [userId, sessionId],
+    'SELECT agent_id AS agentId FROM pi_sessions WHERE session_id = ?',
+    ['legacy-main-session'],
   ) as { agentId: string } | undefined;
-  assert.equal(session?.agentId, DEFAULT_AGENT_ID);
-
-  const automationId = 'bradley-runtime-automation';
-  await database.run(
-    `INSERT INTO automation_jobs (
-       id, name, status, owner_user_id, prompt, preferred_skill,
-       workspace_context_paths_json, schedule_kind, schedule_config_json,
-       time_zone, created_by_user_id, delivery_mode, delivery_session_mode,
-       created_at, updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [
-      automationId,
-      'Bradley runtime stability',
-      'paused',
-      userId,
-      'Verify the stable internal agent identity.',
-      '',
-      '[]',
-      'manual',
-      '{}',
-      'Europe/Berlin',
-      userId,
-      'web',
-      'new_session',
-      now,
-      now,
-    ],
-  );
+  assert.equal(session?.agentId, 'bradley');
   const automation = await database.get(
-    `SELECT agent_id AS agentId FROM automation_jobs WHERE id = ?`,
-    [automationId],
+    'SELECT agent_id AS agentId FROM automation_jobs WHERE id = ?',
+    ['legacy-main-automation'],
   ) as { agentId: string } | undefined;
-  assert.equal(automation?.agentId, DEFAULT_AGENT_ID);
+  assert.equal(automation?.agentId, 'bradley');
+
+  const migratedSoul = await readManagedAgentFile('SOUL.md', 'canvas-agent', { userId });
+  const canonicalSoulPath = path.join(dataDir, 'users', userId, 'agents', 'bradley', 'SOUL.md');
+  assert.equal(migratedSoul, soulContent);
+  assert.equal(readFileSync(canonicalSoulPath, 'utf8'), soulContent);
+  assert.equal(existsSync(legacySoulPath), true, 'the rollback-safe legacy copy must remain intact');
 
   console.log('bradley-runtime-stability-test: ok');
 }

--- a/scripts/bradley-ui-preflight-test.ts
+++ b/scripts/bradley-ui-preflight-test.ts
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
   assert.match(identitySource, /\[forced-color-adjust:auto\]/u);
   assert.match(identitySource, /@media \(prefers-reduced-motion: reduce\)/u);
   assert.match(identitySource, /animation: none !important/u);
-  assert.match(identitySource, /agentId === DEFAULT_AGENT_ID/u);
+  assert.match(identitySource, /isMainAgentId\(agentId\)/u);
 
   const selectorSource = readProjectFile(
     'app/components/canvas-agent-chat/ChatAgentSelector.tsx',
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
   assert.match(starterSource, /alt=""/u);
   assert.match(starterSource, /aria-hidden="true"/u);
   assert.match(starterSource, /h-32 w-32[^']*md:h-36 md:w-36/u);
-  assert.match(starterSource, /activeAgentId === DEFAULT_AGENT_ID/u);
+  assert.match(starterSource, /isMainAgentId\(activeAgentId\)/u);
   assert.match(starterSource, /!isStudioChatContext/u);
 
   const runtimeSource = readProjectFile(


### PR DESCRIPTION
## Summary
- make `bradley` the canonical main-agent identifier across registry, API, persistence, and UI defaults
- continue accepting the legacy `canvas-agent` alias so existing links, sessions, automations, and clients remain compatible
- migrate SQLite and PostgreSQL agent references plus scoped legacy agent files without deleting old data
- update tests and architecture documentation, including the matching mobile migration
- keep Canvas Host Agent infrastructure paths such as `/data/canvas-agent` unchanged

## Verification
- `npm run test:agent:bradley-ui-preflight`
- `npm run test:agent:bradley-stability`
- changed-file ESLint checks
- `CANVAS_DATABASE_PROVIDER=sqlite npm run build`

## Screenshots
The visible Bradley name and artwork are unchanged. This PR updates the technical identifier shown below Bradley from `canvas-agent` to `bradley` and adds compatibility/migration behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes the canonical main-agent identifier from `canvas-agent` to `bradley` while retaining the former value as a compatibility alias.
- Centralizes main-agent identity normalization and updates API, persistence, runtime, automation, and UI defaults.
- Adds SQLite and PostgreSQL migrations for existing agent references and database defaults.
- Adds scoped legacy-file migration behavior and migration-focused verification scripts.
- Updates architecture documentation to define the new canonical and legacy identifiers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect established by the reviewed migration and compatibility paths.

The canonical identifier is applied consistently across defaults and boundary normalization, while both database providers migrate legacy references and storage retains compatibility fallbacks without an accepted blocking failure.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/db/main-agent-id-migration.ts | Adds broad SQLite and PostgreSQL migrations that copy the canonical agent, rewrite agent-reference columns and defaults, remove the legacy agent row, and record completion. |
| app/lib/agents/storage.ts | Canonicalizes the managed main-agent ID and adds scoped fallback migration from legacy `canvas-agent` files. |
| app/lib/agents/main-agent.ts | Defines the canonical and legacy IDs and provides centralized alias normalization and identity checks. |
| app/lib/db/migrate.ts | Changes SQLite defaults and backfills to `bradley` and invokes the new data migration before ensuring the canonical agent. |
| app/lib/db/postgres.ts | Integrates the PostgreSQL ID migration before inserting the canonical Bradley agent. |
| app/lib/db/schema.ts | Replaces hard-coded main-agent defaults with the centralized canonical identifier. |
| app/lib/agents/registry.ts | Normalizes the legacy alias to the canonical ID at the managed-agent registry boundary. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Legacy["Legacy input or stored ID<br/>canvas-agent"] --> Normalize["Alias normalization"]
  Canonical["Canonical input<br/>bradley"] --> Normalize
  Normalize --> Bradley["Canonical main-agent ID<br/>bradley"]
  DB["SQLite / PostgreSQL migration"] --> Bradley
  Files["Scoped legacy agent files"] --> Copy["Copy on first access"]
  Copy --> BradleyFiles["Scoped bradley files"]
  Host["Canvas Host Agent paths<br/>/data/canvas-agent"] --> Unchanged["Remain unchanged"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Migrate legacy SQLite agent defaults"](https://github.com/canvascoding/canvas-notebook/commit/e3b29826797f0d2b8d702abf87209a9ad2bffd04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59403852)</sub>

<!-- /greptile_comment -->