### PR TITLE
Harden in-app update lifecycle

### DIFF
--- a/.github/workflows/build-both.yml
+++ b/.github/workflows/build-both.yml
@@ -86,6 +86,7 @@ jobs:
           npm run test:install:managed-env
           npm run test:cli:updater
           npm run test:install:updater
+          npm run test:system-updates
 
       - name: Verify update rollback and CLI artifact gate
         run: |
@@ -98,6 +99,7 @@ jobs:
         run: |
           npm run test:release:payload
           npm run test:release:host-cli
+          npm run test:release:updates
 
   build-amd64:
     runs-on: ubuntu-latest
@@ -576,6 +578,30 @@ jobs:
           fs.writeFileSync('dist-release/canvas-notebook-release-metadata.json', `${JSON.stringify(metadata, null, 2)}\n`);
           NODE
 
+      - name: Sign standalone update manifest
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          RELEASE_TAG: ${{ needs.source.outputs.release_tag }}
+          RELEASE_COMMIT_SHA: ${{ needs.source.outputs.commit_sha }}
+          RELEASE_RUN_ID: ${{ github.run_id }}
+          CANVAS_UPDATE_SIGNING_KEY_ID: canvas-updates-2026-09
+          CANVAS_UPDATE_SIGNING_PRIVATE_KEY: ${{ secrets.CANVAS_UPDATE_SIGNING_PRIVATE_KEY }}
+        run: >-
+          npx --no-install tsx scripts/system-update-release.ts sign
+          dist-release/canvas-notebook-release-metadata.json
+          dist-release/canvas-notebook-update-stable.json
+
+      - name: Upload signed standalone update metadata
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v7
+        with:
+          name: standalone-update-${{ needs.source.outputs.release_version }}
+          if-no-files-found: error
+          retention-days: 90
+          path: |
+            dist-release/canvas-notebook-release-metadata.json
+            dist-release/canvas-notebook-update-stable.json
+
       - name: Upload gated release bundle
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v7
@@ -595,3 +621,4 @@ jobs:
             dist-native-compliance/canvas-native-compliance-${{ needs.source.outputs.release_version }}.tar.gz
             dist-native-compliance/canvas-native-compliance-${{ needs.source.outputs.release_version }}.sha256
             dist-release/canvas-notebook-release-metadata.json
+            dist-release/canvas-notebook-update-stable.json

--- a/.github/workflows/build-both.yml
+++ b/.github/workflows/build-both.yml
@@ -25,7 +25,7 @@ jobs:
       release_version: ${{ steps.release.outputs.release_version }}
     steps:
       - name: Checkout release metadata source
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
@@ -56,12 +56,12 @@ jobs:
     needs: source
     steps:
       - name: Checkout immutable release source
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.source.outputs.commit_sha }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 26
 
@@ -111,13 +111,13 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.source.outputs.commit_sha }}
 
       - name: Set up Node.js for amd64 Linux CLI
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
           cache: npm
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload amd64 Linux CLI release asset
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-cli-amd64-${{ needs.source.outputs.release_version }}
           if-no-files-found: error
@@ -146,24 +146,24 @@ jobs:
         run: echo "GHCR_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile
@@ -204,7 +204,7 @@ jobs:
           echo "f41285b61bfb495605494f074ca341f7791a1d406e2f157dcea606ef1ae1b146  runtime-compliance/amd64/vips-8.18.3.tar.xz" | sha256sum -c -
 
       - name: Upload amd64 native compliance evidence
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: runtime-compliance-amd64
           path: runtime-compliance/amd64
@@ -221,13 +221,13 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.source.outputs.commit_sha }}
 
       - name: Set up Node.js for arm64 Linux CLI
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
           cache: npm
@@ -242,7 +242,7 @@ jobs:
 
       - name: Upload arm64 Linux CLI release asset
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-cli-arm64-${{ needs.source.outputs.release_version }}
           if-no-files-found: error
@@ -256,24 +256,24 @@ jobs:
         run: echo "GHCR_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile
@@ -314,7 +314,7 @@ jobs:
           echo "f41285b61bfb495605494f074ca341f7791a1d406e2f157dcea606ef1ae1b146  runtime-compliance/arm64/vips-8.18.3.tar.xz" | sha256sum -c -
 
       - name: Upload arm64 native compliance evidence
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: runtime-compliance-arm64
           path: runtime-compliance/arm64
@@ -329,12 +329,12 @@ jobs:
     needs: [source, safety-tests, build-amd64, build-arm64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.source.outputs.commit_sha }}
 
       - name: Set up Node.js for compliance and release assets
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 26
 
@@ -346,27 +346,27 @@ jobs:
         run: echo "GHCR_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
       - name: Download amd64 native compliance evidence
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: runtime-compliance-amd64
           path: runtime-compliance/amd64
 
       - name: Download arm64 native compliance evidence
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: runtime-compliance-arm64
           path: runtime-compliance/arm64
 
       - name: Download amd64 Linux CLI release asset
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: linux-cli-amd64-${{ needs.source.outputs.release_version }}
           path: dist-linux-cli/amd64
 
       - name: Download arm64 Linux CLI release asset
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: linux-cli-arm64-${{ needs.source.outputs.release_version }}
           path: dist-linux-cli/arm64
@@ -403,7 +403,7 @@ jobs:
           (cd dist-native-compliance && sha256sum "${asset}.tar.gz" > "${asset}.sha256")
 
       - name: Upload native compliance release evidence
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: native-compliance-${{ needs.source.outputs.release_version }}
           path: |
@@ -413,17 +413,17 @@ jobs:
           retention-days: 90
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -593,7 +593,7 @@ jobs:
 
       - name: Upload signed standalone update metadata
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: standalone-update-${{ needs.source.outputs.release_version }}
           if-no-files-found: error
@@ -604,7 +604,7 @@ jobs:
 
       - name: Upload gated release bundle
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-bundle-${{ needs.source.outputs.release_version }}
           if-no-files-found: error

--- a/.github/workflows/publish-standalone-update.yml
+++ b/.github/workflows/publish-standalone-update.yml
@@ -1,0 +1,101 @@
+name: Publish Standalone Update
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Already published stable release tag to verify and repair
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: standalone-update-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && !github.event.release.draft)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: canvascoding/canvas-notebook
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - name: Check stable release identity
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REPOSITORY" == "$GH_REPO" ]]
+          [[ "$RELEASE_TAG" =~ ^v[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(\.[0-9]+)?$ ]]
+          gh release view "$RELEASE_TAG" --json tagName,isDraft,isPrerelease |
+            jq -e --arg tag "$RELEASE_TAG" '.tagName == $tag and .isDraft == false and .isPrerelease == false'
+
+      - name: Checkout exact release source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Find successful build for this exact tag
+        run: |
+          set -euo pipefail
+          release_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          [[ "$(git rev-parse HEAD)" == "$release_sha" ]]
+          [[ "v$(node -p "require('./package.json').version")" == "$RELEASE_TAG" ]]
+          run_id="$(gh run list --workflow build-both.yml --event push --branch "$RELEASE_TAG" \
+            --commit "$release_sha" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
+          [[ "$run_id" =~ ^[0-9]+$ ]]
+          gh api "repos/${GH_REPO}/actions/runs/${run_id}" |
+            jq -e --arg sha "$release_sha" --arg tag "$RELEASE_TAG" \
+              '.head_sha == $sha and .head_branch == $tag and .event == "push" and
+               .path == ".github/workflows/build-both.yml" and .conclusion == "success"'
+          echo "RELEASE_COMMIT_SHA=${release_sha}" >> "$GITHUB_ENV"
+          echo "RELEASE_RUN_ID=${run_id}" >> "$GITHUB_ENV"
+
+      - name: Download signed artifact and published release inputs
+        run: |
+          set -euo pipefail
+          gh run download "$RELEASE_RUN_ID" --name "standalone-update-${RELEASE_TAG#v}" --dir signed-update
+          gh release download "$RELEASE_TAG" --dir published-update \
+            --pattern canvas-notebook-release-metadata.json \
+            --pattern canvas-notebook-linux-cli-amd64.tar.gz \
+            --pattern canvas-notebook-linux-cli-arm64.tar.gz
+          cmp signed-update/canvas-notebook-release-metadata.json published-update/canvas-notebook-release-metadata.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+
+      - name: Install verification dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Verify signature, provenance, and public CLI bytes
+        run: >-
+          npx --no-install tsx scripts/system-update-release.ts verify
+          published-update/canvas-notebook-release-metadata.json
+          signed-update/canvas-notebook-update-stable.json
+          published-update
+
+      - name: Attach verified standalone update manifest
+        run: |
+          set -euo pipefail
+          asset_name=canvas-notebook-update-stable.json
+          asset_count="$(gh release view "$RELEASE_TAG" --json assets \
+            --jq '[.assets[] | select(.name == "canvas-notebook-update-stable.json")] | length')"
+          if [[ "$asset_count" == 0 ]]; then
+            # Never overwrite a published manifest. Retrying with identical bytes is safe.
+            gh release upload "$RELEASE_TAG" "signed-update/${asset_name}"
+          else
+            [[ "$asset_count" == 1 ]]
+          fi
+          gh release download "$RELEASE_TAG" --pattern "$asset_name" --dir verified-update
+          cmp "signed-update/${asset_name}" "verified-update/${asset_name}"

--- a/.github/workflows/publish-standalone-update.yml
+++ b/.github/workflows/publish-standalone-update.yml
@@ -38,7 +38,8 @@ jobs:
             jq -e --arg tag "$RELEASE_TAG" '.tagName == $tag and .isDraft == false and .isPrerelease == false'
 
       - name: Checkout exact release source
-        uses: actions/checkout@v6
+        # v6.1.0 — immutable pin because this job can attach release assets.
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
           fetch-depth: 0
@@ -71,7 +72,8 @@ jobs:
           cmp signed-update/canvas-notebook-release-metadata.json published-update/canvas-notebook-release-metadata.json
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        # v6.5.0 — immutable pin because this job can attach release assets.
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
           node-version: 26
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@
 *.key
 *.pub
 keys/
+# Only the public update trust store is distributed with the installer.
+!/install/keys/
+/install/keys/*
+!/install/keys/update-trust.json
 
 # Security-sensitive files
 *.crt

--- a/app/components/settings/UpdateCenterPanel.tsx
+++ b/app/components/settings/UpdateCenterPanel.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/app/lib/system-updates/types';
 import { isTerminalSystemUpdateStatus, type SystemUpdateEvent } from '@/cli/src/core/systemUpdateContract';
 import { UpdateAvailabilityCard, UpdateOperationCard } from './UpdateCenterSections';
+import { SystemUpdateObservation } from '@/app/lib/system-updates/observation';
 
 const ACTIVE_OPERATION_STORAGE_KEY = 'canvas.system-update.operation-id';
 const STATUS_ACCESS_STORAGE_KEY = 'canvas.system-update.status-access';
@@ -39,12 +40,6 @@ async function readApiJson<T>(response: Response): Promise<T> {
   }
   if (!payload) throw new Error('The server returned an empty response.');
   return payload;
-}
-
-function mergeUpdateEvents(current: SystemUpdateEvent[], incoming: SystemUpdateEvent[]): SystemUpdateEvent[] {
-  const byId = new Map(current.map((event) => [event.eventId, event]));
-  for (const event of incoming) byId.set(event.eventId, event);
-  return [...byId.values()].sort((left, right) => left.sequence - right.sequence);
 }
 
 async function consumeStatusStream(
@@ -93,8 +88,10 @@ export function UpdateCenterPanel() {
   const [error, setError] = useState<string | null>(null);
   const [connectionInterrupted, setConnectionInterrupted] = useState(false);
   const [statusAccess, setStatusAccess] = useState<SystemUpdateStatusAccess | null>(null);
-  const eventCursorRef = useRef(0);
+  const [activeOperationId, setActiveOperationId] = useState<string | null>(null);
+  const observationRef = useRef<SystemUpdateObservation | null>(null);
   const reloadScheduledRef = useRef(false);
+  const reloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const loadAvailability = useCallback(async () => {
     setLoading(true);
@@ -110,43 +107,60 @@ export function UpdateCenterPanel() {
     }
   }, [t]);
 
-  const loadOperation = useCallback(async (operationId: string, quiet = false) => {
-    try {
-      const response = await fetch(
-        `/api/admin/system-updates/${encodeURIComponent(operationId)}/events?after=${eventCursorRef.current}`,
-        { cache: 'no-store' },
-      );
-      const payload = await readApiJson<{ success: true } & SystemUpdateOperationSnapshot>(response);
-      setOperation(payload.operation);
-      if (payload.events.length > 0) {
-        setEvents((current) => mergeUpdateEvents(current, payload.events));
-        eventCursorRef.current = Math.max(eventCursorRef.current, ...payload.events.map((event) => event.sequence));
-      }
-      setConnectionInterrupted(false);
-      setError(null);
-      if (isTerminalSystemUpdateStatus(payload.operation.status)) {
+  const acceptOperation = useCallback((next: SystemUpdateOperationView) => {
+    const observation = observationRef.current;
+    if (!observation?.acceptOperation(next)) return;
+    setOperation(observation.operation);
+    setConnectionInterrupted(false);
+    setError(null);
+    if (isTerminalSystemUpdateStatus(next.status)) {
+      setActiveOperationId(null);
+      setStatusAccess(null);
+      try {
         window.localStorage.removeItem(ACTIVE_OPERATION_STORAGE_KEY);
+        window.sessionStorage.removeItem(STATUS_ACCESS_STORAGE_KEY);
+      } catch { /* Completion does not depend on storage availability. */ }
+      if (next.status === 'succeeded' && !reloadScheduledRef.current) {
+        reloadScheduledRef.current = true;
+        reloadTimerRef.current = setTimeout(() => window.location.reload(), 1_500);
+      } else {
         void loadAvailability();
       }
