### PR TITLE
Use workspace colors as Canvas accents

### DIFF
--- a/app/components/WorkspaceAppearanceProvider.tsx
+++ b/app/components/WorkspaceAppearanceProvider.tsx
@@ -17,15 +17,17 @@ import {
   WorkspaceBrandingContext,
 } from '@/app/components/workspaces/WorkspaceBrandingContext';
 import {
+  WORKSPACE_ACCENT_CSS_PROPERTIES,
   WORKSPACE_APPEARANCE_CSS_PROPERTIES,
   WORKSPACE_APPEARANCE_UPDATED_EVENT,
+  createWorkspaceAccentCssTokens,
   createWorkspaceAppearanceCssTokens,
   normalizeWorkspaceAppearanceDefinition,
   workspaceAppearanceDefinitionFromProfile,
   type WorkspaceAppearanceDefinition,
 } from '@/app/lib/workspaces/appearance-theme';
 import { normalizeWorkspaceBrandProfile } from '@/app/lib/workspaces/brand-profile';
-import { useWorkspaceStore } from '@/app/store/workspace-store';
+import { selectActiveWorkspace, useWorkspaceStore } from '@/app/store/workspace-store';
 
 const CACHE_PREFIX = 'canvas.workspaceAppearance.';
 const NON_WORKSPACE_ROUTE_PATTERN = /\/(?:login|sign-in|sign-up|setup|onboarding)(?:\/|$)/u;
@@ -97,10 +99,26 @@ function applyWorkspaceAppearance(
   }
 }
 
+function applyWorkspaceAccent(
+  root: HTMLElement,
+  workspaceId: string,
+  accentColor: string,
+  mode: 'light' | 'dark',
+) {
+  clearWorkspaceAppearance(root);
+  const tokens = createWorkspaceAccentCssTokens(accentColor, mode);
+  root.dataset.workspaceAppearance = 'accent';
+  root.dataset.workspaceAppearanceWorkspace = workspaceId;
+  for (const property of WORKSPACE_ACCENT_CSS_PROPERTIES) {
+    root.style.setProperty(property, tokens[property]);
+  }
+}
+
 export function WorkspaceAppearanceProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const { resolvedTheme } = useTheme();
-  const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
+  const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
+  const activeWorkspaceId = activeWorkspace?.id || null;
   const hydrateWorkspaces = useWorkspaceStore((state) => state.hydrateWorkspaces);
   const [loadedBranding, setLoadedBranding] = useState<LoadedWorkspaceBranding | null>(null);
   const [refreshRevision, setRefreshRevision] = useState(0);
