### PR TITLE
Show mobile app promotion as a quiet popup

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -33,6 +33,10 @@ LOG_TO_STDOUT=false
 # you want to enable the in-app walkthrough for users.
 # ONBOARDING_HINTS=true
 
+# The Mobile App promotion remains off until the public App Store listing is ready.
+# It is shown only to eligible desktop users and is frequency-capped per account.
+# CANVAS_MOBILE_APP_PROMO_ENABLED=true
+
 # Browser-based exports (PDF/Marp/Mermaid) are CPU/RAM intensive.
 # Defaults are conservative for small Cube instances: one active job and one queued job.
 # CANVAS_BROWSER_EXPORT_MAX_QUEUE=1

--- a/app/api/mobile-app-promotion/route.ts
+++ b/app/api/mobile-app-promotion/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@/app/lib/auth';
+import { ensureUserExists } from '@/app/lib/db/ensure-user';
+import { parseMobileAppPromotionAction } from '@/app/lib/mobile/promotion-contract';
+import {
+  getMobileAppPromotionStatus,
+  recordMobileAppPromotionAction,
+} from '@/app/lib/mobile/promotion-state';
+
+export const dynamic = 'force-dynamic';
+
+const responseHeaders = {
+  'Cache-Control': 'no-store, max-age=0',
+  Vary: 'Cookie',
+  'X-Content-Type-Options': 'nosniff',
+};
+
+function unauthorized() {
+  return NextResponse.json(
+    { success: false, error: 'Unauthorized' },
+    { status: 401, headers: responseHeaders },
+  );
+}
+
+async function prepareUser(session: NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>) {
+  await ensureUserExists(session.user.id, {
+    name: session.user.name ?? undefined,
+    email: session.user.email ?? undefined,
+    image: session.user.image ?? undefined,
+    role: session.user.role ?? undefined,
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return unauthorized();
+
+  try {
+    await prepareUser(session);
+    const promotion = await getMobileAppPromotionStatus({ userId: session.user.id });
+    return NextResponse.json({ success: true, promotion }, { headers: responseHeaders });
+  } catch (error) {
+    console.error('[API] Mobile App promotion status failed:', error);
+    return NextResponse.json(
+      { success: false, error: 'Could not load Mobile App promotion status.' },
+      { status: 500, headers: responseHeaders },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return unauthorized();
+
+  const action = parseMobileAppPromotionAction(await request.json().catch(() => null));
+  if (!action) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid promotion action.' },
+      { status: 400, headers: responseHeaders },
+    );
+  }
+
+  try {
+    await prepareUser(session);
+    const result = await recordMobileAppPromotionAction({ userId: session.user.id, action });
+    return NextResponse.json({ success: true, ...result }, { headers: responseHeaders });
+  } catch (error) {
+    console.error('[API] Mobile App promotion action failed:', error);
+    return NextResponse.json(
+      { success: false, error: 'Could not update Mobile App promotion status.' },
+      { status: 500, headers: responseHeaders },
+    );
+  }
+}

--- a/app/components/home/HomeWorkspaceView.tsx
+++ b/app/components/home/HomeWorkspaceView.tsx
@@ -11,7 +11,7 @@ import { HomeAttentionPanel } from './HomeAttentionPanel';
 import { HomeFocusCards } from './HomeFocusCards';
 import { HomeAppLinks } from './HomeAppLinks';
 import { MoreToolsSection } from './MoreToolsSection';
-import { HomeMobileAppPromo } from '@/app/components/mobile/MobileAppSetupCard';
+import { HomeMobileAppPromo } from '@/app/components/mobile/HomeMobileAppPromo';
 
 export function HomeWorkspaceView({
   showBrowserLab = false,
@@ -96,7 +96,9 @@ export function HomeWorkspaceView({
         </section>
 
         <HomeFocusCards summary={summary} />
-        <HomeMobileAppPromo />
+        <HomeMobileAppPromo
+          hasPriorityAttention={Boolean(summary?.items.some((item) => item.unread && item.priority === 'high'))}
+        />
         <HomeAppLinks />
 
         <MoreToolsSection showBrowserLab={showBrowserLab} />

--- a/app/components/mobile/HomeMobileAppPromo.tsx
+++ b/app/components/mobile/HomeMobileAppPromo.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useHintContext } from '@/app/components/onboarding/HintProvider';
+import {
+  MOBILE_APP_PROMOTION_CTA_DELAY_MS,
+  MOBILE_APP_PROMOTION_REPEAT_DELAY_MS,
+  type MobileAppPromotionAction,
+  type MobileAppPromotionStatus,
+} from '@/app/lib/mobile/promotion-contract';
+import {
+  MobileAppSetupDialog,
+  type MobileAppSetupAction,
+} from './MobileAppSetupCard';
+
+const LEGACY_DISMISSAL_KEY = 'canvas-home-mobile-app-promo-v1';
+const LOCAL_FALLBACK_KEY = 'canvas-home-mobile-app-promo-v2';
+const SESSION_IMPRESSION_KEY = 'canvas-home-mobile-app-promo-v2-shown';
+const ACTIVE_USAGE_DELAY_MS = 45_000;
+const BLOCKED_RETRY_DELAY_MS = 15_000;
+const DESKTOP_MEDIA_QUERY = '(min-width: 900px)';
+
+type PromotionStatusResponse = {
+  success: boolean;
+  promotion?: MobileAppPromotionStatus;
+};
+
+type PromotionActionResponse = {
+  success: boolean;
+  recorded?: boolean;
+  status?: MobileAppPromotionStatus;
+};
+
+type LocalFallbackState = {
+  dismissedUntil?: string;
+  permanentlyDismissed?: boolean;
+};
+
+function readLocalFallback(now = Date.now()): LocalFallbackState | null {
+  try {
+    const raw = window.localStorage.getItem(LOCAL_FALLBACK_KEY);
+    if (!raw) return null;
+    const value = JSON.parse(raw) as LocalFallbackState;
+    if (value.permanentlyDismissed) return value;
+    if (value.dismissedUntil && new Date(value.dismissedUntil).getTime() > now) return value;
+    window.localStorage.removeItem(LOCAL_FALLBACK_KEY);
+  } catch {
+    // Server state remains authoritative if local storage is unavailable or malformed.
+  }
+  return null;
+}
+
+function writeLocalFallback(state: LocalFallbackState) {
+  try {
+    window.localStorage.setItem(LOCAL_FALLBACK_KEY, JSON.stringify(state));
+  } catch {
+    // The server state still prevents repeated impressions.
+  }
+}
+
+function markShownInSession() {
+  try {
+    window.sessionStorage.setItem(SESSION_IMPRESSION_KEY, 'shown');
+  } catch {
+    // The server-side impression cooldown is the durable fallback.
+  }
+}
+
+function wasShownInSession(): boolean {
+  try {
+    return window.sessionStorage.getItem(SESSION_IMPRESSION_KEY) === 'shown';
+  } catch {
+    return false;
+  }
+}
+
+function isDesktopViewport(): boolean {
+  if (typeof window.matchMedia === 'function') return window.matchMedia(DESKTOP_MEDIA_QUERY).matches;
+  return window.innerWidth >= 900;
+}
+
+function anotherDialogIsOpen(): boolean {
+  return document.querySelector('[role="dialog"]') !== null;
+}
+
+async function postPromotionAction(action: MobileAppPromotionAction): Promise<PromotionActionResponse | null> {
+  try {
+    const response = await fetch('/api/mobile-app-promotion', {
+      method: 'POST',
+      credentials: 'include',
+      cache: 'no-store',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(action),
+    });
+    if (!response.ok) return null;
+    return await response.json() as PromotionActionResponse;
+  } catch {
+    return null;
+  }
+}
+
+function updateFallbackFromStatus(status: MobileAppPromotionStatus | undefined) {
+  if (status?.permanentlyDismissedAt) {
+    writeLocalFallback({ permanentlyDismissed: true });
+  } else if (status?.dismissedUntil) {
+    writeLocalFallback({ dismissedUntil: status.dismissedUntil });
+  }
+}
+
+export function HomeMobileAppPromo({ hasPriorityAttention = false }: { hasPriorityAttention?: boolean }) {
+  const { showHint } = useHintContext();
+  const [eligible, setEligible] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!isDesktopViewport() || wasShownInSession() || readLocalFallback()) return;
+
+    async function loadEligibility() {
+      try {
+        if (window.localStorage.getItem(LEGACY_DISMISSAL_KEY) === 'dismissed') {
+          const dismissedUntil = new Date(Date.now() + MOBILE_APP_PROMOTION_REPEAT_DELAY_MS).toISOString();
+          writeLocalFallback({ dismissedUntil });
+          markShownInSession();
+          const result = await postPromotionAction({ action: 'dismissed', source: 'legacy' });
+          if (result?.success) {
+            window.localStorage.removeItem(LEGACY_DISMISSAL_KEY);
+            updateFallbackFromStatus(result.status);
+          }
+          return;
+        }
+
+        const response = await fetch('/api/mobile-app-promotion', {
+          credentials: 'include',
+          cache: 'no-store',
+        });
+        if (!response.ok) return;
+        const payload = await response.json() as PromotionStatusResponse;
+        if (!cancelled && payload.success && payload.promotion?.eligible) setEligible(true);
+      } catch {
+        // A promotion must never interfere with the home page when eligibility cannot be loaded.
+      }
+    }
+
+    void loadEligibility();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!eligible || open || showHint || hasPriorityAttention) return;
+
+    let cancelled = false;
+    let showTimer: number | undefined;
+
+    const attemptShow = async () => {
+      if (cancelled) return;
+      if (document.visibilityState !== 'visible' || anotherDialogIsOpen()) {
+        showTimer = window.setTimeout(() => void attemptShow(), BLOCKED_RETRY_DELAY_MS);
+        return;
+      }
+
+      const result = await postPromotionAction({ action: 'shown' });
+      if (cancelled) return;
+      if (result?.success && result.recorded) {
+        markShownInSession();
+        setEligible(false);
+        setOpen(true);
+        return;
+      }
+      if (result) setEligible(false);
+      else showTimer = window.setTimeout(() => void attemptShow(), BLOCKED_RETRY_DELAY_MS);
+    };
+
+    const startActiveUsageTimer = () => {
+      window.removeEventListener('pointerdown', startActiveUsageTimer);
+      window.removeEventListener('keydown', startActiveUsageTimer);
+      showTimer = window.setTimeout(() => void attemptShow(), ACTIVE_USAGE_DELAY_MS);
+    };
+
+    if (navigator.userActivation?.hasBeenActive) startActiveUsageTimer();
+    else {
+      window.addEventListener('pointerdown', startActiveUsageTimer, { once: true });
+      window.addEventListener('keydown', startActiveUsageTimer, { once: true });
+    }
+
+    return () => {
+      cancelled = true;
+      if (showTimer !== undefined) window.clearTimeout(showTimer);
+      window.removeEventListener('pointerdown', startActiveUsageTimer);
+      window.removeEventListener('keydown', startActiveUsageTimer);
+    };
+  }, [eligible, hasPriorityAttention, open, showHint]);
+
+  const dismiss = useCallback(() => {
+    setOpen(false);
+    const dismissedUntil = new Date(Date.now() + MOBILE_APP_PROMOTION_REPEAT_DELAY_MS).toISOString();
+    writeLocalFallback({ dismissedUntil });
+    void postPromotionAction({ action: 'dismissed', source: 'dialog' }).then((result) => {
+      updateFallbackFromStatus(result?.status);
+    });
+  }, []);
+
+  const permanentlyDismiss = useCallback(() => {
+    setOpen(false);
+    writeLocalFallback({ permanentlyDismissed: true });
+    void postPromotionAction({ action: 'permanently_dismissed' }).then((result) => {
+      updateFallbackFromStatus(result?.status);
+    });
+  }, []);
+
+  const recordAction = useCallback((action: MobileAppSetupAction) => {
+    writeLocalFallback({
+      dismissedUntil: new Date(Date.now() + MOBILE_APP_PROMOTION_CTA_DELAY_MS).toISOString(),
+    });
+    void postPromotionAction({ action: 'cta_clicked', kind: action }).then((result) => {
+      updateFallbackFromStatus(result?.status);
+    });
+  }, []);
+
+  return (
+    <MobileAppSetupDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && open) dismiss();
+      }}
+      onPermanentDismiss={permanentlyDismiss}
+      onAction={recordAction}
+    />
+  );
+}