-    } catch (loadError) {
-      if (quiet) {
-        setConnectionInterrupted(true);
-        void fetch('/api/health', { cache: 'no-store' }).then((health) => {
-          if (health.ok) setConnectionInterrupted(false);
-        }).catch(() => undefined);
-      } else {
-        setError(loadError instanceof Error ? loadError.message : t('errors.operation'));
-      }
     }
-  }, [loadAvailability, t]);
+  }, [loadAvailability]);
 
-  const requestStatusAccess = useCallback(async (operationId: string) => {
+  const acceptEvents = useCallback((operationId: string, incoming: SystemUpdateEvent[]) => {
+    const observation = observationRef.current;
+    if (!observation || observation.operationId !== operationId) return;
+    observation.acceptEvents(incoming);
+    setEvents(observation.events);
+  }, []);
+
+  const loadOperation = useCallback(async (operationId: string, signal: AbortSignal) => {
+    try {
+      const response = await fetch(
+        `/api/admin/system-updates/${encodeURIComponent(operationId)}/events?after=${observationRef.current?.cursor || 0}`,
+        { cache: 'no-store', signal },
+      );
+      const payload = await readApiJson<{ success: true } & SystemUpdateOperationSnapshot>(response);
+      if (signal.aborted || observationRef.current?.operationId !== operationId) return;
+      acceptEvents(operationId, payload.events);
+      acceptOperation(payload.operation);
+      setConnectionInterrupted(false);
+    } catch {
+      if (!signal.aborted && observationRef.current?.operationId === operationId) setConnectionInterrupted(true);
+    }
+  }, [acceptEvents, acceptOperation]);
+
+  const requestStatusAccess = useCallback(async (operationId: string, signal: AbortSignal) => {
     try {
       const response = await fetch(`/api/admin/system-updates/${encodeURIComponent(operationId)}/status-access`, {
         method: 'POST',
         cache: 'no-store',
+        signal,
       });
       const payload = await readApiJson<{ success: true; access: SystemUpdateStatusAccess | null }>(response);
+      if (signal.aborted || observationRef.current?.operationId !== operationId) return;
       setStatusAccess(payload.access);
       if (payload.access) {
         window.sessionStorage.setItem(STATUS_ACCESS_STORAGE_KEY, JSON.stringify({ operationId, ...payload.access }));
@@ -162,35 +176,60 @@ export function UpdateCenterPanel() {
       try {
         const storedOperationId = window.localStorage.getItem(ACTIVE_OPERATION_STORAGE_KEY);
         if (storedOperationId) {
-          void loadOperation(storedOperationId);
+          observationRef.current = new SystemUpdateObservation(storedOperationId);
+          setActiveOperationId(storedOperationId);
           const storedAccess = window.sessionStorage.getItem(STATUS_ACCESS_STORAGE_KEY);
           if (storedAccess) {
             const parsed = JSON.parse(storedAccess) as SystemUpdateStatusAccess & { operationId?: string };
-            if (parsed.operationId === storedOperationId && Date.parse(parsed.expiresAt) > Date.now()) setStatusAccess(parsed);
-            else void requestStatusAccess(storedOperationId);
-          } else {
-            void requestStatusAccess(storedOperationId);
+            if (parsed.operationId === storedOperationId && parsed.path === `/__canvas-host/operations/${storedOperationId}/events` && Date.parse(parsed.expiresAt) > Date.now()) setStatusAccess(parsed);
           }
         }
       } catch {
         // The update remains observable for this page even without browser storage.
       }
     }, 0);
-    return () => window.clearTimeout(timer);
-  }, [loadAvailability, loadOperation, requestStatusAccess]);
+    return () => {
+      window.clearTimeout(timer);
+      if (reloadTimerRef.current) clearTimeout(reloadTimerRef.current);
+    };
+  }, [loadAvailability]);
 
   useEffect(() => {
-    if (!operation || isTerminalSystemUpdateStatus(operation.status)) return;
-    const timer = window.setInterval(() => void loadOperation(operation.operationId, true), POLL_INTERVAL_MS);
-    return () => window.clearInterval(timer);
-  }, [loadOperation, operation]);
+    if (!activeOperationId) return;
+    let disposed = false;
+    let timer: ReturnType<typeof setTimeout>;
+    let request: AbortController | null = null;
+    const poll = async () => {
+      request = new AbortController();
+      const timeout = setTimeout(() => request?.abort(), 15_000);
+      await loadOperation(activeOperationId, request.signal);
+      clearTimeout(timeout);
+      if (!disposed) timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    };
+    timer = setTimeout(() => void poll(), 0);
+    return () => { disposed = true; clearTimeout(timer); request?.abort(); };
+  }, [loadOperation, activeOperationId]);
 
