### PR TITLE
Improve app back navigation

### DIFF
--- a/app/apps/knowledge-graph/components/KnowledgeGraphShell.tsx
+++ b/app/apps/knowledge-graph/components/KnowledgeGraphShell.tsx
@@ -11,7 +11,6 @@ import { usePathname } from '@/i18n/navigation';
 
 export function KnowledgeGraphShell() {
   const t = useTranslations('knowledgeGraph');
-  const tCommon = useTranslations('common');
   const pathname = usePathname();
   const requestContext = useMemo<ChatRequestContext>(() => ({
     currentPage: pathname ?? '/knowledge-graph',
@@ -21,7 +20,6 @@ export function KnowledgeGraphShell() {
     <ChatDockShell
       title={t('title')}
       backHref="/"
-      backLabel={tCommon('suite')}
       requestContext={requestContext}
       storageKeyPrefix="knowledgeGraph"
       hintPage="knowledge-graph"

--- a/app/apps/todos/components/TodosShell.tsx
+++ b/app/apps/todos/components/TodosShell.tsx
@@ -8,7 +8,6 @@ import type { ChatRequestContext } from '@/app/lib/chat/types';
 import { usePathname } from '@/i18n/navigation';
 
 export function TodosShell({ children, hintEnabled = true }: { children: ReactNode; hintEnabled?: boolean }) {
-  const tCommon = useTranslations('common');
   const tTodos = useTranslations('todos');
   const pathname = usePathname();
   const requestContext = useMemo<ChatRequestContext>(
@@ -20,7 +19,6 @@ export function TodosShell({ children, hintEnabled = true }: { children: ReactNo
     <ChatDockShell
       title={tTodos('title')}
       backHref="/"
-      backLabel={tCommon('suite')}
       requestContext={requestContext}
       storageKeyPrefix="todos"
       hintPage="todos"

--- a/app/components/DashboardShell.tsx
+++ b/app/components/DashboardShell.tsx
@@ -11,7 +11,6 @@ import {
 } from 'react';
 import { useSearchParams } from 'next/navigation';
 import {
-  ArrowLeft,
   Files,
   FileText,
   Globe2,
@@ -24,7 +23,7 @@ import {
 import { useLocale, useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 
-import { Link } from '@/i18n/navigation';
+import { AppBackButton } from '@/app/components/navigation/AppBackButton';
 import { Button } from '@/components/ui/button';
 import {
   Sheet,
@@ -1119,12 +1118,7 @@ export function DashboardShell({ hintEnabled = true }: { hintEnabled?: boolean }
         <div className="fixed inset-0 flex flex-col overflow-hidden bg-background text-foreground">
           <header className="z-40 flex h-14 shrink-0 items-center justify-between gap-3 border-b border-border bg-background/95 px-3 pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-background/88 sm:px-4">
             <div className="flex min-w-0 items-center gap-2">
-              <Button asChild variant="outline" size="sm" className="shrink-0 gap-2 px-2 sm:px-3">
-                <Link href="/">
-                  <ArrowLeft className="h-4 w-4" />
-                  <span className="hidden sm:inline">{tCommon('suite')}</span>
-                </Link>
-              </Button>
+              <AppBackButton fallbackHref="/" className="shrink-0 gap-2 px-2 sm:px-3" />
               <div className="hidden min-w-0 md:block">
                 <div className="truncate text-sm font-semibold">{tNotebook('workbenchTitle')}</div>
                 <div className="truncate text-[11px] text-muted-foreground">{tNotebook('workbenchSubtitle')}</div>

--- a/app/components/EmailShell.tsx
+++ b/app/components/EmailShell.tsx
@@ -10,7 +10,6 @@ import type { ChatRequestContext } from '@/app/lib/chat/types';
 import { usePathname } from '@/i18n/navigation';
 
 export function EmailShell({ children, hintEnabled = true }: { children: ReactNode; hintEnabled?: boolean }) {
-  const tCommon = useTranslations('common');
   const tEmails = useTranslations('emails');
   const pathname = usePathname();
   const { chatContext } = useEmailChatContext();
@@ -23,7 +22,6 @@ export function EmailShell({ children, hintEnabled = true }: { children: ReactNo
     <ChatDockShell
       title={tEmails('title')}
       backHref="/"
-      backLabel={tCommon('suite')}
       requestContext={requestContext}
       storageKeyPrefix="emails"
       chatVisibleStorageKey="emails.chatVisible"

--- a/app/components/StudioShell.tsx
+++ b/app/components/StudioShell.tsx
@@ -24,7 +24,6 @@ function getStudioTitle(pathname: string | null, tStudio: ReturnType<typeof useT
 }
 
 export function StudioShell({ children, hintEnabled = true }: { children: ReactNode; hintEnabled?: boolean }) {
-  const tCommon = useTranslations('common');
   const tStudio = useTranslations('studio');
   const pathname = usePathname();
   const { chatContext } = useStudioChatContext();
@@ -32,11 +31,6 @@ export function StudioShell({ children, hintEnabled = true }: { children: ReactN
   const chatVisibleStorageKey = isAspectRatioEditor ? 'studio.chatVisible.aspectRatio' : 'studio.chatVisible';
   const title = getStudioTitle(pathname, tStudio);
   const backDestination = getStudioBackDestination(pathname);
-  const backLabel = backDestination.label === 'models'
-    ? tStudio('tabs.models')
-    : backDestination.label === 'presets'
-      ? tStudio('tabs.presets')
-      : tCommon('suite');
   const requestContext = useMemo<ChatRequestContext>(
     () => (chatContext?.currentPage === pathname ? chatContext : { currentPage: pathname ?? '/studio' }),
     [chatContext, pathname]
@@ -47,7 +41,7 @@ export function StudioShell({ children, hintEnabled = true }: { children: ReactN
       key={chatVisibleStorageKey}
       title={title}
       backHref={backDestination.href}
-      backLabel={backLabel}
+      preferBackFallback={backDestination.href !== '/'}
       requestContext={requestContext}
       storageKeyPrefix="studio"
       chatVisibleStorageKey={chatVisibleStorageKey}

--- a/app/components/SuitePageLayout.tsx
+++ b/app/components/SuitePageLayout.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 
-import { Link, usePathname } from '@/i18n/navigation';
+import { usePathname } from '@/i18n/navigation';
 import type { ReactNode } from 'react';
-import { ArrowLeft } from 'lucide-react';
-import { useTranslations } from 'next-intl';
 
 import { cn } from '@/lib/utils';
 
@@ -14,8 +12,7 @@ import { NotificationBell } from '@/app/components/notifications/NotificationBel
 import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { HintProvider } from '@/app/components/onboarding/HintProvider';
 import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
-
-import { Button } from '@/components/ui/button';
+import { AppBackButton } from '@/app/components/navigation/AppBackButton';
 
 type SuitePageLayoutProps = {
   title: string;
@@ -34,7 +31,6 @@ export function SuitePageLayout({
   hintPage,
   hintEnabled = true,
 }: SuitePageLayoutProps) {
-  const t = useTranslations('common');
   const pathname = usePathname();
   
   // Determine back navigation based on current route
@@ -62,8 +58,10 @@ export function SuitePageLayout({
   };
   
   const backHref = getBackHref();
-  const isStudioSubroute = pathname?.startsWith('/studio/');
-  const backLabel = isStudioSubroute ? t('studio') : t('suite');
+  const prefersParentFallback = Boolean(
+    pathname?.match(/^\/automations\/[^/]+$/)
+    || pathname?.match(/^\/studio\/(?:models|presets|products|personas)\/[^/]+$/),
+  );
 
   const content = (
     <div className="fixed inset-0 overflow-hidden bg-background text-foreground">
@@ -71,12 +69,7 @@ export function SuitePageLayout({
         <header className="sticky top-0 z-20 shrink-0 border-b border-border bg-background/95 pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-background/85">
           <div className="mx-auto flex min-h-16 max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-3 md:px-6">
             <div className="min-w-0 flex items-center gap-2 sm:gap-3">
-              <Button asChild variant="outline" size="sm" className="gap-2 px-2 sm:px-3">
-                <Link href={backHref}>
-                  <ArrowLeft className="h-4 w-4" />
-                  <span className="hidden sm:inline">{backLabel}</span>
-                </Link>
-              </Button>
+              <AppBackButton fallbackHref={backHref} preferFallback={prefersParentFallback} />
 
               <div className="min-w-0">
                 <h1 className={cn('truncate text-sm font-semibold sm:text-base md:text-lg', titleClassName)}>{title}</h1>

--- a/app/components/SuitePageLayout.tsx
+++ b/app/components/SuitePageLayout.tsx
@@ -48,6 +48,10 @@ export function SuitePageLayout({
     if (pathname?.match(/^\/studio\/personas\/[^/]+$/)) {
       return '/studio/personas';
     }
+
+    if (pathname?.match(/^\/automations\/[^/]+$/)) {
+      return '/automations';
+    }
     
     // Default studio back navigation
     if (pathname?.startsWith('/studio/')) {

--- a/app/components/browser-lab/BrowserLabShell.tsx
+++ b/app/components/browser-lab/BrowserLabShell.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useTranslations } from 'next-intl';
-
 import { BrowserLabClient } from '@/app/components/browser-lab/BrowserLabClient';
 import { ChatDockShell } from '@/app/components/layout/ChatDockShell';
 import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
@@ -13,7 +11,6 @@ type BrowserLabShellProps = {
 };
 
 export function BrowserLabShell({ locale }: BrowserLabShellProps) {
-  const tCommon = useTranslations('common');
   const requestContext = useMemo<ChatRequestContext>(() => ({
     currentPage: '/browser/lab',
   }), []);
@@ -22,7 +19,6 @@ export function BrowserLabShell({ locale }: BrowserLabShellProps) {
     <ChatDockShell
       title={locale === 'en' ? 'Browser Lab' : 'Browser-Labor'}
       backHref="/"
-      backLabel={tCommon('suite')}
       requestContext={requestContext}
       storageKeyPrefix="browserLab"
       defaultChatVisible

--- a/app/components/canvas-agent-chat/ChatHeader.tsx
+++ b/app/components/canvas-agent-chat/ChatHeader.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import {
-  ArrowLeft,
   ChevronLeft,
   Gauge,
   History,
@@ -17,6 +16,7 @@ import {
   WandSparkles,
 } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
+import { AppBackButton } from '@/app/components/navigation/AppBackButton';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -144,12 +144,7 @@ export function ChatHeader({
         <header className="z-40 h-16 flex-shrink-0 border-b border-border bg-background/95 pt-[env(safe-area-inset-top)]">
           <div className="mx-auto flex h-full items-center justify-between px-4">
             <div className="flex items-center gap-2">
-              <Button asChild variant="outline" size="sm" className="gap-2 px-2 sm:px-3">
-                <Link href="/">
-                  <ArrowLeft className="h-4 w-4" />
-                  <span className="hidden sm:inline">{tCommon('suite')}</span>
-                </Link>
-              </Button>
+              <AppBackButton fallbackHref="/" />
               <h1 className="hidden truncate text-lg font-bold md:block md:text-2xl">{t('title')}</h1>
             </div>
             <div className="flex items-center gap-1.5 md:gap-4">

--- a/app/components/file-browser/FileBrowser.tsx
+++ b/app/components/file-browser/FileBrowser.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState, useCallback, useEffect, type DragEvent } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { ArrowLeft, Download, Globe2, Move, Search, X } from 'lucide-react';
+import { Download, Globe2, Move, Search, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -22,7 +22,6 @@ import { useImagePreprocess } from '@/app/hooks/useImagePreprocess';
 import { ImagePreprocessDialog } from '@/app/components/shared/ImagePreprocessDialog';
 import { getDroppedFiles } from '@/app/lib/drop-traverse';
 import { FilePreviewDialog } from '@/app/components/files/FilePreviewDialog';
-import { Link } from '@/i18n/navigation';
 import { ThemeToggle } from '@/app/components/ThemeToggle';
 import { notifyWorkspaceFileOpened } from '@/app/lib/files/workspace-file-events';
 import { PublicShareDialog } from './PublicShareDialog';
@@ -38,6 +37,7 @@ import { useFileMoveDrag } from './useFileMoveDrag';
 
 
 import { AppLauncher } from '@/app/components/AppLauncher';
+import { AppBackButton } from '@/app/components/navigation/AppBackButton';
 import { NotificationBell } from '@/app/components/notifications/NotificationBell';
 import { WorkspaceSwitcher } from '@/app/components/workspaces/WorkspaceSwitcher';
 
@@ -48,7 +48,6 @@ interface FileBrowserProps {
 
 export function FileBrowser({ variant = 'default', onFileSelect }: FileBrowserProps) {
   const t = useTranslations('notebook');
-  const tCommon = useTranslations('common');
   const searchParams = useSearchParams();
   const dragCounter = useRef(0);
   const openedPathParamRef = useRef<string | null>(null);
@@ -539,12 +538,7 @@ export function FileBrowser({ variant = 'default', onFileSelect }: FileBrowserPr
       <header className="z-40 h-16 flex-shrink-0 border-b border-border bg-background/95 pt-[env(safe-area-inset-top)]">
         <div className="mx-auto flex h-full items-center justify-between px-4">
           <div className="flex items-center gap-2">
-            <Button asChild variant="outline" size="sm" className="gap-2 px-2 sm:px-3">
-              <Link href="/">
-                <ArrowLeft className="h-4 w-4" />
-                <span className="hidden sm:inline">{tCommon('suite')}</span>
-              </Link>
-            </Button>
+            <AppBackButton fallbackHref="/" />
             <h1 className="hidden md:block text-lg md:text-2xl font-bold truncate">{t('filesTitle')}</h1>
           </div>
           <div className="flex items-center gap-1.5 md:gap-4">

--- a/app/components/layout/ChatDockShell.tsx
+++ b/app/components/layout/ChatDockShell.tsx
@@ -9,12 +9,12 @@ import {
   type CSSProperties,
   type ReactNode,
 } from 'react';
-import { ArrowLeft, ChevronDown, Maximize2, MessageSquare, PanelRight, X } from 'lucide-react';
+import { ChevronDown, Maximize2, MessageSquare, PanelRight, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 
-import { Link } from '@/i18n/navigation';
 import CanvasAgentChat from '@/app/components/canvas-agent-chat/CanvasAgentChat';
+import { AppBackButton } from '@/app/components/navigation/AppBackButton';
 import { AppLauncher } from '@/app/components/AppLauncher';
 import { NotificationBell } from '@/app/components/notifications/NotificationBell';
 import { ThemeToggle } from '@/app/components/ThemeToggle';
@@ -85,7 +85,7 @@ type ChatDockShellProps = {
   children: ReactNode;
   title: ReactNode;
   backHref: string;
-  backLabel: string;
+  preferBackFallback?: boolean;
   requestContext: ChatRequestContext;
   storageKeyPrefix: string;
   hintPage?: string;
@@ -104,7 +104,7 @@ export function ChatDockShell({
   children,
   title,
   backHref,
-  backLabel,
+  preferBackFallback = false,
   requestContext,
   storageKeyPrefix,
   hintPage = '',
@@ -375,12 +375,7 @@ export function ChatDockShell({
         <header className="z-40 h-16 flex-shrink-0 border-b border-border bg-background/95 pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-background/85">
           <div className="relative flex h-full items-center justify-between gap-3 px-4 md:px-6">
             <div className="relative z-10 min-w-0 flex items-center gap-2 sm:gap-3">
-              <Button asChild variant="outline" size="sm" className="gap-2 px-2 sm:px-3">
-                <Link href={backHref}>
-                  <ArrowLeft className="h-4 w-4" />
-                  <span className="hidden sm:inline">{backLabel}</span>
-                </Link>
-              </Button>
+              <AppBackButton fallbackHref={backHref} preferFallback={preferBackFallback} />
               <h1 className={cn('min-w-0 truncate text-sm font-semibold sm:text-base md:text-lg', titleClassName)}>
                 {title}
               </h1>

--- a/app/components/navigation/AppBackButton.tsx
+++ b/app/components/navigation/AppBackButton.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { useRouter } from '@/i18n/navigation';
+import { Button } from '@/components/ui/button';
+
+type AppBackButtonProps = {
+  fallbackHref: string;
+  /** Use this for detail views with a stable, meaningful parent page. */
+  preferFallback?: boolean;
+  className?: string;
+};
+
+export function AppBackButton({ fallbackHref, preferFallback = false, className }: AppBackButtonProps) {
+  const router = useRouter();
+  const t = useTranslations('common');
+
+  const handleBack = () => {
+    // A new tab starts with one history entry. In that case we keep people in Canvas
+    // rather than invoking the browser's unavailable back action.
+    if (preferFallback || window.history.length <= 1) {
+      router.push(fallbackHref);
+      return;
+    }
+
+    router.back();
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className={className ?? 'gap-2 px-2 sm:px-3'}
+      onClick={handleBack}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="hidden sm:inline">{t('back')}</span>
+    </Button>
+  );
+}

--- a/app/components/navigation/AppBackButton.tsx
+++ b/app/components/navigation/AppBackButton.tsx
@@ -21,7 +21,7 @@ export function AppBackButton({ fallbackHref, preferFallback = false, className 
     // A new tab starts with one history entry. In that case we keep people in Canvas
     // rather than invoking the browser's unavailable back action.
     if (preferFallback || window.history.length <= 1) {
-      router.push(fallbackHref);
+      router.replace(fallbackHref);
       return;
     }
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "cancel": "Abbrechen",
+    "back": "Zurück",
     "suite": "Suite",
     "terminal": "Terminal",
     "aiChat": "AI Chat",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "cancel": "Cancel",
+    "back": "Back",
     "suite": "Suite",
     "terminal": "Terminal",
     "aiChat": "AI Chat",


### PR DESCRIPTION
## Summary
- add a shared router-aware back button with a start-page fallback
- use browser history for app entry screens and stable parent destinations for detail screens
- replace the misleading Suite label with localized Back/Zurück text

## Verification
- npm run lint (passes; two pre-existing warnings)
- npm run build (passes)

UI/E2E browser test was not run because it requires separate Playwright authorization.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a shared, localized, router-aware back button and applies it across the application. The latest changes complete the prior automation-navigation fixes by selecting `/automations` as the stable detail parent and replacing the detail history entry to prevent reopening it.
- Uses browser history for entry screens with a fallback when no prior entry exists.
- Uses stable parent destinations for automation and Studio detail screens.
- Replaces the Suite label with localized Back/Zurück text.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/components/navigation/AppBackButton.tsx | Adds the shared localized back control and uses replacement navigation for stable-parent fallbacks, resolving the previously reported detail-history bounce. |
| app/components/SuitePageLayout.tsx | Maps automation detail routes to `/automations` and enables stable-parent fallback behavior for supported detail screens. |
| app/components/StudioShell.tsx | Routes Studio detail screens through stable parent destinations while leaving entry screens history-aware. |
| app/components/layout/ChatDockShell.tsx | Integrates the shared back button and forwards the detail-screen fallback preference. |
| messages/en.json | Adds the English Back label used by the shared navigation control. |
| messages/de.json | Adds the German Zurück label used by the shared navigation control. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant Detail as Automation detail
    participant Back as AppBackButton
    participant Router
    participant List as Automation list
    User->>Detail: Open /automations/[jobId]
    User->>Back: Click Back
    Back->>Router: replace('/automations')
    Router->>List: Render stable parent
    Note over Router,List: Detail entry is removed from history
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Avoid back navigation loops"](https://github.com/canvascoding/canvas-notebook/commit/496f169c15ba2794ba1d8c686f3a7052c40a896b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59422420)</sub>

<!-- /greptile_comment -->