--- a/app/components/mobile/MobileAppSetupCard.tsx
+++ b/app/components/mobile/MobileAppSetupCard.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useCallback, useEffect, useState } from 'react';
-import { ArrowUpRight, Check, Copy, Download, Loader2, QrCode, ShieldCheck, Smartphone, X } from 'lucide-react';
+import { ArrowUpRight, Check, Clock3, Copy, Download, Loader2, QrCode, ShieldCheck, Smartphone, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { QRCodeSVG } from 'qrcode.react';
 
@@ -13,13 +13,20 @@ import {
   type MobileSetupCompatibility,
 } from '@/app/lib/mobile/setup-link';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
-const HOME_PROMO_DISMISSAL_KEY = 'canvas-home-mobile-app-promo-v1';
+export type MobileAppSetupAction = 'open-app' | 'app-store' | 'copy-link';
 
 type MobileAppSetupCardProps = {
-  placement: 'home' | 'settings';
-  onDismiss?: () => void;
+  placement: 'dialog' | 'settings';
+  onAction?: (action: MobileAppSetupAction) => void;
 };
 
 type SetupState =
@@ -66,12 +73,12 @@ function useMobileSetupState(revision: number): SetupState {
   return state;
 }
 
-export function MobileAppSetupCard({ placement, onDismiss }: MobileAppSetupCardProps) {
+export function MobileAppSetupCard({ placement, onAction }: MobileAppSetupCardProps) {
   const t = useTranslations('mobileAppSetup');
   const [revision, setRevision] = useState(0);
   const [copied, setCopied] = useState(false);
   const state = useMobileSetupState(revision);
-  const isHome = placement === 'home';
+  const isDialog = placement === 'dialog';
   const serverLabel = state.status === 'ready'
     ? state.compatibility.instance.name
     : t('serverFallback');
@@ -82,41 +89,33 @@ export function MobileAppSetupCard({ placement, onDismiss }: MobileAppSetupCardP
     try {
       await navigator.clipboard.writeText(state.setupLink);
       setCopied(true);
+      onAction?.('copy-link');
       window.setTimeout(() => setCopied(false), 2_500);
     } catch {
       setCopied(false);
     }
-  }, [state]);
+  }, [onAction, state]);
 
   return (
     <section
       aria-labelledby={`mobile-app-setup-title-${placement}`}
       className={cn(
         'relative isolate overflow-hidden border border-border bg-card shadow-sm',
-        isHome ? 'min-h-[22rem]' : 'min-h-[30rem]',
+        isDialog ? 'min-h-[22rem] border-0 shadow-none' : 'min-h-[30rem]',
       )}
     >
       <div className="absolute inset-0 -z-20 bg-gradient-to-br from-card via-card to-muted/50" />
       <div className="absolute -left-24 -top-24 -z-10 h-72 w-72 rounded-full bg-primary/10 blur-3xl" />
       <div className="absolute inset-y-0 left-0 -z-10 w-px bg-primary" />
-      <div className="absolute right-5 top-5 flex items-center gap-2 text-[0.62rem] font-bold uppercase tracking-[0.2em] text-muted-foreground">
-        <span className="h-1.5 w-1.5 bg-emerald-500" aria-hidden="true" />
-        {t('available')}
-      </div>
-
-      {onDismiss ? (
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="absolute right-3 top-12 z-20 flex h-9 w-9 items-center justify-center border border-transparent text-muted-foreground transition-colors hover:border-border hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          aria-label={t('dismiss')}
-        >
-          <X className="h-4 w-4" />
-        </button>
+      {!isDialog ? (
+        <div className="absolute right-5 top-5 flex items-center gap-2 text-[0.62rem] font-bold uppercase tracking-[0.2em] text-muted-foreground">
+          <span className="h-1.5 w-1.5 bg-emerald-500" aria-hidden="true" />
+          {t('available')}
+        </div>
       ) : null}
 
-      <div className={cn('grid h-full', isHome ? 'lg:grid-cols-[minmax(0,1fr)_16rem]' : 'lg:grid-cols-[minmax(0,1fr)_20rem]')}>
-        <div className={cn('relative flex min-w-0 flex-col px-5 pb-5 pt-16 sm:px-7 sm:pb-7', !isHome && 'lg:px-10 lg:pb-10')}>
+      <div className={cn('grid h-full', isDialog ? 'lg:grid-cols-[minmax(0,1fr)_18rem]' : 'lg:grid-cols-[minmax(0,1fr)_20rem]')}>
+        <div className={cn('relative flex min-w-0 flex-col px-5 pb-5 sm:px-7 sm:pb-7', isDialog ? 'pt-7 sm:pt-9' : 'pt-16 lg:px-10 lg:pb-10')}>
           <div className="max-w-2xl">
             <div className="mb-5 flex items-center gap-3">
               <span className="flex h-10 w-10 items-center justify-center border border-primary/30 bg-primary/10 text-primary">
@@ -124,7 +123,7 @@ export function MobileAppSetupCard({ placement, onDismiss }: MobileAppSetupCardP
               </span>
               <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary">{t('eyebrow')}</p>
             </div>
-            <h3 id={`mobile-app-setup-title-${placement}`} className={cn('font-semibold leading-[1.05] tracking-[-0.04em]', isHome ? 'text-3xl sm:text-4xl' : 'text-4xl sm:text-5xl')}>
+            <h3 id={`mobile-app-setup-title-${placement}`} className={cn('font-semibold leading-[1.05] tracking-[-0.04em]', isDialog ? 'text-3xl sm:text-4xl' : 'text-4xl sm:text-5xl')}>
               {t('title')}
             </h3>
             <p className="mt-4 max-w-xl text-sm leading-6 text-muted-foreground sm:text-base sm:leading-7">
@@ -145,14 +144,14 @@ export function MobileAppSetupCard({ placement, onDismiss }: MobileAppSetupCardP
           <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
             {state.status === 'ready' ? (
               <Button asChild className="rounded-none">
-                <a href={state.setupLink}>
+                <a href={state.setupLink} onClick={() => onAction?.('open-app')}>
                   <Smartphone className="h-4 w-4" />
                   {t('openApp')}
                 </a>
               </Button>
             ) : null}
             <Button asChild variant="outline" className="rounded-none">
-              <a href={MOBILE_APP_STORE_URL} target="_blank" rel="noreferrer">
+              <a href={MOBILE_APP_STORE_URL} target="_blank" rel="noreferrer" onClick={() => onAction?.('app-store')}>
                 <Download className="h-4 w-4" />
                 {t('appStore')}
                 <ArrowUpRight className="h-3.5 w-3.5" />
@@ -229,33 +228,65 @@ export function MobileAppSetupCard({ placement, onDismiss }: MobileAppSetupCardP
   );
 }
 
-export function HomeMobileAppPromo() {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const frame = window.requestAnimationFrame(() => {
-      try {
-        setVisible(window.localStorage.getItem(HOME_PROMO_DISMISSAL_KEY) !== 'dismissed');
-      } catch {
-        setVisible(true);
-      }
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, []);
-
-  if (!visible) return null;
-
+export function MobileAppSetupDialog({
+  open,
+  onOpenChange,
+  onPermanentDismiss,
+  onAction,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPermanentDismiss: () => void;
+  onAction?: (action: MobileAppSetupAction) => void;
+}) {
+  const t = useTranslations('mobileAppSetup');
   return (
-    <MobileAppSetupCard
-      placement="home"
-      onDismiss={() => {
-        try {
-          window.localStorage.setItem(HOME_PROMO_DISMISSAL_KEY, 'dismissed');
-        } catch {
-          // The card can still be dismissed for this page view without persistent storage.
-        }
-        setVisible(false);
-      }}
-    />
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-h-[calc(100dvh-2rem)] max-w-[calc(100%-1.25rem)] gap-0 overflow-y-auto rounded-none border-border p-0 shadow-2xl sm:max-w-5xl"
+      >
+        <DialogTitle className="sr-only">{t('title')}</DialogTitle>
+        <DialogDescription className="sr-only">{t('description')}</DialogDescription>
+
+        <header className="flex min-h-16 items-center justify-between gap-4 border-b border-border bg-background px-4 sm:px-6">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center border border-primary/30 bg-primary/10 text-primary">
+              <Smartphone className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold">Canvas Mobile</p>
+              <p className="mt-0.5 flex items-center gap-2 text-[0.62rem] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+                <span className="h-1.5 w-1.5 bg-emerald-500" aria-hidden="true" />
+                {t('available')}
+              </p>
+            </div>
+          </div>
+          <DialogClose asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-11 w-11 shrink-0 rounded-none"
+              aria-label={t('dismiss')}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </DialogClose>
+        </header>
+
+        <MobileAppSetupCard placement="dialog" onAction={onAction} />
+
+        <footer className="flex flex-col gap-3 border-t border-border bg-muted/25 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-7">
+          <p className="flex items-center gap-2 text-xs leading-5 text-muted-foreground">
+            <Clock3 className="h-4 w-4 shrink-0" aria-hidden="true" />
+            {t('reminderHint')}
+          </p>
+          <Button type="button" variant="ghost" className="h-10 justify-start rounded-none sm:justify-center" onClick={onPermanentDismiss}>
+            {t('neverShow')}
+          </Button>
+        </footer>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/app/lib/db/migrate.ts
+++ b/app/lib/db/migrate.ts
@@ -1753,6 +1753,21 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
       FOREIGN KEY (user_id) REFERENCES user(id)
     );
 
+    CREATE TABLE IF NOT EXISTS mobile_app_promotion_states (
+      user_id TEXT PRIMARY KEY NOT NULL,
+      promotion_version INTEGER NOT NULL DEFAULT 1,
+      impression_count INTEGER NOT NULL DEFAULT 0,
+      dismissal_count INTEGER NOT NULL DEFAULT 0,
+      last_shown_at INTEGER,
+      dismissed_until INTEGER,
+      permanently_dismissed_at INTEGER,
+      cta_clicked_at INTEGER,
+      last_action TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+    );
+
     CREATE TABLE IF NOT EXISTS onboarding_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
       completed_at INTEGER NOT NULL,
@@ -2454,6 +2469,7 @@ export function runMigrations(sqlite: InstanceType<typeof Database>): void {
     CREATE INDEX IF NOT EXISTS idx_user_hint_state_user_page ON user_hint_state (user_id, page);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_page_onboarding_state_user_page ON page_onboarding_state (user_id, page);
     CREATE INDEX IF NOT EXISTS idx_page_onboarding_state_user_completed ON page_onboarding_state (user_id, completed);
+    CREATE INDEX IF NOT EXISTS idx_mobile_app_promotion_dismissed_until ON mobile_app_promotion_states (dismissed_until);
     CREATE INDEX IF NOT EXISTS idx_oauth_tokens_provider ON oauth_tokens (provider);
     CREATE INDEX IF NOT EXISTS idx_oauth_tokens_valid ON oauth_tokens (provider, is_valid);
     CREATE INDEX IF NOT EXISTS idx_license_certs_instance ON license_certs (instance_id);

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -2115,6 +2115,22 @@ export const pageOnboardingState = sqliteTable("page_onboarding_state", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });
 
+export const mobileAppPromotionStates = sqliteTable("mobile_app_promotion_states", {
+  userId: text("user_id").primaryKey().references(() => user.id, { onDelete: "cascade" }),
+  promotionVersion: integer("promotion_version").notNull().default(1),
+  impressionCount: integer("impression_count").notNull().default(0),
+  dismissalCount: integer("dismissal_count").notNull().default(0),
+  lastShownAt: integer("last_shown_at", { mode: "timestamp" }),
+  dismissedUntil: integer("dismissed_until", { mode: "timestamp" }),
+  permanentlyDismissedAt: integer("permanently_dismissed_at", { mode: "timestamp" }),
+  ctaClickedAt: integer("cta_clicked_at", { mode: "timestamp" }),
+  lastAction: text("last_action"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+}, (table) => ({
+  dismissedUntilIdx: index("idx_mobile_app_promotion_dismissed_until").on(table.dismissedUntil),
+}));
+
 export const automationRuns = sqliteTable("automation_runs", {
   id: text("id").primaryKey(),
   jobId: text("job_id").notNull().references(() => automationJobs.id),

--- a/app/lib/mobile/promotion-contract.ts
+++ b/app/lib/mobile/promotion-contract.ts
@@ -1,0 +1,53 @@
+export const MOBILE_APP_PROMOTION_VERSION = 2;
+export const MOBILE_APP_PROMOTION_INITIAL_DELAY_MS = 48 * 60 * 60 * 1_000;
+export const MOBILE_APP_PROMOTION_REPEAT_DELAY_MS = 30 * 24 * 60 * 60 * 1_000;
+export const MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS = 90 * 24 * 60 * 60 * 1_000;
+export const MOBILE_APP_PROMOTION_CTA_DELAY_MS = 180 * 24 * 60 * 60 * 1_000;
+export const MOBILE_APP_PROMOTION_EXTENDED_DELAY_AFTER_DISMISSALS = 3;
+
+export type MobileAppPromotionReason =
+  | 'eligible'
+  | 'rollout_disabled'
+  | 'new_account'
+  | 'mobile_device_registered'
+  | 'permanently_dismissed'
+  | 'cooldown';
+
+export type MobileAppPromotionStatus = {
+  eligible: boolean;
+  reason: MobileAppPromotionReason;
+  version: number;
+  impressionCount: number;
+  dismissalCount: number;
+  lastShownAt: string | null;
+  dismissedUntil: string | null;
+  permanentlyDismissedAt: string | null;
+  ctaClickedAt: string | null;
+};
+
+export type MobileAppPromotionAction =
+  | { action: 'shown' }
+  | { action: 'dismissed'; source?: 'dialog' | 'legacy' }
+  | { action: 'permanently_dismissed' }
+  | { action: 'cta_clicked'; kind: 'open-app' | 'app-store' | 'copy-link' };
+
+export function parseMobileAppPromotionAction(value: unknown): MobileAppPromotionAction | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.action === 'shown') return { action: 'shown' };
+  if (candidate.action === 'permanently_dismissed') return { action: 'permanently_dismissed' };
+  if (candidate.action === 'dismissed') {
+    const source = candidate.source;
+    if (source === undefined || source === 'dialog' || source === 'legacy') {
+      return { action: 'dismissed', source };
+    }
+    return null;
+  }
+  if (candidate.action === 'cta_clicked') {
+    const kind = candidate.kind;
+    if (kind === 'open-app' || kind === 'app-store' || kind === 'copy-link') {
+      return { action: 'cta_clicked', kind };
+    }
+  }
+  return null;
+}

--- a/app/lib/mobile/promotion-state.ts
+++ b/app/lib/mobile/promotion-state.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull, lte, ne, or, sql } from 'drizzle-orm';
 
 import { db } from '@/app/lib/db';
 import { mobileAppPromotionStates, mobilePushDevices, user } from '@/app/lib/db/schema';
@@ -118,6 +118,56 @@ function baseValues(userId: string, now: Date) {
   };
 }
 
+function preservedPromotionFields() {
+  return {
+    impressionCount: sql<number>`case
+      when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+        then ${mobileAppPromotionStates.impressionCount}
+      else 0
+    end`,
+    dismissalCount: sql<number>`case
+      when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+        then ${mobileAppPromotionStates.dismissalCount}
+      else 0
+    end`,
+    lastShownAt: sql<Date | null>`case
+      when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+        then ${mobileAppPromotionStates.lastShownAt}
+      else null
+    end`,
+    dismissedUntil: sql<Date | null>`case
+      when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+        then ${mobileAppPromotionStates.dismissedUntil}
+      else null
+    end`,
+    permanentlyDismissedAt: sql<Date | null>`case
+      when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+        then ${mobileAppPromotionStates.permanentlyDismissedAt}
+      else null
+    end`,
+    ctaClickedAt: sql<Date | null>`case
+      when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+        then ${mobileAppPromotionStates.ctaClickedAt}
+      else null
+    end`,
+  };
+}
+
+function latestPromotionAuditFields(lastAction: string, nowSeconds: number) {
+  return {
+    lastAction: sql<string>`case
+      when ${mobileAppPromotionStates.promotionVersion} != ${MOBILE_APP_PROMOTION_VERSION}
+        or ${mobileAppPromotionStates.updatedAt} <= ${nowSeconds}
+        then ${lastAction}
+      else ${mobileAppPromotionStates.lastAction}
+    end`,
+    updatedAt: sql<Date>`case
+      when ${mobileAppPromotionStates.updatedAt} < ${nowSeconds} then ${nowSeconds}
+      else ${mobileAppPromotionStates.updatedAt}
+    end`,
+  };
+}
+
 export async function recordMobileAppPromotionAction(input: {
   userId: string;
   action: MobileAppPromotionAction;
@@ -125,56 +175,101 @@ export async function recordMobileAppPromotionAction(input: {
   rolloutEnabled?: boolean;
 }): Promise<{ recorded: boolean; status: MobileAppPromotionStatus }> {
   const now = input.now ?? new Date();
-  const snapshot = await loadPromotionSnapshot(input.userId);
-  const existing = currentVersionRow(snapshot.row);
   const rolloutEnabled = input.rolloutEnabled ?? isMobileAppPromotionRolloutEnabled();
+  const nowSeconds = Math.floor(now.getTime() / 1_000);
 
   if (input.action.action === 'shown') {
+    const snapshot = await loadPromotionSnapshot(input.userId);
     const before = evaluateMobileAppPromotion({ ...snapshot, now, rolloutEnabled });
     if (!before.eligible) return { recorded: false, status: before };
-    const impressionCount = (existing?.impressionCount ?? 0) + 1;
-    await db.insert(mobileAppPromotionStates).values({
+
+    const repeatCutoff = new Date(now.getTime() - MOBILE_APP_PROMOTION_REPEAT_DELAY_MS);
+    const rows = await db.insert(mobileAppPromotionStates).values({
       ...baseValues(input.userId, now),
-      impressionCount,
+      impressionCount: 1,
       lastShownAt: now,
       lastAction: 'shown',
     }).onConflictDoUpdate({
       target: mobileAppPromotionStates.userId,
       set: {
         promotionVersion: MOBILE_APP_PROMOTION_VERSION,
-        impressionCount,
-        dismissalCount: existing?.dismissalCount ?? 0,
+        ...preservedPromotionFields(),
+        impressionCount: sql<number>`case
+          when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+            then ${mobileAppPromotionStates.impressionCount} + 1
+          else 1
+        end`,
         lastShownAt: now,
-        dismissedUntil: existing?.dismissedUntil ?? null,
-        permanentlyDismissedAt: existing?.permanentlyDismissedAt ?? null,
-        ctaClickedAt: existing?.ctaClickedAt ?? null,
-        lastAction: 'shown',
-        updatedAt: now,
+        ...latestPromotionAuditFields('shown', nowSeconds),
       },
-    });
+      setWhere: or(
+        ne(mobileAppPromotionStates.promotionVersion, MOBILE_APP_PROMOTION_VERSION),
+        and(
+          isNull(mobileAppPromotionStates.permanentlyDismissedAt),
+          or(
+            isNull(mobileAppPromotionStates.dismissedUntil),
+            lte(mobileAppPromotionStates.dismissedUntil, now),
+          ),
+          or(
+            isNull(mobileAppPromotionStates.lastShownAt),
+            lte(mobileAppPromotionStates.lastShownAt, repeatCutoff),
+          ),
+        ),
+      ),
+    }).returning({ userId: mobileAppPromotionStates.userId });
+
+    if (rows.length === 0) {
+      return {
+        recorded: false,
+        status: await getMobileAppPromotionStatus({ userId: input.userId, now, rolloutEnabled }),
+      };
+    }
   } else if (input.action.action === 'dismissed') {
-    const dismissalCount = (existing?.dismissalCount ?? 0) + 1;
-    const delay = dismissalCount >= MOBILE_APP_PROMOTION_EXTENDED_DELAY_AFTER_DISMISSALS
-      ? MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS
-      : MOBILE_APP_PROMOTION_REPEAT_DELAY_MS;
-    const dismissedUntil = new Date(now.getTime() + delay);
+    const dismissedUntil = new Date(now.getTime() + MOBILE_APP_PROMOTION_REPEAT_DELAY_MS);
+    const dismissedUntilSeconds = Math.floor(dismissedUntil.getTime() / 1_000);
+    const extendedUntil = new Date(now.getTime() + MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS);
+    const extendedUntilSeconds = Math.floor(extendedUntil.getTime() / 1_000);
+    const lastAction = input.action.source === 'legacy' ? 'dismissed:legacy' : 'dismissed:dialog';
+
     await db.insert(mobileAppPromotionStates).values({
       ...baseValues(input.userId, now),
-      dismissalCount,
+      dismissalCount: 1,
       dismissedUntil,
-      lastAction: input.action.source === 'legacy' ? 'dismissed:legacy' : 'dismissed:dialog',
+      lastAction,
     }).onConflictDoUpdate({
       target: mobileAppPromotionStates.userId,
       set: {
         promotionVersion: MOBILE_APP_PROMOTION_VERSION,
-        impressionCount: existing?.impressionCount ?? 0,
-        dismissalCount,
-        lastShownAt: existing?.lastShownAt ?? null,
-        dismissedUntil,
-        permanentlyDismissedAt: existing?.permanentlyDismissedAt ?? null,
-        ctaClickedAt: existing?.ctaClickedAt ?? null,
-        lastAction: input.action.source === 'legacy' ? 'dismissed:legacy' : 'dismissed:dialog',
-        updatedAt: now,
+        ...preservedPromotionFields(),
+        dismissalCount: sql<number>`case
+          when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+            then ${mobileAppPromotionStates.dismissalCount} + 1
+          else 1
+        end`,
+        dismissedUntil: sql<Date>`case
+          when (
+            case
+              when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+                then ${mobileAppPromotionStates.dismissalCount} + 1
+              else 1
+            end
+          ) >= ${MOBILE_APP_PROMOTION_EXTENDED_DELAY_AFTER_DISMISSALS}
+            then case
+              when ${mobileAppPromotionStates.promotionVersion} != ${MOBILE_APP_PROMOTION_VERSION}
+                or ${mobileAppPromotionStates.dismissedUntil} is null
+                or ${mobileAppPromotionStates.dismissedUntil} < ${extendedUntilSeconds}
+                then ${extendedUntilSeconds}
+              else ${mobileAppPromotionStates.dismissedUntil}
+            end
+          else case
+            when ${mobileAppPromotionStates.promotionVersion} != ${MOBILE_APP_PROMOTION_VERSION}
+              or ${mobileAppPromotionStates.dismissedUntil} is null
+              or ${mobileAppPromotionStates.dismissedUntil} < ${dismissedUntilSeconds}
+              then ${dismissedUntilSeconds}
+            else ${mobileAppPromotionStates.dismissedUntil}
+          end
+        end`,
+        ...latestPromotionAuditFields(lastAction, nowSeconds),
       },
     });
   } else if (input.action.action === 'permanently_dismissed') {
@@ -186,35 +281,46 @@ export async function recordMobileAppPromotionAction(input: {
       target: mobileAppPromotionStates.userId,
       set: {
         promotionVersion: MOBILE_APP_PROMOTION_VERSION,
-        impressionCount: existing?.impressionCount ?? 0,
-        dismissalCount: existing?.dismissalCount ?? 0,
-        lastShownAt: existing?.lastShownAt ?? null,
-        dismissedUntil: existing?.dismissedUntil ?? null,
-        permanentlyDismissedAt: now,
-        ctaClickedAt: existing?.ctaClickedAt ?? null,
-        lastAction: 'permanently_dismissed',
-        updatedAt: now,
+        ...preservedPromotionFields(),
+        permanentlyDismissedAt: sql<Date>`case
+          when ${mobileAppPromotionStates.promotionVersion} = ${MOBILE_APP_PROMOTION_VERSION}
+            and ${mobileAppPromotionStates.permanentlyDismissedAt} is not null
+            then ${mobileAppPromotionStates.permanentlyDismissedAt}
+          else ${nowSeconds}
+        end`,
+        ...latestPromotionAuditFields('permanently_dismissed', nowSeconds),
       },
     });
   } else {
     const dismissedUntil = new Date(now.getTime() + MOBILE_APP_PROMOTION_CTA_DELAY_MS);
+    const dismissedUntilSeconds = Math.floor(dismissedUntil.getTime() / 1_000);
+    const lastAction = `cta_clicked:${input.action.kind}`;
+
     await db.insert(mobileAppPromotionStates).values({
       ...baseValues(input.userId, now),
       dismissedUntil,
       ctaClickedAt: now,
-      lastAction: `cta_clicked:${input.action.kind}`,
+      lastAction,
     }).onConflictDoUpdate({
       target: mobileAppPromotionStates.userId,
       set: {
         promotionVersion: MOBILE_APP_PROMOTION_VERSION,
-        impressionCount: existing?.impressionCount ?? 0,
-        dismissalCount: existing?.dismissalCount ?? 0,
-        lastShownAt: existing?.lastShownAt ?? null,
-        dismissedUntil,
-        permanentlyDismissedAt: existing?.permanentlyDismissedAt ?? null,
-        ctaClickedAt: now,
-        lastAction: `cta_clicked:${input.action.kind}`,
-        updatedAt: now,
+        ...preservedPromotionFields(),
+        dismissedUntil: sql<Date>`case
+          when ${mobileAppPromotionStates.promotionVersion} != ${MOBILE_APP_PROMOTION_VERSION}
+            or ${mobileAppPromotionStates.dismissedUntil} is null
+            or ${mobileAppPromotionStates.dismissedUntil} < ${dismissedUntilSeconds}
+            then ${dismissedUntilSeconds}
+          else ${mobileAppPromotionStates.dismissedUntil}
+        end`,
+        ctaClickedAt: sql<Date>`case
+          when ${mobileAppPromotionStates.promotionVersion} != ${MOBILE_APP_PROMOTION_VERSION}
+            or ${mobileAppPromotionStates.ctaClickedAt} is null
+            or ${mobileAppPromotionStates.ctaClickedAt} < ${nowSeconds}
+            then ${nowSeconds}
+          else ${mobileAppPromotionStates.ctaClickedAt}
+        end`,
+        ...latestPromotionAuditFields(lastAction, nowSeconds),
       },
     });
   }

--- a/app/lib/mobile/promotion-state.ts
+++ b/app/lib/mobile/promotion-state.ts
@@ -1,0 +1,226 @@
+import 'server-only';
+
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/app/lib/db';
+import { mobileAppPromotionStates, mobilePushDevices, user } from '@/app/lib/db/schema';
+import {
+  MOBILE_APP_PROMOTION_CTA_DELAY_MS,
+  MOBILE_APP_PROMOTION_EXTENDED_DELAY_AFTER_DISMISSALS,
+  MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS,
+  MOBILE_APP_PROMOTION_INITIAL_DELAY_MS,
+  MOBILE_APP_PROMOTION_REPEAT_DELAY_MS,
+  MOBILE_APP_PROMOTION_VERSION,
+  type MobileAppPromotionAction,
+  type MobileAppPromotionReason,
+  type MobileAppPromotionStatus,
+} from './promotion-contract';
+
+type PromotionRow = typeof mobileAppPromotionStates.$inferSelect;
+
+type PromotionSnapshot = {
+  accountCreatedAt: Date;
+  hasRegisteredMobileDevice: boolean;
+  row: PromotionRow | null;
+};
+
+export type MobileAppPromotionEvaluation = {
+  rolloutEnabled: boolean;
+  now: Date;
+  accountCreatedAt: Date;
+  hasRegisteredMobileDevice: boolean;
+  row: PromotionRow | null;
+};
+
+export function isMobileAppPromotionRolloutEnabled(
+  value = process.env.CANVAS_MOBILE_APP_PROMO_ENABLED,
+): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(value?.trim().toLowerCase() ?? '');
+}
+
+function currentVersionRow(row: PromotionRow | null): PromotionRow | null {
+  return row?.promotionVersion === MOBILE_APP_PROMOTION_VERSION ? row : null;
+}
+
+function dateString(value: Date | null | undefined): string | null {
+  return value ? value.toISOString() : null;
+}
+
+export function evaluateMobileAppPromotion(input: MobileAppPromotionEvaluation): MobileAppPromotionStatus {
+  const row = currentVersionRow(input.row);
+  let reason: MobileAppPromotionReason = 'eligible';
+
+  if (!input.rolloutEnabled) reason = 'rollout_disabled';
+  else if (input.hasRegisteredMobileDevice) reason = 'mobile_device_registered';
+  else if (row?.permanentlyDismissedAt) reason = 'permanently_dismissed';
+  else if (input.now.getTime() - input.accountCreatedAt.getTime() < MOBILE_APP_PROMOTION_INITIAL_DELAY_MS) {
+    reason = 'new_account';
+  } else if (
+    (row?.dismissedUntil && row.dismissedUntil.getTime() > input.now.getTime())
+    || (row?.lastShownAt && input.now.getTime() - row.lastShownAt.getTime() < MOBILE_APP_PROMOTION_REPEAT_DELAY_MS)
+  ) {
+    reason = 'cooldown';
+  }
+
+  return {
+    eligible: reason === 'eligible',
+    reason,
+    version: MOBILE_APP_PROMOTION_VERSION,
+    impressionCount: row?.impressionCount ?? 0,
+    dismissalCount: row?.dismissalCount ?? 0,
+    lastShownAt: dateString(row?.lastShownAt),
+    dismissedUntil: dateString(row?.dismissedUntil),
+    permanentlyDismissedAt: dateString(row?.permanentlyDismissedAt),
+    ctaClickedAt: dateString(row?.ctaClickedAt),
+  };
+}
+
+async function loadPromotionSnapshot(userId: string): Promise<PromotionSnapshot> {
+  const [userRows, stateRows, deviceRows] = await Promise.all([
+    db.select({ createdAt: user.createdAt }).from(user).where(eq(user.id, userId)).limit(1),
+    db.select().from(mobileAppPromotionStates).where(eq(mobileAppPromotionStates.userId, userId)).limit(1),
+    db.select({ id: mobilePushDevices.id }).from(mobilePushDevices).where(eq(mobilePushDevices.userId, userId)).limit(1),
+  ]);
+
+  return {
+    accountCreatedAt: userRows[0]?.createdAt ?? new Date(),
+    hasRegisteredMobileDevice: deviceRows.length > 0,
+    row: stateRows[0] ?? null,
+  };
+}
+
+export async function getMobileAppPromotionStatus(input: {
+  userId: string;
+  now?: Date;
+  rolloutEnabled?: boolean;
+}): Promise<MobileAppPromotionStatus> {
+  const snapshot = await loadPromotionSnapshot(input.userId);
+  return evaluateMobileAppPromotion({
+    ...snapshot,
+    now: input.now ?? new Date(),
+    rolloutEnabled: input.rolloutEnabled ?? isMobileAppPromotionRolloutEnabled(),
+  });
+}
+
+function baseValues(userId: string, now: Date) {
+  return {
+    userId,
+    promotionVersion: MOBILE_APP_PROMOTION_VERSION,
+    impressionCount: 0,
+    dismissalCount: 0,
+    lastShownAt: null,
+    dismissedUntil: null,
+    permanentlyDismissedAt: null,
+    ctaClickedAt: null,
+    lastAction: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function recordMobileAppPromotionAction(input: {
+  userId: string;
+  action: MobileAppPromotionAction;
+  now?: Date;
+  rolloutEnabled?: boolean;
+}): Promise<{ recorded: boolean; status: MobileAppPromotionStatus }> {
+  const now = input.now ?? new Date();
+  const snapshot = await loadPromotionSnapshot(input.userId);
+  const existing = currentVersionRow(snapshot.row);
+  const rolloutEnabled = input.rolloutEnabled ?? isMobileAppPromotionRolloutEnabled();
+
+  if (input.action.action === 'shown') {
+    const before = evaluateMobileAppPromotion({ ...snapshot, now, rolloutEnabled });
+    if (!before.eligible) return { recorded: false, status: before };
+    const impressionCount = (existing?.impressionCount ?? 0) + 1;
+    await db.insert(mobileAppPromotionStates).values({
+      ...baseValues(input.userId, now),
+      impressionCount,
+      lastShownAt: now,
+      lastAction: 'shown',
+    }).onConflictDoUpdate({
+      target: mobileAppPromotionStates.userId,
+      set: {
+        promotionVersion: MOBILE_APP_PROMOTION_VERSION,
+        impressionCount,
+        dismissalCount: existing?.dismissalCount ?? 0,
+        lastShownAt: now,
+        dismissedUntil: existing?.dismissedUntil ?? null,
+        permanentlyDismissedAt: existing?.permanentlyDismissedAt ?? null,
+        ctaClickedAt: existing?.ctaClickedAt ?? null,
+        lastAction: 'shown',
+        updatedAt: now,
+      },
+    });
+  } else if (input.action.action === 'dismissed') {
+    const dismissalCount = (existing?.dismissalCount ?? 0) + 1;
+    const delay = dismissalCount >= MOBILE_APP_PROMOTION_EXTENDED_DELAY_AFTER_DISMISSALS
+      ? MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS
+      : MOBILE_APP_PROMOTION_REPEAT_DELAY_MS;
+    const dismissedUntil = new Date(now.getTime() + delay);
+    await db.insert(mobileAppPromotionStates).values({
+      ...baseValues(input.userId, now),
+      dismissalCount,
+      dismissedUntil,
+      lastAction: input.action.source === 'legacy' ? 'dismissed:legacy' : 'dismissed:dialog',
+    }).onConflictDoUpdate({
+      target: mobileAppPromotionStates.userId,
+      set: {
+        promotionVersion: MOBILE_APP_PROMOTION_VERSION,
+        impressionCount: existing?.impressionCount ?? 0,
+        dismissalCount,
+        lastShownAt: existing?.lastShownAt ?? null,
+        dismissedUntil,
+        permanentlyDismissedAt: existing?.permanentlyDismissedAt ?? null,
+        ctaClickedAt: existing?.ctaClickedAt ?? null,
+        lastAction: input.action.source === 'legacy' ? 'dismissed:legacy' : 'dismissed:dialog',
+        updatedAt: now,
+      },
+    });
+  } else if (input.action.action === 'permanently_dismissed') {
+    await db.insert(mobileAppPromotionStates).values({
+      ...baseValues(input.userId, now),
+      permanentlyDismissedAt: now,
+      lastAction: 'permanently_dismissed',
+    }).onConflictDoUpdate({
+      target: mobileAppPromotionStates.userId,
+      set: {
+        promotionVersion: MOBILE_APP_PROMOTION_VERSION,
+        impressionCount: existing?.impressionCount ?? 0,
+        dismissalCount: existing?.dismissalCount ?? 0,
+        lastShownAt: existing?.lastShownAt ?? null,
+        dismissedUntil: existing?.dismissedUntil ?? null,
+        permanentlyDismissedAt: now,
+        ctaClickedAt: existing?.ctaClickedAt ?? null,
+        lastAction: 'permanently_dismissed',
+        updatedAt: now,
+      },
+    });
+  } else {
+    const dismissedUntil = new Date(now.getTime() + MOBILE_APP_PROMOTION_CTA_DELAY_MS);
+    await db.insert(mobileAppPromotionStates).values({
+      ...baseValues(input.userId, now),
+      dismissedUntil,
+      ctaClickedAt: now,
+      lastAction: `cta_clicked:${input.action.kind}`,
+    }).onConflictDoUpdate({
+      target: mobileAppPromotionStates.userId,
+      set: {
+        promotionVersion: MOBILE_APP_PROMOTION_VERSION,
+        impressionCount: existing?.impressionCount ?? 0,
+        dismissalCount: existing?.dismissalCount ?? 0,
+        lastShownAt: existing?.lastShownAt ?? null,
+        dismissedUntil,
+        permanentlyDismissedAt: existing?.permanentlyDismissedAt ?? null,
+        ctaClickedAt: now,
+        lastAction: `cta_clicked:${input.action.kind}`,
+        updatedAt: now,
+      },
+    });
+  }
+
+  return {
+    recorded: true,
+    status: await getMobileAppPromotionStatus({ userId: input.userId, now, rolloutEnabled }),
+  };
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -2120,6 +2120,8 @@
   "mobileAppSetup": {
     "available": "Für iPhone verfügbar",
     "dismiss": "Hinweis zur Mobile App ausblenden",
+    "reminderHint": "Beim Schließen erinnern wir dich frühestens in 30 Tagen wieder.",
+    "neverShow": "Nicht mehr anzeigen",
     "eyebrow": "Canvas für unterwegs",
     "title": "Nimm dein Notebook einfach mit.",
     "description": "Scanne den QR-Code mit deinem iPhone. Canvas Mobile öffnet sich mit genau diesem Server – du musst nur noch deine normalen Zugangsdaten eingeben.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2121,6 +2121,8 @@
   "mobileAppSetup": {
     "available": "Available for iPhone",
     "dismiss": "Dismiss the Mobile App notice",
+    "reminderHint": "If you close this, we will wait at least 30 days before reminding you again.",
+    "neverShow": "Don't show this again",
     "eyebrow": "Canvas on the go",
     "title": "Take your notebook with you.",
     "description": "Scan the QR code with your iPhone. Canvas Mobile opens with this exact server selected – all that remains is signing in with your normal credentials.",

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "test:composio:user-scope": "tsx scripts/composio-user-scope-test.ts",
     "test:auth:setup": "tsx --conditions react-server scripts/auth-setup-test.ts",
     "test:auth:seat-limit": "tsx --conditions react-server scripts/auth-seat-limit-test.ts",
-    "test:mobile:compatibility": "tsx --conditions react-server scripts/mobile-compatibility-test.ts && tsx --conditions react-server scripts/mobile-compatibility-route-test.ts && tsx --conditions react-server scripts/mobile-app-promotion-test.ts && tsx scripts/mobile-setup-link-test.ts && tsx scripts/mobile-setup-card-ui-test.tsx",
+    "test:mobile:compatibility": "tsx --conditions react-server scripts/mobile-compatibility-test.ts && tsx --conditions react-server scripts/mobile-compatibility-route-test.ts && tsx --conditions react-server scripts/mobile-app-promotion-test.ts && tsx --conditions react-server scripts/mobile-app-promotion-postgres-test.ts && tsx scripts/mobile-setup-link-test.ts && tsx scripts/mobile-setup-card-ui-test.tsx",
     "test:mobile:bootstrap": "tsx --conditions react-server scripts/mobile-bootstrap-test.ts && tsx --conditions react-server scripts/mobile-bootstrap-route-test.ts",
     "test:mobile:account": "tsx --conditions react-server scripts/mobile-account-preferences-test.ts && tsx --conditions react-server scripts/mobile-account-profile-test.ts",
     "test:mobile:brand": "tsx --conditions react-server scripts/mobile-workspace-brand-route-test.ts",

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "test:composio:user-scope": "tsx scripts/composio-user-scope-test.ts",
     "test:auth:setup": "tsx --conditions react-server scripts/auth-setup-test.ts",
     "test:auth:seat-limit": "tsx --conditions react-server scripts/auth-seat-limit-test.ts",
-    "test:mobile:compatibility": "tsx --conditions react-server scripts/mobile-compatibility-test.ts && tsx --conditions react-server scripts/mobile-compatibility-route-test.ts && tsx scripts/mobile-setup-link-test.ts && tsx scripts/mobile-setup-card-ui-test.tsx",
+    "test:mobile:compatibility": "tsx --conditions react-server scripts/mobile-compatibility-test.ts && tsx --conditions react-server scripts/mobile-compatibility-route-test.ts && tsx --conditions react-server scripts/mobile-app-promotion-test.ts && tsx scripts/mobile-setup-link-test.ts && tsx scripts/mobile-setup-card-ui-test.tsx",
     "test:mobile:bootstrap": "tsx --conditions react-server scripts/mobile-bootstrap-test.ts && tsx --conditions react-server scripts/mobile-bootstrap-route-test.ts",
     "test:mobile:account": "tsx --conditions react-server scripts/mobile-account-preferences-test.ts && tsx --conditions react-server scripts/mobile-account-profile-test.ts",
     "test:mobile:brand": "tsx --conditions react-server scripts/mobile-workspace-brand-route-test.ts",

--- a/scripts/mobile-app-promotion-postgres-test.ts
+++ b/scripts/mobile-app-promotion-postgres-test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+
+import { PGlite } from '@electric-sql/pglite';
+
+import { runPostgresMigrations } from '../app/lib/db/postgres';
+
+type PgQueryable = Parameters<typeof runPostgresMigrations>[0];
+
+async function main() {
+  const postgres = new PGlite();
+  try {
+    await runPostgresMigrations(postgres as unknown as PgQueryable);
+
+    const columns = await postgres.query<{ column_name: string }>(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'mobile_app_promotion_states'
+      ORDER BY ordinal_position
+    `);
+    assert.deepEqual(columns.rows.map((row) => row.column_name), [
+      'user_id',
+      'promotion_version',
+      'impression_count',
+      'dismissal_count',
+      'last_shown_at',
+      'dismissed_until',
+      'permanently_dismissed_at',
+      'cta_clicked_at',
+      'last_action',
+      'created_at',
+      'updated_at',
+    ]);
+
+    const indexes = await postgres.query<{ indexname: string }>(`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'mobile_app_promotion_states'
+    `);
+    assert.ok(indexes.rows.some((row) => row.indexname === 'idx_mobile_app_promotion_dismissed_until'));
+  } finally {
+    await postgres.close();
+  }
+
+  console.log('mobile-app-promotion-postgres-test: ok');
+}
+
+void main();

--- a/scripts/mobile-app-promotion-test.ts
+++ b/scripts/mobile-app-promotion-test.ts
@@ -3,6 +3,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import { eq } from 'drizzle-orm';
+
 async function main() {
   const dataDir = await mkdtemp(path.join(os.tmpdir(), 'canvas-mobile-promotion-'));
   const previousData = process.env.DATA;
@@ -12,6 +14,7 @@ async function main() {
     const { db } = await import('../app/lib/db');
     const { mobileAppPromotionStates, mobilePushDevices, session, user } = await import('../app/lib/db/schema');
     const {
+      MOBILE_APP_PROMOTION_CTA_DELAY_MS,
       MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS,
       MOBILE_APP_PROMOTION_REPEAT_DELAY_MS,
       parseMobileAppPromotionAction,
@@ -94,6 +97,97 @@ async function main() {
     assert.equal(
       Math.floor((rows[0]?.dismissedUntil?.getTime() ?? 0) / 1_000),
       Math.floor((lastDismissalAt.getTime() + MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS) / 1_000),
+    );
+
+    const concurrentShownUserId = 'mobile-promo-concurrent-shown';
+    await db.insert(user).values({
+      id: concurrentShownUserId,
+      name: 'Concurrent Shown User',
+      email: 'mobile-promo-concurrent-shown@example.test',
+      emailVerified: true,
+      role: 'user',
+      createdAt: accountCreatedAt,
+      updatedAt: accountCreatedAt,
+    });
+    const concurrentShown = await Promise.all(Array.from({ length: 8 }, () => (
+      recordMobileAppPromotionAction({
+        userId: concurrentShownUserId,
+        action: { action: 'shown' },
+        now,
+        rolloutEnabled: true,
+      })
+    )));
+    assert.equal(concurrentShown.filter((result) => result.recorded).length, 1);
+    assert.equal(
+      (await getMobileAppPromotionStatus({ userId: concurrentShownUserId, now, rolloutEnabled: true })).impressionCount,
+      1,
+    );
+
+    const concurrentDismissUserId = 'mobile-promo-concurrent-dismiss';
+    await db.insert(user).values({
+      id: concurrentDismissUserId,
+      name: 'Concurrent Dismiss User',
+      email: 'mobile-promo-concurrent-dismiss@example.test',
+      emailVerified: true,
+      role: 'user',
+      createdAt: accountCreatedAt,
+      updatedAt: accountCreatedAt,
+    });
+    await Promise.all(Array.from({ length: 8 }, () => (
+      recordMobileAppPromotionAction({
+        userId: concurrentDismissUserId,
+        action: { action: 'dismissed', source: 'dialog' },
+        now,
+        rolloutEnabled: true,
+      })
+    )));
+    const [concurrentDismissRow] = await db.select()
+      .from(mobileAppPromotionStates)
+      .where(eq(mobileAppPromotionStates.userId, concurrentDismissUserId));
+    assert.equal(concurrentDismissRow?.dismissalCount, 8);
+    assert.equal(
+      concurrentDismissRow?.dismissedUntil?.getTime(),
+      now.getTime() + MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS,
+    );
+
+    const concurrentOptOutUserId = 'mobile-promo-concurrent-opt-out';
+    await db.insert(user).values({
+      id: concurrentOptOutUserId,
+      name: 'Concurrent Opt-out User',
+      email: 'mobile-promo-concurrent-opt-out@example.test',
+      emailVerified: true,
+      role: 'user',
+      createdAt: accountCreatedAt,
+      updatedAt: accountCreatedAt,
+    });
+    await Promise.all([
+      recordMobileAppPromotionAction({
+        userId: concurrentOptOutUserId,
+        action: { action: 'permanently_dismissed' },
+        now,
+        rolloutEnabled: true,
+      }),
+      recordMobileAppPromotionAction({
+        userId: concurrentOptOutUserId,
+        action: { action: 'cta_clicked', kind: 'open-app' },
+        now,
+        rolloutEnabled: true,
+      }),
+      recordMobileAppPromotionAction({
+        userId: concurrentOptOutUserId,
+        action: { action: 'dismissed', source: 'dialog' },
+        now,
+        rolloutEnabled: true,
+      }),
+    ]);
+    const [concurrentOptOutRow] = await db.select()
+      .from(mobileAppPromotionStates)
+      .where(eq(mobileAppPromotionStates.userId, concurrentOptOutUserId));
+    assert.ok(concurrentOptOutRow?.permanentlyDismissedAt);
+    assert.equal(concurrentOptOutRow?.dismissalCount, 1);
+    assert.equal(
+      concurrentOptOutRow?.dismissedUntil?.getTime(),
+      now.getTime() + MOBILE_APP_PROMOTION_CTA_DELAY_MS,
     );
 
     const authSessionId = 'mobile-promo-session';

--- a/scripts/mobile-app-promotion-test.ts
+++ b/scripts/mobile-app-promotion-test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+async function main() {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), 'canvas-mobile-promotion-'));
+  const previousData = process.env.DATA;
+  process.env.DATA = dataDir;
+
+  try {
+    const { db } = await import('../app/lib/db');
+    const { mobileAppPromotionStates, mobilePushDevices, session, user } = await import('../app/lib/db/schema');
+    const {
+      MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS,
+      MOBILE_APP_PROMOTION_REPEAT_DELAY_MS,
+      parseMobileAppPromotionAction,
+    } = await import('../app/lib/mobile/promotion-contract');
+    const {
+      evaluateMobileAppPromotion,
+      getMobileAppPromotionStatus,
+      recordMobileAppPromotionAction,
+    } = await import('../app/lib/mobile/promotion-state');
+
+    const now = new Date('2026-09-04T12:00:00.000Z');
+    const accountCreatedAt = new Date('2026-08-01T12:00:00.000Z');
+    const userId = 'mobile-promo-user';
+    await db.insert(user).values({
+      id: userId,
+      name: 'Mobile Promo User',
+      email: 'mobile-promo@example.test',
+      emailVerified: true,
+      role: 'user',
+      createdAt: accountCreatedAt,
+      updatedAt: accountCreatedAt,
+    });
+
+    assert.deepEqual(parseMobileAppPromotionAction({ action: 'shown' }), { action: 'shown' });
+    assert.deepEqual(parseMobileAppPromotionAction({ action: 'cta_clicked', kind: 'copy-link' }), {
+      action: 'cta_clicked',
+      kind: 'copy-link',
+    });
+    assert.equal(parseMobileAppPromotionAction({ action: 'cta_clicked', kind: 'unknown' }), null);
+
+    const disabled = evaluateMobileAppPromotion({
+      rolloutEnabled: false,
+      now,
+      accountCreatedAt,
+      hasRegisteredMobileDevice: false,
+      row: null,
+    });
+    assert.equal(disabled.reason, 'rollout_disabled');
+
+    const initial = await getMobileAppPromotionStatus({ userId, now, rolloutEnabled: true });
+    assert.equal(initial.eligible, true);
+
+    const shown = await recordMobileAppPromotionAction({
+      userId,
+      action: { action: 'shown' },
+      now,
+      rolloutEnabled: true,
+    });
+    assert.equal(shown.recorded, true);
+    assert.equal(shown.status.reason, 'cooldown');
+    assert.equal(shown.status.impressionCount, 1);
+
+    const duplicateShown = await recordMobileAppPromotionAction({
+      userId,
+      action: { action: 'shown' },
+      now,
+      rolloutEnabled: true,
+    });
+    assert.equal(duplicateShown.recorded, false);
+    assert.equal(duplicateShown.status.impressionCount, 1);
+
+    const afterRepeatDelay = new Date(now.getTime() + MOBILE_APP_PROMOTION_REPEAT_DELAY_MS + 1);
+    assert.equal((await getMobileAppPromotionStatus({ userId, now: afterRepeatDelay, rolloutEnabled: true })).eligible, true);
+
+    let dismissalTime = afterRepeatDelay;
+    let lastDismissalAt = dismissalTime;
+    for (let dismissal = 1; dismissal <= 3; dismissal += 1) {
+      lastDismissalAt = dismissalTime;
+      const result = await recordMobileAppPromotionAction({
+        userId,
+        action: { action: 'dismissed', source: 'dialog' },
+        now: dismissalTime,
+        rolloutEnabled: true,
+      });
+      assert.equal(result.status.dismissalCount, dismissal);
+      dismissalTime = new Date(dismissalTime.getTime() + MOBILE_APP_PROMOTION_REPEAT_DELAY_MS + 1);
+    }
+    const rows = await db.select().from(mobileAppPromotionStates);
+    assert.equal(rows[0]?.lastAction, 'dismissed:dialog');
+    assert.equal(
+      Math.floor((rows[0]?.dismissedUntil?.getTime() ?? 0) / 1_000),
+      Math.floor((lastDismissalAt.getTime() + MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS) / 1_000),
+    );
+
+    const authSessionId = 'mobile-promo-session';
+    await db.insert(session).values({
+      id: authSessionId,
+      userId,
+      token: 'mobile-promo-token',
+      expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(mobilePushDevices).values({
+      id: 'mobile-promo-device',
+      installationId: 'cmi_mobilepromotestdevice',
+      userId,
+      authSessionId,
+      expoPushToken: 'ExponentPushToken[mobile-promo-test]',
+      platform: 'ios',
+      appVariant: 'production',
+      enabled: true,
+      agentResponseReady: true,
+      todoAttention: true,
+      emailReview: true,
+      studioCompleted: true,
+      failureAttention: true,
+      automationRunStatus: false,
+      previewEnabled: false,
+      lastRegisteredAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const afterExtendedDelay = new Date(dismissalTime.getTime() + MOBILE_APP_PROMOTION_EXTENDED_DELAY_MS);
+    const mobileUserStatus = await getMobileAppPromotionStatus({
+      userId,
+      now: afterExtendedDelay,
+      rolloutEnabled: true,
+    });
+    assert.equal(mobileUserStatus.reason, 'mobile_device_registered');
+
+    console.log('mobile-app-promotion-test: ok');
+  } finally {
+    if (previousData === undefined) delete process.env.DATA;
+    else process.env.DATA = previousData;
+    await rm(dataDir, { recursive: true, force: true });
+  }
+}
+
+void main();

--- a/scripts/mobile-setup-card-ui-test.tsx
+++ b/scripts/mobile-setup-card-ui-test.tsx
@@ -4,11 +4,6 @@ import { NextIntlClientProvider } from 'next-intl';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import {
-  HomeMobileAppPromo,
-  MobileAppSetupCard,
-} from '../app/components/mobile/MobileAppSetupCard';
-
 const dom = new JSDOM('<!doctype html><html><body></body></html>', {
   pretendToBeVisual: true,
   url: 'https://notebook.example.com/de',
@@ -17,8 +12,16 @@ Object.defineProperty(globalThis, 'window', { value: dom.window, configurable: t
 Object.defineProperty(globalThis, 'document', { value: dom.window.document, configurable: true });
 Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
 Object.defineProperty(globalThis, 'HTMLElement', { value: dom.window.HTMLElement, configurable: true });
+Object.defineProperty(globalThis, 'HTMLInputElement', { value: dom.window.HTMLInputElement, configurable: true });
+Object.defineProperty(globalThis, 'HTMLButtonElement', { value: dom.window.HTMLButtonElement, configurable: true });
+Object.defineProperty(globalThis, 'HTMLAnchorElement', { value: dom.window.HTMLAnchorElement, configurable: true });
 Object.defineProperty(globalThis, 'SVGElement', { value: dom.window.SVGElement, configurable: true });
 Object.defineProperty(globalThis, 'Node', { value: dom.window.Node, configurable: true });
+Object.defineProperty(globalThis, 'NodeFilter', { value: dom.window.NodeFilter, configurable: true });
+Object.defineProperty(globalThis, 'Event', { value: dom.window.Event, configurable: true });
+Object.defineProperty(globalThis, 'CustomEvent', { value: dom.window.CustomEvent, configurable: true });
+Object.defineProperty(globalThis, 'MutationObserver', { value: dom.window.MutationObserver, configurable: true });
+Object.defineProperty(globalThis, 'getComputedStyle', { value: dom.window.getComputedStyle, configurable: true });
 Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true, configurable: true });
 
 const instanceId = 'cni_0123456789abcdef01234567';
@@ -42,6 +45,8 @@ const messages = {
   mobileAppSetup: {
     available: 'Available for iPhone',
     dismiss: 'Dismiss the Mobile App notice',
+    reminderHint: 'We will wait before reminding you again.',
+    neverShow: "Don't show this again",
     eyebrow: 'Canvas on the go',
     title: 'Take your notebook with you.',
     description: 'Scan the QR code with your iPhone.',
@@ -86,6 +91,8 @@ function renderWithMessages(container: HTMLElement, children: React.ReactNode) {
 }
 
 async function main() {
+  const { MobileAppSetupCard, MobileAppSetupDialog } = await import('../app/components/mobile/MobileAppSetupCard');
+  const { HomeMobileAppPromo } = await import('../app/components/mobile/HomeMobileAppPromo');
   const settingsContainer = document.createElement('div');
   document.body.appendChild(settingsContainer);
   let settingsRoot: ReturnType<typeof createRoot>;
@@ -112,39 +119,50 @@ async function main() {
   await act(async () => settingsRoot!.unmount());
   settingsContainer.remove();
 
+  const dialogContainer = document.createElement('div');
+  document.body.appendChild(dialogContainer);
+  let dialogRoot: ReturnType<typeof createRoot>;
+  let dialogOpen = true;
+  let permanentlyDismissed = false;
+  await act(async () => {
+    dialogRoot = renderWithMessages(dialogContainer, (
+      <MobileAppSetupDialog
+        open={dialogOpen}
+        onOpenChange={(open) => { dialogOpen = open; }}
+        onPermanentDismiss={() => { permanentlyDismissed = true; }}
+      />
+    ));
+  });
+  await settle();
+  assert.match(document.body.textContent ?? '', /Take your notebook with you\./u);
+  assert.match(document.body.textContent ?? '', /We will wait before reminding you again\./u);
+  assert.equal(document.body.querySelector('[role="dialog"]') !== null, true);
+  assert.equal(document.body.querySelector('img[alt="Bradley, the Canvas mascot"]') !== null, true);
+
+  const dismissButton = document.body.querySelector<HTMLButtonElement>('button[aria-label="Dismiss the Mobile App notice"]');
+  assert.ok(dismissButton);
+  await act(async () => {
+    dismissButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  });
+  assert.equal(dialogOpen, false);
+  assert.equal(permanentlyDismissed, false);
+
+  await act(async () => dialogRoot!.unmount());
+  dialogContainer.remove();
+
   window.localStorage.clear();
+  window.sessionStorage.clear();
   const homeContainer = document.createElement('div');
   document.body.appendChild(homeContainer);
   let homeRoot: ReturnType<typeof createRoot>;
   await act(async () => {
     homeRoot = renderWithMessages(homeContainer, <HomeMobileAppPromo />);
   });
-  await settle(25);
   await settle();
-  assert.match(homeContainer.textContent ?? '', /Take your notebook with you\./u);
-
-  const dismissButton = homeContainer.querySelector<HTMLButtonElement>('button[aria-label="Dismiss the Mobile App notice"]');
-  assert.ok(dismissButton);
-  await act(async () => {
-    dismissButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
-  });
-  assert.equal(homeContainer.textContent, '');
-  assert.equal(window.localStorage.getItem('canvas-home-mobile-app-promo-v1'), 'dismissed');
+  assert.equal(homeContainer.textContent, '', 'The home promotion must not be embedded or open immediately');
 
   await act(async () => homeRoot!.unmount());
   homeContainer.remove();
-
-  const dismissedContainer = document.createElement('div');
-  document.body.appendChild(dismissedContainer);
-  let dismissedRoot: ReturnType<typeof createRoot>;
-  await act(async () => {
-    dismissedRoot = renderWithMessages(dismissedContainer, <HomeMobileAppPromo />);
-  });
-  await settle(25);
-  assert.equal(dismissedContainer.textContent, '');
-
-  await act(async () => dismissedRoot!.unmount());
-  dismissedContainer.remove();
   console.log('mobile setup card UI test: ok');
 }
 

--- a/scripts/mobile-setup-link-test.ts
+++ b/scripts/mobile-setup-link-test.ts
@@ -32,13 +32,18 @@ assert.equal(isMobileSetupCompatibility({
 }), false);
 
 const setupCardSource = readFileSync('app/components/mobile/MobileAppSetupCard.tsx', 'utf8');
+const homePromoSource = readFileSync('app/components/mobile/HomeMobileAppPromo.tsx', 'utf8');
 const homeSource = readFileSync('app/components/home/HomeWorkspaceView.tsx', 'utf8');
 const settingsNavigationSource = readFileSync('app/components/settings/SettingsNavigation.tsx', 'utf8');
 const settingsClientSource = readFileSync('app/components/settings/IntegrationsSettingsClient.tsx', 'utf8');
 assert.match(setupCardSource, /<QRCodeSVG/u);
 assert.match(setupCardSource, /bradley-character-starter\.png/u);
-assert.match(setupCardSource, /HOME_PROMO_DISMISSAL_KEY/u);
-assert.match(homeSource, /<HomeMobileAppPromo \/>/u);
+assert.match(setupCardSource, /<DialogContent/u);
+assert.match(setupCardSource, /onPermanentDismiss/u);
+assert.match(homePromoSource, /ACTIVE_USAGE_DELAY_MS\s*=\s*45_000/u);
+assert.match(homePromoSource, /SESSION_IMPRESSION_KEY/u);
+assert.match(homePromoSource, /LEGACY_DISMISSAL_KEY/u);
+assert.match(homeSource, /<HomeMobileAppPromo/u);
 assert.match(settingsNavigationSource, /value: 'mobile-app'/u);
 assert.match(settingsClientSource, /<MobileAppSetupCard placement="settings" \/>/u);
 


### PR DESCRIPTION
## Summary

- replaces the embedded home-page mobile card with a Bradley setup dialog that has a dedicated, accessible close area
- waits for meaningful user activity and 45 seconds before showing the promotion, and suppresses it during onboarding, other dialogs, high-priority notifications, and mobile use
- stores per-user impressions, dismissals, CTA activity, cooldowns, and permanent opt-out server-side with a local fallback
- keeps the Mobile App setup card permanently available in Settings
- leaves the promotion disabled by default until the App Store listing is ready; enable it with `CANVAS_MOBILE_APP_PROMO_ENABLED=true`

## Frequency policy

- first eligible display: at least 48 hours after account creation
- normal reminder: after 30 days
- after three dismissals: after 90 days
- after a setup CTA: after 180 days
- at most once per browser session

## Testing

- `npm run test:mobile:compatibility`
- `npm run lint`
- `npm run build`
- SQLite and PostgreSQL migration coverage
- DOM-level dialog and delayed-display contract coverage

## Screenshots

- Not captured because browser automation was not authorized for this task. The dialog DOM contract is covered by the UI test.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the home-page mobile card with a delayed, frequency-capped setup dialog backed by per-user promotion state.
- Adds authenticated promotion status and action endpoints.
- Persists impressions, dismissals, CTA cooldowns, and permanent opt-outs using atomic conflict updates.
- Suppresses the dialog during onboarding, priority notifications, other dialogs, mobile use, and the current browser session.
- Adds SQLite, PostgreSQL migration, concurrency, and dialog contract coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported lost-update issue is fixed by atomic conflict updates that preserve permanent opt-outs and later cooldowns, increment counters in the database, and reject concurrent duplicate impressions; no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/mobile/promotion-state.ts | Implements eligibility evaluation and atomic conflict updates that preserve counters, later cooldowns, and permanent opt-outs during concurrent actions. |
| app/api/mobile-app-promotion/route.ts | Adds authenticated, non-cacheable endpoints for reading and updating promotion state. |
| app/components/mobile/HomeMobileAppPromo.tsx | Coordinates delayed eligibility checks, suppression conditions, session limits, local fallback state, and dialog actions. |
| app/components/mobile/MobileAppSetupCard.tsx | Refactors the setup card for settings and dialog placements and adds accessible dismissal and permanent opt-out controls. |
| app/lib/db/schema.ts | Defines the per-user promotion state table and cooldown index. |
| app/lib/db/migrate.ts | Adds the corresponding promotion-state table and index to SQLite migrations. |
| scripts/mobile-app-promotion-test.ts | Covers eligibility, frequency policy, duplicate impressions, concurrent counters, cooldown preservation, and permanent opt-out preservation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Home promotion dialog
  participant API as Promotion API
  participant DB as Promotion state
  UI->>API: GET eligibility
  API->>DB: Load account, device, and promotion state
  DB-->>API: Current snapshot
  API-->>UI: Eligibility and cooldown status
  UI->>UI: Wait for activity and 45-second delay
  UI->>API: POST shown
  API->>DB: Atomic guarded upsert
  DB-->>API: Recorded or rejected
  API-->>UI: Updated status
  UI->>API: POST dismissal, opt-out, or CTA
  API->>DB: Atomic monotonic state update
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Make mobile promotion updates atomic"](https://github.com/canvascoding/canvas-notebook/commit/7283b66356b5387f30cb7ecfe1a2ade337a01f74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60526481)</sub>

<!-- /greptile_comment -->