@@ -122,12 +140,12 @@ export function WorkspaceAppearanceProvider({ children }: { children: ReactNode 
     const definition = loadedBranding?.workspaceId === activeWorkspaceId
       ? loadedBranding.definition
       : readCachedAppearance(activeWorkspaceId);
-    if (!definition) {
-      clearWorkspaceAppearance(root);
-      return;
+    if (definition?.enabled) {
+      applyWorkspaceAppearance(root, activeWorkspaceId, definition, resolvedTheme);
+    } else {
+      applyWorkspaceAccent(root, activeWorkspaceId, activeWorkspace.color, resolvedTheme);
     }
-    applyWorkspaceAppearance(root, activeWorkspaceId, definition, resolvedTheme);
-  }, [activeWorkspaceId, loadedBranding, resolvedTheme, workspaceAppearanceAllowed]);
+  }, [activeWorkspace?.color, activeWorkspaceId, loadedBranding, resolvedTheme, workspaceAppearanceAllowed]);
 
   useEffect(() => {
     if (!workspaceAppearanceAllowed || !activeWorkspaceId) return;

--- a/app/components/WorkspaceAppearanceProvider.tsx
+++ b/app/components/WorkspaceAppearanceProvider.tsx
@@ -132,20 +132,21 @@ export function WorkspaceAppearanceProvider({ children }: { children: ReactNode 
 
   useLayoutEffect(() => {
     const root = document.documentElement;
-    if (!workspaceAppearanceAllowed || !activeWorkspaceId) {
+    if (!workspaceAppearanceAllowed || !activeWorkspace) {
       clearWorkspaceAppearance(root);
       return;
     }
+    const workspaceId = activeWorkspace.id;
 
-    const definition = loadedBranding?.workspaceId === activeWorkspaceId
+    const definition = loadedBranding?.workspaceId === workspaceId
       ? loadedBranding.definition
-      : readCachedAppearance(activeWorkspaceId);
+      : readCachedAppearance(workspaceId);
     if (definition?.enabled) {
-      applyWorkspaceAppearance(root, activeWorkspaceId, definition, resolvedTheme);
+      applyWorkspaceAppearance(root, workspaceId, definition, resolvedTheme);
     } else {
-      applyWorkspaceAccent(root, activeWorkspaceId, activeWorkspace.color, resolvedTheme);
+      applyWorkspaceAccent(root, workspaceId, activeWorkspace.color, resolvedTheme);
     }
-  }, [activeWorkspace?.color, activeWorkspaceId, loadedBranding, resolvedTheme, workspaceAppearanceAllowed]);
+  }, [activeWorkspace, loadedBranding, resolvedTheme, workspaceAppearanceAllowed]);
 
   useEffect(() => {
     if (!workspaceAppearanceAllowed || !activeWorkspaceId) return;

--- a/app/components/settings/BrandSettingsPanel.tsx
+++ b/app/components/settings/BrandSettingsPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
 import { startTransition, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type DragEvent, type ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
 import { AlignLeft, AlignRight, Boxes, Building2, CheckCircle2, FileImage, FileText, Loader2, Monitor, Palette, RotateCcw, Save, ShieldCheck, SlidersHorizontal, Sparkles, Trash2, Upload } from 'lucide-react';
@@ -587,14 +588,19 @@ export function BrandSettingsPanel({
   canManageOrganizationBrand?: boolean;
 }) {
   const t = useTranslations('settings.brandDesign');
+  const searchParams = useSearchParams();
+  const requestedScope = searchParams.get('scope');
+  const requestedWorkspaceId = searchParams.get('workspaceId')?.trim() || null;
   const workspaces = useWorkspaceStore((state) => state.workspaces);
   const activeWorkspace = useWorkspaceStore(selectActiveWorkspace);
   const organizationId = useWorkspaceStore((state) => state.organizationId);
   const initialized = useWorkspaceStore((state) => state.initialized);
   const isWorkspaceLoading = useWorkspaceStore((state) => state.isLoading);
   const hydrateWorkspaces = useWorkspaceStore((state) => state.hydrateWorkspaces);
-  const [scope, setScope] = useState<BrandScope>(() => canManageOrganizationBrand ? 'organization' : 'workspace');
-  const [manualWorkspaceId, setManualWorkspaceId] = useState<string | null>(null);
+  const [scope, setScope] = useState<BrandScope>(() => (
+    requestedScope === 'workspace' || !canManageOrganizationBrand ? 'workspace' : 'organization'
+  ));
+  const [manualWorkspaceId, setManualWorkspaceId] = useState<string | null>(() => requestedWorkspaceId);
   const [profile, setProfile] = useState<WorkspaceBrandProfile>(() => cloneWorkspaceBrandProfile(WORKSPACE_BRAND_PRESETS.canvas));
   const [savedProfile, setSavedProfile] = useState<WorkspaceBrandProfile>(() => cloneWorkspaceBrandProfile(WORKSPACE_BRAND_PRESETS.canvas));
   const [configured, setConfigured] = useState(false);

--- a/app/components/settings/CreateWorkspaceDialog.tsx
+++ b/app/components/settings/CreateWorkspaceDialog.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import Link from 'next/link';
 import { FormEvent, useCallback, useEffect, useId, useMemo, useState } from 'react';
-import { Loader2, Plus } from 'lucide-react';
+import { CheckCircle2, Loader2, Palette, Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
@@ -18,7 +19,9 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { WorkspaceMembersEditor } from '@/app/components/settings/WorkspaceMembersEditor';
 import { WorkspaceColorPicker } from '@/app/components/workspaces/WorkspaceColorPicker';
+import { WorkspaceIdentityMark } from '@/app/components/workspaces/WorkspaceIdentityMark';
 import { WorkspaceIconPicker } from '@/app/components/workspaces/WorkspaceIconPicker';
+import { workspaceBrandDesignHref } from '@/app/lib/workspaces/brand-navigation';
 import type { ClientWorkspaceSummary, ClientWorkspaceType } from '@/app/lib/workspaces/client-types';
 import { DEFAULT_WORKSPACE_COLOR, type WorkspaceColor } from '@/app/lib/workspaces/colors';
 import { WORKSPACE_DESCRIPTION_MAX_LENGTH } from '@/app/lib/workspaces/description';
@@ -68,6 +71,7 @@ export function CreateWorkspaceDialog({
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [createdWorkspace, setCreatedWorkspace] = useState<ClientWorkspaceSummary | null>(null);
+  const createdWorkspaceSupportsMembers = createdWorkspace?.type === 'team' || createdWorkspace?.type === 'project';
 
   const loadProjects = useCallback(async () => {
     if (!open || !projectFeaturesEnabled || !canCreateSharedWorkspace) return;
@@ -202,12 +206,7 @@ export function CreateWorkspaceDialog({
       }
       const workspace = payload.workspace as ClientWorkspaceSummary;
       await onCreated(workspace);
-      if (workspace.type === 'team' || workspace.type === 'project') {
-        setCreatedWorkspace(workspace);
-      } else {
-        resetForm();
-        onOpenChange(false);
-      }
+      setCreatedWorkspace(workspace);
     } catch (err) {
       const message = err instanceof Error ? err.message : t('errors.createFailed');
       setError(message);
@@ -218,22 +217,49 @@ export function CreateWorkspaceDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className={createdWorkspace ? "!flex max-h-[calc(100dvh-2rem)] !w-[min(100%_-_2rem,_48rem)] !max-w-none !flex-col !gap-0 !overflow-hidden !p-0 sm:!max-w-none" : undefined}>
+      <DialogContent className={createdWorkspaceSupportsMembers ? "!flex max-h-[calc(100dvh-2rem)] !w-[min(100%_-_2rem,_48rem)] !max-w-none !flex-col !gap-0 !overflow-hidden !p-0 sm:!max-w-none" : undefined}>
         {createdWorkspace ? (
           <div className="flex min-h-0 flex-1 flex-col">
             <DialogHeader className="border-b border-border px-5 py-5 pr-12 sm:px-6 sm:pr-14">
-              <DialogTitle>{t('createDialog.accessTitle', { name: createdWorkspace.name })}</DialogTitle>
-              <DialogDescription>{t('createDialog.accessDescription')}</DialogDescription>
+              <DialogTitle>
+                {createdWorkspaceSupportsMembers
+                  ? t('createDialog.accessTitle', { name: createdWorkspace.name })
+                  : t('createDialog.createdTitle', { name: createdWorkspace.name })}
+              </DialogTitle>
+              <DialogDescription>
+                {createdWorkspaceSupportsMembers
+                  ? t('createDialog.accessDescription')
+                  : t('createDialog.createdDescription')}
+              </DialogDescription>
             </DialogHeader>
             <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6">
-              <WorkspaceMembersEditor
-                key={createdWorkspace.id}
-                active={open}
-                workspace={createdWorkspace}
-                onChanged={() => onCreated(createdWorkspace)}
-              />
+              {createdWorkspaceSupportsMembers ? (
+                <WorkspaceMembersEditor
+                  key={createdWorkspace.id}
+                  active={open}
+                  workspace={createdWorkspace}
+                  onChanged={() => onCreated(createdWorkspace)}
+                />
+              ) : (
+                <div className="flex items-start gap-4 rounded-xl border border-primary/20 bg-primary/[0.045] p-4">
+                  <WorkspaceIdentityMark workspace={createdWorkspace} className="h-11 w-11 rounded-xl" iconClassName="h-5 w-5" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate text-sm font-semibold">{createdWorkspace.name}</p>
+                      <CheckCircle2 className="h-4 w-4 shrink-0 text-primary" />
+                    </div>
+                    <p className="mt-1 text-xs leading-5 text-muted-foreground">{t('brandDesign.createdHint')}</p>
+                  </div>
+                </div>
+              )}
             </div>
-            <DialogFooter className="border-t border-border px-5 py-4 sm:px-6">
+            <DialogFooter className="gap-2 border-t border-border px-5 py-4 sm:px-6">
+              <Button type="button" variant="outline" asChild>
+                <Link href={workspaceBrandDesignHref(createdWorkspace.id)} onClick={() => handleOpenChange(false)}>
+                  <Palette data-icon="inline-start" />
+                  {t('brandDesign.open')}
+                </Link>
+              </Button>
               <Button type="button" onClick={() => handleOpenChange(false)}>
                 {t('createDialog.done')}
               </Button>

--- a/app/components/settings/EditWorkspaceDialog.tsx
+++ b/app/components/settings/EditWorkspaceDialog.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { FormEvent, useId, useState } from 'react';
-import { Loader2, Save } from 'lucide-react';
+import { Loader2, Palette, Save } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -20,6 +21,7 @@ import { DirectMcpWorkspaceAccessSwitch } from '@/app/components/settings/Direct
 import { WorkspaceMembersEditor } from '@/app/components/settings/WorkspaceMembersEditor';
 import { WorkspaceColorPicker } from '@/app/components/workspaces/WorkspaceColorPicker';
 import { WorkspaceIconPicker } from '@/app/components/workspaces/WorkspaceIconPicker';
+import { workspaceBrandDesignHref } from '@/app/lib/workspaces/brand-navigation';
 import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
 import { DEFAULT_WORKSPACE_COLOR, type WorkspaceColor } from '@/app/lib/workspaces/colors';
 import { WORKSPACE_DESCRIPTION_MAX_LENGTH } from '@/app/lib/workspaces/description';
@@ -58,6 +60,7 @@ function EditWorkspaceDialogContent({
   onChanged,
 }: EditWorkspaceDialogProps) {
   const t = useTranslations('settings.workspacePanel.management');
+  const router = useRouter();
   const nameId = useId();
   const descriptionId = useId();
   const [name, setName] = useState(() => workspace?.name ?? '');
@@ -78,6 +81,8 @@ function EditWorkspaceDialogContent({
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!workspace) return;
+    const submitter = (event.nativeEvent as SubmitEvent).submitter as HTMLElement | null;
+    const shouldOpenBrandDesign = submitter?.dataset.workspaceSubmitIntent === 'brand-design';
     const trimmedName = name.trim();
     if (!trimmedName) {
       setError(t('errors.nameRequired'));
@@ -108,6 +113,7 @@ function EditWorkspaceDialogContent({
       }
       await onChanged();
       onOpenChange(false);
+      if (shouldOpenBrandDesign) router.push(workspaceBrandDesignHref(workspace.id));
     } catch (err) {
       setError(err instanceof Error ? err.message : t('errors.updateFailed'));
     } finally {
@@ -169,6 +175,33 @@ function EditWorkspaceDialogContent({
               <WorkspaceIconPicker value={icon} onChange={setIcon} disabled={isSubmitting} />
 
               <WorkspaceColorPicker value={color} onChange={setColor} disabled={isSubmitting} />
+
+              {workspace?.permissions.canManageWorkspace ? (
+                <section className="rounded-xl border border-primary/20 bg-primary/[0.045] p-4" aria-labelledby="workspace-brand-design-title">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex min-w-0 items-start gap-3">
+                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/12 text-primary">
+                        <Palette className="h-4 w-4" />
+                      </span>
+                      <div className="min-w-0">
+                        <h3 id="workspace-brand-design-title" className="text-sm font-semibold">{t('brandDesign.title')}</h3>
+                        <p className="mt-1 text-xs leading-5 text-muted-foreground">{t('brandDesign.description')}</p>
+                      </div>
+                    </div>
+                    <Button
+                      type="submit"
+                      variant="outline"
+                      size="sm"
+                      data-workspace-submit-intent="brand-design"
+                      disabled={isSubmitting || !name.trim()}
+                      className="shrink-0 bg-background/80"
+                    >
+                      <Palette data-icon="inline-start" />
+                      {t('brandDesign.saveAndOpen')}
+                    </Button>
+                  </div>
+                </section>
+              ) : null}
 
               {workspace ? (
                 <section className="rounded-lg border bg-muted/20 p-4" aria-labelledby="workspace-mcp-access-title">

--- a/app/components/settings/WorkspaceExportCard.tsx
+++ b/app/components/settings/WorkspaceExportCard.tsx
@@ -16,9 +16,9 @@ import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { WorkspaceIdentityMark } from '@/app/components/workspaces/WorkspaceIdentityMark';
 import {
   getWorkspaceKindLabel,
-  renderWorkspaceIcon,
   type WorkspaceKindLabels,
 } from '@/app/components/workspaces/workspace-utils';
 import { canExportWorkspaceFiles } from '@/app/lib/workspaces/export-access';
@@ -230,7 +230,7 @@ export function WorkspaceExportCard({ isAdmin = false }: WorkspaceExportCardProp
           ) : selectedWorkspace ? (
             <div className="flex min-w-0 items-center gap-3 rounded-md border border-border bg-muted/30 px-3 py-3">
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-background">
-                {renderWorkspaceIcon(selectedWorkspace, 'h-4 w-4 text-muted-foreground')}
+                <WorkspaceIdentityMark workspace={selectedWorkspace} className="h-7 w-7" iconClassName="h-4 w-4" />
               </div>
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium">{selectedWorkspace.name}</p>

--- a/app/components/settings/WorkspaceManagementCard.tsx
+++ b/app/components/settings/WorkspaceManagementCard.tsx
@@ -28,10 +28,10 @@ import { EditWorkspaceDialog } from '@/app/components/settings/EditWorkspaceDial
 import { WorkspaceMembersDialog } from '@/app/components/settings/WorkspaceMembersDialog';
 import { WorkspaceTypeChangeDialog } from '@/app/components/settings/WorkspaceTypeChangeDialog';
 import { WorkspaceMailboxAssignmentDialog } from '@/app/components/settings/WorkspaceMailboxAssignmentDialog';
+import { WorkspaceIdentityMark } from '@/app/components/workspaces/WorkspaceIdentityMark';
 import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
 import {
   getWorkspaceKindLabel,
-  renderWorkspaceIcon,
   type WorkspaceKindLabels,
 } from '@/app/components/workspaces/workspace-utils';
 import { useWorkspaceStore } from '@/app/store/workspace-store';
@@ -241,7 +241,7 @@ export function WorkspaceManagementCard({
                       className="grid min-w-0 gap-3 rounded-md border border-border px-3 py-3 sm:grid-cols-[minmax(0,1fr)_auto]"
                     >
                       <div className="flex min-w-0 items-start gap-3">
-                        {renderWorkspaceIcon(workspace, 'mt-0.5 h-4 w-4 shrink-0 text-muted-foreground')}
+                        <WorkspaceIdentityMark workspace={workspace} className="h-8 w-8" iconClassName="h-4 w-4" />
                         <div className="min-w-0">
                           <div className="flex min-w-0 flex-wrap items-center gap-2">
                             <span className="min-w-0 truncate text-sm font-medium">{workspace.name}</span>

--- a/app/components/workspaces/WorkspaceBadge.tsx
+++ b/app/components/workspaces/WorkspaceBadge.tsx
@@ -12,9 +12,9 @@ import {
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
+import { WorkspaceIdentityMark } from '@/app/components/workspaces/WorkspaceIdentityMark';
 import {
   getWorkspaceKindLabel,
-  renderWorkspaceIcon,
   type WorkspaceKindLabels,
 } from '@/app/components/workspaces/workspace-utils';
 import { selectActiveWorkspace, useWorkspaceStore } from '@/app/store/workspace-store';
@@ -56,7 +56,7 @@ export function WorkspaceBadge({ workspace: providedWorkspace, compact = false, 
               className
             )}
           >
-            {renderWorkspaceIcon(workspace, 'h-3.5 w-3.5 shrink-0 text-muted-foreground')}
+            <WorkspaceIdentityMark workspace={workspace} className="h-5 w-5 rounded-[5px]" iconClassName="h-3 w-3" />
             {!compact && (
               <span className="min-w-0 truncate">
                 {label}

--- a/app/components/workspaces/WorkspaceIdentityMark.tsx
+++ b/app/components/workspaces/WorkspaceIdentityMark.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
+import { DEFAULT_WORKSPACE_COLOR } from '@/app/lib/workspaces/colors';
+import { cn } from '@/lib/utils';
+import { renderWorkspaceIcon } from './workspace-utils';
+
+type WorkspaceIdentityMarkProps = {
+  workspace: ClientWorkspaceSummary | null | undefined;
+  className?: string;
+  iconClassName?: string;
+};
+
+export function WorkspaceIdentityMark({
+  workspace,
+  className,
+  iconClassName = 'h-3.5 w-3.5',
+}: WorkspaceIdentityMarkProps) {
+  const color = workspace?.color || DEFAULT_WORKSPACE_COLOR;
+
+  return (
+    <span
+      aria-hidden="true"
+      data-workspace-color={color}
+      className={cn(
+        'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-white shadow-xs ring-1 ring-black/10',
+        className,
+      )}
+      style={{ backgroundColor: color }}
+    >
+      {renderWorkspaceIcon(workspace, iconClassName)}
+    </span>
+  );
+}

--- a/app/components/workspaces/WorkspaceSwitcher.tsx
+++ b/app/components/workspaces/WorkspaceSwitcher.tsx
@@ -27,10 +27,10 @@ import {
 import { cn } from '@/lib/utils';
 import { CreateWorkspaceDialog } from '@/app/components/settings/CreateWorkspaceDialog';
 import { EditWorkspaceDialog } from '@/app/components/settings/EditWorkspaceDialog';
+import { WorkspaceIdentityMark } from '@/app/components/workspaces/WorkspaceIdentityMark';
 import type { ClientWorkspaceSummary } from '@/app/lib/workspaces/client-types';
 import {
   getWorkspaceKindLabel,
-  renderWorkspaceIcon,
   type WorkspaceKindLabels,
 } from '@/app/components/workspaces/workspace-utils';
 import {
@@ -215,7 +215,7 @@ export function WorkspaceSwitcher({
                 {isLoading && !initialized ? (
                   <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
                 ) : (
-                  renderWorkspaceIcon(activeWorkspace, 'h-4 w-4 shrink-0')
+                  <WorkspaceIdentityMark workspace={activeWorkspace} className="h-6 w-6" iconClassName="h-3.5 w-3.5" />
                 )}
                 <span className="min-w-0">
                   <span className="block truncate text-sm font-semibold">{activeLabel}</span>
@@ -308,7 +308,7 @@ export function WorkspaceSwitcher({
                     setMobileSheetOpen(false);
                   }}
                 >
-                  {renderWorkspaceIcon(workspace, 'mt-0.5 h-4 w-4 shrink-0')}
+                  <WorkspaceIdentityMark workspace={workspace} className="mt-0.5 h-7 w-7" iconClassName="h-4 w-4" />
                   <span className="min-w-0 flex-1">
                     <span className="flex min-w-0 flex-wrap items-center gap-2 text-sm font-medium">
                       <span className="min-w-0 truncate">{workspace.name}</span>
@@ -382,7 +382,7 @@ export function WorkspaceSwitcher({
           {isLoading && !initialized ? (
             <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
           ) : (
-            renderWorkspaceIcon(activeWorkspace, 'h-3.5 w-3.5 shrink-0')
+            <WorkspaceIdentityMark workspace={activeWorkspace} className="h-5 w-5 rounded-[5px]" iconClassName="h-3 w-3" />
           )}
           <span className={cn(
             'min-w-0 truncate',
@@ -461,7 +461,7 @@ export function WorkspaceSwitcher({
                   data-testid={`workspace-option-${workspace.id}`}
                   className="min-w-0 flex-1 items-start gap-2"
                 >
-                  {renderWorkspaceIcon(workspace, 'mt-0.5 h-4 w-4')}
+                  <WorkspaceIdentityMark workspace={workspace} className="mt-0.5 h-7 w-7" iconClassName="h-4 w-4" />
                   <span className="min-w-0 flex-1">
                     <span className="flex min-w-0 flex-wrap items-center gap-2 text-sm font-medium">
                       <span className="min-w-0 truncate">{workspace.name}</span>

--- a/app/lib/workspaces/appearance-theme.ts
+++ b/app/lib/workspaces/appearance-theme.ts
@@ -52,6 +52,23 @@ export const WORKSPACE_APPEARANCE_CSS_PROPERTIES = [
 export type WorkspaceAppearanceCssProperty = (typeof WORKSPACE_APPEARANCE_CSS_PROPERTIES)[number];
 export type WorkspaceAppearanceCssTokens = Record<WorkspaceAppearanceCssProperty, string>;
 
+export const WORKSPACE_ACCENT_CSS_PROPERTIES = [
+  '--primary',
+  '--primary-foreground',
+  '--accent',
+  '--accent-foreground',
+  '--ring',
+  '--chart-1',
+  '--sidebar-primary',
+  '--sidebar-primary-foreground',
+  '--sidebar-accent',
+  '--sidebar-accent-foreground',
+  '--sidebar-ring',
+] as const satisfies readonly WorkspaceAppearanceCssProperty[];
+
+export type WorkspaceAccentCssProperty = (typeof WORKSPACE_ACCENT_CSS_PROPERTIES)[number];
+export type WorkspaceAccentCssTokens = Record<WorkspaceAccentCssProperty, string>;
+
 const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/iu;
 
 type RgbColor = { red: number; green: number; blue: number };
@@ -202,6 +219,32 @@ export function createWorkspaceAppearanceCssTokens(
     '--sidebar-accent': accent,
     '--sidebar-accent-foreground': foreground,
     '--sidebar-border': border,
+    '--sidebar-ring': primary,
+  };
+}
+
+export function createWorkspaceAccentCssTokens(
+  accentColor: string,
+  mode: WorkspaceAppearanceColorMode,
+): WorkspaceAccentCssTokens {
+  const configuredAccent = HEX_COLOR_PATTERN.test(accentColor) ? accentColor.toLowerCase() : '#2563eb';
+  const background = mode === 'dark' ? '#090c12' : '#ffffff';
+  const foreground = mode === 'dark' ? '#f7f8fa' : '#111111';
+  const primary = ensureContrast(configuredAccent, background, 3);
+  const primaryForeground = bestContrastColor(primary);
+  const accent = mixWorkspaceAppearanceColor(background, primary, mode === 'dark' ? 0.24 : 0.12);
+
+  return {
+    '--primary': primary,
+    '--primary-foreground': primaryForeground,
+    '--accent': accent,
+    '--accent-foreground': foreground,
+    '--ring': primary,
+    '--chart-1': primary,
+    '--sidebar-primary': primary,
+    '--sidebar-primary-foreground': primaryForeground,
+    '--sidebar-accent': accent,
+    '--sidebar-accent-foreground': foreground,
     '--sidebar-ring': primary,
   };
 }

--- a/app/lib/workspaces/brand-navigation.ts
+++ b/app/lib/workspaces/brand-navigation.ts
@@ -1,0 +1,8 @@
+export function workspaceBrandDesignHref(workspaceId: string): string {
+  const params = new URLSearchParams({
+    tab: 'brand-design',
+    scope: 'workspace',
+    workspaceId,
+  });
+  return `/settings?${params.toString()}`;
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -4037,7 +4037,7 @@
         "usageTitle": "Wo soll das Profil verwendet werden?",
         "usageDescription": "Beide Bereiche verwenden dieselben Designwerte und können unabhängig aktiviert werden.",
         "canvasTitle": "Canvas-Oberfläche",
-        "canvasDescription": "Farben, Schrift und Ecken im Workspace",
+        "canvasDescription": "Vollständiges Brand-Design im Workspace; sonst gilt der Canvas-Standard mit Workspace-Akzent",
         "documentsTitle": "PDFs und Agent",
         "documentsDescription": "Dokumentdesign und Markenrichtlinien",
         "sharedSettings": "Änderungen am Preset oder an den individuellen Einstellungen wirken in beiden Bereichen."
@@ -4054,7 +4054,7 @@
         "description": "Ein einfaches Grunddesign für den gesamten Workspace. Die gleichen Farben und die gleiche Schrift werden auch in deinen Dokumenten verwendet.",
         "apply": "In Canvas verwenden",
         "on": "Oberfläche folgt dem Brand-Design",
-        "off": "Oberfläche bleibt im Canvas-Standard",
+        "off": "Canvas-Standard mit Workspace-Akzent",
         "base": {
           "title": "Grunddesign",
           "description": "Drei Farben und eine Schrift reichen aus. Passende Flächen, Rahmen und Zustände erzeugt Canvas automatisch."
@@ -4294,7 +4294,7 @@
           "descriptionHint": "Diese kurze Einordnung wird dem KI-Agenten im aktiven Workspace mitgegeben.",
           "descriptionCount": "{count}/{max} Zeichen",
           "icon": "Icon",
-          "color": "Farbe",
+          "color": "Workspace-Akzent",
           "type": "Typ",
           "project": "Projekt",
           "projectPlaceholder": "Projekt auswählen"
@@ -4326,7 +4326,7 @@
           }
         },
         "colorPicker": {
-          "hint": "Wähle eine Farbe, an der du den Workspace auf einen Blick erkennst.",
+          "hint": "Diese Farbe kennzeichnet den Workspace und dient im Canvas-Standard automatisch als Akzent.",
           "colors": {
             "blue": "Blau",
             "indigo": "Indigo",
@@ -4418,6 +4418,8 @@
           "cancel": "Abbrechen",
           "accessTitle": "Zugriff für {name} festlegen",
           "accessDescription": "Der Workspace ist erstellt. Füge jetzt Nutzer hinzu und passe ihre Zugriffsrollen an.",
+          "createdTitle": "{name} ist bereit",
+          "createdDescription": "Der Workspace wurde erstellt und verwendet seine Farbe bereits als Canvas-Akzent.",
           "done": "Fertig"
         },
         "editDialog": {
@@ -4426,6 +4428,13 @@
           "descriptionFallback": "Name, Kurzbeschreibung, Icon, Farbe und Zugriff des Workspace anpassen.",
           "cancel": "Abbrechen",
           "save": "Änderungen speichern"
+        },
+        "brandDesign": {
+          "title": "Design & Logo",
+          "description": "Ohne eigenes Brand-Design bleibt Canvas im Standarddesign und verwendet den Workspace-Akzent. Logo, Schrift und weitere Farben kannst du zentral ergänzen.",
+          "saveAndOpen": "Speichern & Design öffnen",
+          "open": "Design & Logo einrichten",
+          "createdHint": "Der Workspace-Akzent ist aktiv. Optional kannst du jetzt Logo, Schrift und Dokumentdesign ergänzen."
         },
         "mcp": {
           "title": "Direct-MCP-Zugriff",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4038,7 +4038,7 @@
         "usageTitle": "Where should this profile be used?",
         "usageDescription": "Both areas use the same design values and can be enabled independently.",
         "canvasTitle": "Canvas interface",
-        "canvasDescription": "Colors, font, and corners in the workspace",
+        "canvasDescription": "Full brand design in the workspace; otherwise Canvas stays standard with the workspace accent",
         "documentsTitle": "PDFs and agent",
         "documentsDescription": "Document design and brand guidelines",
         "sharedSettings": "Changes to the preset or custom settings flow through to both areas."
@@ -4055,7 +4055,7 @@
         "description": "A simple foundation for the whole workspace. The same colors and font are also used in your documents.",
         "apply": "Use in Canvas",
         "on": "The interface follows the brand design",
-        "off": "The interface keeps the Canvas default",
+        "off": "Standard Canvas design with workspace accent",
         "base": {
           "title": "Foundation",
           "description": "Three colors and one font are enough. Canvas creates matching surfaces, borders, and states automatically."
@@ -4295,7 +4295,7 @@
           "descriptionHint": "This short summary is included in the AI agent's active workspace context.",
           "descriptionCount": "{count}/{max} characters",
           "icon": "Icon",
-          "color": "Color",
+          "color": "Workspace accent",
           "type": "Type",
           "project": "Project",
           "projectPlaceholder": "Select project"
@@ -4327,7 +4327,7 @@
           }
         },
         "colorPicker": {
-          "hint": "Choose a color that makes this workspace recognizable at a glance.",
+          "hint": "This color identifies the workspace and automatically becomes its accent in the standard Canvas design.",
           "colors": {
             "blue": "Blue",
             "indigo": "Indigo",
@@ -4419,6 +4419,8 @@
           "cancel": "Cancel",
           "accessTitle": "Set access for {name}",
           "accessDescription": "The workspace has been created. Add users and adjust their access roles now.",
+          "createdTitle": "{name} is ready",
+          "createdDescription": "The workspace has been created and already uses its color as the Canvas accent.",
           "done": "Done"
         },
         "editDialog": {
@@ -4427,6 +4429,13 @@
           "descriptionFallback": "Update the workspace name, short description, icon, color, and access.",
           "cancel": "Cancel",
           "save": "Save changes"
+        },
+        "brandDesign": {
+          "title": "Design & logo",
+          "description": "Without custom brand design, Canvas keeps its standard design and uses the workspace accent. Add a logo, fonts, and more colors centrally when needed.",
+          "saveAndOpen": "Save & open design",
+          "open": "Set up design & logo",
+          "createdHint": "The workspace accent is active. You can now optionally add a logo, fonts, and document design."
         },
         "mcp": {
           "title": "Direct MCP access",

--- a/package.json
+++ b/package.json
@@ -355,6 +355,7 @@
     "test:workspace:api-routes:orbstack": "bash scripts/workspace-api-routes-orbstack-test.sh",
     "test:workspace:switcher-ui": "tsx scripts/workspace-switcher-ui-test.ts",
     "test:workspace:appearance": "tsx scripts/workspace-appearance-theme-test.ts && tsx scripts/workspace-accent-ui-test.ts",
+    "test:workspace:branding": "tsx scripts/workspace-brand-workflow-ui-test.ts",
     "test:workspace:cross-copy": "tsx --conditions react-server scripts/workspace-cross-copy-test.ts",
     "test:workspace:reference-client": "tsx scripts/workspace-reference-client-test.ts",
     "test:workspace:trash-client": "tsx scripts/workspace-trash-client-test.ts",

--- a/package.json
+++ b/package.json
@@ -354,6 +354,7 @@
     "test:workspace:api-routes": "tsx --conditions react-server scripts/workspace-api-routes-postgres-runner.ts",
     "test:workspace:api-routes:orbstack": "bash scripts/workspace-api-routes-orbstack-test.sh",
     "test:workspace:switcher-ui": "tsx scripts/workspace-switcher-ui-test.ts",
+    "test:workspace:appearance": "tsx scripts/workspace-appearance-theme-test.ts && tsx scripts/workspace-accent-ui-test.ts",
     "test:workspace:cross-copy": "tsx --conditions react-server scripts/workspace-cross-copy-test.ts",
     "test:workspace:reference-client": "tsx scripts/workspace-reference-client-test.ts",
     "test:workspace:trash-client": "tsx scripts/workspace-trash-client-test.ts",

--- a/scripts/workspace-accent-ui-test.ts
+++ b/scripts/workspace-accent-ui-test.ts
@@ -11,7 +11,7 @@ const appearanceProviderSource = readFileSync(
 assert.match(appearanceProviderSource, /const activeWorkspace = useWorkspaceStore\(selectActiveWorkspace\)/u);
 assert.match(
   appearanceProviderSource,
-  /definition\?\.enabled[\s\S]*?applyWorkspaceAppearance[\s\S]*?applyWorkspaceAccent\(root, activeWorkspaceId, activeWorkspace\.color/u,
+  /definition\?\.enabled[\s\S]*?applyWorkspaceAppearance[\s\S]*?applyWorkspaceAccent\(root, workspaceId, activeWorkspace\.color/u,
   'The standard Canvas appearance must use the active workspace color without replacing a full brand profile.',
 );
 assert.match(appearanceProviderSource, /root\.dataset\.workspaceAppearance = 'accent'/u);

--- a/scripts/workspace-accent-ui-test.ts
+++ b/scripts/workspace-accent-ui-test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const appearanceProviderSource = readFileSync(
+  path.join(root, 'app/components/WorkspaceAppearanceProvider.tsx'),
+  'utf8',
+);
+
+assert.match(appearanceProviderSource, /const activeWorkspace = useWorkspaceStore\(selectActiveWorkspace\)/u);
+assert.match(
+  appearanceProviderSource,
+  /definition\?\.enabled[\s\S]*?applyWorkspaceAppearance[\s\S]*?applyWorkspaceAccent\(root, activeWorkspaceId, activeWorkspace\.color/u,
+  'The standard Canvas appearance must use the active workspace color without replacing a full brand profile.',
+);
+assert.match(appearanceProviderSource, /root\.dataset\.workspaceAppearance = 'accent'/u);
+assert.match(appearanceProviderSource, /WORKSPACE_ACCENT_CSS_PROPERTIES/u);
+
+console.log('workspace-accent-ui-test: ok');

--- a/scripts/workspace-appearance-theme-test.ts
+++ b/scripts/workspace-appearance-theme-test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 
 import {
+  createWorkspaceAccentCssTokens,
   createWorkspaceAppearanceCssTokens,
   normalizeWorkspaceAppearanceDefinition,
   workspaceAppearanceContrastRatio,
@@ -44,5 +45,18 @@ const dark = createWorkspaceAppearanceCssTokens(definition, 'dark');
 assert.notEqual(dark['--background'], light['--background']);
 assert.ok(workspaceAppearanceContrastRatio(dark['--foreground'], dark['--background']) >= 4.5);
 assert.ok(workspaceAppearanceContrastRatio(dark['--muted-foreground'], dark['--muted']) >= 4.5);
+
+const workspaceAccent = createWorkspaceAccentCssTokens('#047857', 'light');
+assert.equal(workspaceAccent['--primary'], '#047857');
+assert.equal(workspaceAccent['--ring'], workspaceAccent['--primary']);
+assert.equal(workspaceAccent['--sidebar-primary'], workspaceAccent['--primary']);
+assert.ok(workspaceAppearanceContrastRatio(workspaceAccent['--primary-foreground'], workspaceAccent['--primary']) >= 4.5);
+
+const darkWorkspaceAccent = createWorkspaceAccentCssTokens('#A16207', 'dark');
+assert.ok(workspaceAppearanceContrastRatio(darkWorkspaceAccent['--primary'], '#090c12') >= 3);
+assert.notEqual(darkWorkspaceAccent['--accent'], workspaceAccent['--accent']);
+
+const fallbackAccent = createWorkspaceAccentCssTokens('not-a-color', 'light');
+assert.equal(fallbackAccent['--primary'], '#2563eb');
 
 console.log('workspace-appearance-theme-test: ok');

--- a/scripts/workspace-brand-workflow-ui-test.ts
+++ b/scripts/workspace-brand-workflow-ui-test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { workspaceBrandDesignHref } from '../app/lib/workspaces/brand-navigation';
+
+const root = process.cwd();
+const readSource = (relativePath: string) => readFileSync(path.join(root, relativePath), 'utf8');
+const createDialogSource = readSource('app/components/settings/CreateWorkspaceDialog.tsx');
+const editDialogSource = readSource('app/components/settings/EditWorkspaceDialog.tsx');
+const brandPanelSource = readSource('app/components/settings/BrandSettingsPanel.tsx');
+const german = JSON.parse(readSource('messages/de.json')) as Record<string, unknown>;
+const english = JSON.parse(readSource('messages/en.json')) as Record<string, unknown>;
+
+assert.equal(
+  workspaceBrandDesignHref('workspace / 1'),
+  '/settings?tab=brand-design&scope=workspace&workspaceId=workspace+%2F+1',
+);
+assert.match(createDialogSource, /setCreatedWorkspace\(workspace\)/u);
+assert.doesNotMatch(createDialogSource, /workspace\.type === 'team'[\s\S]*?setCreatedWorkspace/u);
+assert.match(createDialogSource, /href=\{workspaceBrandDesignHref\(createdWorkspace\.id\)\}/u);
+assert.match(createDialogSource, /<WorkspaceIdentityMark workspace=\{createdWorkspace\}/u);
+assert.match(editDialogSource, /data-workspace-submit-intent="brand-design"/u);
+assert.match(editDialogSource, /router\.push\(workspaceBrandDesignHref\(workspace\.id\)\)/u);
+assert.match(brandPanelSource, /const requestedWorkspaceId = searchParams\.get\('workspaceId'\)/u);
+assert.match(
+  brandPanelSource,
+  /useState<string \| null>\(\(\) => requestedWorkspaceId\)/u,
+);
+
+for (const messages of [german, english]) {
+  const settings = messages.settings as Record<string, unknown>;
+  const settingsBrandDesign = settings.brandDesign as Record<string, unknown>;
+  const appearance = settingsBrandDesign.appearance as Record<string, unknown>;
+  const workspacePanel = settings.workspacePanel as Record<string, unknown>;
+  const management = workspacePanel.management as Record<string, unknown>;
+  const brandDesign = management.brandDesign as Record<string, unknown>;
+  const fields = management.fields as Record<string, unknown>;
+  const colorPicker = management.colorPicker as Record<string, unknown>;
+  assert.equal(typeof brandDesign.open, 'string');
+  assert.equal(typeof brandDesign.saveAndOpen, 'string');
+  assert.match(String(fields.color), /accent|Akzent/iu);
+  assert.match(String(colorPicker.hint), /accent|Akzent/iu);
+  assert.match(String(appearance.off), /accent|Akzent/iu);
+}
+
+console.log('workspace-brand-workflow-ui-test: ok');

--- a/scripts/workspace-switcher-ui-test.ts
+++ b/scripts/workspace-switcher-ui-test.ts
@@ -180,6 +180,18 @@ async function main() {
     path.join(process.cwd(), 'app', 'components', 'workspaces', 'WorkspaceSwitcher.tsx'),
     'utf8',
   );
+  const workspaceIdentityMarkSource = fs.readFileSync(
+    path.join(process.cwd(), 'app', 'components', 'workspaces', 'WorkspaceIdentityMark.tsx'),
+    'utf8',
+  );
+  const workspaceBadgeSource = fs.readFileSync(
+    path.join(process.cwd(), 'app', 'components', 'workspaces', 'WorkspaceBadge.tsx'),
+    'utf8',
+  );
+  const workspaceExportCardSource = fs.readFileSync(
+    path.join(process.cwd(), 'app', 'components', 'settings', 'WorkspaceExportCard.tsx'),
+    'utf8',
+  );
   assert.match(chatHeaderSource, /@container relative z-10/u);
   assert.match(chatHeaderSource, /\{sessionId \? \(/u);
   assert.match(chatHeaderSource, /hidden @\[44rem\]:inline-flex/u);
@@ -193,6 +205,12 @@ async function main() {
   );
   assert.match(workspaceSwitcherSource, /const mobileSheetOpen = controlledMobileSheetOpen \?\? internalMobileSheetOpen/u);
   assert.match(workspaceSwitcherSource, /\{!hideMobileSheetTrigger \? \(\s*<SheetTrigger asChild>/u);
+  assert.match(workspaceIdentityMarkSource, /data-workspace-color=\{color\}/u);
+  assert.match(workspaceIdentityMarkSource, /style=\{\{ backgroundColor: color \}\}/u);
+  assert.ok((workspaceSwitcherSource.match(/<WorkspaceIdentityMark/gu) || []).length >= 4);
+  assert.match(workspaceBadgeSource, /<WorkspaceIdentityMark/u);
+  assert.match(workspaceManagementCardSource, /<WorkspaceIdentityMark/u);
+  assert.match(workspaceExportCardSource, /<WorkspaceIdentityMark/u);
 
   const {
     WORKSPACE_CHANGED_EVENT,


### PR DESCRIPTION
## Summary

- show the configured workspace color as an identity mark in navigation, management, and export surfaces
- use the workspace color as the accent for the standard Canvas theme while preserving the existing base design
- keep enabled workspace appearance profiles as the higher-priority theme
- connect workspace creation and editing to the existing Brand Design and logo workflow
- update German and English workspace-branding copy

## Verification

- npm run build
- npm run test:workspace:branding
- npm run test:workspace:appearance
- npm run test:workspace:switcher-ui
- targeted ESLint checks for the changed workspace and branding files
- GitNexus staged change analysis

## Screenshots

Not included. Repository instructions require explicit approval before running Playwright, so browser-based UI capture was not performed.