-  const streamOperationId = operation && !isTerminalSystemUpdateStatus(operation.status) ? operation.operationId : null;
+  useEffect(() => {
+    if (!activeOperationId) return;
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout>;
+    const refresh = async () => {
+      await requestStatusAccess(activeOperationId, controller.signal);
+      if (!controller.signal.aborted) timer = setTimeout(() => void refresh(), 60_000);
+    };
+    const delay = statusAccess ? Math.max(0, Date.parse(statusAccess.expiresAt) - Date.now() - 60_000) : 0;
+    timer = setTimeout(() => void refresh(), delay);
+    return () => { controller.abort(); clearTimeout(timer); };
+  }, [activeOperationId, statusAccess, requestStatusAccess]);
+
+  const streamOperationId = activeOperationId;
   useEffect(() => {
     if (!streamOperationId || !statusAccess || Date.parse(statusAccess.expiresAt) <= Date.now()) return;
     const controller = new AbortController();
-    const timer = window.setTimeout(() => {
-      void fetch(`${statusAccess.path}?after=${eventCursorRef.current}`, {
+    let timer: ReturnType<typeof setTimeout>;
+    const connect = async () => {
+      await fetch(`${statusAccess.path}?after=${observationRef.current?.cursor || 0}`, {
         headers: { Accept: 'text/event-stream', Authorization: `Bearer ${statusAccess.ticket}` },
         cache: 'no-store',
         credentials: 'same-origin',
@@ -198,32 +237,23 @@ export function UpdateCenterPanel() {
       }).then((response) => consumeStatusStream(
         response,
         streamOperationId,
-        (nextOperation) => {
-          setOperation(nextOperation);
-          setConnectionInterrupted(false);
-          if (isTerminalSystemUpdateStatus(nextOperation.status)) {
-            window.localStorage.removeItem(ACTIVE_OPERATION_STORAGE_KEY);
-            window.sessionStorage.removeItem(STATUS_ACCESS_STORAGE_KEY);
-            if (nextOperation.status === 'succeeded' && !reloadScheduledRef.current) {
-              reloadScheduledRef.current = true;
-              window.setTimeout(() => window.location.reload(), 1_500);
-            }
-          }
-        },
+        (nextOperation) => { if (!controller.signal.aborted) acceptOperation(nextOperation); },
         (event) => {
-          eventCursorRef.current = Math.max(eventCursorRef.current, event.sequence);
-          setEvents((current) => mergeUpdateEvents(current, [event]));
+          if (controller.signal.aborted) return;
+          acceptEvents(streamOperationId, [event]);
           setConnectionInterrupted(false);
         },
       )).catch(() => {
         // The authenticated application polling continues as the no-Caddy fallback.
       });
-    }, 0);
+      if (!controller.signal.aborted && Date.parse(statusAccess.expiresAt) > Date.now()) timer = setTimeout(() => void connect(), POLL_INTERVAL_MS);
+    };
+    timer = setTimeout(() => void connect(), 0);
     return () => {
       window.clearTimeout(timer);
       controller.abort();
     };
-  }, [statusAccess, streamOperationId]);
+  }, [statusAccess, streamOperationId, acceptOperation, acceptEvents]);
 
   const startUpdate = async () => {
     if (!availability?.release) return;
@@ -236,17 +266,18 @@ export function UpdateCenterPanel() {
         body: JSON.stringify({ channel: 'stable', expectedReleaseId: availability.release.releaseId }),
       });
       const payload = await readApiJson<{ success: true; operation: SystemUpdateOperationView }>(response);
-      eventCursorRef.current = 0;
+      observationRef.current = new SystemUpdateObservation(payload.operation.operationId);
+      reloadScheduledRef.current = false;
       setEvents([]);
-      setOperation(payload.operation);
+      setStatusAccess(null);
+      setActiveOperationId(payload.operation.operationId);
+      acceptOperation(payload.operation);
       setConfirmOpen(false);
       try {
         window.localStorage.setItem(ACTIVE_OPERATION_STORAGE_KEY, payload.operation.operationId);
       } catch {
         // Polling still works while this page remains open.
       }
-      void requestStatusAccess(payload.operation.operationId);
-      void loadOperation(payload.operation.operationId, true);
     } catch (startError) {
       setError(startError instanceof Error ? startError.message : t('errors.start'));
       setConfirmOpen(false);
@@ -256,11 +287,12 @@ export function UpdateCenterPanel() {
   };
 
   const returnToOverview = () => {
+    observationRef.current = null;
+    setActiveOperationId(null);
     setOperation(null);
     setEvents([]);
     setConnectionInterrupted(false);
     setStatusAccess(null);
-    eventCursorRef.current = 0;
     try {
       window.localStorage.removeItem(ACTIVE_OPERATION_STORAGE_KEY);
       window.sessionStorage.removeItem(STATUS_ACCESS_STORAGE_KEY);
@@ -270,7 +302,7 @@ export function UpdateCenterPanel() {
     void loadAvailability();
   };
 
-  if (loading && !availability) {
+  if (loading && !availability && !activeOperationId && !operation) {
     return (
       <Card>
         <CardContent className="flex min-h-48 items-center justify-center gap-3 text-sm text-muted-foreground">
@@ -296,7 +328,13 @@ export function UpdateCenterPanel() {
         </Alert>
       )}
 
-      {operation ? (
+      {activeOperationId && !operation ? (
+        <Alert>
+          <Loader2 className="animate-spin" aria-hidden="true" />
+          <AlertTitle>{t('reconnecting.title')}</AlertTitle>
+          <AlertDescription>{t('reconnecting.description')}</AlertDescription>
+        </Alert>
+      ) : operation ? (
         <UpdateOperationCard
           operation={operation}
           events={events}

--- a/app/lib/system-updates/observation.ts
+++ b/app/lib/system-updates/observation.ts
@@ -1,0 +1,33 @@
+import { isTerminalSystemUpdateStatus, validateSystemUpdateEvent, type SystemUpdateEvent } from '@/cli/src/core/systemUpdateContract';
+import { validateSystemUpdateOperationView, type SystemUpdateOperationView } from './types';
+
+/** One operation, shared by REST and SSE; delayed responses cannot undo completion. */
+export class SystemUpdateObservation {
+  operation: SystemUpdateOperationView | null = null;
+  cursor = 0;
+  private readonly bySequence = new Map<number, SystemUpdateEvent>();
+
+  constructor(readonly operationId: string) {}
+
+  get events(): SystemUpdateEvent[] { return [...this.bySequence.values()].sort((a, b) => a.sequence - b.sequence); }
+
+  acceptOperation(value: unknown): boolean {
+    const next = validateSystemUpdateOperationView(value);
+    if (!next || next.operationId !== this.operationId) return false;
+    const previous = this.operation;
+    if (previous && (isTerminalSystemUpdateStatus(previous.status) || next.lastSequence < previous.lastSequence ||
+      (next.lastSequence === previous.lastSequence && Date.parse(next.updatedAt) < Date.parse(previous.updatedAt)))) return false;
+    this.operation = next;
+    return true;
+  }
+
+  acceptEvents(values: unknown[]): void {
+    for (const value of values) {
+      const parsed = validateSystemUpdateEvent(value);
+      if (!parsed.ok || parsed.value.operationId !== this.operationId) continue;
+      if (!this.bySequence.has(parsed.value.sequence)) this.bySequence.set(parsed.value.sequence, parsed.value);
+    }
+    // Reconnect must request gaps, even if SSE delivered a later event first.
+    while (this.bySequence.has(this.cursor + 1)) this.cursor++;
+  }
+}

--- a/cli/src/core/standaloneUpdateRelease.ts
+++ b/cli/src/core/standaloneUpdateRelease.ts
@@ -116,8 +116,23 @@ async function responseJsonWithinLimit(response: Response): Promise<unknown> {
   if (!response.ok) throw new Error(`Update release is unavailable (HTTP ${response.status}).`);
   const declaredLength = Number(response.headers.get('content-length') || 0);
   if (declaredLength > MAX_MANIFEST_BYTES) throw new Error('Update manifest is too large.');
-  const bytes = Buffer.from(await response.arrayBuffer());
-  if (bytes.length > MAX_MANIFEST_BYTES) throw new Error('Update manifest is too large.');
+  if (!response.body) throw new Error('Update manifest response is empty.');
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_MANIFEST_BYTES) {
+        void reader.cancel().catch(() => undefined);
+        throw new Error('Update manifest is too large.');
+      }
+      chunks.push(value);
+    }
+  } finally { reader.releaseLock(); }
+  const bytes = Buffer.concat(chunks);
   try {
     return JSON.parse(bytes.toString('utf8')) as unknown;
   } catch {
@@ -178,22 +193,24 @@ export class StandaloneReleaseResolver {
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     timeout.unref();
     let response: Response;
+    let manifestInput: unknown;
     try {
       response = await this.fetchImplementation(manifestUrl(channel, this.env), {
         headers: { accept: 'application/json' },
         redirect: 'follow',
         signal: controller.signal,
       });
+      if (new URL(response.url || manifestUrl(channel, this.env)).protocol !== 'https:') {
+        throw new Error('Update manifest redirect must use HTTPS.');
+      }
+      manifestInput = await responseJsonWithinLimit(response);
     } catch (error) {
-      if ((error as Error).name === 'AbortError') throw new Error('Update manifest request timed out.');
-      throw new Error('Update release information could not be loaded.');
+      if (controller.signal.aborted) throw new Error('Update manifest request timed out.');
+      throw error;
     } finally {
       clearTimeout(timeout);
     }
-    if (new URL(response.url || manifestUrl(channel, this.env)).protocol !== 'https:') {
-      throw new Error('Update manifest redirect must use HTTPS.');
-    }
-    const parsed = validateSystemUpdateSignedReleaseManifest(await responseJsonWithinLimit(response));
+    const parsed = validateSystemUpdateSignedReleaseManifest(manifestInput);
     if (!parsed.ok) throw new Error(parsed.error);
     if (parsed.value.manifest.channel !== channel) throw new Error('Update manifest channel does not match the request.');
     const now = this.now();

--- a/cli/src/core/standaloneUpdater.ts
+++ b/cli/src/core/standaloneUpdater.ts
@@ -196,6 +196,8 @@ async function executeCliUpdate(
     ], {
       env: {
         ...env,
+        // The host CLI has already been selected and verified for this release.
+        CANVAS_CLI_SELF_UPDATE: 'false',
         CANVAS_UPDATE_DEADLINE_EPOCH_MS: String(Date.now() + UPDATE_DEADLINE_MS),
       },
       shell: false,
@@ -260,9 +262,10 @@ async function prepareVerifiedHostCli(
 ): Promise<void> {
   if (current.cliVersion && compareCanvasVersions(current.cliVersion, release.signed.manifest.cliVersion) >= 0) return;
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-updater-cli-'));
-  const checksumPath = path.join(directory, 'canvas-notebook-linux-cli.sha256');
+  const archiveName = `canvas-notebook-linux-cli-${release.architecture}.tar.gz`;
+  const checksumPath = path.join(directory, `canvas-notebook-linux-cli-${release.architecture}.sha256`);
   try {
-    await fs.writeFile(checksumPath, `${release.cliArtifact.sha256}  canvas-notebook-linux-cli.tar.gz\n`, { mode: 0o600 });
+    await fs.writeFile(checksumPath, `${release.cliArtifact.sha256}  ${archiveName}\n`, { mode: 0o600 });
     const result = await new Promise<{ code: number; stderr: string }>((resolve, reject) => {
       const child = spawn(resolveCliPath(env), ['cli-update', '--json', '--no-banner'], {
         env: {

--- a/cli/src/core/standaloneUpdater.ts
+++ b/cli/src/core/standaloneUpdater.ts
@@ -8,6 +8,7 @@ import readline from 'node:readline';
 import { pathToFileURL } from 'node:url';
 
 import { resolveCliPath } from './cliPath';
+import { systemUpdateApplyAcknowledgement } from './systemUpdateApplyGate';
 import {
   SYSTEM_UPDATE_CONTRACT_VERSION,
   isTerminalSystemUpdateStatus,
@@ -198,15 +199,17 @@ async function executeCliUpdate(
         ...env,
         // The host CLI has already been selected and verified for this release.
         CANVAS_CLI_SELF_UPDATE: 'false',
+        CANVAS_UPDATE_APPLY_HANDSHAKE: '1',
         CANVAS_UPDATE_DEADLINE_EPOCH_MS: String(Date.now() + UPDATE_DEADLINE_MS),
       },
       shell: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
     });
     const stderr: Buffer[] = [];
     let stderrBytes = 0;
     const abort = () => child.kill('SIGTERM');
+    child.stdin.on('error', () => child.kill('SIGTERM'));
     if (signal.aborted) abort();
     else signal.addEventListener('abort', abort, { once: true });
     child.stderr.on('data', (chunk: Buffer) => {
@@ -237,6 +240,10 @@ async function executeCliUpdate(
           throw new Error(event.ok ? 'Canvas CLI returned an event for another operation.' : event.error);
         }
         await onEvent(event.value);
+        if (event.value.stage === 'image_pull' && event.value.status === 'running') {
+          if (signal.aborted) throw new Error('Update was canceled before apply.');
+          child.stdin.end(`${systemUpdateApplyAcknowledgement(operation.operationId)}\n`);
+        }
       }).catch((error) => {
         protocolError = error instanceof Error ? error : new Error('Canvas CLI update event handling failed.');
         child.kill('SIGTERM');
@@ -312,6 +319,13 @@ export class StandaloneUpdater {
   private activeOperationId: string | null = null;
   private activeAbortController: AbortController | null = null;
   private reserving = false;
+  private mutationTail: Promise<void> = Promise.resolve();
+
+  private serializeMutation<T>(action: () => Promise<T>): Promise<T> {
+    const result = this.mutationTail.then(action);
+    this.mutationTail = result.then(() => undefined, () => undefined);
+    return result;
+  }
 
   constructor(options: StandaloneUpdaterOptions = {}) {
     this.env = options.env || process.env;
@@ -412,25 +426,27 @@ export class StandaloneUpdater {
   }
 
   private async recordEvent(operationId: string, event: SystemUpdateEvent): Promise<void> {
-    const operation = await this.journal.readOperation(operationId);
-    if (!operation) throw new Error('Active update operation disappeared from the journal.');
-    if (isTerminalSystemUpdateStatus(operation.status)) throw new Error('Update operation is already terminal.');
-    if (event.sequence !== operation.lastSequence + 1) throw new Error('Canvas CLI update event sequence is not contiguous.');
-    await this.journal.appendEvent(event);
-    const rolledBack = operation.rolledBack || (event.stage === 'rollback' && event.status === 'succeeded');
-    const status = statusForEvent({ ...operation, rolledBack }, event);
-    const terminal = isTerminalSystemUpdateStatus(status);
-    await this.journal.writeOperation({
-      ...operation,
-      status,
-      stage: event.stage,
-      startedAt: operation.startedAt || event.occurredAt,
-      updatedAt: event.occurredAt,
-      completedAt: terminal ? event.occurredAt : null,
-      rolledBack,
-      errorCode: event.status === 'failed' ? (event.errorCode || 'update_execution_failed') : operation.errorCode,
-      error: event.status === 'failed' ? safeMessage(event.message, 'Canvas Notebook update failed.') : operation.error,
-      lastSequence: event.sequence,
+    return this.serializeMutation(async () => {
+      const operation = await this.journal.readOperation(operationId);
+      if (!operation) throw new Error('Active update operation disappeared from the journal.');
+      if (isTerminalSystemUpdateStatus(operation.status)) throw new Error('Update operation is already terminal.');
+      if (event.sequence !== operation.lastSequence + 1) throw new Error('Canvas CLI update event sequence is not contiguous.');
+      await this.journal.appendEvent(event);
+      const rolledBack = operation.rolledBack || (event.stage === 'rollback' && event.status === 'succeeded');
+      const status = statusForEvent({ ...operation, rolledBack }, event);
+      const terminal = isTerminalSystemUpdateStatus(status);
+      await this.journal.writeOperation({
+        ...operation,
+        status,
+        stage: event.stage,
+        startedAt: operation.startedAt || event.occurredAt,
+        updatedAt: event.occurredAt,
+        completedAt: terminal ? event.occurredAt : null,
+        rolledBack,
+        errorCode: event.status === 'failed' ? (event.errorCode || 'update_execution_failed') : operation.errorCode,
+        error: event.status === 'failed' ? safeMessage(event.message, 'Canvas Notebook update failed.') : operation.error,
+        lastSequence: event.sequence,
+    });
     });
   }
 
@@ -449,33 +465,37 @@ export class StandaloneUpdater {
         release,
         abortController.signal,
       );
-      const operation = await this.journal.readOperation(initial.operationId);
-      if (operation && !isTerminalSystemUpdateStatus(operation.status)) {
-        const completedAt = this.now().toISOString();
-        await this.journal.writeOperation({
-          ...operation,
-          status: exitCode === 0 ? 'indeterminate' : (operation.rolledBack ? 'rolled_back' : 'failed'),
-          updatedAt: completedAt,
-          completedAt,
-          errorCode: exitCode === 0 ? 'operation_interrupted' : (operation.errorCode || 'update_execution_failed'),
-          error: operation.error || (exitCode === 0
-            ? 'Canvas CLI exited without a final verification event.'
-            : 'Canvas CLI update execution failed.'),
-        });
-      }
+      await this.serializeMutation(async () => {
+        const operation = await this.journal.readOperation(initial.operationId);
+        if (operation && !isTerminalSystemUpdateStatus(operation.status)) {
+          const completedAt = this.now().toISOString();
+          await this.journal.writeOperation({
+            ...operation,
+            status: exitCode === 0 ? 'indeterminate' : (operation.rolledBack ? 'rolled_back' : 'failed'),
+            updatedAt: completedAt,
+            completedAt,
+            errorCode: exitCode === 0 ? 'operation_interrupted' : (operation.errorCode || 'update_execution_failed'),
+            error: operation.error || (exitCode === 0
+              ? 'Canvas CLI exited without a final verification event.'
+              : 'Canvas CLI update execution failed.'),
+          });
+        }
+      });
     } catch (error) {
-      const operation = await this.journal.readOperation(initial.operationId).catch(() => initial) || initial;
-      if (!isTerminalSystemUpdateStatus(operation.status)) {
-        const completedAt = this.now().toISOString();
-        await this.journal.writeOperation({
-          ...operation,
-          status: operation.rolledBack ? 'rolled_back' : 'failed',
-          updatedAt: completedAt,
-          completedAt,
-          errorCode: operation.errorCode || 'update_execution_failed',
-          error: safeMessage(error, 'Canvas CLI update execution failed.'),
-        });
-      }
+      await this.serializeMutation(async () => {
+        const operation = await this.journal.readOperation(initial.operationId).catch(() => initial) || initial;
+        if (!isTerminalSystemUpdateStatus(operation.status)) {
+          const completedAt = this.now().toISOString();
+          await this.journal.writeOperation({
+            ...operation,
+            status: operation.rolledBack ? 'rolled_back' : 'failed',
+            updatedAt: completedAt,
+            completedAt,
+            errorCode: operation.errorCode || 'update_execution_failed',
+            error: safeMessage(error, 'Canvas CLI update execution failed.'),
+          });
+        }
+      });
     } finally {
       this.activeOperationId = null;
       if (this.activeAbortController === abortController) this.activeAbortController = null;
@@ -493,34 +513,36 @@ export class StandaloneUpdater {
   }
 
   async cancelUpdate(operationId: string): Promise<SystemUpdateOperation> {
-    const operation = await this.journal.readOperation(operationId);
-    if (!operation) throw new StandaloneUpdaterHttpError(404, 'operation_not_found', 'Update operation was not found.');
-    if (isTerminalSystemUpdateStatus(operation.status)) return operation;
-    if (this.activeOperationId !== operationId || !this.activeAbortController) {
-      throw new StandaloneUpdaterHttpError(409, 'operation_conflict', 'Update operation cannot be canceled from this updater process.');
-    }
-    if ([
-      'image_pull',
-      'container_recreate',
-      'health_verification',
-      'version_verification',
-      'rollback',
-      'completed',
-    ].includes(operation.stage)) {
-      throw new StandaloneUpdaterHttpError(409, 'operation_conflict', 'Update can no longer be canceled after the apply phase has started.');
-    }
-    const completedAt = this.now().toISOString();
-    const canceled: SystemUpdateOperation = {
-      ...operation,
-      status: 'failed',
-      updatedAt: completedAt,
-      completedAt,
-      errorCode: 'operation_interrupted',
-      error: 'Canvas Notebook update was canceled before the apply phase.',
-    };
-    await this.journal.writeOperation(canceled);
-    this.activeAbortController.abort();
-    return canceled;
+    return this.serializeMutation(async () => {
+      const operation = await this.journal.readOperation(operationId);
+      if (!operation) throw new StandaloneUpdaterHttpError(404, 'operation_not_found', 'Update operation was not found.');
+      if (isTerminalSystemUpdateStatus(operation.status)) return operation;
+      if (this.activeOperationId !== operationId || !this.activeAbortController) {
+        throw new StandaloneUpdaterHttpError(409, 'operation_conflict', 'Update operation cannot be canceled from this updater process.');
+      }
+      if ([
+        'image_pull',
+        'container_recreate',
+        'health_verification',
+        'version_verification',
+        'rollback',
+        'completed',
+      ].includes(operation.stage)) {
+        throw new StandaloneUpdaterHttpError(409, 'operation_conflict', 'Update can no longer be canceled after the apply phase has started.');
+      }
+      const completedAt = this.now().toISOString();
+      const canceled: SystemUpdateOperation = {
+        ...operation,
+        status: 'failed',
+        updatedAt: completedAt,
+        completedAt,
+        errorCode: 'operation_interrupted',
+        error: 'Canvas Notebook update was canceled before the apply phase.',
+      };
+      await this.journal.writeOperation(canceled);
+      this.activeAbortController.abort();
+      return canceled;
+    });
   }
 }
 

--- a/cli/src/core/systemUpdateApplyGate.ts
+++ b/cli/src/core/systemUpdateApplyGate.ts
@@ -1,0 +1,37 @@
+import readline from 'node:readline';
+import type { Readable } from 'node:stream';
+import type { SystemUpdateEventReporter } from './systemUpdateReporter';
+
+export function systemUpdateApplyAcknowledgement(operationId: string): string {
+  return `canvas-update-apply:${operationId}`;
+}
+
+/** Install cannot begin until the host durably records that cancellation is closed. */
+export async function beginSystemUpdateApply(
+  reporter: SystemUpdateEventReporter,
+  options: { required: boolean; input?: Readable; timeoutMs?: number },
+): Promise<void> {
+  const announce = () => reporter.running('image_pull', 'Pulling the pinned Canvas Notebook image.');
+  if (!options.required) { announce(); return; }
+  const input = options.input || process.stdin;
+  await new Promise<void>((resolve, reject) => {
+    const lines = readline.createInterface({ input, crlfDelay: Infinity });
+    const timer = setTimeout(() => finish(new Error('Host update apply acknowledgement timed out.')), options.timeoutMs ?? 30_000);
+    let settled = false;
+    function finish(error?: Error) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      lines.close();
+      input.pause();
+      input.removeListener('error', onError);
+      if (error) reject(error); else resolve();
+    }
+    function onError(error: Error) { finish(error); }
+    input.once('error', onError);
+    lines.once('close', () => finish(new Error('Host disconnected before update apply acknowledgement.')));
+    lines.once('line', (line) => finish(line === systemUpdateApplyAcknowledgement(reporter.operationId)
+      ? undefined : new Error('Host update apply acknowledgement is invalid.')));
+    try { announce(); } catch (error) { finish(error instanceof Error ? error : new Error('Update announcement failed.')); }
+  });
+}

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -59,6 +59,7 @@ import { runStandaloneUpdaterFromEnvironment, triggerStandaloneUpdateFromHost } 
 import { isSwapCommand, SwapManager, validateSwapConfig, type SwapStatus } from './core/swap';
 import { type SystemUpdateErrorCode, type SystemUpdateStage } from './core/systemUpdateContract';
 import { SystemUpdateEventReporter } from './core/systemUpdateReporter';
+import { beginSystemUpdateApply } from './core/systemUpdateApplyGate';
 import type { CanvasCliConfig, RuntimeContext, StatusJson } from './core/types';
 import { CLI_COMMANDS, CLI_GENERATION, CONFIG_SCHEMA_VERSION, resolveCliVersion } from './core/version';
 
@@ -769,7 +770,10 @@ export async function update(
     runConfig.image = targetImage;
     const targetEnvironment = { ...process.env, CANVAS_IMAGE: targetImage };
     phase = 'pull';
-    reporter.running('image_pull', 'Pulling the pinned Canvas Notebook image.');
+    await beginSystemUpdateApply(reporter, {
+      required: options.eventStream === true && process.env.CANVAS_UPDATE_APPLY_HANDSHAKE === '1',
+      timeoutMs: Math.min(30_000, remainingUpdateTime(deadline, true) ?? 30_000),
+    });
     await docker.pull(runConfig, machineOutput ? 'pipe' : 'inherit', remainingUpdateTime(deadline, true), targetEnvironment);
     reporter.succeeded('image_pull', 'Pinned Canvas Notebook image pulled.');
     if (await docker.needsRecreate(runConfig)) {

--- a/docs/architecture/canvas-notebook/standalone-update-releases.md
+++ b/docs/architecture/canvas-notebook/standalone-update-releases.md
@@ -1,0 +1,69 @@
+# Standalone update releases
+
+Standalone installations do not use the Control Plane release catalog or its
+credentials. The host updater reads the latest stable GitHub Release asset
+`canvas-notebook-update-stable.json` and verifies its Ed25519 signature against
+`/etc/canvas-notebook/update-trust.json` before downloading or executing anything.
+
+## Build and publication
+
+1. The normal tag-triggered **Build and Push (Both Arch)** workflow builds and
+   tests the exact tag, records the multi-architecture image digest and both
+   Linux CLI checksums, and signs that metadata using
+   `CANVAS_UPDATE_SIGNING_PRIVATE_KEY`. A missing key or a key that does not match
+   the public installer trust store fails the build.
+2. The signed manifest is included in both `release-bundle-VERSION` and the small
+   `standalone-update-VERSION` artifact. Release publishers should upload the
+   signed manifest together with the other assets from the same successful run.
+   Never regenerate the manifest locally or substitute a different build.
+3. Publishing the GitHub Release triggers **Publish Standalone Update**. It finds
+   the successful push build for the exact tag and commit, compares public
+   release metadata with that build, verifies the signature with the shipped
+   public key, and hashes the actual public amd64 and arm64 CLI archives. It
+   attaches the signed manifest if missing and downloads it again to verify the
+   published bytes. An existing different manifest is never overwritten.
+4. Wait for this workflow to succeed before announcing standalone update
+   availability. It runs independently of **Notify Control Plane Release**;
+   neither workflow requires the other service's availability or credentials.
+
+Only published stable calendar-version releases are supported by this pipeline.
+The manifest references an immutable image digest and immutable tag-specific CLI
+URLs, requires a backup, and imposes no additional minimum-version policy. If a
+future migration requires a minimum version, change and test the signing policy
+before publishing that release. There is no unsigned fallback.
+
+The publication workflow can be retried via `workflow_dispatch` with an already
+published tag while its 90-day build artifact is retained. It does not build,
+create a release, promote a Control Plane deployment, or overwrite assets.
+
+## Trust provisioning and rotation
+
+`install/keys/update-trust.json` contains only public keys. The installer copies
+it into `/etc/canvas-notebook/update-trust.json`; the complete host CLI package
+ships the same file. The signing private key is a repository Actions secret,
+available only to the manifest-signing step of the release build. It must never
+be included in source, artifacts, application integration settings, or logs.
+
+Installations created before the public trust store shipped need the updated
+host installer applied once by their administrator. An installation without a
+trusted key must not bootstrap trust from an unverified update manifest. A
+custom `CANVAS_UPDATE_TRUST_STORE_SOURCE` remains supported by the installer.
+
+For rotation, first distribute an overlapping trust store containing the old
+and new public keys to hosts, then switch the Actions signing secret and key ID.
+The Linux CLI self-update does not replace the host trust store. Do not retire
+the old key or sign exclusively with the new key until the host trust-store
+rollout is complete. If the secret is lost, generate a replacement and perform
+that controlled trust-store rollout; do not silently replace the signing key.
+
+## Verification
+
+- `npm run test:release:updates`: signing and runtime verification for both
+  architectures, tamper rejection, exact-build provenance, published archive
+  checksums, and workflow wiring.
+- `npm run test:release:host-cli`: reproducible package including public trust.
+- `npm run test:cli:updater` and `npm run test:install:updater`: host lifecycle,
+  cancellation/apply barrier, download deadline, and installer regressions.
+- `npm run test:system-updates`: UI recovery and state reconciliation, including
+  rendered JSDOM tests during simulated downtime. These are not real-browser or
+  live Linux/systemd tests.

--- a/install/keys/update-trust.json
+++ b/install/keys/update-trust.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "keys": [
+    {
+      "keyId": "canvas-updates-2026-09",
+      "algorithm": "ed25519",
+      "publicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA6g+n3u88rkoEA/ryHUEDTG7D6rO7sD6A3egE7jzYPYY=\n-----END PUBLIC KEY-----\n"
+    }
+  ]
+}

--- a/install/linux-cli.sh
+++ b/install/linux-cli.sh
@@ -198,6 +198,11 @@ retire_legacy_cli() {
 
 activate_entrypoint() {
   local target="$1" tmp="${BIN_PATH}.new.$$"
+  # A service with ProtectSystem=full can update releases under /opt, but
+  # cannot rewrite /usr/local/bin. Its existing managed entrypoint is stable.
+  if [[ -L "$BIN_PATH" && "$(readlink "$BIN_PATH")" == "$target" ]]; then
+    return 0
+  fi
   mkdir -p "$(dirname "$BIN_PATH")"
   rm -f -- "$tmp"
   ln -s "$target" "$tmp"

--- a/package.json
+++ b/package.json
@@ -310,6 +310,7 @@
     "test:cli:postgres-recovery": "tsx scripts/cli-postgres-recovery-state-test.ts",
     "test:release:payload": "node scripts/control-plane-release-payload-test.mjs",
     "test:release:host-cli": "node scripts/host-cli-package-test.mjs",
+    "test:release:updates": "tsx scripts/system-update-release-test.ts",
     "test:release:linux-cli": "node scripts/linux-cli-package-test.mjs",
     "test:release:linux-cli-integration": "bash scripts/linux-cli-package-integration-test.sh",
     "test:release:linux-cli-installer": "bash scripts/linux-cli-installer-test.sh",

--- a/package.json
+++ b/package.json
@@ -323,7 +323,7 @@
     "test:cli:auto-update-linux-integration": "bash scripts/portable-cli-linux-auto-update-integration-test.sh",
     "test:cli:updater": "tsx scripts/standalone-updater-test.ts",
     "test:system-updates": "tsx scripts/system-update-presentation-test.ts && tsx scripts/system-update-ui-contract-test.ts && tsx --conditions react-server scripts/system-update-backend-test.ts",
-    "test:install:updater": "tsx scripts/standalone-updater-installer-test.ts && tsx scripts/portable-cli-service-test.ts",
+    "test:install:updater": "tsx scripts/standalone-updater-installer-test.ts && tsx scripts/portable-cli-service-test.ts && tsx scripts/linux-cli-stable-entrypoint-test.ts",
     "test:cli:service-portable": "tsx scripts/portable-cli-service-test.ts",
     "test:cli:service-linux-integration": "bash scripts/portable-cli-linux-service-integration-test.sh",
     "test:cli:update-rollback": "bash scripts/cli-update-rollback-test.sh",

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "test:cli:caddy-linux-integration": "bash scripts/portable-cli-linux-caddy-integration-test.sh",
     "test:cli:auto-update-portable": "tsx scripts/portable-cli-auto-update-test.ts",
     "test:cli:auto-update-linux-integration": "bash scripts/portable-cli-linux-auto-update-integration-test.sh",
-    "test:cli:updater": "tsx scripts/standalone-updater-test.ts",
+    "test:cli:updater": "tsx scripts/standalone-updater-test.ts && tsx scripts/system-update-apply-gate-test.ts",
     "test:system-updates": "tsx scripts/system-update-presentation-test.ts && tsx scripts/system-update-ui-contract-test.ts && tsx --conditions react-server scripts/system-update-backend-test.ts",
     "test:install:updater": "tsx scripts/standalone-updater-installer-test.ts && tsx scripts/portable-cli-service-test.ts && tsx scripts/linux-cli-stable-entrypoint-test.ts",
     "test:cli:service-portable": "tsx scripts/portable-cli-service-test.ts",

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "test:cli:caddy-linux-integration": "bash scripts/portable-cli-linux-caddy-integration-test.sh",
     "test:cli:auto-update-portable": "tsx scripts/portable-cli-auto-update-test.ts",
     "test:cli:auto-update-linux-integration": "bash scripts/portable-cli-linux-auto-update-integration-test.sh",
-    "test:cli:updater": "tsx scripts/standalone-updater-test.ts && tsx scripts/system-update-apply-gate-test.ts",
+    "test:cli:updater": "tsx scripts/standalone-updater-test.ts && tsx scripts/system-update-apply-gate-test.ts && tsx scripts/system-update-download-test.ts",
     "test:system-updates": "tsx scripts/system-update-presentation-test.ts && tsx scripts/system-update-ui-contract-test.ts && tsx --conditions react-server scripts/system-update-backend-test.ts",
     "test:install:updater": "tsx scripts/standalone-updater-installer-test.ts && tsx scripts/portable-cli-service-test.ts && tsx scripts/linux-cli-stable-entrypoint-test.ts",
     "test:cli:service-portable": "tsx scripts/portable-cli-service-test.ts",

--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "test:cli:auto-update-portable": "tsx scripts/portable-cli-auto-update-test.ts",
     "test:cli:auto-update-linux-integration": "bash scripts/portable-cli-linux-auto-update-integration-test.sh",
     "test:cli:updater": "tsx scripts/standalone-updater-test.ts && tsx scripts/system-update-apply-gate-test.ts && tsx scripts/system-update-download-test.ts",
-    "test:system-updates": "tsx scripts/system-update-presentation-test.ts && tsx scripts/system-update-ui-contract-test.ts && tsx --conditions react-server scripts/system-update-backend-test.ts",
+    "test:system-updates": "tsx scripts/system-update-presentation-test.ts && tsx scripts/system-update-ui-contract-test.ts && tsx scripts/system-update-observation-test.ts && tsx scripts/system-update-recovery-ui-test.tsx && tsx --conditions react-server scripts/system-update-backend-test.ts",
     "test:install:updater": "tsx scripts/standalone-updater-installer-test.ts && tsx scripts/portable-cli-service-test.ts && tsx scripts/linux-cli-stable-entrypoint-test.ts",
     "test:cli:service-portable": "tsx scripts/portable-cli-service-test.ts",
     "test:cli:service-linux-integration": "bash scripts/portable-cli-linux-service-integration-test.sh",

--- a/scripts/host-cli-package-test.mjs
+++ b/scripts/host-cli-package-test.mjs
@@ -47,6 +47,7 @@ for (const required of [
   'canvas-notebook-host-cli/install/bin/canvas-notebook',
   'canvas-notebook-host-cli/install/lib/common.sh',
   'canvas-notebook-host-cli/install/lib/systemd.sh',
+  'canvas-notebook-host-cli/install/keys/update-trust.json',
 ]) {
   assert.equal(entries.some((entry) => entry.path === required), true, required);
 }

--- a/scripts/lib/standalone-release-manifest.ts
+++ b/scripts/lib/standalone-release-manifest.ts
@@ -1,0 +1,123 @@
+import crypto from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import path from 'node:path';
+
+import {
+  canonicalizeSystemUpdateReleaseManifest,
+  SYSTEM_UPDATE_CONTRACT_VERSION,
+  validateSystemUpdateReleaseManifest,
+  type SystemUpdateReleaseManifest,
+  type SystemUpdateSignedReleaseManifest,
+} from '../../cli/src/core/systemUpdateContract';
+import { StandaloneReleaseResolver } from '../../cli/src/core/standaloneUpdateRelease';
+
+const REPOSITORY = 'canvascoding/canvas-notebook';
+const IMAGE = 'ghcr.io/canvascoding/canvas-notebook';
+
+export interface ReleaseProvenance {
+  tag: string;
+  commitSha: string;
+  runId: string;
+}
+
+function record(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('Invalid release metadata.');
+  return input as Record<string, unknown>;
+}
+
+export function manifestFromReleaseMetadata(
+  input: unknown,
+  expected: ReleaseProvenance,
+  publishedAt: string,
+): SystemUpdateReleaseManifest {
+  const metadata = record(input);
+  const image = record(metadata.image);
+  const build = record(metadata.build);
+  const linuxCli = record(metadata.linuxCli);
+  if (!/^v\d{4}\.\d{1,2}\.\d{1,2}(?:\.\d+)?$/u.test(expected.tag) ||
+    !/^[a-f0-9]{40}$/u.test(expected.commitSha) || !/^\d+$/u.test(expected.runId) ||
+    metadata.schemaVersion !== 1 || metadata.repository !== REPOSITORY ||
+    metadata.tag !== expected.tag || metadata.version !== expected.tag.slice(1) ||
+    metadata.commitSha !== expected.commitSha || build.runId !== expected.runId ||
+    image.name !== IMAGE || typeof image.digest !== 'string' || !/^sha256:[a-f0-9]{64}$/u.test(image.digest)) {
+    throw new Error('Release metadata does not match the exact trusted tag build.');
+  }
+  const releaseBase = `https://github.com/${REPOSITORY}/releases`;
+  const cliArtifacts = (['amd64', 'arm64'] as const).map((architecture) => {
+    const artifact = record(linuxCli[architecture]);
+    const filename = `canvas-notebook-linux-cli-${architecture}.tar.gz`;
+    if (artifact.filename !== filename || typeof artifact.sha256 !== 'string' || !/^[a-f0-9]{64}$/u.test(artifact.sha256)) {
+      throw new Error(`Release metadata has an invalid ${architecture} CLI artifact.`);
+    }
+    return { architecture, url: `${releaseBase}/download/${expected.tag}/${filename}`, sha256: artifact.sha256 };
+  });
+  const parsed = validateSystemUpdateReleaseManifest({
+    contractVersion: SYSTEM_UPDATE_CONTRACT_VERSION,
+    releaseId: expected.tag,
+    version: metadata.version,
+    channel: 'stable',
+    imageRef: `${IMAGE}@${image.digest}`,
+    imageDigest: image.digest.slice('sha256:'.length),
+    cliVersion: metadata.version,
+    cliArtifacts,
+    minimumVersion: null,
+    backupRequired: true,
+    releaseNotesUrl: `${releaseBase}/tag/${expected.tag}`,
+    publishedAt,
+  });
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
+}
+
+export async function verifyReleaseUpdateManifest(
+  input: unknown,
+  metadata: unknown,
+  expected: ReleaseProvenance,
+  trustStorePath: string,
+): Promise<SystemUpdateSignedReleaseManifest> {
+  // Use the host's real trust/contract checks rather than a second signature implementation.
+  const resolver = new StandaloneReleaseResolver({
+    env: { NODE_ENV: 'production', CANVAS_UPDATE_TRUST_STORE: trustStorePath },
+    platformArchitecture: 'x64',
+    fetch: async () => new Response(JSON.stringify(input)),
+  });
+  const { signed } = await resolver.resolve('stable');
+  const expectedManifest = manifestFromReleaseMetadata(metadata, expected, signed.manifest.publishedAt);
+  if (canonicalizeSystemUpdateReleaseManifest(signed.manifest) !== canonicalizeSystemUpdateReleaseManifest(expectedManifest)) {
+    throw new Error('Signed update manifest does not match the release assets and provenance.');
+  }
+  return signed;
+}
+
+export async function signReleaseUpdateManifest(
+  metadata: unknown,
+  expected: ReleaseProvenance,
+  privateKeyPem: string,
+  keyId: string,
+  trustStorePath: string,
+  publishedAt = new Date().toISOString(),
+): Promise<SystemUpdateSignedReleaseManifest> {
+  if (!privateKeyPem) throw new Error('CANVAS_UPDATE_SIGNING_PRIVATE_KEY is required for a release build.');
+  const privateKey = crypto.createPrivateKey(privateKeyPem);
+  if (privateKey.asymmetricKeyType !== 'ed25519') throw new Error('Update signing key must use Ed25519.');
+  const manifest = manifestFromReleaseMetadata(metadata, expected, publishedAt);
+  const signed: SystemUpdateSignedReleaseManifest = {
+    manifest,
+    signature: {
+      algorithm: 'ed25519',
+      keyId,
+      value: crypto.sign(null, Buffer.from(canonicalizeSystemUpdateReleaseManifest(manifest)), privateKey).toString('base64'),
+    },
+  };
+  // Fail the build when the CI secret and the public key shipped by the installer differ.
+  return verifyReleaseUpdateManifest(signed, metadata, expected, trustStorePath);
+}
+
+export async function verifyPublishedCliAssets(manifest: SystemUpdateReleaseManifest, directory: string): Promise<void> {
+  for (const artifact of manifest.cliArtifacts) {
+    const filename = `canvas-notebook-linux-cli-${artifact.architecture}.tar.gz`;
+    const hash = crypto.createHash('sha256');
+    for await (const chunk of createReadStream(path.join(directory, filename))) hash.update(chunk);
+    if (hash.digest('hex') !== artifact.sha256) throw new Error(`Published CLI checksum mismatch: ${filename}`);
+  }
+}

--- a/scripts/linux-cli-stable-entrypoint-test.ts
+++ b/scripts/linux-cli-stable-entrypoint-test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+async function main() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-entrypoint-test-'));
+  try {
+    const installer = await fs.readFile(path.resolve('install/linux-cli.sh'), 'utf8');
+    const functionSource = installer.match(/^activate_entrypoint\(\) \{[\s\S]*?^\}/mu)?.[0];
+    assert.ok(functionSource);
+    const target = path.join(root, 'managed-cli');
+    const entrypoint = path.join(root, 'canvas-notebook');
+    await fs.writeFile(target, 'fixture');
+    await fs.symlink(target, entrypoint);
+    const before = await fs.lstat(entrypoint);
+    // Execute the actual installer function. Deny all mutation commands,
+    // as they would be denied below ProtectSystem=full on the host.
+    const result = spawnSync('bash', ['-eu', '-c', `${functionSource}\nmkdir() { return 91; }; rm() { return 92; }; ln() { return 93; }; mv() { return 94; }; activate_entrypoint "$TEST_TARGET"`], {
+      env: { ...process.env, BIN_PATH: entrypoint, TEST_TARGET: target }, encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal((await fs.lstat(entrypoint)).ino, before.ino);
+    assert.equal(await fs.readlink(entrypoint), target);
+    // Initial installation still creates an entrypoint when none exists.
+    await fs.unlink(entrypoint);
+    const fresh = spawnSync('bash', ['-eu', '-c', `${functionSource}\nactivate_entrypoint "$TEST_TARGET"`], {
+      env: { ...process.env, BIN_PATH: entrypoint, TEST_TARGET: target }, encoding: 'utf8',
+    });
+    assert.equal(fresh.status, 0, fresh.stderr);
+    assert.equal(await fs.readlink(entrypoint), target);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+  console.log('linux-cli-stable-entrypoint-test: ok');
+}
+
+void main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/scripts/standalone-updater-test.ts
+++ b/scripts/standalone-updater-test.ts
@@ -230,7 +230,7 @@ process.exit(2);
     const invocation = JSON.parse(await fs.readFile(cliLog, 'utf8')) as { url: string; checksum: string; version: string };
     assert.equal(invocation.url, 'https://example.com/canvas-notebook-linux-x64.tar.gz');
     assert.equal(invocation.version, '2026.9.5');
-    assert.match(invocation.checksum, new RegExp(`^${'b'.repeat(64)}\\s`, 'u'));
+    assert.equal(invocation.checksum, `${'b'.repeat(64)}  canvas-notebook-linux-cli-amd64.tar.gz\n`);
   });
 
   await withTempDirectory(async (directory) => {

--- a/scripts/system-update-apply-gate-test.ts
+++ b/scripts/system-update-apply-gate-test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { beginSystemUpdateApply, systemUpdateApplyAcknowledgement } from '../cli/src/core/systemUpdateApplyGate';
+import { SystemUpdateEventReporter } from '../cli/src/core/systemUpdateReporter';
+import { StandaloneUpdater } from '../cli/src/core/standaloneUpdater';
+import { StandaloneUpdateJournal } from '../cli/src/core/standaloneUpdateJournal';
+import { StandaloneReleaseResolver, type VerifiedStandaloneRelease } from '../cli/src/core/standaloneUpdateRelease';
+import type { SystemUpdateEvent, SystemUpdateOperation } from '../cli/src/core/systemUpdateContract';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+const release = {
+  signed: { manifest: { releaseId: 'test', version: '2026.9.6', cliVersion: '2026.9.6',
+    minimumVersion: null, imageRef: `ghcr.io/canvascoding/canvas-notebook@sha256:${'a'.repeat(64)}`, backupRequired: false } },
+} as VerifiedStandaloneRelease;
+class Resolver extends StandaloneReleaseResolver {
+  async resolve() { return release; }
+}
+
+async function waitIdle(updater: StandaloneUpdater) {
+  for (let i = 0; i < 200 && updater.busy; i++) await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(updater.busy, false);
+}
+
+async function testConcurrentCancel(applyFirst: boolean) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-cancel-race-'));
+  const reachedWrite = deferred();
+  const releaseWrite = deferred();
+  const execute = deferred();
+  const finish = deferred();
+  class DelayedJournal extends StandaloneUpdateJournal {
+    async writeOperation(operation: SystemUpdateOperation) {
+      if ((applyFirst && operation.stage === 'image_pull') || (!applyFirst && operation.errorCode === 'operation_interrupted')) {
+        reachedWrite.resolve(); await releaseWrite.promise;
+      }
+      return super.writeOperation(operation);
+    }
+  }
+  const updater = new StandaloneUpdater({
+    journal: new DelayedJournal(root), releaseResolver: new Resolver(),
+    currentVersion: async () => ({ appVersion: '2026.9.5', cliVersion: '2026.9.6' }), prepareHostCli: async () => {},
+    executeUpdate: async (operation, onEvent) => {
+      await execute.promise;
+      await onEvent({ contractVersion: 1, operationId: operation.operationId, eventId: crypto.randomUUID(),
+        sequence: 1, stage: 'image_pull', status: 'running', message: 'Ready to apply', occurredAt: new Date().toISOString() });
+      await finish.promise; return 1;
+    },
+  });
+  try {
+    await updater.initialize();
+    const operation = await updater.startUpdate({ channel: 'stable' });
+    if (applyFirst) execute.resolve();
+    else await new Promise((resolve) => setImmediate(resolve));
+    const cancel = applyFirst ? reachedWrite.promise.then(() => updater.cancelUpdate(operation.operationId)) : updater.cancelUpdate(operation.operationId);
+    const checked = applyFirst ? assert.rejects(cancel, /no longer be canceled/) : cancel.then((value) => assert.equal(value.status, 'failed'));
+    await reachedWrite.promise;
+    execute.resolve(); releaseWrite.resolve();
+    await checked;
+    const stored = await updater.getOperation(operation.operationId);
+    assert.equal(stored?.status, applyFirst ? 'running' : 'failed');
+    finish.resolve(); await waitIdle(updater);
+    if (!applyFirst) assert.equal((await updater.getOperation(operation.operationId))?.errorCode, 'operation_interrupted');
+  } finally { execute.resolve(); releaseWrite.resolve(); finish.resolve(); await fs.rm(root, { recursive: true, force: true }); }
+}
+
+async function main() {
+  const input = new PassThrough();
+  const reported: SystemUpdateEvent[] = [];
+  const reporter = new SystemUpdateEventReporter({ enabled: true, write: (line) => reported.push(JSON.parse(line)) });
+  let applied = false;
+  const waiting = beginSystemUpdateApply(reporter, { required: true, input }).then(() => { applied = true; });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(reported[0].stage, 'image_pull'); assert.equal(applied, false);
+  input.end(`${systemUpdateApplyAcknowledgement(reporter.operationId)}\n`);
+  await waiting; assert.equal(applied, true);
+  await assert.rejects(beginSystemUpdateApply(reporter, { required: true, input: new PassThrough(), timeoutMs: 5 }), /timed out/);
+  const disconnected = new PassThrough();
+  const rejected = assert.rejects(beginSystemUpdateApply(reporter, { required: true, input: disconnected }), /disconnected/);
+  disconnected.end(); await rejected;
+  await testConcurrentCancel(true);
+  await testConcurrentCancel(false);
+
+  // Exercise the actual child-process transport: ack arrives only after the
+  // host callback has saved the apply stage, and self-update stays disabled.
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-apply-child-'));
+  try {
+    const child = path.join(root, 'cli');
+    await fs.writeFile(child, `#!/usr/bin/env node
+const assert = require('node:assert/strict');
+assert.equal(process.env.CANVAS_CLI_SELF_UPDATE, 'false');
+assert.equal(process.env.CANVAS_UPDATE_APPLY_HANDSHAKE, '1');
+const id = process.argv[process.argv.indexOf('--operation-id') + 1];
+function event(sequence, stage, status) { process.stdout.write(JSON.stringify({contractVersion:1,eventId:require('node:crypto').randomUUID(),operationId:id,sequence,stage,status,message:'test',occurredAt:new Date().toISOString()})+'\\n'); }
+require('node:readline').createInterface({input:process.stdin}).once('line', line => {
+  assert.equal(line, 'canvas-update-apply:'+id);
+  event(2,'completed','succeeded');
+});
+event(1,'image_pull','running');
+`, { mode: 0o700 });
+    const updater = new StandaloneUpdater({ env: { ...process.env, CANVAS_CLI_PATH: child },
+      journal: new StandaloneUpdateJournal(path.join(root, 'journal')), releaseResolver: new Resolver(),
+      currentVersion: async () => ({ appVersion: '2026.9.5', cliVersion: '2026.9.6' }), prepareHostCli: async () => {},
+    });
+    await updater.initialize(); const op = await updater.startUpdate({ channel: 'stable' });
+    await waitIdle(updater);
+    assert.equal((await updater.getOperation(op.operationId))?.status, 'succeeded');
+  } finally { await fs.rm(root, { recursive: true, force: true }); }
+  console.log('system-update-apply-gate-test: ok');
+}
+void main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/scripts/system-update-download-test.ts
+++ b/scripts/system-update-download-test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+import { StandaloneReleaseResolver } from '../cli/src/core/standaloneUpdateRelease';
+
+async function main() {
+  let signal: AbortSignal | undefined;
+  const resolver = new StandaloneReleaseResolver({ fetch: async (_url, options) => {
+    signal = options?.signal as AbortSignal;
+    return new Response(new ReadableStream({ start(controller) {
+      controller.enqueue(new TextEncoder().encode('{'));
+      signal!.addEventListener('abort', () => controller.error(new DOMException('aborted', 'AbortError')), { once: true });
+    } }));
+  } });
+  mock.timers.enable({ apis: ['setTimeout'] });
+  try {
+    const request = assert.rejects(resolver.resolve('stable'), /timed out/);
+    // Let fetch resolve and the body reader block before advancing the clock.
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    mock.timers.tick(15_001);
+    assert.equal(signal?.aborted, true);
+    await request;
+  } finally { mock.timers.reset(); }
+
+  let canceled = false;
+  const oversized = new StandaloneReleaseResolver({ fetch: async () => new Response(new ReadableStream({
+    pull(controller) { controller.enqueue(new Uint8Array(256 * 1024 + 1)); },
+    cancel() { canceled = true; },
+  })) });
+  await assert.rejects(oversized.resolve('stable'), /too large/);
+  assert.equal(canceled, true);
+  console.log('system-update-download-test: ok');
+}
+void main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/scripts/system-update-observation-test.ts
+++ b/scripts/system-update-observation-test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { SystemUpdateObservation } from '../app/lib/system-updates/observation';
+import type { SystemUpdateOperationView } from '../app/lib/system-updates/types';
+
+const id = crypto.randomUUID();
+const observation = new SystemUpdateObservation(id);
+const base: SystemUpdateOperationView = { contractVersion: 1, operationId: id, currentVersion: '2026.9.5', targetVersion: '2026.9.6',
+  status: 'running', stage: 'image_pull', startedAt: '2026-09-05T00:00:00Z', updatedAt: '2026-09-05T00:00:02Z',
+  completedAt: null, rolledBack: false, errorCode: null, error: null, lastSequence: 2 };
+assert.equal(observation.acceptOperation(base), true);
+assert.equal(observation.acceptOperation({ ...base, lastSequence: 1 }), false);
+assert.equal(observation.acceptOperation({ ...base, updatedAt: '2026-09-05T00:00:01Z' }), false);
+assert.equal(observation.acceptOperation({ ...base, operationId: crypto.randomUUID() }), false);
+assert.equal(observation.acceptOperation({ ...base, status: 'succeeded', stage: 'completed', completedAt: base.updatedAt }), true);
+assert.equal(observation.acceptOperation({ ...base, lastSequence: 3 }), false);
+const event = (sequence: number) => ({ contractVersion: 1, operationId: id, eventId: crypto.randomUUID(), sequence,
+  stage: 'image_pull', status: 'running', message: 'test', occurredAt: base.updatedAt });
+observation.acceptEvents([event(2)]); assert.equal(observation.cursor, 0);
+observation.acceptEvents([event(1)]); assert.equal(observation.cursor, 2);
+observation.acceptEvents([event(2)]); assert.equal(observation.events.length, 2);
+console.log('system-update-observation-test: ok');

--- a/scripts/system-update-recovery-ui-test.tsx
+++ b/scripts/system-update-recovery-ui-test.tsx
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { JSDOM, VirtualConsole } from 'jsdom';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import messages from '../messages/en.json';
+import type { SystemUpdateOperationView } from '../app/lib/system-updates/types';
+
+let reloads = 0;
+const virtualConsole = new VirtualConsole();
+virtualConsole.on('jsdomError', (error) => {
+  if (error.message.includes('navigation')) reloads++; else throw error;
+});
+const dom = new JSDOM('<html><body></body></html>', { url: 'https://notebook.example.com/en/settings', pretendToBeVisual: true, virtualConsole });
+for (const name of ['window', 'document', 'navigator', 'HTMLElement', 'HTMLInputElement', 'HTMLButtonElement', 'SVGElement', 'Node', 'NodeFilter', 'Event', 'CustomEvent', 'MutationObserver', 'getComputedStyle'] as const) {
+  Object.defineProperty(globalThis, name, { value: name === 'window' ? dom.window : dom.window[name], configurable: true });
+}
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true, configurable: true });
+Object.defineProperty(globalThis, 'requestAnimationFrame', { value: dom.window.requestAnimationFrame.bind(dom.window), configurable: true });
+Object.defineProperty(globalThis, 'cancelAnimationFrame', { value: dom.window.cancelAnimationFrame.bind(dom.window), configurable: true });
+const id = '76e6f9f6-510a-4f00-babd-f9d3f3c17d15';
+const key = 'canvas.system-update.operation-id';
+const ticketKey = 'canvas.system-update.status-access';
+const base: SystemUpdateOperationView = { contractVersion: 1, operationId: id, currentVersion: '2026.9.5', targetVersion: '2026.9.6',
+  status: 'queued', stage: 'request_validation', startedAt: null, updatedAt: '2026-09-05T00:00:00Z',
+  completedAt: null, rolledBack: false, errorCode: null, error: null, lastSequence: 0 };
+const verifying: SystemUpdateOperationView = { ...base, status: 'verifying', stage: 'health_verification', lastSequence: 2 };
+const succeeded: SystemUpdateOperationView = { ...base, status: 'succeeded', stage: 'completed', lastSequence: 3, completedAt: base.updatedAt };
+const json = (value: unknown) => new Response(JSON.stringify(value), { headers: { 'content-type': 'application/json' } });
+async function until(condition: () => boolean, timeout = 5_000) {
+  const deadline = Date.now() + timeout;
+  while (!condition() && Date.now() < deadline) await act(async () => { await new Promise((resolve) => setTimeout(resolve, 25)); });
+  assert.ok(condition(), 'UI condition timed out');
+}
+
+async function main() {
+  const { UpdateCenterPanel } = await import('../app/components/settings/UpdateCenterPanel');
+  const originalFetch = globalThis.fetch;
+  try {
+    for (const mode of ['sse', 'managed'] as const) {
+      const beforeReload = reloads;
+      dom.window.localStorage.setItem(key, id);
+      dom.window.sessionStorage.clear();
+      if (mode === 'sse') dom.window.sessionStorage.setItem(ticketKey, JSON.stringify({ operationId: id,
+        path: `/__canvas-host/operations/${id}/events`, ticket: 'fixture', expiresAt: new Date(Date.now() + 120_000).toISOString() }));
+      let pollCount = 0;
+      let stream: ReadableStreamDefaultController<Uint8Array> | null = null;
+      let delayedPoll: ((response: Response) => void) | null = null;
+      globalThis.fetch = async (input, options) => {
+        const url = String(input);
+        if (url.startsWith('/__canvas-host/')) {
+          assert.equal(new Headers(options?.headers).get('authorization'), 'Bearer fixture');
+          return new Response(new ReadableStream({ start(controller) {
+            stream = controller;
+            options?.signal?.addEventListener('abort', () => { try { controller.close(); } catch {} }, { once: true });
+          } }), { headers: { 'content-type': 'text/event-stream' } });
+        }
+        if (url.includes('/events?')) {
+          pollCount++;
+          if (mode === 'managed') {
+            if (pollCount === 1) throw new Error('App restarting');
+            return json({ success: true, operation: succeeded, events: [] });
+          }
+          return new Promise<Response>((resolve) => { delayedPoll = resolve; });
+        }
+        if (url.endsWith('/status-access')) return json({ success: true, access: null });
+        throw new Error('App unavailable during restart');
+      };
+      const container = document.createElement('div'); document.body.append(container);
+      const root = createRoot(container);
+      await act(async () => root.render(<NextIntlClientProvider locale="en" timeZone="UTC" messages={messages}><UpdateCenterPanel /></NextIntlClientProvider>));
+      try {
+        if (mode === 'sse') {
+          await until(() => stream !== null && delayedPoll !== null);
+          const send = (operation: SystemUpdateOperationView) => stream!.enqueue(new TextEncoder().encode(`event: operation\ndata: ${JSON.stringify(operation)}\n\n`));
+          await act(async () => send(verifying));
+          assert.ok(container.textContent?.includes(messages.settings.updates.phases.restarting.title));
+          await act(async () => delayedPoll!(json({ success: true, operation: base, events: [] })));
+          assert.ok(container.textContent?.includes(messages.settings.updates.phases.restarting.title), 'stale REST response must not undo SSE progress');
+          await act(async () => send(succeeded));
+        }
+        await until(() => dom.window.localStorage.getItem(key) === null);
+        assert.ok(container.textContent?.includes(messages.settings.updates.operation.status.succeeded));
+        await until(() => reloads === beforeReload + 1);
+        assert.equal(dom.window.sessionStorage.getItem(ticketKey), null);
+        if (mode === 'managed') assert.equal(pollCount, 2, 'REST must retry even when the first operation load fails');
+      } finally { await act(async () => root.unmount()); container.remove(); }
+    }
+  } finally { globalThis.fetch = originalFetch; dom.window.close(); }
+  console.log('system-update-recovery-ui-test: ok');
+}
+void main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/scripts/system-update-release-test.ts
+++ b/scripts/system-update-release-test.ts
@@ -84,6 +84,11 @@ async function main(): Promise<void> {
     assert.equal(signStep.env.CANVAS_UPDATE_SIGNING_KEY_ID, publicStore.keys[0].keyId);
     assert.match(signStep.if, /refs\/tags\/v/u);
     assert.match(signStep.env.CANVAS_UPDATE_SIGNING_PRIVATE_KEY, /secrets.CANVAS_UPDATE_SIGNING_PRIVATE_KEY/u);
+    for (const job of Object.values(buildWorkflow.jobs) as Array<{ steps?: Array<{ uses?: string }> }>) {
+      for (const step of job.steps || []) {
+        if (step.uses) assert.match(step.uses, /@[a-f0-9]{40}$/u, `Mutable GitHub Action: ${step.uses}`);
+      }
+    }
     const bundle = steps.find((step: { name: string }) => step.name === 'Upload gated release bundle');
     assert.match(bundle.with.path, /canvas-notebook-update-stable.json/u);
     const publicationSource = await fs.readFile('.github/workflows/publish-standalone-update.yml', 'utf8');

--- a/scripts/system-update-release-test.ts
+++ b/scripts/system-update-release-test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import YAML from 'yaml';
+
+import { StandaloneReleaseResolver } from '../cli/src/core/standaloneUpdateRelease';
+import {
+  manifestFromReleaseMetadata, signReleaseUpdateManifest,
+  verifyReleaseUpdateManifest, verifyPublishedCliAssets,
+} from './lib/standalone-release-manifest';
+
+async function main(): Promise<void> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-release-signing-test-'));
+  try {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const trustStorePath = path.join(directory, 'trust.json');
+    await fs.writeFile(trustStorePath, JSON.stringify({ version: 1, keys: [{
+      keyId: 'test-only', algorithm: 'ed25519', publicKey: publicKey.export({ type: 'spki', format: 'pem' }),
+    }] }), { mode: 0o600 });
+    const expected = { tag: 'v2026.9.5.1', commitSha: 'a'.repeat(40), runId: '12345' };
+    const payload = Buffer.from('test CLI archive bytes');
+    const checksum = crypto.createHash('sha256').update(payload).digest('hex');
+    const metadata = {
+      schemaVersion: 1, repository: 'canvascoding/canvas-notebook', version: '2026.9.5.1',
+      tag: expected.tag, commitSha: expected.commitSha, build: { runId: expected.runId },
+      image: { name: 'ghcr.io/canvascoding/canvas-notebook', digest: `sha256:${'b'.repeat(64)}` },
+      linuxCli: {
+        amd64: { filename: 'canvas-notebook-linux-cli-amd64.tar.gz', sha256: checksum },
+        arm64: { filename: 'canvas-notebook-linux-cli-arm64.tar.gz', sha256: checksum },
+      },
+    };
+    const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    const signed = await signReleaseUpdateManifest(metadata, expected, privateKeyPem, 'test-only', trustStorePath);
+    assert.equal(signed.manifest.backupRequired, true);
+    assert.equal(signed.manifest.minimumVersion, null);
+    assert.equal(signed.manifest.imageRef, `${metadata.image.name}@${metadata.image.digest}`);
+    for (const [platformArchitecture, architecture] of [['x64', 'amd64'], ['arm64', 'arm64']] as const) {
+      const resolver = new StandaloneReleaseResolver({
+        env: { NODE_ENV: 'test', CANVAS_UPDATE_TRUST_STORE: trustStorePath }, platformArchitecture,
+        fetch: async (url) => {
+          assert.equal(url, 'https://github.com/canvascoding/canvas-notebook/releases/latest/download/canvas-notebook-update-stable.json');
+          return new Response(JSON.stringify(signed));
+        },
+      });
+      const verified = await resolver.resolve('stable');
+      assert.equal(verified.cliArtifact.architecture, architecture);
+      assert.equal(verified.cliArtifact.url,
+        `https://github.com/canvascoding/canvas-notebook/releases/download/${expected.tag}/canvas-notebook-linux-cli-${architecture}.tar.gz`);
+      await fs.writeFile(path.join(directory, `canvas-notebook-linux-cli-${architecture}.tar.gz`), payload);
+    }
+    await verifyPublishedCliAssets(signed.manifest, directory);
+    await fs.writeFile(path.join(directory, 'canvas-notebook-linux-cli-arm64.tar.gz'), 'tampered');
+    await assert.rejects(verifyPublishedCliAssets(signed.manifest, directory), /checksum mismatch/u);
+    await verifyReleaseUpdateManifest(signed, metadata, expected, trustStorePath);
+    await assert.rejects(verifyReleaseUpdateManifest({ ...signed, manifest: { ...signed.manifest, backupRequired: false } },
+      metadata, expected, trustStorePath), /signature is invalid/u);
+    const mismatched = structuredClone(metadata);
+    mismatched.linuxCli.amd64.sha256 = 'c'.repeat(64);
+    await assert.rejects(verifyReleaseUpdateManifest(signed, mismatched, expected, trustStorePath), /does not match/u);
+    for (const provenance of [
+      { ...expected, tag: 'v2026.9.6.1' }, { ...expected, runId: '999' }, { ...expected, commitSha: 'd'.repeat(40) },
+    ]) {
+      assert.throws(() => manifestFromReleaseMetadata(metadata, provenance, signed.manifest.publishedAt), /exact trusted tag build/u);
+    }
+    const wrongPrivateKey = crypto.generateKeyPairSync('ed25519').privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    await assert.rejects(signReleaseUpdateManifest(metadata, expected, wrongPrivateKey, 'test-only', trustStorePath), /signature is invalid/u);
+    await assert.rejects(signReleaseUpdateManifest(metadata, expected, '', 'test-only', trustStorePath), /required/u);
+    await assert.rejects(signReleaseUpdateManifest(metadata, expected, privateKeyPem, 'unknown', trustStorePath), /unknown key/u);
+
+    const publicStore = JSON.parse(await fs.readFile('install/keys/update-trust.json', 'utf8'));
+    assert.equal(publicStore.version, 1);
+    assert.ok(publicStore.keys.length > 0);
+    for (const key of publicStore.keys) {
+      assert.equal(key.algorithm, 'ed25519');
+      assert.match(key.publicKey, /^-----BEGIN PUBLIC KEY-----/u);
+      assert.equal(crypto.createPublicKey(key.publicKey).asymmetricKeyType, 'ed25519');
+    }
+    const buildSource = await fs.readFile('.github/workflows/build-both.yml', 'utf8');
+    const buildWorkflow = YAML.parse(buildSource);
+    const steps = buildWorkflow.jobs.merge.steps;
+    const signStep = steps.find((step: { name: string }) => step.name === 'Sign standalone update manifest');
+    assert.equal(signStep.env.CANVAS_UPDATE_SIGNING_KEY_ID, publicStore.keys[0].keyId);
+    assert.match(signStep.if, /refs\/tags\/v/u);
+    assert.match(signStep.env.CANVAS_UPDATE_SIGNING_PRIVATE_KEY, /secrets.CANVAS_UPDATE_SIGNING_PRIVATE_KEY/u);
+    const bundle = steps.find((step: { name: string }) => step.name === 'Upload gated release bundle');
+    assert.match(bundle.with.path, /canvas-notebook-update-stable.json/u);
+    const publicationSource = await fs.readFile('.github/workflows/publish-standalone-update.yml', 'utf8');
+    const publication = YAML.parse(publicationSource);
+    assert.deepEqual(publication.on.release.types, ['published']);
+    assert.equal(publication.jobs.publish.permissions.contents, 'write');
+    assert.doesNotMatch(publicationSource, /CONTROL_PLANE|CANVAS_UPDATE_SIGNING_PRIVATE_KEY|--clobber/u);
+    assert.match(publicationSource, /\.conclusion == "success"/u);
+    assert.match(publicationSource, /system-update-release.ts verify/u);
+    assert.match(publicationSource, /cmp "signed-update/u);
+    console.log('Standalone release manifest signing, provenance, published assets, and workflow tests passed.');
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+}
+
+main().catch((error: unknown) => { console.error(error); process.exitCode = 1; });

--- a/scripts/system-update-release.ts
+++ b/scripts/system-update-release.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { signReleaseUpdateManifest, verifyReleaseUpdateManifest, verifyPublishedCliAssets } from './lib/standalone-release-manifest';
+
+async function main(): Promise<void> {
+  const [mode, metadataPath, manifestPath, publicAssets] = process.argv.slice(2);
+  if (!['sign', 'verify'].includes(mode) || !metadataPath || !manifestPath) {
+    throw new Error('Usage: system-update-release.ts sign|verify METADATA MANIFEST [PUBLIC_ASSET_DIRECTORY]');
+  }
+  const expected = {
+    tag: process.env.RELEASE_TAG || '',
+    commitSha: process.env.RELEASE_COMMIT_SHA || '',
+    runId: process.env.RELEASE_RUN_ID || '',
+  };
+  const trustStorePath = path.resolve('install/keys/update-trust.json');
+  const metadata: unknown = JSON.parse(await fs.readFile(metadataPath, 'utf8'));
+  if (mode === 'sign') {
+    const signed = await signReleaseUpdateManifest(metadata, expected,
+      process.env.CANVAS_UPDATE_SIGNING_PRIVATE_KEY || '',
+      process.env.CANVAS_UPDATE_SIGNING_KEY_ID || '', trustStorePath);
+    await fs.mkdir(path.dirname(manifestPath), { recursive: true });
+    await fs.writeFile(manifestPath, `${JSON.stringify(signed, null, 2)}\n`, { flag: 'wx' });
+    console.log('Signed and verified standalone update manifest.');
+  } else {
+    const signed = await verifyReleaseUpdateManifest(JSON.parse(await fs.readFile(manifestPath, 'utf8')) as unknown,
+      metadata, expected, trustStorePath);
+    if (publicAssets) await verifyPublishedCliAssets(signed.manifest, publicAssets);
+    console.log('Verified standalone update manifest and release provenance.');
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : 'Release manifest operation failed.');
+  process.exitCode = 1;
+});

--- a/scripts/system-update-ui-contract-test.ts
+++ b/scripts/system-update-ui-contract-test.ts
@@ -22,7 +22,6 @@ async function main(): Promise<void> {
   assert.match(panel, /setConnectionInterrupted\(true\)/u);
   assert.match(panel, /text\/event-stream/u);
   assert.match(panel, /Authorization: `Bearer \$\{statusAccess\.ticket\}`/u);
-  assert.match(panel, /fetch\('\/api\/health'/u);
   assert.match(panel, /<UpdateAvailabilityCard/u);
   assert.match(panel, /<UpdateOperationCard/u);
   assert.match(sections, /availability\.mode === 'manual'/u);


### PR DESCRIPTION
## Summary

- serialize cancellation with the update apply boundary and fix architecture-specific CLI verification under the updater sandbox
- recover the settings UI across app downtime and reconcile REST/SSE observations without stale state overwrites
- enforce the manifest timeout through body download and publish signed, provenance-checked standalone update manifests

## Verification

- `npm run lint`
- `npm run build`
- `npm run test:release:updates`
- `npm run test:release:host-cli`
- `npm run test:cli:updater`
- `npm run test:install:updater`
- `npm run test:system-updates`
- `npm run cli:build`
- `npm run test:cli:update-rollback`
- `npm run test:cli:update`
- `npm run test:cli:portable-update`
- `npm run test:cli:portable`

## Notes

- No containers or real-browser tests were run. UI recovery is covered by rendered JSDOM tests; the host installer and update lifecycle are covered by isolated tests.
- Existing standalone hosts without a trust store need one updated host-installer run before signed in-app updates can work.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens standalone-update publication, application, and recovery across the release pipeline, host updater, and settings UI.
- Pins privileged release-workflow actions to immutable commit SHAs and publishes signed, provenance-checked update manifests.
- Serializes cancellation with update application and corrects architecture-specific CLI verification.
- Reconciles REST and SSE observations, restores UI state after downtime, and extends manifest timeouts through body download.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-both.yml | Pins release-build actions to immutable SHAs and adds signed standalone-update metadata to the gated release bundle. |
| .github/workflows/publish-standalone-update.yml | Adds an immutable-action publication workflow that verifies release provenance, signatures, and public CLI bytes before attaching the manifest. |
| cli/src/core/standaloneUpdater.ts | Hardens standalone update download, verification, architecture selection, and lifecycle handling. |
| cli/src/core/systemUpdateApplyGate.ts | Serializes cancellation and update application around the apply boundary. |
| app/components/settings/UpdateCenterPanel.tsx | Adds downtime recovery and coordinated REST/SSE observation handling for active updates. |
| app/lib/system-updates/observation.ts | Centralizes monotonic operation and event reconciliation to prevent stale observations from overwriting newer state. |
| scripts/system-update-release.ts | Implements signing and verification of standalone update manifests with release provenance checks. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Build as Release Build
  participant Publish as Publication Workflow
  participant Host as Standalone Host
  participant UI as Update Center
  Build->>Build: Build architecture-specific CLI assets
  Build->>Build: Sign update manifest
  Build-->>Publish: Upload signed manifest artifact
  Publish->>Publish: Verify signature, provenance, and public asset hashes
  Publish-->>Host: Attach verified manifest to release
  Host->>Host: Download and verify update
  Host->>Host: Serialize cancellation with apply boundary
  Host-->>UI: Publish operation snapshots and events
  UI->>UI: Reconcile REST and SSE observations
  UI->>Host: Recover status after application downtime
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Pin release build actions before signing"](https://github.com/canvascoding/canvas-notebook/commit/0167168a295fefbc171e4f3746946e86803d0a6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60743459)</sub>

<!-- /greptile_comment -->