### PR TITLE
Cache email lists and message reads in PostgreSQL

### DIFF
--- a/app/api/email/accounts/[accountId]/messages/[messageId]/actions/route.ts
+++ b/app/api/email/accounts/[accountId]/messages/[messageId]/actions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { auth } from '@/app/lib/auth';
+import { isImapMailboxChangedError } from '@/app/lib/email/imap-service';
 import {
   archiveEmailMessage,
   deleteEmailMessagePermanently,
@@ -76,6 +77,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
     return NextResponse.json({ success: true, data });
   } catch (error) {
+    if (isImapMailboxChangedError(error)) {
+      return NextResponse.json({ success: false, code: error.code, error: error.message }, { status: error.status });
+    }
     const message = error instanceof Error ? error.message : 'Failed to update email message';
     return NextResponse.json({ success: false, error: message }, { status: 500 });
   }

--- a/app/api/email/accounts/[accountId]/messages/[messageId]/ai-reply/route.ts
+++ b/app/api/email/accounts/[accountId]/messages/[messageId]/ai-reply/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { emailAiRequestBodyErrorStatus, readEmailAiJsonObject } from '@/app/lib/email/ai-request-body';
 import { requireEmailAiRouteSession } from '@/app/lib/email/ai-route-guard';
+import { isImapMailboxChangedError } from '@/app/lib/email/imap-service';
 import { createEmailAiReplyDraft } from '@/app/lib/email/service';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 
@@ -30,6 +31,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     );
     return NextResponse.json({ success: true, data });
   } catch (error) {
+    if (isImapMailboxChangedError(error)) {
+      return NextResponse.json(
+        { success: false, code: error.code, error: error.message },
+        { status: error.status },
+      );
+    }
     const message = error instanceof Error ? error.message : 'Failed to create AI reply draft';
     return NextResponse.json(
       { success: false, error: message },

--- a/app/api/email/accounts/[accountId]/messages/[messageId]/draft/route.ts
+++ b/app/api/email/accounts/[accountId]/messages/[messageId]/draft/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { auth } from '@/app/lib/auth';
+import { isImapMailboxChangedError } from '@/app/lib/email/imap-service';
 import { createEmailDerivedDraft } from '@/app/lib/email/service';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 
@@ -36,6 +37,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     const data = await createEmailDerivedDraft(session.user.id, accountId, messageId, folder, mode, undefined, { enforceReadPolicy: false });
     return NextResponse.json({ success: true, data });
   } catch (error) {
+    if (isImapMailboxChangedError(error)) {
+      return NextResponse.json({ success: false, code: error.code, error: error.message }, { status: error.status });
+    }
     const message = error instanceof Error ? error.message : 'Failed to create email draft';
     return NextResponse.json({ success: false, error: message }, { status: 500 });
   }

--- a/app/api/email/accounts/[accountId]/messages/[messageId]/route.ts
+++ b/app/api/email/accounts/[accountId]/messages/[messageId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { auth } from '@/app/lib/auth';
 import { isEmailMessageNotFoundError } from '@/app/lib/email/errors';
+import { isImapMailboxChangedError } from '@/app/lib/email/imap-service';
 import { readEmailMessage } from '@/app/lib/email/service';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 
@@ -22,6 +23,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const data = await readEmailMessage(session.user.id, accountId, messageId, folder, { enforceReadPolicy: false });
     return NextResponse.json({ success: true, data });
   } catch (error) {
+    if (isImapMailboxChangedError(error)) {
+      return NextResponse.json({ success: false, code: error.code, error: error.message }, { status: error.status });
+    }
     if (isEmailMessageNotFoundError(error)) {
       return NextResponse.json({ success: false, code: 'EMAIL_MESSAGE_NOT_FOUND', error: 'Email message is no longer available.' }, { status: 404 });
     }

--- a/app/api/email/accounts/[accountId]/messages/[messageId]/route.ts
+++ b/app/api/email/accounts/[accountId]/messages/[messageId]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { after, NextRequest, NextResponse } from 'next/server';
 
 import { auth } from '@/app/lib/auth';
 import { isEmailMessageNotFoundError } from '@/app/lib/email/errors';
@@ -20,7 +20,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   try {
     const { accountId, messageId } = await params;
     const folder = request.nextUrl.searchParams.get('folder') || undefined;
-    const data = await readEmailMessage(session.user.id, accountId, messageId, folder, { enforceReadPolicy: false });
+    const data = await readEmailMessage(session.user.id, accountId, messageId, folder, {
+      enforceReadPolicy: false,
+      cacheMode: 'swr',
+      scheduleBackgroundTask: after,
+    });
     return NextResponse.json({ success: true, data });
   } catch (error) {
     if (isImapMailboxChangedError(error)) {

--- a/app/api/email/accounts/[accountId]/messages/[messageId]/summary/route.ts
+++ b/app/api/email/accounts/[accountId]/messages/[messageId]/summary/route.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage } from '@earendil-works/pi-ai';
 
 import { emailAiRequestBodyErrorStatus, readEmailAiJsonObject } from '@/app/lib/email/ai-request-body';
 import { requireEmailAiRouteSession } from '@/app/lib/email/ai-route-guard';
+import { isImapMailboxChangedError } from '@/app/lib/email/imap-service';
 import { streamEmailMessageSummary, summarizeEmailMessage } from '@/app/lib/email/service';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 
@@ -126,6 +127,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     );
     return NextResponse.json({ success: true, data });
   } catch (error) {
+    if (isImapMailboxChangedError(error)) {
+      return NextResponse.json(
+        { success: false, code: error.code, error: error.message },
+        { status: error.status },
+      );
+    }
     const message = error instanceof Error ? error.message : 'Failed to summarize email message';
     return NextResponse.json(
       { success: false, error: message },

--- a/app/api/email/accounts/[accountId]/messages/actions/route.ts
+++ b/app/api/email/accounts/[accountId]/messages/actions/route.ts
@@ -19,6 +19,7 @@ import {
 import { normalizeEmailAttachmentInputs } from '@/app/lib/email/attachments';
 import { emailAiRequestBodyErrorStatus, readEmailAiJsonObject } from '@/app/lib/email/ai-request-body';
 import { requireEmailAiRouteSession } from '@/app/lib/email/ai-route-guard';
+import { isImapMailboxChangedError } from '@/app/lib/email/imap-service';
 import { logEmailClientEvent } from '@/app/lib/email/logging';
 import { rateLimit } from '@/app/lib/utils/rate-limit';
 
@@ -377,6 +378,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       status: 'failed',
       userId: session.user.id,
     });
+    if (isImapMailboxChangedError(error)) {
+      return NextResponse.json(
+        { success: false, code: error.code, error: error.message },
+        { status: error.status },
+      );
+    }
     const message = error instanceof Error ? error.message : 'Failed to update email message';
     return NextResponse.json(
       { success: false, error: message },

--- a/app/api/email/messages/list/route.ts
+++ b/app/api/email/messages/list/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { after, NextRequest, NextResponse } from 'next/server';
 
 import { auth } from '@/app/lib/auth';
 import { listEmailMessages } from '@/app/lib/email/service';
@@ -18,7 +18,11 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json().catch(() => ({}));
-    const data = await listEmailMessages(session.user.id, body, { enforceReadPolicy: false });
+    const data = await listEmailMessages(session.user.id, body, {
+      enforceReadPolicy: false,
+      cacheMode: 'swr',
+      scheduleBackgroundTask: after,
+    });
     return NextResponse.json({ success: true, data });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to list email messages';

--- a/app/api/home/workspace-widgets/route.ts
+++ b/app/api/home/workspace-widgets/route.ts
@@ -1,17 +1,17 @@
-import { NextRequest } from 'next/server';
+import { after, NextRequest } from 'next/server';
 
 import { applyRateLimit, jsonError, jsonSuccess } from '@/app/lib/api/route-helpers';
+import { listEmailAccounts, listEmailMessages } from '@/app/lib/email/service';
 import { loadCachedWorkspaceWidget } from '@/app/lib/home/workspace-widget-cache';
 import {
   loadHomeWidgetAutomation,
-  loadHomeWidgetEmails,
   loadHomeWidgetStudio,
   loadHomeWidgetTodos,
 } from '@/app/lib/home/workspace-widget-data';
+import { loadHomeWidgetEmails } from '@/app/lib/home/workspace-email-widget';
 import { requireRequestWorkspace } from '@/app/lib/workspaces/request';
 
 const TTL = {
-  emails: 60_000,
   todos: 30_000,
   automation: 30_000,
   studio: 30_000,
@@ -47,7 +47,10 @@ export async function GET(request: NextRequest) {
   const fetcher = requestFetcher(request);
   const cacheInput = { userId: access.session.user.id, workspaceId, forceRefresh };
   const [emails, todos, automation, studio] = await Promise.all([
-    widgetResult(() => loadCachedWorkspaceWidget({ ...cacheInput, widget: 'emails', ttlMs: TTL.emails, load: () => loadHomeWidgetEmails(fetcher) })),
+    widgetResult(() => loadHomeWidgetEmails(access.session.user.id, {
+      scheduleBackgroundTask: after,
+      services: { listAccounts: listEmailAccounts, listMessages: listEmailMessages },
+    })),
     widgetResult(() => loadCachedWorkspaceWidget({ ...cacheInput, widget: 'todos', ttlMs: TTL.todos, load: () => loadHomeWidgetTodos(fetcher, workspaceId) })),
     widgetResult(() => loadCachedWorkspaceWidget({ ...cacheInput, widget: 'automation', ttlMs: TTL.automation, load: () => loadHomeWidgetAutomation(fetcher, workspaceId) })),
     widgetResult(() => loadCachedWorkspaceWidget({ ...cacheInput, widget: 'studio', ttlMs: TTL.studio, load: () => loadHomeWidgetStudio(fetcher, workspaceId) })),

--- a/app/api/home/workspace-widgets/route.ts
+++ b/app/api/home/workspace-widgets/route.ts
@@ -9,6 +9,7 @@ import {
   loadHomeWidgetTodos,
 } from '@/app/lib/home/workspace-widget-data';
 import { loadHomeWidgetEmails } from '@/app/lib/home/workspace-email-widget';
+import { HOME_WIDGET_NAMES, parseHomeWidgetSelection } from '@/app/lib/home/workspace-widget-request';
 import { requireRequestWorkspace } from '@/app/lib/workspaces/request';
 
 const TTL = {
@@ -43,20 +44,61 @@ export async function GET(request: NextRequest) {
   const limited = applyRateLimit(request, { limit: 120, windowMs: 60_000, keyPrefix: 'home-workspace-widgets' });
   if (limited) return limited;
 
-  const forceRefresh = request.nextUrl.searchParams.get('refresh') === '1';
+  const requestedWidgets = parseHomeWidgetSelection(request.nextUrl.searchParams.get('widgets'), HOME_WIDGET_NAMES);
+  if (!requestedWidgets) return jsonError('Invalid workspace widget selection', 400);
+  const refreshParam = request.nextUrl.searchParams.get('refresh');
+  const forceRefreshWidgets = refreshParam === '1'
+    ? requestedWidgets
+    : parseHomeWidgetSelection(refreshParam, []);
+  if (!forceRefreshWidgets) return jsonError('Invalid workspace widget refresh selection', 400);
+  const selected = new Set(requestedWidgets);
+  const forced = new Set(forceRefreshWidgets);
   const fetcher = requestFetcher(request);
-  const cacheInput = { userId: access.session.user.id, workspaceId, forceRefresh };
   const [emails, todos, automation, studio] = await Promise.all([
-    widgetResult(() => loadHomeWidgetEmails(access.session.user.id, {
-      scheduleBackgroundTask: after,
-      services: { listAccounts: listEmailAccounts, listMessages: listEmailMessages },
-    })),
-    widgetResult(() => loadCachedWorkspaceWidget({ ...cacheInput, widget: 'todos', ttlMs: TTL.todos, load: () => loadHomeWidgetTodos(fetcher, workspaceId) })),
-    widgetResult(() => loadCachedWorkspaceWidget({ ...cacheInput, widget: 'automation', ttlMs: TTL.automation, load: () => loadHomeWidgetAutomation(fetcher, workspaceId) })),
-    widgetResult(() => loadCachedWorkspaceWidget({ ...cacheInput, widget: 'studio', ttlMs: TTL.studio, load: () => loadHomeWidgetStudio(fetcher, workspaceId) })),
+    selected.has('emails')
+      ? widgetResult(() => loadHomeWidgetEmails(access.session.user.id, {
+        scheduleBackgroundTask: after,
+        services: { listAccounts: listEmailAccounts, listMessages: listEmailMessages },
+      }))
+      : undefined,
+    selected.has('todos')
+      ? widgetResult(() => loadCachedWorkspaceWidget({
+        userId: access.session.user.id,
+        workspaceId,
+        forceRefresh: forced.has('todos'),
+        widget: 'todos',
+        ttlMs: TTL.todos,
+        load: () => loadHomeWidgetTodos(fetcher, workspaceId),
+      }))
+      : undefined,
+    selected.has('automation')
+      ? widgetResult(() => loadCachedWorkspaceWidget({
+        userId: access.session.user.id,
+        workspaceId,
+        forceRefresh: forced.has('automation'),
+        widget: 'automation',
+        ttlMs: TTL.automation,
+        load: () => loadHomeWidgetAutomation(fetcher, workspaceId),
+      }))
+      : undefined,
+    selected.has('studio')
+      ? widgetResult(() => loadCachedWorkspaceWidget({
+        userId: access.session.user.id,
+        workspaceId,
+        forceRefresh: forced.has('studio'),
+        widget: 'studio',
+        ttlMs: TTL.studio,
+        load: () => loadHomeWidgetStudio(fetcher, workspaceId),
+      }))
+      : undefined,
   ]);
 
-  return jsonSuccess({ data: { emails, todos, automation, studio } }, {
+  return jsonSuccess({ data: {
+    ...(emails ? { emails } : {}),
+    ...(todos ? { todos } : {}),
+    ...(automation ? { automation } : {}),
+    ...(studio ? { studio } : {}),
+  } }, {
     headers: { 'Cache-Control': 'private, no-store' },
   });
 }

--- a/app/apps/email/components/EmailClient.tsx
+++ b/app/apps/email/components/EmailClient.tsx
@@ -36,7 +36,15 @@ import {
   readEmailSummaryStream,
   type EmailAiStreamStage,
 } from '@/app/lib/email/client-ai-stream';
-import { emailMessageContentRevision, emailMessageListScopeKey } from '@/app/lib/email/reader-refresh';
+import {
+  claimEmailCacheFollowUp,
+  EMAIL_CACHE_FOLLOW_UP_DELAY_MS,
+  emailCacheFollowUpKey,
+  emailMessageContentRevision,
+  emailMessageDetailScopeKey,
+  emailMessageListScopeKey,
+  shouldApplyEmailRefresh,
+} from '@/app/lib/email/reader-refresh';
 import type { NotebookEmailContextIntent } from '@/app/lib/notebook/context-surface';
 import { useWorkspaceStore } from '@/app/store/workspace-store';
 import { Button } from '@/components/ui/button';
@@ -101,6 +109,18 @@ export function EmailClient({
   const listRequestScopeRef = useRef<string | null>(null);
   const detailRequestRef = useRef<AbortController | null>(null);
   const detailRefreshRequestRef = useRef<AbortController | null>(null);
+  const listFollowUpTimerRef = useRef<number | null>(null);
+  const detailFollowUpTimerRef = useRef<number | null>(null);
+  const listFollowUpKeysRef = useRef(new Set<string>());
+  const detailFollowUpKeysRef = useRef(new Set<string>());
+  const listRequestEpochRef = useRef(0);
+  const detailRequestEpochRef = useRef(0);
+  const messageMutationRevisionRef = useRef(0);
+  const activeMessageMutationsRef = useRef(0);
+  const pendingListFollowUpRef = useRef(false);
+  const pendingDetailFollowUpRef = useRef(false);
+  const listFollowUpRunnerRef = useRef<() => void>(() => undefined);
+  const detailFollowUpRunnerRef = useRef<() => void>(() => undefined);
   const selectedMessageRef = useRef<EmailMessageDetail | null>(null);
   const dismissedMessageRevisionRef = useRef<string | null>(null);
   const hasMessagesRef = useRef(false);
@@ -138,7 +158,72 @@ export function EmailClient({
     setMessageSummaryStatus(null);
   }, [stopMessageSummaryStream]);
 
+  const cancelListFollowUp = useCallback(() => {
+    if (listFollowUpTimerRef.current !== null) window.clearTimeout(listFollowUpTimerRef.current);
+    listFollowUpTimerRef.current = null;
+    pendingListFollowUpRef.current = false;
+  }, []);
+
+  const cancelDetailFollowUp = useCallback(() => {
+    if (detailFollowUpTimerRef.current !== null) window.clearTimeout(detailFollowUpTimerRef.current);
+    detailFollowUpTimerRef.current = null;
+    pendingDetailFollowUpRef.current = false;
+  }, []);
+
+  const beginMessageMutation = useCallback(() => {
+    activeMessageMutationsRef.current += 1;
+    messageMutationRevisionRef.current += 1;
+    let finished = false;
+    return () => {
+      if (finished) return;
+      finished = true;
+      activeMessageMutationsRef.current = Math.max(0, activeMessageMutationsRef.current - 1);
+      messageMutationRevisionRef.current += 1;
+      if (activeMessageMutationsRef.current > 0) return;
+      if (pendingListFollowUpRef.current) {
+        pendingListFollowUpRef.current = false;
+        listFollowUpRunnerRef.current();
+      }
+      if (pendingDetailFollowUpRef.current) {
+        pendingDetailFollowUpRef.current = false;
+        detailFollowUpRunnerRef.current();
+      }
+    };
+  }, []);
+
+  const scheduleListFollowUp = useCallback((scopeKey: string, cache: unknown, requestEpoch: number) => {
+    const followUpKey = emailCacheFollowUpKey(scopeKey, cache);
+    if (!claimEmailCacheFollowUp(listFollowUpKeysRef.current, followUpKey)) return;
+    cancelListFollowUp();
+    listFollowUpTimerRef.current = window.setTimeout(() => {
+      listFollowUpTimerRef.current = null;
+      if (listRequestEpochRef.current !== requestEpoch) return;
+      if (activeMessageMutationsRef.current > 0) {
+        pendingListFollowUpRef.current = true;
+        return;
+      }
+      listFollowUpRunnerRef.current();
+    }, EMAIL_CACHE_FOLLOW_UP_DELAY_MS);
+  }, [cancelListFollowUp]);
+
+  const scheduleDetailFollowUp = useCallback((scopeKey: string, cache: unknown, requestEpoch: number) => {
+    const followUpKey = emailCacheFollowUpKey(scopeKey, cache);
+    if (!claimEmailCacheFollowUp(detailFollowUpKeysRef.current, followUpKey)) return;
+    cancelDetailFollowUp();
+    detailFollowUpTimerRef.current = window.setTimeout(() => {
+      detailFollowUpTimerRef.current = null;
+      if (detailRequestEpochRef.current !== requestEpoch) return;
+      if (activeMessageMutationsRef.current > 0) {
+        pendingDetailFollowUpRef.current = true;
+        return;
+      }
+      detailFollowUpRunnerRef.current();
+    }, EMAIL_CACHE_FOLLOW_UP_DELAY_MS);
+  }, [cancelDetailFollowUp]);
+
   const clearReader = useCallback(() => {
+    cancelDetailFollowUp();
+    detailRequestEpochRef.current += 1;
     detailRequestRef.current?.abort();
     detailRefreshRequestRef.current?.abort();
     setSelectedMessage(null);
@@ -150,7 +235,7 @@ export function EmailClient({
     setMessageActionNotice(null);
     clearMessageSummary();
     setMessageDialogOpen(false);
-  }, [clearMessageSummary]);
+  }, [cancelDetailFollowUp, clearMessageSummary]);
 
   const summaryAiStageLabel = useCallback((stage: EmailAiStreamStage | undefined, fallback?: string) => {
     if (stage === 'reading_context') return t('summaryReadingContext');
@@ -296,6 +381,9 @@ export function EmailClient({
     if (!activeAccount || !current) return;
     const accountId = activeAccount.id;
     const folder = current.folder || activeFolder;
+    cancelDetailFollowUp();
+    const requestEpoch = ++detailRequestEpochRef.current;
+    const mutationRevision = messageMutationRevisionRef.current;
     detailRefreshRequestRef.current?.abort();
     const controller = new AbortController();
     detailRefreshRequestRef.current = controller;
@@ -311,6 +399,13 @@ export function EmailClient({
         || activeAccountRef.current !== accountId
         || activeFolderRef.current !== folder
         || selectedMessageRef.current?.id !== current.id
+        || !shouldApplyEmailRefresh({
+          requestEpoch,
+          currentEpoch: detailRequestEpochRef.current,
+          mutationRevision,
+          currentMutationRevision: messageMutationRevisionRef.current,
+          mutationInFlight: activeMessageMutationsRef.current > 0,
+        })
       ) return;
       if (response.status === 404 && payload.code === 'EMAIL_MESSAGE_NOT_FOUND') {
         setMessageUnavailable(current);
@@ -321,6 +416,7 @@ export function EmailClient({
       const nextMessage = payload.data?.message as EmailMessageDetail | undefined;
       if (!nextMessage) throw new Error(t('errors.loadMessage'));
       setMessageUnavailable(null);
+      scheduleDetailFollowUp(emailMessageDetailScopeKey({ accountId, folder, messageId: current.id }), payload.data?.cache, requestEpoch);
       const nextRevision = emailMessageContentRevision(nextMessage);
       if (nextRevision !== emailMessageContentRevision(current) && dismissedMessageRevisionRef.current !== nextRevision) {
         setPendingMessageUpdate(nextMessage);
@@ -329,9 +425,9 @@ export function EmailClient({
       if (controller.signal.aborted || detailRefreshRequestRef.current !== controller) return;
       setError(refreshError instanceof Error ? refreshError.message : t('errors.loadMessage'));
     }
-  }, [activeAccount, activeFolder, t]);
+  }, [activeAccount, activeFolder, cancelDetailFollowUp, scheduleDetailFollowUp, t]);
 
-  const loadMessages = useCallback(async (options?: { background?: boolean }) => {
+  const loadMessages = useCallback(async (options?: { background?: boolean; swrFollowUp?: boolean }) => {
     if (!activeAccount || !canReadActiveAccount || foldersAccountId !== activeAccount.id) return;
     const scopeKey = emailMessageListScopeKey({
       accountId: activeAccount.id,
@@ -341,6 +437,9 @@ export function EmailClient({
       query: submittedQuery,
     });
     if (listRequestRef.current && listRequestScopeRef.current === scopeKey) return;
+    cancelListFollowUp();
+    const requestEpoch = ++listRequestEpochRef.current;
+    const mutationRevision = messageMutationRevisionRef.current;
     listRequestRef.current?.abort();
     const controller = new AbortController();
     listRequestRef.current = controller;
@@ -370,11 +469,19 @@ export function EmailClient({
         listRequestRef.current !== controller
         || activeAccountRef.current !== activeAccount.id
         || activeFolderRef.current !== activeFolder
+        || !shouldApplyEmailRefresh({
+          requestEpoch,
+          currentEpoch: listRequestEpochRef.current,
+          mutationRevision,
+          currentMutationRevision: messageMutationRevisionRef.current,
+          mutationInFlight: activeMessageMutationsRef.current > 0,
+        })
       ) return;
       const nextMessages = (payload.data?.messages || []) as EmailMessageSummary[];
       setMessages(nextMessages);
       setMessageTotal(typeof payload.data?.total === 'number' ? payload.data.total : null);
-      void refreshSelectedMessage();
+      scheduleListFollowUp(scopeKey, payload.data?.cache, requestEpoch);
+      if (!options?.swrFollowUp) void refreshSelectedMessage();
     } catch (loadError) {
       if (controller.signal.aborted || listRequestRef.current !== controller) return;
       if (!preserveVisibleData) {
@@ -390,7 +497,7 @@ export function EmailClient({
         setIsRefreshingMessages(false);
       }
     }
-  }, [activeAccount, activeFolder, canReadActiveAccount, foldersAccountId, messageFilter, messagePage, refreshSelectedMessage, submittedQuery, t]);
+  }, [activeAccount, activeFolder, canReadActiveAccount, cancelListFollowUp, foldersAccountId, messageFilter, messagePage, refreshSelectedMessage, scheduleListFollowUp, submittedQuery, t]);
 
   const updateMessageReadState = useCallback((messageId: string, isRead: boolean) => {
     setMessages((current) => current.map((message) => message.id === messageId ? { ...message, isRead } : message));
@@ -400,6 +507,7 @@ export function EmailClient({
   const markMessageReadOnOpen = useCallback(async (message: EmailMessageSummary | EmailMessageDetail) => {
     if (!activeAccount || message.isRead) return;
     const folder = message.folder || activeFolder;
+    const finishMutation = beginMessageMutation();
     updateMessageReadState(message.id, true);
 
     try {
@@ -414,11 +522,16 @@ export function EmailClient({
       void loadFolders(activeAccount.id);
     } catch {
       updateMessageReadState(message.id, false);
+    } finally {
+      finishMutation();
     }
-  }, [activeAccount, activeFolder, loadFolders, t, updateMessageReadState]);
+  }, [activeAccount, activeFolder, beginMessageMutation, loadFolders, t, updateMessageReadState]);
 
   const loadMessage = useCallback(async (message: EmailMessageSummary, options?: { openDialog?: boolean }) => {
     if (!activeAccount) return;
+    cancelDetailFollowUp();
+    const requestEpoch = ++detailRequestEpochRef.current;
+    const mutationRevision = messageMutationRevisionRef.current;
     detailRequestRef.current?.abort();
     detailRefreshRequestRef.current?.abort();
     const controller = new AbortController();
@@ -446,6 +559,13 @@ export function EmailClient({
         detailRequestRef.current !== controller
         || activeAccountRef.current !== accountId
         || activeFolderRef.current !== folder
+        || !shouldApplyEmailRefresh({
+          requestEpoch,
+          currentEpoch: detailRequestEpochRef.current,
+          mutationRevision,
+          currentMutationRevision: messageMutationRevisionRef.current,
+          mutationInFlight: activeMessageMutationsRef.current > 0,
+        })
       ) return;
       if (response.status === 404 && payload.code === 'EMAIL_MESSAGE_NOT_FOUND') {
         setSelectedMessage(null);
@@ -456,6 +576,7 @@ export function EmailClient({
       const nextMessage = payload.data?.message as EmailMessageDetail | undefined;
       if (!nextMessage) throw new Error(t('errors.loadMessage'));
       setSelectedMessage({ ...nextMessage, folder: nextMessage.folder || folder });
+      scheduleDetailFollowUp(emailMessageDetailScopeKey({ accountId, folder, messageId: message.id }), payload.data?.cache, requestEpoch);
       void markMessageReadOnOpen(nextMessage);
     } catch (loadError) {
       if (controller.signal.aborted || detailRequestRef.current !== controller) return;
@@ -463,7 +584,35 @@ export function EmailClient({
     } finally {
       if (detailRequestRef.current === controller) setIsLoadingMessage(false);
     }
-  }, [activeAccount, activeFolder, clearMessageSummary, layoutMode, markMessageReadOnOpen, t]);
+  }, [activeAccount, activeFolder, cancelDetailFollowUp, clearMessageSummary, layoutMode, markMessageReadOnOpen, scheduleDetailFollowUp, t]);
+
+  useEffect(() => {
+    listFollowUpRunnerRef.current = () => {
+      void loadMessages({ background: true, swrFollowUp: true });
+    };
+  }, [loadMessages]);
+
+  useEffect(() => {
+    detailFollowUpRunnerRef.current = () => {
+      void refreshSelectedMessage();
+    };
+  }, [refreshSelectedMessage]);
+
+  useEffect(() => {
+    cancelListFollowUp();
+    listRequestEpochRef.current += 1;
+    listRequestRef.current?.abort();
+  }, [activeAccount?.id, activeFolder, cancelListFollowUp, foldersAccountId, messageFilter, messagePage, submittedQuery]);
+
+  useEffect(() => () => {
+    cancelListFollowUp();
+    cancelDetailFollowUp();
+    listRequestEpochRef.current += 1;
+    detailRequestEpochRef.current += 1;
+    listRequestRef.current?.abort();
+    detailRequestRef.current?.abort();
+    detailRefreshRequestRef.current?.abort();
+  }, [cancelDetailFollowUp, cancelListFollowUp]);
 
   useEffect(() => {
     if (!contextIntent) {
@@ -680,6 +829,7 @@ export function EmailClient({
     setActiveMessageAction(action);
     setMessageActionNotice(null);
     setError(null);
+    let finishMutation: (() => void) | null = null;
 
     try {
       if (action === 'summary') {
@@ -732,6 +882,7 @@ export function EmailClient({
         return;
       }
 
+      finishMutation = beginMessageMutation();
       const body: Record<string, unknown> = { action, destination, folder, messageId: selectedMessage.id, operation: 'action' };
 
       const endpoint = `/api/email/accounts/${encodeURIComponent(activeAccount.id)}/messages/actions`;
@@ -771,9 +922,10 @@ export function EmailClient({
         ? t('errors.actionRequest')
         : actionError instanceof Error ? actionError.message : t('errors.updateMessage'));
     } finally {
+      finishMutation?.();
       setActiveMessageAction(null);
     }
-  }, [activeAccount, activeFolder, activeWorkspaceId, clearReader, generateAiReplyPreview, loadFolders, openComposeDraft, selectedMessage, summaryAiStageLabel, t]);
+  }, [activeAccount, activeFolder, activeWorkspaceId, beginMessageMutation, clearReader, generateAiReplyPreview, loadFolders, openComposeDraft, selectedMessage, summaryAiStageLabel, t]);
 
   const handleMessageListAction = useCallback(async (message: EmailMessageSummary, action: EmailMessageListActionName, destination?: string) => {
     if (!activeAccount) return;
@@ -785,6 +937,7 @@ export function EmailClient({
     setActiveMessageListAction({ action, messageId: message.id });
     setMessageActionNotice(null);
     setError(null);
+    const finishMutation = beginMessageMutation();
 
     try {
       const response = await fetch(endpoint, {
@@ -815,9 +968,10 @@ export function EmailClient({
         ? t('errors.actionRequest')
         : actionError instanceof Error ? actionError.message : t('errors.updateMessage'));
     } finally {
+      finishMutation();
       setActiveMessageListAction(null);
     }
-  }, [activeAccount, activeFolder, clearReader, loadFolders, selectedMessageId, t]);
+  }, [activeAccount, activeFolder, beginMessageMutation, clearReader, loadFolders, selectedMessageId, t]);
 
   const messageOffset = messagePage * MESSAGE_PAGE_SIZE;
   const messageStart = messages.length > 0 ? messageOffset + 1 : 0;

--- a/app/components/home/HomeAppLinks.tsx
+++ b/app/components/home/HomeAppLinks.tsx
@@ -147,10 +147,10 @@ export function HomeAppLinks({ active, workspaceId }: { active: boolean; workspa
         <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{t('pages.workspaceDescription')}</p>
       </div>
       {workspaceId ? <div className="grid flex-1 gap-4 md:min-h-0 md:grid-cols-2 md:grid-rows-[repeat(2,minmax(15rem,1fr))]">
-        <EmailWidget state={widgets.emails} onRetry={widgets.retry} />
-        <TodoWidget state={widgets.todos} workspaceId={workspaceId} onRetry={widgets.retry} />
-        <StudioWidget state={widgets.studio} workspaceId={workspaceId} onRetry={widgets.retry} />
-        <AutomationWidget state={widgets.automation} onRetry={widgets.retry} />
+        <EmailWidget state={widgets.emails} onRetry={() => widgets.retry('emails')} />
+        <TodoWidget state={widgets.todos} workspaceId={workspaceId} onRetry={() => widgets.retry('todos')} />
+        <StudioWidget state={widgets.studio} workspaceId={workspaceId} onRetry={() => widgets.retry('studio')} />
+        <AutomationWidget state={widgets.automation} onRetry={() => widgets.retry('automation')} />
       </div> : <div className="grid flex-1 gap-4 md:grid-cols-2 lg:grid-rows-2">{Array.from({ length: 4 }, (_, index) => <div key={index} className="min-h-64 animate-pulse rounded-xl border border-border bg-muted/40" />)}</div>}
     </section>
   );

--- a/app/components/home/useHomeWorkspaceWidgets.ts
+++ b/app/components/home/useHomeWorkspaceWidgets.ts
@@ -10,13 +10,21 @@ import {
   type HomeWidgetTodo,
 } from '@/app/lib/home/workspace-widget-data';
 import {
-  claimHomeWidgetRefreshToken,
   HOME_WIDGET_NAMES,
   isHomeWidgetName,
   type HomeWidgetName,
 } from '@/app/lib/home/workspace-widget-request';
 
 export const HOME_EMAIL_STALE_FOLLOW_UP_MS = 500;
+export const HOME_EMAIL_STALE_FOLLOW_UP_MAX_ATTEMPTS = 8;
+export const HOME_EMAIL_STALE_FOLLOW_UP_MAX_DELAY_MS = 4_000;
+
+export function homeEmailStaleFollowUpDelay(attempt: number): number {
+  return Math.min(
+    HOME_EMAIL_STALE_FOLLOW_UP_MS * (2 ** Math.max(0, attempt - 1)),
+    HOME_EMAIL_STALE_FOLLOW_UP_MAX_DELAY_MS,
+  );
+}
 
 export type HomeWidgetState<T> = {
   status: 'idle' | 'loading' | 'ready' | 'error';
@@ -58,6 +66,8 @@ type HomeWorkspaceWidgetResponse = {
 type LoadWidgetOptions = {
   allowEmailFollowUp?: boolean;
   background?: boolean;
+  emailFollowUpAttempt?: number;
+  emailFollowUpToken?: string;
   force?: boolean;
 };
 
@@ -105,7 +115,6 @@ export function useHomeWorkspaceWidgets(workspaceId: string | undefined, active:
   const [snapshot, setSnapshot] = useState<HomeWorkspaceWidgetSnapshot>(() => initialSnapshot(workspaceId ?? null));
   const requestGenerationRef = useRef<Record<HomeWidgetName, number>>({ emails: 0, todos: 0, automation: 0, studio: 0 });
   const activeControllersRef = useRef(new Set<AbortController>());
-  const scheduledEmailTokensRef = useRef(new Set<string>());
   const emailFollowUpTimersRef = useRef(new Map<string, number>());
   const loadWidgetsRef = useRef<LoadWidgets>(async () => undefined);
   const current = snapshot.workspaceId === (workspaceId ?? null) ? snapshot : initialSnapshot(workspaceId ?? null);
@@ -125,6 +134,10 @@ export function useHomeWorkspaceWidgets(workspaceId: string | undefined, active:
       const generation = requestGenerationRef.current[widget] + 1;
       requestGenerationRef.current[widget] = generation;
       generations.set(widget, generation);
+    }
+    if (requested.includes('emails')) {
+      for (const timer of emailFollowUpTimersRef.current.values()) window.clearTimeout(timer);
+      emailFollowUpTimersRef.current.clear();
     }
     const isCurrent = (widget: HomeWidgetName) => requestGenerationRef.current[widget] === generations.get(widget);
     const controller = new AbortController();
@@ -168,29 +181,46 @@ export function useHomeWorkspaceWidgets(workspaceId: string | undefined, active:
 
       const emailResult = data.emails;
       const emailCache = emailResult?.status === 'ready' ? emailResult.cache : undefined;
-      if (
+      const shouldFollowUpEmail = (
         requested.includes('emails')
         && isCurrent('emails')
         && options.allowEmailFollowUp !== false
         && emailCache?.state === 'stale'
         && emailCache.refreshQueued
         && emailCache.refreshToken
-      ) {
+      );
+      if (shouldFollowUpEmail) {
         const followUpKey = `${requestWorkspaceId}\0${emailCache.refreshToken}`;
-        if (claimHomeWidgetRefreshToken(scheduledEmailTokensRef.current, followUpKey)) {
+        const attempts = options.emailFollowUpToken === emailCache.refreshToken
+          ? Math.max(0, options.emailFollowUpAttempt ?? 0)
+          : 0;
+        if (
+          attempts < HOME_EMAIL_STALE_FOLLOW_UP_MAX_ATTEMPTS
+          && !emailFollowUpTimersRef.current.has(followUpKey)
+        ) {
+          const nextAttempt = attempts + 1;
           const timer = window.setTimeout(() => {
             emailFollowUpTimersRef.current.delete(followUpKey);
             const latest = currentSnapshotRef.current;
             if (
-              latest.workspaceId !== requestWorkspaceId
+              requestGenerationRef.current.emails !== generations.get('emails')
+              || latest.workspaceId !== requestWorkspaceId
               || latest.emails.cache?.refreshToken !== emailCache.refreshToken
               || latest.emails.cache.state !== 'stale'
               || !latest.emails.cache.refreshQueued
             ) return;
-            void loadWidgetsRef.current(['emails'], { allowEmailFollowUp: false, background: true });
-          }, HOME_EMAIL_STALE_FOLLOW_UP_MS);
+            void loadWidgetsRef.current(['emails'], {
+              allowEmailFollowUp: true,
+              background: true,
+              emailFollowUpAttempt: nextAttempt,
+              emailFollowUpToken: emailCache.refreshToken,
+            });
+          }, homeEmailStaleFollowUpDelay(nextAttempt));
           emailFollowUpTimersRef.current.set(followUpKey, timer);
         }
+      } else if (requested.includes('emails') && isCurrent('emails')) {
+        for (const timer of emailFollowUpTimersRef.current.values()) window.clearTimeout(timer);
+        emailFollowUpTimersRef.current.clear();
       }
     } catch {
       if (controller.signal.aborted) return;
@@ -220,7 +250,6 @@ export function useHomeWorkspaceWidgets(workspaceId: string | undefined, active:
     if (!active || !workspaceId) return;
     const controllers = activeControllersRef.current;
     const followUpTimers = emailFollowUpTimersRef.current;
-    const scheduledTokens = scheduledEmailTokensRef.current;
     const initialTimer = window.setTimeout(() => {
       void loadWidgets(HOME_WIDGET_NAMES, { allowEmailFollowUp: true });
     }, 0);
@@ -230,7 +259,6 @@ export function useHomeWorkspaceWidgets(workspaceId: string | undefined, active:
       controllers.clear();
       for (const timer of followUpTimers.values()) window.clearTimeout(timer);
       followUpTimers.clear();
-      scheduledTokens.clear();
     };
   }, [active, loadWidgets, workspaceId]);
 

--- a/app/components/home/useHomeWorkspaceWidgets.ts
+++ b/app/components/home/useHomeWorkspaceWidgets.ts
@@ -16,12 +16,12 @@ import {
 } from '@/app/lib/home/workspace-widget-request';
 
 export const HOME_EMAIL_STALE_FOLLOW_UP_MS = 500;
-export const HOME_EMAIL_STALE_FOLLOW_UP_MAX_ATTEMPTS = 8;
 export const HOME_EMAIL_STALE_FOLLOW_UP_MAX_DELAY_MS = 4_000;
 
 export function homeEmailStaleFollowUpDelay(attempt: number): number {
+  const exponent = Math.min(Math.max(0, Math.floor(attempt) - 1), 3);
   return Math.min(
-    HOME_EMAIL_STALE_FOLLOW_UP_MS * (2 ** Math.max(0, attempt - 1)),
+    HOME_EMAIL_STALE_FOLLOW_UP_MS * (2 ** exponent),
     HOME_EMAIL_STALE_FOLLOW_UP_MAX_DELAY_MS,
   );
 }
@@ -194,10 +194,7 @@ export function useHomeWorkspaceWidgets(workspaceId: string | undefined, active:
         const attempts = options.emailFollowUpToken === emailCache.refreshToken
           ? Math.max(0, options.emailFollowUpAttempt ?? 0)
           : 0;
-        if (
-          attempts < HOME_EMAIL_STALE_FOLLOW_UP_MAX_ATTEMPTS
-          && !emailFollowUpTimersRef.current.has(followUpKey)
-        ) {
+        if (!emailFollowUpTimersRef.current.has(followUpKey)) {
           const nextAttempt = attempts + 1;
           const timer = window.setTimeout(() => {
             emailFollowUpTimersRef.current.delete(followUpKey);

--- a/app/components/home/useHomeWorkspaceWidgets.ts
+++ b/app/components/home/useHomeWorkspaceWidgets.ts
@@ -1,17 +1,29 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
+import type { HomeWidgetEmailCacheMetadata } from '@/app/lib/home/workspace-email-widget';
 import {
   type HomeWidgetAutomation,
   type HomeWidgetEmail,
   type HomeWidgetStudio,
   type HomeWidgetTodo,
 } from '@/app/lib/home/workspace-widget-data';
+import {
+  claimHomeWidgetRefreshToken,
+  HOME_WIDGET_NAMES,
+  isHomeWidgetName,
+  type HomeWidgetName,
+} from '@/app/lib/home/workspace-widget-request';
+
+export const HOME_EMAIL_STALE_FOLLOW_UP_MS = 500;
 
 export type HomeWidgetState<T> = {
   status: 'idle' | 'loading' | 'ready' | 'error';
   data: T;
+  cachedAt?: string;
+  stale?: boolean;
+  cache?: HomeWidgetEmailCacheMetadata;
 };
 
 type HomeWorkspaceWidgetSnapshot = {
@@ -27,6 +39,7 @@ type WidgetApiResult<T> = {
   data: T;
   cachedAt: string;
   stale: boolean;
+  cache?: HomeWidgetEmailCacheMetadata;
 } | {
   status: 'error';
   errorCode: 'source_unavailable';
@@ -35,12 +48,20 @@ type WidgetApiResult<T> = {
 type HomeWorkspaceWidgetResponse = {
   success?: boolean;
   data?: {
-    emails: WidgetApiResult<HomeWidgetEmail[]>;
-    todos: WidgetApiResult<HomeWidgetTodo[]>;
-    automation: WidgetApiResult<HomeWidgetAutomation | null>;
-    studio: WidgetApiResult<HomeWidgetStudio | null>;
+    emails?: WidgetApiResult<HomeWidgetEmail[]>;
+    todos?: WidgetApiResult<HomeWidgetTodo[]>;
+    automation?: WidgetApiResult<HomeWidgetAutomation | null>;
+    studio?: WidgetApiResult<HomeWidgetStudio | null>;
   };
 };
+
+type LoadWidgetOptions = {
+  allowEmailFollowUp?: boolean;
+  background?: boolean;
+  force?: boolean;
+};
+
+type LoadWidgets = (widgets: readonly HomeWidgetName[], options?: LoadWidgetOptions) => Promise<void>;
 
 function initialSnapshot(workspaceId: string | null): HomeWorkspaceWidgetSnapshot {
   return {
@@ -52,86 +73,189 @@ function initialSnapshot(workspaceId: string | null): HomeWorkspaceWidgetSnapsho
   };
 }
 
+function loadingGate<T>(state: HomeWidgetState<T>): HomeWidgetState<T> {
+  return state.status === 'ready' ? state : { ...state, status: 'loading' };
+}
+
+function failedState<T>(state: HomeWidgetState<T>): HomeWidgetState<T> {
+  return state.status === 'ready' ? state : { ...state, status: 'error' };
+}
+
+function resultState<T>(
+  previous: HomeWidgetState<T>,
+  result: WidgetApiResult<T> | undefined,
+): HomeWidgetState<T> {
+  if (!result || result.status === 'error') return failedState(previous);
+  return {
+    status: 'ready',
+    data: result.data,
+    cachedAt: result.cachedAt,
+    stale: result.stale,
+    ...(result.cache ? { cache: result.cache } : {}),
+  };
+}
+
+function eventWidgetSelection(event: Event): HomeWidgetName[] {
+  if (!(event instanceof CustomEvent) || !Array.isArray(event.detail?.widgets)) return [...HOME_WIDGET_NAMES];
+  const selected = event.detail.widgets.filter(isHomeWidgetName);
+  return selected.length > 0 ? HOME_WIDGET_NAMES.filter((name) => selected.includes(name)) : [...HOME_WIDGET_NAMES];
+}
+
 export function useHomeWorkspaceWidgets(workspaceId: string | undefined, active: boolean) {
   const [snapshot, setSnapshot] = useState<HomeWorkspaceWidgetSnapshot>(() => initialSnapshot(workspaceId ?? null));
-  const [revision, setRevision] = useState(0);
-  const retry = useCallback(() => setRevision((value) => value + 1), []);
+  const requestGenerationRef = useRef<Record<HomeWidgetName, number>>({ emails: 0, todos: 0, automation: 0, studio: 0 });
+  const activeControllersRef = useRef(new Set<AbortController>());
+  const scheduledEmailTokensRef = useRef(new Set<string>());
+  const emailFollowUpTimersRef = useRef(new Map<string, number>());
+  const loadWidgetsRef = useRef<LoadWidgets>(async () => undefined);
   const current = snapshot.workspaceId === (workspaceId ?? null) ? snapshot : initialSnapshot(workspaceId ?? null);
+  const currentSnapshotRef = useRef(current);
 
   useEffect(() => {
-    if (!active || !workspaceId) return;
-    const controller = new AbortController();
-    const forceRefresh = revision > 0;
+    currentSnapshotRef.current = current;
+  }, [current]);
 
-    const loadingTimer = window.setTimeout(() => {
-      if (controller.signal.aborted) return;
+  const loadWidgets = useCallback<LoadWidgets>(async (widgets, options = {}) => {
+    if (!active || !workspaceId) return;
+    const requested = HOME_WIDGET_NAMES.filter((name) => widgets.includes(name));
+    if (requested.length === 0) return;
+    const requestWorkspaceId = workspaceId;
+    const generations = new Map<HomeWidgetName, number>();
+    for (const widget of requested) {
+      const generation = requestGenerationRef.current[widget] + 1;
+      requestGenerationRef.current[widget] = generation;
+      generations.set(widget, generation);
+    }
+    const isCurrent = (widget: HomeWidgetName) => requestGenerationRef.current[widget] === generations.get(widget);
+    const controller = new AbortController();
+    activeControllersRef.current.add(controller);
+
+    if (!options.background) {
       setSnapshot((previous) => {
-        const hasReadyData = previous.workspaceId === workspaceId
-          && [previous.emails, previous.todos, previous.automation, previous.studio].some((value) => value.status === 'ready');
-        if (hasReadyData) return previous;
-        const start = initialSnapshot(workspaceId);
-        start.emails.status = 'loading';
-        start.todos.status = 'loading';
-        start.automation.status = 'loading';
-        start.studio.status = 'loading';
-        return start;
+        const base = previous.workspaceId === requestWorkspaceId ? previous : initialSnapshot(requestWorkspaceId);
+        return {
+          ...base,
+          emails: requested.includes('emails') ? loadingGate(base.emails) : base.emails,
+          todos: requested.includes('todos') ? loadingGate(base.todos) : base.todos,
+          automation: requested.includes('automation') ? loadingGate(base.automation) : base.automation,
+          studio: requested.includes('studio') ? loadingGate(base.studio) : base.studio,
+        };
       });
-      const params = new URLSearchParams({ workspaceId, ...(forceRefresh ? { refresh: '1' } : {}) });
-      void fetch(`/api/home/workspace-widgets?${params}`, {
+    }
+
+    const params = new URLSearchParams({ workspaceId: requestWorkspaceId, widgets: requested.join(',') });
+    if (options.force) params.set('refresh', requested.join(','));
+    try {
+      const response = await fetch(`/api/home/workspace-widgets?${params}`, {
         credentials: 'include',
         cache: 'no-store',
         signal: controller.signal,
-      }).then(async (response) => {
-        const payload = await response.json().catch(() => null) as HomeWorkspaceWidgetResponse | null;
-        if (!response.ok || !payload?.success || !payload.data) throw new Error('Workspace widgets could not be loaded.');
-        if (controller.signal.aborted) return;
-        const data = payload.data;
-        setSnapshot((currentSnapshot) => {
-          const previous = currentSnapshot.workspaceId === workspaceId ? currentSnapshot : initialSnapshot(workspaceId);
-          return {
-            workspaceId,
-            emails: data.emails.status === 'ready' ? { status: 'ready', data: data.emails.data } : { status: 'error', data: previous.emails.data },
-            todos: data.todos.status === 'ready' ? { status: 'ready', data: data.todos.data } : { status: 'error', data: previous.todos.data },
-            automation: data.automation.status === 'ready' ? { status: 'ready', data: data.automation.data } : { status: 'error', data: previous.automation.data },
-            studio: data.studio.status === 'ready' ? { status: 'ready', data: data.studio.data } : { status: 'error', data: previous.studio.data },
-          };
-        });
-      }).catch(() => {
-        if (controller.signal.aborted) return;
-        setSnapshot((previous) => {
-          if (previous.workspaceId !== workspaceId) return previous;
-          return {
-            ...previous,
-            emails: previous.emails.status === 'ready' ? previous.emails : { status: 'error', data: previous.emails.data },
-            todos: previous.todos.status === 'ready' ? previous.todos : { status: 'error', data: previous.todos.data },
-            automation: previous.automation.status === 'ready' ? previous.automation : { status: 'error', data: previous.automation.data },
-            studio: previous.studio.status === 'ready' ? previous.studio : { status: 'error', data: previous.studio.data },
-          };
-        });
       });
-    }, 0);
+      const payload = await response.json().catch(() => null) as HomeWorkspaceWidgetResponse | null;
+      if (!response.ok || !payload?.success || !payload.data) throw new Error('Workspace widgets could not be loaded.');
+      if (controller.signal.aborted) return;
+      const data = payload.data;
+      setSnapshot((previous) => {
+        if (previous.workspaceId !== requestWorkspaceId) return previous;
+        return {
+          ...previous,
+          emails: requested.includes('emails') && isCurrent('emails') ? resultState(previous.emails, data.emails) : previous.emails,
+          todos: requested.includes('todos') && isCurrent('todos') ? resultState(previous.todos, data.todos) : previous.todos,
+          automation: requested.includes('automation') && isCurrent('automation') ? resultState(previous.automation, data.automation) : previous.automation,
+          studio: requested.includes('studio') && isCurrent('studio') ? resultState(previous.studio, data.studio) : previous.studio,
+        };
+      });
 
+      const emailResult = data.emails;
+      const emailCache = emailResult?.status === 'ready' ? emailResult.cache : undefined;
+      if (
+        requested.includes('emails')
+        && isCurrent('emails')
+        && options.allowEmailFollowUp !== false
+        && emailCache?.state === 'stale'
+        && emailCache.refreshQueued
+        && emailCache.refreshToken
+      ) {
+        const followUpKey = `${requestWorkspaceId}\0${emailCache.refreshToken}`;
+        if (claimHomeWidgetRefreshToken(scheduledEmailTokensRef.current, followUpKey)) {
+          const timer = window.setTimeout(() => {
+            emailFollowUpTimersRef.current.delete(followUpKey);
+            const latest = currentSnapshotRef.current;
+            if (
+              latest.workspaceId !== requestWorkspaceId
+              || latest.emails.cache?.refreshToken !== emailCache.refreshToken
+              || latest.emails.cache.state !== 'stale'
+              || !latest.emails.cache.refreshQueued
+            ) return;
+            void loadWidgetsRef.current(['emails'], { allowEmailFollowUp: false, background: true });
+          }, HOME_EMAIL_STALE_FOLLOW_UP_MS);
+          emailFollowUpTimersRef.current.set(followUpKey, timer);
+        }
+      }
+    } catch {
+      if (controller.signal.aborted) return;
+      setSnapshot((previous) => {
+        if (previous.workspaceId !== requestWorkspaceId) return previous;
+        return {
+          ...previous,
+          emails: requested.includes('emails') && isCurrent('emails') ? failedState(previous.emails) : previous.emails,
+          todos: requested.includes('todos') && isCurrent('todos') ? failedState(previous.todos) : previous.todos,
+          automation: requested.includes('automation') && isCurrent('automation') ? failedState(previous.automation) : previous.automation,
+          studio: requested.includes('studio') && isCurrent('studio') ? failedState(previous.studio) : previous.studio,
+        };
+      });
+    } finally {
+      activeControllersRef.current.delete(controller);
+    }
+  }, [active, workspaceId]);
+  useEffect(() => {
+    loadWidgetsRef.current = loadWidgets;
+  }, [loadWidgets]);
+
+  const retry = useCallback((widget?: HomeWidgetName) => {
+    void loadWidgets(widget ? [widget] : HOME_WIDGET_NAMES, { allowEmailFollowUp: true, force: true });
+  }, [loadWidgets]);
+
+  useEffect(() => {
+    if (!active || !workspaceId) return;
+    const controllers = activeControllersRef.current;
+    const followUpTimers = emailFollowUpTimersRef.current;
+    const scheduledTokens = scheduledEmailTokensRef.current;
+    const initialTimer = window.setTimeout(() => {
+      void loadWidgets(HOME_WIDGET_NAMES, { allowEmailFollowUp: true });
+    }, 0);
     return () => {
-      window.clearTimeout(loadingTimer);
-      controller.abort();
+      window.clearTimeout(initialTimer);
+      for (const controller of controllers) controller.abort();
+      controllers.clear();
+      for (const timer of followUpTimers.values()) window.clearTimeout(timer);
+      followUpTimers.clear();
+      scheduledTokens.clear();
     };
-  }, [active, revision, workspaceId]);
+  }, [active, loadWidgets, workspaceId]);
 
   useEffect(() => {
     if (!active) return;
-    const refresh = () => setRevision((value) => value + 1);
-    const refreshWhenVisible = () => {
-      if (document.visibilityState === 'visible') refresh();
+    const refreshTodos = () => {
+      void loadWidgets(['todos'], { background: true, force: true });
     };
-    window.addEventListener('todo_updated', refresh);
-    window.addEventListener('workspace_widgets_updated', refresh);
+    const refreshWidgets = (event: Event) => {
+      void loadWidgets(eventWidgetSelection(event), { allowEmailFollowUp: true, background: true, force: true });
+    };
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === 'visible') {
+        void loadWidgets(HOME_WIDGET_NAMES, { allowEmailFollowUp: true, background: true });
+      }
+    };
+    window.addEventListener('todo_updated', refreshTodos);
+    window.addEventListener('workspace_widgets_updated', refreshWidgets);
     document.addEventListener('visibilitychange', refreshWhenVisible);
     return () => {
-      window.removeEventListener('todo_updated', refresh);
-      window.removeEventListener('workspace_widgets_updated', refresh);
+      window.removeEventListener('todo_updated', refreshTodos);
+      window.removeEventListener('workspace_widgets_updated', refreshWidgets);
       document.removeEventListener('visibilitychange', refreshWhenVisible);
     };
-  }, [active, workspaceId]);
+  }, [active, loadWidgets]);
 
   return { ...current, retry };
 }

--- a/app/lib/db/index.ts
+++ b/app/lib/db/index.ts
@@ -123,6 +123,15 @@ const postgresPool = provider === 'postgres' && runtimeDatabase.client
   ? runtimeDatabase.client as ReturnType<typeof createPostgresPool>
   : null;
 
+/**
+ * Exposes only query capability from the already-initialized runtime pool.
+ * PostgreSQL-only persistence helpers can share the app pool without creating
+ * their own connection pool or gaining permission to close the runtime pool.
+ */
+export function getPostgresRuntimeQueryable(): Pick<ReturnType<typeof createPostgresPool>, 'query'> | null {
+  return postgresPool;
+}
+
 // The app keeps the existing SQLite-table Drizzle types while runtime dialect selection
 // happens underneath. The Postgres adapter is intentionally cast to that surface until
 // the schema is split into native pgTable definitions.

--- a/app/lib/db/postgres.ts
+++ b/app/lib/db/postgres.ts
@@ -11,6 +11,7 @@ import {
 } from './migrate';
 import { migratePostgresMainAgentId } from './main-agent-id-migration';
 import { STUDIO_WORKSPACE_BACKFILL_STATEMENTS } from './studio-workspace-migration';
+import { runEmailCachePostgresMigration } from '@/app/lib/email/cache/postgres-migration';
 
 const TABLE_NAME_SYMBOL = Symbol.for('drizzle:Name');
 
@@ -910,6 +911,7 @@ export async function runPostgresMigrations(pool: PgQueryable): Promise<void> {
   await pool.query('ALTER TABLE email_accounts ADD COLUMN IF NOT EXISTS automation_enabled_at bigint');
   await pool.query("UPDATE email_accounts SET account_scope = 'personal' WHERE account_scope IS NULL OR account_scope = ''");
   await pool.query("UPDATE email_accounts SET connected_by_user_id = user_id WHERE connected_by_user_id IS NULL OR connected_by_user_id = ''");
+  await runEmailCachePostgresMigration(pool);
   await pool.query(`
     CREATE TABLE IF NOT EXISTS workspace_email_mailboxes (
       id text PRIMARY KEY,

--- a/app/lib/email/cache/consistency.ts
+++ b/app/lib/email/cache/consistency.ts
@@ -1,0 +1,81 @@
+import 'server-only';
+
+import { logEmailClientEvent } from '@/app/lib/email/logging';
+import {
+  getRuntimeEmailCacheStore,
+  type EmailCacheAccountSource,
+  type EmailCacheStore,
+} from './store';
+
+type EmailCacheMailbox = {
+  userId: string;
+  accountId: string;
+  accountSource: EmailCacheAccountSource;
+};
+
+type EmailCacheStoreFactory = () => Promise<EmailCacheStore>;
+
+let emailCacheStoreFactory: EmailCacheStoreFactory = getRuntimeEmailCacheStore;
+
+function isImapMailboxChangedFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const candidate = error as Error & { code?: unknown; status?: unknown };
+  return candidate.code === 'EMAIL_MAILBOX_CHANGED' && candidate.status === 409;
+}
+
+export function setEmailCacheConsistencyStoreFactoryForTests(factory: EmailCacheStoreFactory | null): void {
+  emailCacheStoreFactory = factory || getRuntimeEmailCacheStore;
+}
+
+async function bestEffortEmailCacheOperation(
+  mailbox: EmailCacheMailbox,
+  operation: 'bump-generation' | 'purge-account' | 'reactivate-account',
+  execute: (store: EmailCacheStore) => Promise<unknown>,
+): Promise<void> {
+  try {
+    const store = await emailCacheStoreFactory();
+    await execute(store);
+  } catch (error) {
+    logEmailClientEvent('warn', 'email_cache_consistency_failed', {
+      accountId: mailbox.accountId,
+      error,
+      operation,
+      status: 'failed',
+      userId: mailbox.userId,
+    });
+  }
+}
+
+export async function invalidateEmailMailboxCache(mailbox: EmailCacheMailbox): Promise<void> {
+  await bestEffortEmailCacheOperation(mailbox, 'bump-generation', (store) => store.bumpMailboxGeneration(mailbox));
+}
+
+export async function purgeEmailMailboxCache(mailbox: EmailCacheMailbox): Promise<void> {
+  await bestEffortEmailCacheOperation(mailbox, 'purge-account', (store) => store.purgeAccount(mailbox));
+}
+
+/**
+ * Only call after a completed connect/upsert flow. In particular, a managed
+ * account listing is not a reconnect signal because it may be stale after a
+ * successful Control Plane disconnect.
+ */
+export async function reactivateEmailMailboxCache(mailbox: EmailCacheMailbox): Promise<void> {
+  await bestEffortEmailCacheOperation(mailbox, 'reactivate-account', (store) => store.reactivateAccount(mailbox));
+}
+
+export async function runLocalEmailMailboxMutation<T>(
+  mailbox: Omit<EmailCacheMailbox, 'accountSource'>,
+  mutateProvider: () => Promise<T>,
+): Promise<T> {
+  const localMailbox = { ...mailbox, accountSource: 'local' as const };
+  try {
+    const result = await mutateProvider();
+    await invalidateEmailMailboxCache(localMailbox);
+    return result;
+  } catch (error) {
+    if (isImapMailboxChangedFailure(error)) {
+      await invalidateEmailMailboxCache(localMailbox);
+    }
+    throw error;
+  }
+}

--- a/app/lib/email/cache/postgres-migration.ts
+++ b/app/lib/email/cache/postgres-migration.ts
@@ -1,0 +1,170 @@
+import type { Pool } from 'pg';
+
+export type EmailCachePostgresQueryable = Pick<Pool, 'query'>;
+
+/**
+ * Installs the PostgreSQL-only email cache schema.
+ *
+ * These tables intentionally do not live in the shared SQLite-shaped Drizzle
+ * schema. The cache relies on jsonb, and SQLite runtimes bypass durable email
+ * caching rather than receiving a different, subtly incompatible schema.
+ * Account ownership is re-authorized by the email service before every lookup.
+ * The cache only binds users locally because managed Control Plane accounts do
+ * not necessarily have a corresponding row in local email_accounts.
+ */
+export async function runEmailCachePostgresMigration(
+  postgres: EmailCachePostgresQueryable,
+): Promise<void> {
+  await postgres.query(`
+    CREATE TABLE IF NOT EXISTS email_cache_mailboxes (
+      user_id text NOT NULL,
+      account_source text NOT NULL CHECK (account_source IN ('local', 'managed')),
+      account_id text NOT NULL,
+      generation bigint NOT NULL DEFAULT 1 CHECK (generation >= 1),
+      active boolean NOT NULL DEFAULT true,
+      disconnected_at bigint,
+      last_accessed_at bigint NOT NULL,
+      created_at bigint NOT NULL,
+      updated_at bigint NOT NULL,
+      PRIMARY KEY (user_id, account_source, account_id),
+      CONSTRAINT email_cache_mailboxes_disconnected_check
+        CHECK ((active AND disconnected_at IS NULL) OR (NOT active AND disconnected_at IS NOT NULL)),
+      CONSTRAINT email_cache_mailboxes_user_fk
+        FOREIGN KEY (user_id)
+        REFERENCES "user" (id)
+        ON DELETE CASCADE
+    )
+  `);
+  await postgres.query(`
+    CREATE INDEX IF NOT EXISTS idx_email_cache_mailboxes_last_accessed
+    ON email_cache_mailboxes (last_accessed_at)
+  `);
+
+  await postgres.query(`
+    CREATE TABLE IF NOT EXISTS email_cache_lists (
+      user_id text NOT NULL,
+      account_source text NOT NULL CHECK (account_source IN ('local', 'managed')),
+      account_id text NOT NULL,
+      cache_key text NOT NULL,
+      schema_version bigint NOT NULL,
+      folder text NOT NULL,
+      filter_json jsonb NOT NULL DEFAULT 'null'::jsonb,
+      search_query text NOT NULL DEFAULT '',
+      page_offset bigint NOT NULL CHECK (page_offset >= 0),
+      page_limit bigint NOT NULL CHECK (page_limit > 0),
+      refs_json jsonb,
+      total_count bigint,
+      generation bigint NOT NULL CHECK (generation >= 1),
+      fetched_at bigint,
+      stale_at bigint,
+      expires_at bigint,
+      refresh_owner text,
+      refresh_lease_until bigint,
+      last_accessed_at bigint NOT NULL,
+      created_at bigint NOT NULL,
+      updated_at bigint NOT NULL,
+      PRIMARY KEY (user_id, account_source, account_id, cache_key),
+      CONSTRAINT email_cache_lists_mailbox_fk
+        FOREIGN KEY (user_id, account_source, account_id)
+        REFERENCES email_cache_mailboxes (user_id, account_source, account_id)
+        ON DELETE CASCADE,
+      CONSTRAINT email_cache_lists_refs_array_check
+        CHECK (refs_json IS NULL OR jsonb_typeof(refs_json) = 'array'),
+      CONSTRAINT email_cache_lists_snapshot_timestamps_check
+        CHECK (
+          (refs_json IS NULL AND fetched_at IS NULL AND stale_at IS NULL AND expires_at IS NULL)
+          OR
+          (refs_json IS NOT NULL AND fetched_at IS NOT NULL AND stale_at IS NOT NULL AND expires_at IS NOT NULL
+            AND fetched_at <= stale_at AND stale_at <= expires_at)
+        )
+    )
+  `);
+  await postgres.query(`
+    CREATE INDEX IF NOT EXISTS idx_email_cache_lists_account_lru
+    ON email_cache_lists (user_id, account_source, account_id, last_accessed_at DESC)
+  `);
+  await postgres.query(`
+    CREATE INDEX IF NOT EXISTS idx_email_cache_lists_expiry
+    ON email_cache_lists (expires_at)
+    WHERE expires_at IS NOT NULL
+  `);
+  await postgres.query(`
+    CREATE INDEX IF NOT EXISTS idx_email_cache_lists_refresh_lease
+    ON email_cache_lists (refresh_lease_until)
+    WHERE refresh_lease_until IS NOT NULL
+  `);
+
+  await postgres.query(`
+    CREATE TABLE IF NOT EXISTS email_cache_messages (
+      user_id text NOT NULL,
+      account_source text NOT NULL CHECK (account_source IN ('local', 'managed')),
+      account_id text NOT NULL,
+      message_key text NOT NULL,
+      provider text NOT NULL,
+      provider_message_id text,
+      folder text,
+      uid_validity text,
+      uid bigint,
+      sender text,
+      subject text,
+      message_date bigint,
+      preview text,
+      is_read boolean,
+      metadata_json jsonb,
+      detail_json jsonb,
+      generation bigint NOT NULL CHECK (generation >= 1),
+      metadata_fetched_at bigint,
+      metadata_stale_at bigint,
+      detail_fetched_at bigint,
+      detail_stale_at bigint,
+      expires_at bigint,
+      refresh_owner text,
+      refresh_lease_until bigint,
+      last_accessed_at bigint NOT NULL,
+      created_at bigint NOT NULL,
+      updated_at bigint NOT NULL,
+      PRIMARY KEY (user_id, account_source, account_id, message_key),
+      CONSTRAINT email_cache_messages_mailbox_fk
+        FOREIGN KEY (user_id, account_source, account_id)
+        REFERENCES email_cache_mailboxes (user_id, account_source, account_id)
+        ON DELETE CASCADE,
+      CONSTRAINT email_cache_messages_metadata_object_check
+        CHECK (metadata_json IS NULL OR jsonb_typeof(metadata_json) = 'object'),
+      CONSTRAINT email_cache_messages_detail_object_check
+        CHECK (detail_json IS NULL OR jsonb_typeof(detail_json) = 'object'),
+      CONSTRAINT email_cache_messages_metadata_timestamp_check
+        CHECK (
+          (metadata_json IS NULL AND metadata_fetched_at IS NULL AND metadata_stale_at IS NULL)
+          OR
+          (metadata_json IS NOT NULL AND metadata_fetched_at IS NOT NULL AND metadata_stale_at IS NOT NULL
+            AND metadata_fetched_at <= metadata_stale_at)
+        ),
+      CONSTRAINT email_cache_messages_detail_timestamp_check
+        CHECK (
+          (detail_json IS NULL AND detail_fetched_at IS NULL AND detail_stale_at IS NULL)
+          OR
+          (detail_json IS NOT NULL AND detail_fetched_at IS NOT NULL AND detail_stale_at IS NOT NULL
+            AND detail_fetched_at <= detail_stale_at)
+        ),
+      CONSTRAINT email_cache_messages_imap_identity_check
+        CHECK (
+          provider <> 'imap'
+          OR (folder IS NOT NULL AND folder <> '' AND uid_validity IS NOT NULL AND uid IS NOT NULL AND uid > 0)
+        )
+    )
+  `);
+  await postgres.query(`
+    CREATE INDEX IF NOT EXISTS idx_email_cache_messages_account_lru
+    ON email_cache_messages (user_id, account_source, account_id, last_accessed_at DESC)
+  `);
+  await postgres.query(`
+    CREATE INDEX IF NOT EXISTS idx_email_cache_messages_expiry
+    ON email_cache_messages (expires_at)
+    WHERE expires_at IS NOT NULL
+  `);
+  await postgres.query(`
+    CREATE INDEX IF NOT EXISTS idx_email_cache_messages_refresh_lease
+    ON email_cache_messages (refresh_lease_until)
+    WHERE refresh_lease_until IS NOT NULL
+  `);
+}

--- a/app/lib/email/cache/read-through.ts
+++ b/app/lib/email/cache/read-through.ts
@@ -1,0 +1,740 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+
+import { parseImapMessageReference } from '@/app/lib/email/imap-service';
+import {
+  DEFAULT_EMAIL_CACHE_FRESH_MS,
+  DEFAULT_EMAIL_CACHE_RETENTION_MS,
+  DEFAULT_EMAIL_MESSAGE_RETENTION_MS,
+  normalizeEmailCacheProvider,
+  normalizeEmailMessageRef,
+  type EmailCacheAccountSource,
+  type EmailCachedMessageDetail,
+  type EmailCachedMessageMetadata,
+  type EmailCacheReadMetadata,
+  type EmailCacheStore,
+  type EmailListCacheScopeInput,
+  type EmailMessageRefInput,
+  type NormalizedEmailMessageRef,
+} from '@/app/lib/email/cache/store';
+
+const LIST_LEASE_MS = 15_000;
+const DETAIL_LEASE_MS = 20_000;
+const LEASE_POLL_MS = 50;
+
+type JsonRecord = Record<string, unknown>;
+
+export type EmailCacheMode = 'provider' | 'swr';
+
+export type EmailCacheBackgroundScheduler = (task: () => Promise<void>) => void;
+
+export type EmailResponseCacheMetadata = {
+  enabled: boolean;
+  scope: 'list' | 'detail';
+  state: 'fresh' | 'stale' | 'miss';
+  source: 'cache' | 'provider' | 'bypass';
+  generation: number | null;
+  fetchedAt: string | null;
+  staleAt: string | null;
+  expiresAt: string | null;
+  refreshQueued: boolean;
+  bypassReason?: 'cache_disabled' | 'cache_error' | 'legacy_imap_reference' | 'unsafe_imap_reference' | 'unsafe_message_reference' | 'lease_contention';
+};
+
+export type EmailCacheMailboxContext = {
+  userId: string;
+  accountId: string;
+  accountSource: EmailCacheAccountSource;
+  provider: string;
+};
+
+export type EmailListPayload = JsonRecord & {
+  messages?: unknown[];
+  total?: unknown;
+};
+
+export type EmailDetailPayload = JsonRecord & {
+  message?: JsonRecord;
+};
+
+type CacheRuntime = {
+  store: EmailCacheStore;
+  scheduleBackgroundTask?: EmailCacheBackgroundScheduler;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+};
+
+type CachedListBundle = {
+  messages: JsonRecord[];
+  totalCount: number | null;
+  metadata: EmailCacheReadMetadata;
+};
+
+function nowFor(runtime: CacheRuntime): number {
+  return runtime.now?.() ?? Date.now();
+}
+
+function sleepFor(runtime: CacheRuntime, milliseconds: number): Promise<void> {
+  return runtime.sleep?.(milliseconds) ?? new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function isoTimestamp(value: number | null): string | null {
+  return value === null ? null : new Date(value).toISOString();
+}
+
+function cacheMetadata(
+  scope: 'list' | 'detail',
+  metadata: EmailCacheReadMetadata,
+  source: EmailResponseCacheMetadata['source'],
+  refreshQueued: boolean,
+  bypassReason?: EmailResponseCacheMetadata['bypassReason'],
+): EmailResponseCacheMetadata {
+  return {
+    enabled: metadata.enabled,
+    scope,
+    state: metadata.state,
+    source,
+    generation: metadata.generation,
+    fetchedAt: isoTimestamp(metadata.fetchedAt),
+    staleAt: isoTimestamp(metadata.staleAt),
+    expiresAt: isoTimestamp(metadata.expiresAt),
+    refreshQueued,
+    ...(bypassReason ? { bypassReason } : {}),
+  };
+}
+
+function providerMissMetadata(
+  enabled: boolean,
+  scope: 'list' | 'detail',
+  now: number,
+  generation: number | null,
+  source: EmailResponseCacheMetadata['source'] = 'provider',
+  bypassReason?: EmailResponseCacheMetadata['bypassReason'],
+): EmailResponseCacheMetadata {
+  const retention = scope === 'list' ? DEFAULT_EMAIL_CACHE_RETENTION_MS : DEFAULT_EMAIL_MESSAGE_RETENTION_MS;
+  return cacheMetadata(scope, {
+    enabled,
+    state: source === 'provider' ? 'fresh' : 'miss',
+    generation,
+    fetchedAt: source === 'provider' ? now : null,
+    staleAt: source === 'provider' ? now + DEFAULT_EMAIL_CACHE_FRESH_MS : null,
+    expiresAt: source === 'provider' ? now + retention : null,
+  }, source, false, bypassReason);
+}
+
+function withCache<T extends JsonRecord>(payload: T, cache: EmailResponseCacheMetadata): T & { cache: EmailResponseCacheMetadata } {
+  return { ...payload, cache };
+}
+
+function record(value: unknown): JsonRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : null;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : value === null || value === undefined ? '' : String(value);
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const result = Number(value);
+  return Number.isFinite(result) ? result : null;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return typeof value === 'string' && value ? [value] : [];
+  return value.map((entry) => {
+    if (typeof entry === 'string') return entry;
+    const address = record(entry)?.emailAddress;
+    const addressRecord = record(address);
+    return stringValue(addressRecord?.address || record(entry)?.address || '');
+  }).filter(Boolean);
+}
+
+function sameFolder(left: string, right: string): boolean {
+  return left === right || (left.toLowerCase() === 'inbox' && right.toLowerCase() === 'inbox');
+}
+
+export function emailMessageCacheRef(
+  providerValue: string,
+  messageId: string,
+  folder?: string,
+  message?: JsonRecord,
+): EmailMessageRefInput | null {
+  const provider = normalizeEmailCacheProvider(providerValue);
+  if (provider !== 'imap') {
+    return messageId.trim() ? { provider, messageId, ...(folder?.trim() ? { folder: folder.trim() } : {}) } : null;
+  }
+
+  try {
+    const parsed = parseImapMessageReference(messageId, folder);
+    if (parsed.version !== 1 || !parsed.uidValidity) return null;
+    const responseFolder = stringValue(message?.folder);
+    const responseUid = nullableNumber(message?.uid);
+    const responseUidValidity = message?.uidValidity === undefined ? null : stringValue(message.uidValidity);
+    if (responseFolder && !sameFolder(responseFolder, parsed.folder)) return null;
+    if (responseUid !== null && responseUid !== parsed.uid) return null;
+    if (responseUidValidity && responseUidValidity !== parsed.uidValidity) return null;
+    return {
+      provider: 'imap',
+      messageId,
+      folder: parsed.folder,
+      uidValidity: parsed.uidValidity,
+      uid: parsed.uid,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function cacheRefInput(ref: NormalizedEmailMessageRef): EmailMessageRefInput | null {
+  if (!ref.messageId) return null;
+  if (ref.provider === 'imap') {
+    if (!ref.folder || !ref.uidValidity || ref.uid === null) return null;
+    return {
+      provider: 'imap',
+      messageId: ref.messageId,
+      folder: ref.folder,
+      uidValidity: ref.uidValidity,
+      uid: ref.uid,
+    };
+  }
+  return { provider: ref.provider, messageId: ref.messageId, ...(ref.folder ? { folder: ref.folder } : {}) };
+}
+
+function metadataForMessage(message: JsonRecord): EmailCachedMessageMetadata {
+  const date = stringValue(message.date);
+  const parsedDate = Date.parse(date);
+  const flags = Array.isArray(message.flags) ? message.flags.map(String) : [];
+  return {
+    from: stringValue(message.from),
+    subject: stringValue(message.subject),
+    date,
+    dateTimestamp: Number.isFinite(parsedDate) ? parsedDate : null,
+    snippet: stringValue(message.snippet),
+    isRead: message.isRead !== false,
+    isAnswered: message.isAnswered === true,
+    isFlagged: message.isFlagged === true,
+    hasAttachments: message.hasAttachments === true,
+    size: nullableNumber(message.size),
+    to: stringArray(message.to),
+    cc: stringArray(message.cc),
+    threadId: message.threadId === null || message.threadId === undefined ? null : stringValue(message.threadId),
+    flags,
+  };
+}
+
+function attachmentMetadata(value: unknown, index: number): EmailCachedMessageDetail['attachments'][number] {
+  const attachment = record(value) || {};
+  return {
+    ...(attachment.id !== undefined ? { id: stringValue(attachment.id) } : {}),
+    ...(attachment.index !== undefined ? { index: nullableNumber(attachment.index) ?? index } : { index }),
+    ...(attachment.name !== undefined ? { name: stringValue(attachment.name) } : {}),
+    ...(attachment.filename !== undefined ? { filename: stringValue(attachment.filename) } : {}),
+    ...(attachment.mimeType !== undefined ? { mimeType: stringValue(attachment.mimeType) } : {}),
+    ...(attachment.contentType !== undefined ? { contentType: stringValue(attachment.contentType) } : {}),
+    size: nullableNumber(attachment.size),
+    ...(attachment.inline !== undefined ? { inline: Boolean(attachment.inline) } : {}),
+    ...(attachment.isInline !== undefined ? { inline: Boolean(attachment.isInline) } : {}),
+    ...(attachment.contentId !== undefined ? { contentId: attachment.contentId === null ? null : stringValue(attachment.contentId) } : {}),
+  };
+}
+
+function detailForMessage(message: JsonRecord): EmailCachedMessageDetail {
+  const rawHeaders = record(message.headers);
+  const headers = rawHeaders
+    ? Object.fromEntries(Object.entries(rawHeaders).map(([name, value]) => [
+      name,
+      Array.isArray(value) ? value.map(String) : String(value),
+    ]))
+    : undefined;
+  return {
+    body: message.body === null || message.body === undefined ? null : stringValue(message.body),
+    bodyHtml: message.bodyHtml === null || message.bodyHtml === undefined ? null : stringValue(message.bodyHtml),
+    to: stringArray(message.to),
+    cc: stringArray(message.cc),
+    ...(Array.isArray(message.bcc) ? { bcc: stringArray(message.bcc) } : {}),
+    ...(Array.isArray(message.replyTo) ? { replyTo: stringArray(message.replyTo) } : {}),
+    ...(message.messageId !== undefined ? { messageId: stringValue(message.messageId) } : {}),
+    ...(message.inReplyTo !== undefined ? { inReplyTo: stringValue(message.inReplyTo) } : {}),
+    ...(Array.isArray(message.references) ? { references: message.references.map(String) } : {}),
+    ...(headers ? { headers } : {}),
+    attachments: Array.isArray(message.attachments)
+      ? message.attachments.map(attachmentMetadata)
+      : [],
+  };
+}
+
+function fallbackListMessage(ref: NormalizedEmailMessageRef, metadata: EmailCachedMessageMetadata): JsonRecord {
+  const flags = metadata.flags || [];
+  return {
+    id: ref.messageId || '',
+    uid: ref.uid !== null ? String(ref.uid) : ref.messageId || '',
+    ...(ref.uidValidity ? { uidValidity: ref.uidValidity } : {}),
+    ...(ref.folder ? { folder: ref.folder } : {}),
+    ...(metadata.threadId !== undefined ? { threadId: metadata.threadId || '' } : {}),
+    from: metadata.from,
+    to: metadata.to || [],
+    cc: metadata.cc || [],
+    subject: metadata.subject,
+    date: metadata.date,
+    flags,
+    isRead: metadata.isRead,
+    isAnswered: metadata.isAnswered,
+    isFlagged: metadata.isFlagged,
+    hasAttachments: metadata.hasAttachments,
+    ...(metadata.size !== null ? { size: metadata.size } : {}),
+    snippet: metadata.snippet,
+  };
+}
+
+function fallbackDetailMessage(
+  ref: NormalizedEmailMessageRef,
+  metadata: EmailCachedMessageMetadata,
+  detail: EmailCachedMessageDetail,
+  accountSource: EmailCacheAccountSource,
+): JsonRecord {
+  const providerFields = ref.provider === 'imap' || accountSource === 'managed'
+    ? {
+        uid: ref.uid !== null ? String(ref.uid) : ref.messageId || '',
+        ...(ref.uidValidity ? { uidValidity: ref.uidValidity } : {}),
+        ...(ref.folder ? { folder: ref.folder } : {}),
+        flags: metadata.flags || [],
+        isAnswered: metadata.isAnswered,
+        isFlagged: metadata.isFlagged,
+        hasAttachments: metadata.hasAttachments,
+        attachments: detail.attachments,
+      }
+    : {};
+  return {
+    id: ref.messageId || '',
+    ...(metadata.threadId !== undefined ? { threadId: metadata.threadId || '' } : {}),
+    from: metadata.from,
+    to: detail.to,
+    cc: detail.cc,
+    subject: metadata.subject,
+    date: metadata.date,
+    messageId: detail.messageId || '',
+    inReplyTo: detail.inReplyTo || '',
+    references: detail.references || [],
+    body: detail.body || '',
+    bodyHtml: detail.bodyHtml || '',
+    isRead: metadata.isRead,
+    snippet: metadata.snippet,
+    ...(detail.bcc ? { bcc: detail.bcc } : {}),
+    ...(detail.replyTo ? { replyTo: detail.replyTo } : {}),
+    ...providerFields,
+  };
+}
+
+function mapListMessages(provider: string, messages: unknown[]): Array<{
+  ref: EmailMessageRefInput;
+  metadata: EmailCachedMessageMetadata;
+}> | null {
+  const mapped = [];
+  for (const value of messages) {
+    const message = record(value);
+    if (!message) return null;
+    const messageId = stringValue(message.id);
+    const ref = emailMessageCacheRef(provider, messageId, stringValue(message.folder) || undefined, message);
+    if (!ref) return null;
+    mapped.push({ ref, metadata: metadataForMessage(message) });
+  }
+  return mapped;
+}
+
+async function readListBundle(
+  runtime: CacheRuntime,
+  mailbox: EmailCacheMailboxContext,
+  scope: EmailListCacheScopeInput,
+): Promise<CachedListBundle | null> {
+  const list = await runtime.store.getList({ ...scope, now: nowFor(runtime) });
+  if (!list.value) return null;
+  const refs = list.value.refs.map(cacheRefInput);
+  if (refs.some((ref) => !ref)) return null;
+  const messages = await runtime.store.getMessages({
+    userId: mailbox.userId,
+    accountId: mailbox.accountId,
+    accountSource: mailbox.accountSource,
+    refs: refs as EmailMessageRefInput[],
+    part: 'metadata',
+    now: nowFor(runtime),
+  });
+  const byKey = new Map(messages.map((message) => [message.messageKey, message]));
+  const hydrated: JsonRecord[] = [];
+  let state = list.state;
+  for (const ref of list.value.refs) {
+    const cached = byKey.get(ref.messageKey);
+    if (!cached?.value?.metadata) return null;
+    if (cached.state === 'stale') state = 'stale';
+    hydrated.push(fallbackListMessage(ref, cached.value.metadata));
+  }
+  return {
+    messages: hydrated,
+    totalCount: list.value.totalCount,
+    metadata: { ...list, state, value: undefined } as EmailCacheReadMetadata,
+  };
+}
+
+async function refreshList<T extends EmailListPayload>(input: {
+  runtime: CacheRuntime;
+  mailbox: EmailCacheMailboxContext;
+  scope: EmailListCacheScopeInput;
+  owner: string;
+  generation: number;
+  load: () => Promise<T>;
+}): Promise<{
+  payload: T;
+  cacheable: boolean;
+  bypassReason?: EmailResponseCacheMetadata['bypassReason'];
+}> {
+  let payload: T;
+  try {
+    payload = await input.load();
+  } catch (error) {
+    await input.runtime.store.releaseListRefreshLease({
+      ...input.scope,
+      owner: input.owner,
+      now: nowFor(input.runtime),
+    }).catch(() => false);
+    throw error;
+  }
+  try {
+    const rawMessages = Array.isArray(payload.messages) ? payload.messages : [];
+    const mapped = mapListMessages(input.mailbox.provider, rawMessages);
+    if (!mapped) return { payload, cacheable: false, bypassReason: 'unsafe_message_reference' };
+    const batch = await input.runtime.store.putMessages({
+      userId: input.mailbox.userId,
+      accountId: input.mailbox.accountId,
+      accountSource: input.mailbox.accountSource,
+      messages: mapped,
+      expectedGeneration: input.generation,
+      now: nowFor(input.runtime),
+    });
+    if (batch.storedCount !== mapped.length) return { payload, cacheable: false, bypassReason: 'cache_error' };
+    const stored = await input.runtime.store.putList({
+      ...input.scope,
+      refs: mapped.map((entry) => entry.ref),
+      totalCount: nullableNumber(payload.total),
+      expectedGeneration: input.generation,
+      leaseOwner: input.owner,
+      now: nowFor(input.runtime),
+    });
+    if (stored.stored) void input.runtime.store.maybeCleanup().catch(() => undefined);
+    return { payload, cacheable: stored.stored, ...(stored.stored ? {} : { bypassReason: 'cache_error' as const }) };
+  } catch (error) {
+    console.warn('Email list cache refresh could not be persisted.', error);
+    return { payload, cacheable: false, bypassReason: 'cache_error' };
+  } finally {
+    await input.runtime.store.releaseListRefreshLease({
+      ...input.scope,
+      owner: input.owner,
+      now: nowFor(input.runtime),
+    }).catch(() => false);
+  }
+}
+
+function scheduleRefresh(schedule: EmailCacheBackgroundScheduler, task: () => Promise<void>): boolean {
+  try {
+    schedule(async () => {
+      try {
+        await task();
+      } catch (error) {
+        console.warn('Email cache background refresh failed.', error);
+      }
+    });
+    return true;
+  } catch (error) {
+    console.warn('Email cache background refresh could not be scheduled.', error);
+    return false;
+  }
+}
+
+export async function readThroughEmailList<T extends EmailListPayload>(input: {
+  runtime: CacheRuntime;
+  mailbox: EmailCacheMailboxContext;
+  scope: Omit<EmailListCacheScopeInput, 'userId' | 'accountId' | 'accountSource'>;
+  load: () => Promise<T>;
+  fromCache: (messages: JsonRecord[], totalCount: number | null) => T;
+}): Promise<T & { cache: EmailResponseCacheMetadata }> {
+  const scope: EmailListCacheScopeInput = { ...input.scope, ...input.mailbox };
+  if (!input.runtime.store.enabled) {
+    const payload = await input.load();
+    return withCache(payload, providerMissMetadata(false, 'list', nowFor(input.runtime), null, 'bypass', 'cache_disabled'));
+  }
+
+  let cached: CachedListBundle | null;
+  try {
+    cached = await readListBundle(input.runtime, input.mailbox, scope);
+  } catch {
+    const payload = await input.load();
+    return withCache(payload, providerMissMetadata(true, 'list', nowFor(input.runtime), null, 'bypass', 'cache_error'));
+  }
+
+  if (cached?.metadata.state === 'fresh') {
+    return withCache(input.fromCache(cached.messages, cached.totalCount), cacheMetadata('list', cached.metadata, 'cache', false));
+  }
+
+  if (cached?.metadata.state === 'stale') {
+    let refreshQueued = false;
+    if (input.runtime.scheduleBackgroundTask) {
+      const owner = randomUUID();
+      try {
+        const lease = await input.runtime.store.acquireListRefreshLease({ ...scope, owner, leaseMs: LIST_LEASE_MS, now: nowFor(input.runtime) });
+        if (lease.acquired && lease.generation !== null) {
+          refreshQueued = scheduleRefresh(input.runtime.scheduleBackgroundTask, async () => {
+            await refreshList({ ...input, scope, owner, generation: lease.generation!, runtime: input.runtime });
+          });
+          if (!refreshQueued) {
+            await input.runtime.store.releaseListRefreshLease({ ...scope, owner, now: nowFor(input.runtime) }).catch(() => false);
+          }
+        } else {
+          refreshQueued = Boolean(lease.leaseUntil && lease.leaseUntil > nowFor(input.runtime));
+        }
+      } catch (error) {
+        console.warn('Email list cache refresh lease could not be acquired.', error);
+      }
+    }
+    return withCache(input.fromCache(cached.messages, cached.totalCount), cacheMetadata('list', cached.metadata, 'cache', refreshQueued));
+  }
+
+  const owner = randomUUID();
+  let lease;
+  try {
+    lease = await input.runtime.store.acquireListRefreshLease({ ...scope, owner, leaseMs: LIST_LEASE_MS, now: nowFor(input.runtime) });
+  } catch {
+    const payload = await input.load();
+    return withCache(payload, providerMissMetadata(true, 'list', nowFor(input.runtime), null, 'bypass', 'cache_error'));
+  }
+  if (!lease.acquired) {
+    const waitUntil = Math.min(lease.leaseUntil ?? nowFor(input.runtime), nowFor(input.runtime) + LIST_LEASE_MS);
+    while (nowFor(input.runtime) < waitUntil) {
+      await sleepFor(input.runtime, Math.min(LEASE_POLL_MS, waitUntil - nowFor(input.runtime)));
+      try {
+        cached = await readListBundle(input.runtime, input.mailbox, scope);
+      } catch {
+        const payload = await input.load();
+        return withCache(payload, providerMissMetadata(true, 'list', nowFor(input.runtime), lease.generation, 'bypass', 'cache_error'));
+      }
+      if (cached) {
+        return withCache(input.fromCache(cached.messages, cached.totalCount), cacheMetadata('list', cached.metadata, 'cache', false));
+      }
+    }
+    try {
+      lease = await input.runtime.store.acquireListRefreshLease({ ...scope, owner, leaseMs: LIST_LEASE_MS, now: nowFor(input.runtime) });
+    } catch {
+      const payload = await input.load();
+      return withCache(payload, providerMissMetadata(true, 'list', nowFor(input.runtime), null, 'bypass', 'cache_error'));
+    }
+  }
+  if (!lease.acquired || lease.generation === null) {
+    const payload = await input.load();
+    return withCache(payload, providerMissMetadata(true, 'list', nowFor(input.runtime), lease.generation, 'provider', 'lease_contention'));
+  }
+  const refreshed = await refreshList({ ...input, scope, owner, generation: lease.generation, runtime: input.runtime });
+  return withCache(refreshed.payload, providerMissMetadata(true, 'list', nowFor(input.runtime), lease.generation, refreshed.cacheable ? 'provider' : 'bypass', refreshed.bypassReason));
+}
+
+async function readCachedDetail(
+  runtime: CacheRuntime,
+  mailbox: EmailCacheMailboxContext,
+  ref: EmailMessageRefInput,
+): Promise<{ message: JsonRecord; metadata: EmailCacheReadMetadata } | null> {
+  const cached = await runtime.store.getMessage({
+    userId: mailbox.userId,
+    accountId: mailbox.accountId,
+    accountSource: mailbox.accountSource,
+    ref,
+    part: 'detail',
+    now: nowFor(runtime),
+  });
+  if (!cached.value?.metadata || !cached.value.detail) return null;
+  return {
+    message: fallbackDetailMessage(cached.value.ref, cached.value.metadata, cached.value.detail, mailbox.accountSource),
+    metadata: cached,
+  };
+}
+
+async function refreshDetail<T extends EmailDetailPayload>(input: {
+  runtime: CacheRuntime;
+  mailbox: EmailCacheMailboxContext;
+  ref: EmailMessageRefInput;
+  owner: string;
+  generation: number;
+  load: () => Promise<T>;
+}): Promise<{
+  payload: T;
+  cacheable: boolean;
+  bypassReason?: EmailResponseCacheMetadata['bypassReason'];
+}> {
+  let payload: T;
+  try {
+    payload = await input.load();
+  } catch (error) {
+    await input.runtime.store.releaseMessageRefreshLease({
+      userId: input.mailbox.userId,
+      accountId: input.mailbox.accountId,
+      accountSource: input.mailbox.accountSource,
+      ref: input.ref,
+      owner: input.owner,
+      now: nowFor(input.runtime),
+    }).catch(() => false);
+    throw error;
+  }
+  try {
+    const message = record(payload.message);
+    if (!message) return { payload, cacheable: false, bypassReason: 'unsafe_message_reference' };
+    const actualRef = emailMessageCacheRef(
+      input.mailbox.provider,
+      stringValue(message.id) || ('messageId' in input.ref ? input.ref.messageId : ''),
+      stringValue(message.folder) || ('folder' in input.ref ? input.ref.folder : undefined),
+      message,
+    );
+    if (!actualRef || normalizeEmailMessageRef(actualRef).messageKey !== normalizeEmailMessageRef(input.ref).messageKey) {
+      return { payload, cacheable: false, bypassReason: 'unsafe_message_reference' };
+    }
+    const stored = await input.runtime.store.putMessage({
+      userId: input.mailbox.userId,
+      accountId: input.mailbox.accountId,
+      accountSource: input.mailbox.accountSource,
+      ref: actualRef,
+      metadata: metadataForMessage(message),
+      detail: detailForMessage(message),
+      expectedGeneration: input.generation,
+      leaseOwner: input.owner,
+      now: nowFor(input.runtime),
+    });
+    if (stored.stored) void input.runtime.store.maybeCleanup().catch(() => undefined);
+    return { payload, cacheable: stored.stored, ...(stored.stored ? {} : { bypassReason: 'cache_error' as const }) };
+  } catch (error) {
+    console.warn('Email detail cache refresh could not be persisted.', error);
+    return { payload, cacheable: false, bypassReason: 'cache_error' };
+  } finally {
+    await input.runtime.store.releaseMessageRefreshLease({
+      userId: input.mailbox.userId,
+      accountId: input.mailbox.accountId,
+      accountSource: input.mailbox.accountSource,
+      ref: input.ref,
+      owner: input.owner,
+      now: nowFor(input.runtime),
+    }).catch(() => false);
+  }
+}
+
+export async function readThroughEmailDetail<T extends EmailDetailPayload>(input: {
+  runtime: CacheRuntime;
+  mailbox: EmailCacheMailboxContext;
+  messageId: string;
+  folder?: string;
+  load: () => Promise<T>;
+  fromCache: (message: JsonRecord) => T;
+}): Promise<T & { cache: EmailResponseCacheMetadata }> {
+  const ref = emailMessageCacheRef(input.mailbox.provider, input.messageId, input.folder);
+  if (!ref) {
+    const payload = await input.load();
+    const reason = /^[1-9]\d*$/u.test(input.messageId) ? 'legacy_imap_reference' : 'unsafe_imap_reference';
+    return withCache(payload, providerMissMetadata(input.runtime.store.enabled, 'detail', nowFor(input.runtime), null, 'bypass', reason));
+  }
+  if (!input.runtime.store.enabled) {
+    const payload = await input.load();
+    return withCache(payload, providerMissMetadata(false, 'detail', nowFor(input.runtime), null, 'bypass', 'cache_disabled'));
+  }
+
+  let cached: Awaited<ReturnType<typeof readCachedDetail>>;
+  try {
+    cached = await readCachedDetail(input.runtime, input.mailbox, ref);
+  } catch {
+    const payload = await input.load();
+    return withCache(payload, providerMissMetadata(true, 'detail', nowFor(input.runtime), null, 'bypass', 'cache_error'));
+  }
+  if (cached?.metadata.state === 'fresh') {
+    return withCache(input.fromCache(cached.message), cacheMetadata('detail', cached.metadata, 'cache', false));
+  }
+  if (cached?.metadata.state === 'stale') {
+    let refreshQueued = false;
+    if (input.runtime.scheduleBackgroundTask) {
+      const owner = randomUUID();
+      try {
+        const lease = await input.runtime.store.acquireMessageRefreshLease({
+          userId: input.mailbox.userId,
+          accountId: input.mailbox.accountId,
+          accountSource: input.mailbox.accountSource,
+          ref,
+          owner,
+          leaseMs: DETAIL_LEASE_MS,
+          now: nowFor(input.runtime),
+        });
+        if (lease.acquired && lease.generation !== null) {
+          refreshQueued = scheduleRefresh(input.runtime.scheduleBackgroundTask, async () => {
+            await refreshDetail({ ...input, ref, owner, generation: lease.generation!, runtime: input.runtime });
+          });
+          if (!refreshQueued) {
+            await input.runtime.store.releaseMessageRefreshLease({
+              userId: input.mailbox.userId,
+              accountId: input.mailbox.accountId,
+              accountSource: input.mailbox.accountSource,
+              ref,
+              owner,
+              now: nowFor(input.runtime),
+            }).catch(() => false);
+          }
+        } else {
+          refreshQueued = Boolean(lease.leaseUntil && lease.leaseUntil > nowFor(input.runtime));
+        }
+      } catch (error) {
+        console.warn('Email detail cache refresh lease could not be acquired.', error);
+      }
+    }
+    return withCache(input.fromCache(cached.message), cacheMetadata('detail', cached.metadata, 'cache', refreshQueued));
+  }
+
+  const owner = randomUUID();
+  let lease;
+  try {
+    lease = await input.runtime.store.acquireMessageRefreshLease({
+      userId: input.mailbox.userId,
+      accountId: input.mailbox.accountId,
+      accountSource: input.mailbox.accountSource,
+      ref,
+      owner,
+      leaseMs: DETAIL_LEASE_MS,
+      now: nowFor(input.runtime),
+    });
+  } catch {
+    const payload = await input.load();
+    return withCache(payload, providerMissMetadata(true, 'detail', nowFor(input.runtime), null, 'bypass', 'cache_error'));
+  }
+  if (!lease.acquired) {
+    const waitUntil = Math.min(lease.leaseUntil ?? nowFor(input.runtime), nowFor(input.runtime) + DETAIL_LEASE_MS);
+    while (nowFor(input.runtime) < waitUntil) {
+      await sleepFor(input.runtime, Math.min(LEASE_POLL_MS, waitUntil - nowFor(input.runtime)));
+      try {
+        cached = await readCachedDetail(input.runtime, input.mailbox, ref);
+      } catch {
+        const payload = await input.load();
+        return withCache(payload, providerMissMetadata(true, 'detail', nowFor(input.runtime), lease.generation, 'bypass', 'cache_error'));
+      }
+      if (cached) return withCache(input.fromCache(cached.message), cacheMetadata('detail', cached.metadata, 'cache', false));
+    }
+    try {
+      lease = await input.runtime.store.acquireMessageRefreshLease({
+        userId: input.mailbox.userId,
+        accountId: input.mailbox.accountId,
+        accountSource: input.mailbox.accountSource,
+        ref,
+        owner,
+        leaseMs: DETAIL_LEASE_MS,
+        now: nowFor(input.runtime),
+      });
+    } catch {
+      const payload = await input.load();
+      return withCache(payload, providerMissMetadata(true, 'detail', nowFor(input.runtime), null, 'bypass', 'cache_error'));
+    }
+  }
+  if (!lease.acquired || lease.generation === null) {
+    const payload = await input.load();
+    return withCache(payload, providerMissMetadata(true, 'detail', nowFor(input.runtime), lease.generation, 'provider', 'lease_contention'));
+  }
+  const refreshed = await refreshDetail({ ...input, ref, owner, generation: lease.generation, runtime: input.runtime });
+  return withCache(refreshed.payload, providerMissMetadata(true, 'detail', nowFor(input.runtime), lease.generation, refreshed.cacheable ? 'provider' : 'bypass', refreshed.bypassReason));
+}

--- a/app/lib/email/cache/store.ts
+++ b/app/lib/email/cache/store.ts
@@ -152,6 +152,22 @@ export type EmailCacheWriteResult = {
   reason: 'stored' | 'disabled' | 'generation_changed_or_lease_lost';
 };
 
+export type EmailCacheMessageWriteEntry = {
+  ref: EmailMessageRefInput;
+  metadata?: EmailCachedMessageMetadata;
+  detail?: EmailCachedMessageDetail;
+  leaseOwner?: string;
+};
+
+export type EmailCacheBatchWriteResult = {
+  enabled: boolean;
+  requestedCount: number;
+  storedCount: number;
+  storedMessageKeys: string[];
+  rejectedMessageKeys: string[];
+  reason: 'stored' | 'partial' | 'disabled' | 'generation_changed_or_tombstoned';
+};
+
 export type EmailCacheCleanupResult = {
   enabled: boolean;
   skipped: boolean;
@@ -221,6 +237,15 @@ export interface EmailCacheStore {
       now?: number;
     },
   ): Promise<EmailCacheWriteResult>;
+  putMessages(
+    input: MailboxInput & {
+      messages: EmailCacheMessageWriteEntry[];
+      expectedGeneration: number;
+      freshForMs?: number;
+      retainForMs?: number;
+      now?: number;
+    },
+  ): Promise<EmailCacheBatchWriteResult>;
   releaseMessageRefreshLease(
     input: MailboxInput & { ref: EmailMessageRefInput; owner: string; now?: number },
   ): Promise<boolean>;
@@ -507,6 +532,16 @@ const DISABLED_EMAIL_CACHE_STORE: EmailCacheStore = {
     return { enabled: false, acquired: false, generation: null, leaseUntil: null };
   },
   async putMessage() { return { enabled: false, stored: false, reason: 'disabled' }; },
+  async putMessages(input) {
+    return {
+      enabled: false,
+      requestedCount: input.messages.length,
+      storedCount: 0,
+      storedMessageKeys: [],
+      rejectedMessageKeys: input.messages.map((message) => normalizeEmailMessageRef(message.ref).messageKey),
+      reason: 'disabled',
+    };
+  },
   async releaseMessageRefreshLease() { return false; },
   async purgeAccount() {
     return {
@@ -959,106 +994,290 @@ export class PostgresEmailCacheStore implements EmailCacheStore {
       now?: number;
     },
   ): Promise<EmailCacheWriteResult> {
-    if (!input.metadata && !input.detail) {
-      throw new Error('putMessage requires metadata, detail, or both.');
+    const result = await this.putMessages({
+      userId: input.userId,
+      accountId: input.accountId,
+      accountSource: input.accountSource,
+      messages: [{
+        ref: input.ref,
+        metadata: input.metadata,
+        detail: input.detail,
+        leaseOwner: input.leaseOwner,
+      }],
+      expectedGeneration: input.expectedGeneration,
+      freshForMs: input.freshForMs,
+      retainForMs: input.retainForMs,
+      now: input.now,
+    });
+    return result.storedCount === 1
+      ? { enabled: true, stored: true, reason: 'stored' }
+      : { enabled: true, stored: false, reason: 'generation_changed_or_lease_lost' };
+  }
+
+  async putMessages(
+    input: MailboxInput & {
+      messages: EmailCacheMessageWriteEntry[];
+      expectedGeneration: number;
+      freshForMs?: number;
+      retainForMs?: number;
+      now?: number;
+    },
+  ): Promise<EmailCacheBatchWriteResult> {
+    if (input.messages.length > 50) {
+      throw new Error('putMessages accepts at most 50 messages.');
     }
     const mailbox = normalizeMailbox(input);
-    const ref = normalizeEmailMessageRef(input.ref);
     const expectedGeneration = positiveInteger(input.expectedGeneration, 'expectedGeneration');
-    const leaseOwner = input.leaseOwner ? requiredText(input.leaseOwner, 'leaseOwner') : null;
     const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
     const freshForMs = input.freshForMs ?? DEFAULT_EMAIL_CACHE_FRESH_MS;
     const retainForMs = input.retainForMs ?? DEFAULT_EMAIL_MESSAGE_RETENTION_MS;
     validateCacheWindow(now, freshForMs, retainForMs);
+
+    const normalizedByKey = new Map<string, {
+      message_key: string;
+      provider: string;
+      provider_message_id: string | null;
+      folder: string | null;
+      uid_validity: string | null;
+      uid: number | null;
+      sender: string | null;
+      subject: string | null;
+      message_date: number | null;
+      preview: string | null;
+      is_read: boolean | null;
+      metadata_json: EmailCachedMessageMetadata | null;
+      detail_json: EmailCachedMessageDetail | null;
+      lease_owner: string | null;
+    }>();
+    for (const message of input.messages) {
+      if (!message.metadata && !message.detail) {
+        throw new Error('Every putMessages entry requires metadata, detail, or both.');
+      }
+      const ref = normalizeEmailMessageRef(message.ref);
+      const metadata = message.metadata ? normalizeCachedMessageMetadata(message.metadata) : null;
+      const detail = message.detail ? normalizeCachedMessageDetail(message.detail) : null;
+      normalizedByKey.set(ref.messageKey, {
+        message_key: ref.messageKey,
+        provider: ref.provider,
+        provider_message_id: ref.messageId,
+        folder: ref.folder,
+        uid_validity: ref.uidValidity,
+        uid: ref.uid,
+        sender: metadata?.from ?? null,
+        subject: metadata?.subject ?? null,
+        message_date: metadata?.dateTimestamp ?? null,
+        preview: metadata?.snippet ?? null,
+        is_read: metadata?.isRead ?? null,
+        metadata_json: metadata,
+        detail_json: detail,
+        lease_owner: message.leaseOwner ? requiredText(message.leaseOwner, 'leaseOwner') : null,
+      });
+    }
+    const normalizedMessages = [...normalizedByKey.values()];
+    const requestedKeys = normalizedMessages.map((message) => message.message_key);
+    if (normalizedMessages.length === 0) {
+      return {
+        enabled: true,
+        requestedCount: 0,
+        storedCount: 0,
+        storedMessageKeys: [],
+        rejectedMessageKeys: [],
+        reason: 'stored',
+      };
+    }
+
     const staleAt = now + freshForMs;
     const expiresAt = now + retainForMs;
-    const metadata = input.metadata ? normalizeCachedMessageMetadata(input.metadata) : null;
-    const detail = input.detail ? normalizeCachedMessageDetail(input.detail) : null;
-    const metadataJson = metadata ? JSON.stringify(metadata) : null;
-    const detailJson = detail ? JSON.stringify(detail) : null;
-    const result = await this.query<{ message_key: string }>(`
+    const result = await this.query<{
+      generation: number | string | null;
+      stored_message_keys: string[];
+    }>(`
       WITH mailbox AS MATERIALIZED (
         INSERT INTO email_cache_mailboxes (
           user_id, account_source, account_id, generation, last_accessed_at, created_at, updated_at
-        ) VALUES ($1, $2, $3, 1, $18, $18, $18)
+        ) VALUES ($1, $2, $3, 1, $6, $6, $6)
         ON CONFLICT (user_id, account_source, account_id) DO UPDATE
         SET last_accessed_at = EXCLUDED.last_accessed_at,
             updated_at = EXCLUDED.updated_at
         WHERE email_cache_mailboxes.active = true
         RETURNING generation
-      )
-      INSERT INTO email_cache_messages (
+      ), payload AS MATERIALIZED (
+        SELECT *
+        FROM jsonb_to_recordset($5::jsonb) AS item (
+          message_key text,
+          provider text,
+          provider_message_id text,
+          folder text,
+          uid_validity text,
+          uid bigint,
+          sender text,
+          subject text,
+          message_date bigint,
+          preview text,
+          is_read boolean,
+          metadata_json jsonb,
+          detail_json jsonb,
+          lease_owner text
+        )
+      ), updated AS (
+        UPDATE email_cache_messages AS target
+        SET provider = payload.provider,
+            provider_message_id = payload.provider_message_id,
+            folder = payload.folder,
+            uid_validity = payload.uid_validity,
+            uid = payload.uid,
+            sender = CASE
+              WHEN payload.metadata_json IS NOT NULL THEN payload.sender
+              WHEN target.generation = $4 THEN target.sender
+              ELSE NULL
+            END,
+            subject = CASE
+              WHEN payload.metadata_json IS NOT NULL THEN payload.subject
+              WHEN target.generation = $4 THEN target.subject
+              ELSE NULL
+            END,
+            message_date = CASE
+              WHEN payload.metadata_json IS NOT NULL THEN payload.message_date
+              WHEN target.generation = $4 THEN target.message_date
+              ELSE NULL
+            END,
+            preview = CASE
+              WHEN payload.metadata_json IS NOT NULL THEN payload.preview
+              WHEN target.generation = $4 THEN target.preview
+              ELSE NULL
+            END,
+            is_read = CASE
+              WHEN payload.metadata_json IS NOT NULL THEN payload.is_read
+              WHEN target.generation = $4 THEN target.is_read
+              ELSE NULL
+            END,
+            metadata_json = CASE
+              WHEN payload.metadata_json IS NOT NULL THEN payload.metadata_json
+              WHEN target.generation = $4 THEN target.metadata_json
+              ELSE NULL
+            END,
+            detail_json = CASE
+              WHEN payload.detail_json IS NOT NULL THEN payload.detail_json
+              WHEN target.generation = $4 THEN target.detail_json
+              ELSE NULL
+            END,
+            generation = $4,
+            metadata_fetched_at = CASE
+              WHEN payload.metadata_json IS NOT NULL THEN $6
+              WHEN target.generation = $4 THEN target.metadata_fetched_at
+              ELSE NULL
+            END,
+            metadata_stale_at = CASE
+              WHEN payload.metadata_json IS NOT NULL THEN $7
+              WHEN target.generation = $4 THEN target.metadata_stale_at
+              ELSE NULL
+            END,
+            detail_fetched_at = CASE
+              WHEN payload.detail_json IS NOT NULL THEN $6
+              WHEN target.generation = $4 THEN target.detail_fetched_at
+              ELSE NULL
+            END,
+            detail_stale_at = CASE
+              WHEN payload.detail_json IS NOT NULL THEN $7
+              WHEN target.generation = $4 THEN target.detail_stale_at
+              ELSE NULL
+            END,
+            expires_at = CASE
+              WHEN target.generation = $4 THEN GREATEST(target.expires_at, $8)
+              ELSE $8
+            END,
+            refresh_owner = CASE
+              WHEN payload.lease_owner IS NOT NULL THEN NULL
+              ELSE target.refresh_owner
+            END,
+            refresh_lease_until = CASE
+              WHEN payload.lease_owner IS NOT NULL THEN NULL
+              ELSE target.refresh_lease_until
+            END,
+            last_accessed_at = $6,
+            updated_at = $6
+        FROM payload, mailbox
+        WHERE target.user_id = $1
+          AND target.account_source = $2
+          AND target.account_id = $3
+          AND target.message_key = payload.message_key
+          AND mailbox.generation = $4
+          AND (
+            (payload.lease_owner IS NOT NULL AND target.refresh_owner = payload.lease_owner)
+            OR
+            (payload.lease_owner IS NULL AND (
+              payload.detail_json IS NULL
+              OR target.refresh_lease_until IS NULL
+              OR target.refresh_lease_until <= $6
+            ))
+          )
+        RETURNING target.message_key
+      ), inserted AS (
+        INSERT INTO email_cache_messages (
         user_id, account_source, account_id, message_key, provider, provider_message_id, folder,
         uid_validity, uid, sender, subject, message_date, preview, is_read,
         metadata_json, detail_json, generation, metadata_fetched_at,
         metadata_stale_at, detail_fetched_at, detail_stale_at, expires_at,
         refresh_owner, refresh_lease_until, last_accessed_at, created_at, updated_at
       )
-      SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9,
-        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $11::text END,
-        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $12::text END,
-        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $13::bigint END,
-        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $14::text END,
-        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $15::boolean END,
-        $10::jsonb, $16::jsonb, $17::bigint,
-        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $18::bigint END,
-        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $19::bigint END,
-        CASE WHEN $16::jsonb IS NULL THEN NULL ELSE $18::bigint END,
-        CASE WHEN $16::jsonb IS NULL THEN NULL ELSE $19::bigint END,
-        $20::bigint, NULL, NULL, $18::bigint, $18::bigint, $18::bigint
-      FROM mailbox
-      WHERE mailbox.generation = $17
-      ON CONFLICT (user_id, account_source, account_id, message_key) DO UPDATE
-      SET provider = EXCLUDED.provider,
-          provider_message_id = EXCLUDED.provider_message_id,
-          folder = EXCLUDED.folder,
-          uid_validity = EXCLUDED.uid_validity,
-          uid = EXCLUDED.uid,
-          sender = COALESCE(EXCLUDED.sender, email_cache_messages.sender),
-          subject = COALESCE(EXCLUDED.subject, email_cache_messages.subject),
-          message_date = COALESCE(EXCLUDED.message_date, email_cache_messages.message_date),
-          preview = COALESCE(EXCLUDED.preview, email_cache_messages.preview),
-          is_read = COALESCE(EXCLUDED.is_read, email_cache_messages.is_read),
-          metadata_json = COALESCE(EXCLUDED.metadata_json, email_cache_messages.metadata_json),
-          detail_json = COALESCE(EXCLUDED.detail_json, email_cache_messages.detail_json),
-          generation = EXCLUDED.generation,
-          metadata_fetched_at = COALESCE(EXCLUDED.metadata_fetched_at, email_cache_messages.metadata_fetched_at),
-          metadata_stale_at = COALESCE(EXCLUDED.metadata_stale_at, email_cache_messages.metadata_stale_at),
-          detail_fetched_at = COALESCE(EXCLUDED.detail_fetched_at, email_cache_messages.detail_fetched_at),
-          detail_stale_at = COALESCE(EXCLUDED.detail_stale_at, email_cache_messages.detail_stale_at),
-          expires_at = GREATEST(EXCLUDED.expires_at, email_cache_messages.expires_at),
-          refresh_owner = NULL,
-          refresh_lease_until = NULL,
-          last_accessed_at = EXCLUDED.last_accessed_at,
-          updated_at = EXCLUDED.updated_at
-      WHERE ($21::text IS NULL OR email_cache_messages.refresh_owner = $21)
-      RETURNING message_key
+        SELECT $1, $2, $3, payload.message_key, payload.provider,
+          payload.provider_message_id, payload.folder, payload.uid_validity, payload.uid,
+          payload.sender, payload.subject, payload.message_date, payload.preview, payload.is_read,
+          payload.metadata_json, payload.detail_json, $4,
+          CASE WHEN payload.metadata_json IS NULL THEN NULL ELSE $6 END,
+          CASE WHEN payload.metadata_json IS NULL THEN NULL ELSE $7 END,
+          CASE WHEN payload.detail_json IS NULL THEN NULL ELSE $6 END,
+          CASE WHEN payload.detail_json IS NULL THEN NULL ELSE $7 END,
+          $8, NULL, NULL, $6, $6, $6
+        FROM payload, mailbox
+        WHERE mailbox.generation = $4
+          AND NOT EXISTS (
+            SELECT 1
+            FROM email_cache_messages AS existing
+            WHERE existing.user_id = $1
+              AND existing.account_source = $2
+              AND existing.account_id = $3
+              AND existing.message_key = payload.message_key
+          )
+        ON CONFLICT (user_id, account_source, account_id, message_key) DO NOTHING
+        RETURNING message_key
+      ), stored AS (
+        SELECT message_key FROM updated
+        UNION ALL
+        SELECT message_key FROM inserted
+      )
+      SELECT mailbox.generation,
+        COALESCE((SELECT jsonb_agg(message_key ORDER BY message_key) FROM stored), '[]'::jsonb)
+          AS stored_message_keys
+      FROM (VALUES (1)) AS seed(value)
+      LEFT JOIN mailbox ON true
     `, [
       mailbox.userId,
       mailbox.accountSource,
       mailbox.accountId,
-      ref.messageKey,
-      ref.provider,
-      ref.messageId,
-      ref.folder,
-      ref.uidValidity,
-      ref.uid,
-      metadataJson,
-      metadata?.from ?? null,
-      metadata?.subject ?? null,
-      metadata?.dateTimestamp ?? null,
-      metadata?.snippet ?? null,
-      metadata?.isRead ?? null,
-      detailJson,
       expectedGeneration,
+      JSON.stringify(normalizedMessages),
       now,
       staleAt,
       expiresAt,
-      leaseOwner,
     ]);
-    return result.rows.length
-      ? { enabled: true, stored: true, reason: 'stored' }
-      : { enabled: true, stored: false, reason: 'generation_changed_or_lease_lost' };
+    const row = result.rows[0];
+    const storedMessageKeys = Array.isArray(row?.stored_message_keys)
+      ? row.stored_message_keys.map(String)
+      : [];
+    const storedKeySet = new Set(storedMessageKeys);
+    const rejectedMessageKeys = requestedKeys.filter((key) => !storedKeySet.has(key));
+    const generationMatches = numberOrNull(row?.generation) === expectedGeneration;
+    return {
+      enabled: true,
+      requestedCount: requestedKeys.length,
+      storedCount: storedMessageKeys.length,
+      storedMessageKeys,
+      rejectedMessageKeys,
+      reason: !generationMatches
+        ? 'generation_changed_or_tombstoned'
+        : rejectedMessageKeys.length > 0 ? 'partial' : 'stored',
+    };
   }
 
   async releaseMessageRefreshLease(

--- a/app/lib/email/cache/store.ts
+++ b/app/lib/email/cache/store.ts
@@ -1,0 +1,1272 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+
+import { getDatabaseProvider, type DatabaseProvider } from '@/app/lib/db/provider';
+import type { EmailCachePostgresQueryable } from './postgres-migration';
+
+export const EMAIL_CACHE_SCHEMA_VERSION = 1;
+export const DEFAULT_EMAIL_CACHE_FRESH_MS = 60_000;
+export const DEFAULT_EMAIL_CACHE_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+export const DEFAULT_EMAIL_MESSAGE_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
+export const DEFAULT_EMAIL_CACHE_CLEANUP_INTERVAL_MS = 5 * 60 * 1_000;
+
+export type EmailCacheState = 'fresh' | 'stale' | 'miss';
+export type EmailCacheAccountSource = 'local' | 'managed';
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type EmailListCacheScopeInput = {
+  userId: string;
+  accountId: string;
+  accountSource?: EmailCacheAccountSource;
+  folder: string;
+  filter?: JsonValue;
+  query?: string;
+  offset?: number;
+  limit: number;
+  schemaVersion?: number;
+};
+
+export type NormalizedEmailListCacheScope = {
+  userId: string;
+  accountId: string;
+  accountSource: EmailCacheAccountSource;
+  folder: string;
+  filter: JsonValue;
+  query: string;
+  offset: number;
+  limit: number;
+  schemaVersion: number;
+  cacheKey: string;
+};
+
+export type EmailMessageRefInput =
+  | {
+      provider: 'imap' | 'smtp_imap';
+      folder: string;
+      uidValidity: string | number;
+      uid: number;
+      messageId: string;
+    }
+  | {
+      provider: string;
+      messageId: string;
+      folder?: string;
+      uidValidity?: never;
+      uid?: never;
+    };
+
+export type NormalizedEmailMessageRef = {
+  messageKey: string;
+  provider: string;
+  messageId: string | null;
+  folder: string | null;
+  uidValidity: string | null;
+  uid: number | null;
+};
+
+export type EmailCachedMessageMetadata = {
+  from: string;
+  subject: string;
+  /** Provider-facing date value retained losslessly for the existing UI contract. */
+  date: string;
+  /** Parsed epoch milliseconds used only for normalized persistence/sorting. */
+  dateTimestamp: number | null;
+  snippet: string;
+  isRead: boolean;
+  isAnswered: boolean;
+  isFlagged: boolean;
+  hasAttachments: boolean;
+  size: number | null;
+  to?: string[];
+  cc?: string[];
+  threadId?: string | null;
+  flags?: string[];
+};
+
+export type EmailCachedAttachmentMetadata = {
+  id?: string;
+  index?: number;
+  name?: string;
+  filename?: string;
+  mimeType?: string;
+  contentType?: string;
+  size: number | null;
+  inline?: boolean;
+  contentId?: string | null;
+};
+
+export type EmailCachedMessageDetail = {
+  body: string | null;
+  bodyHtml: string | null;
+  to: string[];
+  cc: string[];
+  bcc?: string[];
+  replyTo?: string[];
+  messageId?: string;
+  inReplyTo?: string;
+  references?: string[];
+  headers?: Record<string, string | string[]>;
+  attachments: EmailCachedAttachmentMetadata[];
+};
+
+export type EmailCachedListSnapshot = {
+  refs: NormalizedEmailMessageRef[];
+  totalCount: number | null;
+};
+
+export type EmailCachedMessage = {
+  ref: NormalizedEmailMessageRef;
+  metadata: EmailCachedMessageMetadata | null;
+  detail: EmailCachedMessageDetail | null;
+};
+
+export type EmailCacheReadMetadata = {
+  state: EmailCacheState;
+  enabled: boolean;
+  generation: number | null;
+  fetchedAt: number | null;
+  staleAt: number | null;
+  expiresAt: number | null;
+};
+
+export type EmailCacheReadResult<T> = EmailCacheReadMetadata & {
+  value: T | null;
+};
+
+export type EmailCacheBatchMessageResult = EmailCacheReadResult<EmailCachedMessage> & {
+  messageKey: string;
+};
+
+export type EmailCacheLeaseResult = {
+  enabled: boolean;
+  acquired: boolean;
+  generation: number | null;
+  leaseUntil: number | null;
+};
+
+export type EmailCacheWriteResult = {
+  enabled: boolean;
+  stored: boolean;
+  reason: 'stored' | 'disabled' | 'generation_changed_or_lease_lost';
+};
+
+export type EmailCacheCleanupResult = {
+  enabled: boolean;
+  skipped: boolean;
+  deletedLists: number;
+  deletedMessages: number;
+};
+
+export type EmailCachePurgeResult = {
+  enabled: boolean;
+  tombstoned: boolean;
+  generation: number | null;
+  deletedLists: number;
+  deletedMessages: number;
+};
+
+type MailboxInput = {
+  userId: string;
+  accountId: string;
+  accountSource?: EmailCacheAccountSource;
+};
+
+export interface EmailCacheStore {
+  /**
+   * Persistence-only capabilities. Callers must re-authorize the current user
+   * against the requested local or managed account before every cache read.
+   */
+  readonly enabled: boolean;
+  getMailboxGeneration(input: MailboxInput & { now?: number }): Promise<number | null>;
+  bumpMailboxGeneration(input: MailboxInput & { now?: number }): Promise<number | null>;
+  reactivateAccount(input: MailboxInput & { now?: number }): Promise<number | null>;
+  getList(input: EmailListCacheScopeInput & { now?: number }): Promise<EmailCacheReadResult<EmailCachedListSnapshot>>;
+  acquireListRefreshLease(
+    input: EmailListCacheScopeInput & { owner: string; leaseMs: number; now?: number },
+  ): Promise<EmailCacheLeaseResult>;
+  putList(
+    input: EmailListCacheScopeInput & {
+      refs: EmailMessageRefInput[];
+      totalCount?: number | null;
+      expectedGeneration: number;
+      leaseOwner?: string;
+      freshForMs?: number;
+      retainForMs?: number;
+      now?: number;
+    },
+  ): Promise<EmailCacheWriteResult>;
+  releaseListRefreshLease(
+    input: EmailListCacheScopeInput & { owner: string; now?: number },
+  ): Promise<boolean>;
+  getMessage(
+    input: MailboxInput & { ref: EmailMessageRefInput; part?: 'metadata' | 'detail'; now?: number },
+  ): Promise<EmailCacheReadResult<EmailCachedMessage>>;
+  getMessages(
+    input: MailboxInput & { refs: EmailMessageRefInput[]; part?: 'metadata' | 'detail'; now?: number },
+  ): Promise<EmailCacheBatchMessageResult[]>;
+  acquireMessageRefreshLease(
+    input: MailboxInput & { ref: EmailMessageRefInput; owner: string; leaseMs: number; now?: number },
+  ): Promise<EmailCacheLeaseResult>;
+  putMessage(
+    input: MailboxInput & {
+      ref: EmailMessageRefInput;
+      metadata?: EmailCachedMessageMetadata;
+      detail?: EmailCachedMessageDetail;
+      expectedGeneration: number;
+      leaseOwner?: string;
+      freshForMs?: number;
+      retainForMs?: number;
+      now?: number;
+    },
+  ): Promise<EmailCacheWriteResult>;
+  releaseMessageRefreshLease(
+    input: MailboxInput & { ref: EmailMessageRefInput; owner: string; now?: number },
+  ): Promise<boolean>;
+  purgeAccount(input: MailboxInput & { now?: number }): Promise<EmailCachePurgeResult>;
+  cleanup(input?: {
+    now?: number;
+    maxListsPerAccount?: number;
+    maxMessagesPerAccount?: number;
+    maxDeletesPerTable?: number;
+  }): Promise<EmailCacheCleanupResult>;
+  maybeCleanup(input?: {
+    now?: number;
+    intervalMs?: number;
+    maxListsPerAccount?: number;
+    maxMessagesPerAccount?: number;
+    maxDeletesPerTable?: number;
+  }): Promise<EmailCacheCleanupResult>;
+}
+
+type QueryResult<Row> = { rows: Row[]; rowCount?: number | null };
+
+type CacheRow = {
+  generation: number | string;
+  fetched_at: number | string | null;
+  stale_at: number | string | null;
+  expires_at: number | string | null;
+};
+
+function requiredText(value: string, name: string): string {
+  const normalized = value.normalize('NFC').trim();
+  if (!normalized) throw new Error(`${name} must not be empty.`);
+  return normalized;
+}
+
+function normalizeMailbox(input: MailboxInput): Required<MailboxInput> {
+  const accountSource = input.accountSource ?? 'local';
+  if (accountSource !== 'local' && accountSource !== 'managed') {
+    throw new Error('accountSource must be local or managed.');
+  }
+  return {
+    userId: requiredText(input.userId, 'userId'),
+    accountId: requiredText(input.accountId, 'accountId'),
+    accountSource,
+  };
+}
+
+function nonNegativeInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative safe integer.`);
+  }
+  return value;
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive safe integer.`);
+  }
+  return value;
+}
+
+function normalizeImapUint32(value: string | number, name: string): string {
+  const candidate = String(value);
+  if (!/^[1-9][0-9]*$/u.test(candidate)) {
+    throw new Error(`${name} must be a positive decimal integer.`);
+  }
+  const parsed = Number(candidate);
+  if (!Number.isSafeInteger(parsed) || parsed > 4_294_967_295) {
+    throw new Error(`${name} must fit in an unsigned 32-bit integer.`);
+  }
+  return String(parsed);
+}
+
+export function normalizeEmailCacheProvider(value: string): string {
+  const provider = requiredText(value, 'provider').toLowerCase();
+  if (provider === 'imap' || provider === 'smtp_imap') return 'imap';
+  if (provider === 'gmail') return 'google';
+  if (provider === 'outlook' || provider === 'office365') return 'microsoft';
+  return provider;
+}
+
+function normalizeJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) return value.map(normalizeJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, normalizeJson(nested)]),
+    );
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new Error('Email cache filters only accept finite JSON numbers.');
+  }
+  return value;
+}
+
+export function normalizeEmailListCacheScope(
+  input: EmailListCacheScopeInput,
+): NormalizedEmailListCacheScope {
+  const mailbox = normalizeMailbox(input);
+  const normalized = {
+    ...mailbox,
+    folder: requiredText(input.folder, 'folder'),
+    filter: normalizeJson(input.filter ?? null),
+    query: (input.query ?? '').normalize('NFC').trim(),
+    offset: nonNegativeInteger(input.offset ?? 0, 'offset'),
+    limit: positiveInteger(input.limit, 'limit'),
+    schemaVersion: positiveInteger(input.schemaVersion ?? EMAIL_CACHE_SCHEMA_VERSION, 'schemaVersion'),
+  };
+  const canonicalScope = JSON.stringify({
+    version: normalized.schemaVersion,
+    folder: normalized.folder,
+    filter: normalized.filter,
+    query: normalized.query,
+    offset: normalized.offset,
+    limit: normalized.limit,
+  });
+  return {
+    ...normalized,
+    cacheKey: createHash('sha256').update(canonicalScope).digest('hex'),
+  };
+}
+
+export function normalizeEmailMessageRef(input: EmailMessageRefInput): NormalizedEmailMessageRef {
+  const provider = normalizeEmailCacheProvider(input.provider);
+  const candidate = input as {
+    messageId?: string;
+    folder?: string;
+    uidValidity?: string | number;
+    uid?: number;
+  };
+  if (provider === 'imap') {
+    if (candidate.uid === undefined || candidate.uidValidity === undefined || candidate.folder === undefined) {
+      throw new Error('IMAP cache references require folder, UIDVALIDITY, and UID.');
+    }
+    const folder = requiredText(candidate.folder, 'folder');
+    const uidValidity = normalizeImapUint32(candidate.uidValidity, 'uidValidity');
+    const uid = positiveInteger(candidate.uid, 'uid');
+    if (uid > 4_294_967_295) throw new Error('uid must fit in an unsigned 32-bit integer.');
+    const messageId = candidate.messageId ? requiredText(candidate.messageId, 'messageId') : '';
+    if (!messageId || /^[0-9]+$/u.test(messageId)) {
+      throw new Error('IMAP cache references require an opaque, non-legacy messageId.');
+    }
+    const identity = JSON.stringify({ provider, folder, uidValidity, uid });
+    return {
+      messageKey: createHash('sha256').update(identity).digest('hex'),
+      provider,
+      messageId,
+      folder,
+      uidValidity,
+      uid,
+    };
+  }
+
+  if (!candidate.messageId) throw new Error('Provider cache references require messageId.');
+  const messageId = requiredText(candidate.messageId, 'messageId');
+  const folder = candidate.folder ? requiredText(candidate.folder, 'folder') : null;
+  const identity = JSON.stringify({ provider, messageId });
+  return {
+    messageKey: createHash('sha256').update(identity).digest('hex'),
+    provider,
+    messageId,
+    folder,
+    uidValidity: null,
+    uid: null,
+  };
+}
+
+function numberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const normalized = Number(value);
+  return Number.isFinite(normalized) ? normalized : null;
+}
+
+function miss<T>(enabled: boolean): EmailCacheReadResult<T> {
+  return {
+    state: 'miss',
+    enabled,
+    generation: null,
+    fetchedAt: null,
+    staleAt: null,
+    expiresAt: null,
+    value: null,
+  };
+}
+
+function readMetadata(row: CacheRow, now: number): Omit<EmailCacheReadMetadata, 'enabled'> {
+  const fetchedAt = numberOrNull(row.fetched_at);
+  const staleAt = numberOrNull(row.stale_at);
+  const expiresAt = numberOrNull(row.expires_at);
+  return {
+    state: staleAt !== null && staleAt <= now ? 'stale' : 'fresh',
+    generation: numberOrNull(row.generation),
+    fetchedAt,
+    staleAt,
+    expiresAt,
+  };
+}
+
+function validateCacheWindow(now: number, freshForMs: number, retainForMs: number): void {
+  nonNegativeInteger(now, 'now');
+  nonNegativeInteger(freshForMs, 'freshForMs');
+  positiveInteger(retainForMs, 'retainForMs');
+  if (retainForMs < freshForMs) throw new Error('retainForMs must be at least freshForMs.');
+}
+
+function stringList(value: string[] | undefined): string[] | undefined {
+  return value?.map((entry) => String(entry));
+}
+
+function normalizeCachedMessageMetadata(
+  metadata: EmailCachedMessageMetadata,
+): EmailCachedMessageMetadata {
+  return {
+    from: String(metadata.from),
+    subject: String(metadata.subject),
+    date: String(metadata.date),
+    dateTimestamp: metadata.dateTimestamp === null ? null : Number(metadata.dateTimestamp),
+    snippet: String(metadata.snippet),
+    isRead: Boolean(metadata.isRead),
+    isAnswered: Boolean(metadata.isAnswered),
+    isFlagged: Boolean(metadata.isFlagged),
+    hasAttachments: Boolean(metadata.hasAttachments),
+    size: metadata.size === null ? null : Number(metadata.size),
+    ...(metadata.to ? { to: stringList(metadata.to) } : {}),
+    ...(metadata.cc ? { cc: stringList(metadata.cc) } : {}),
+    ...(metadata.threadId !== undefined ? {
+      threadId: metadata.threadId === null ? null : String(metadata.threadId),
+    } : {}),
+    ...(metadata.flags ? { flags: stringList(metadata.flags) } : {}),
+  };
+}
+
+function normalizeCachedMessageDetail(detail: EmailCachedMessageDetail): EmailCachedMessageDetail {
+  return {
+    body: detail.body === null ? null : String(detail.body),
+    bodyHtml: detail.bodyHtml === null ? null : String(detail.bodyHtml),
+    to: stringList(detail.to) ?? [],
+    cc: stringList(detail.cc) ?? [],
+    ...(detail.bcc ? { bcc: stringList(detail.bcc) } : {}),
+    ...(detail.replyTo ? { replyTo: stringList(detail.replyTo) } : {}),
+    ...(detail.messageId !== undefined ? { messageId: String(detail.messageId) } : {}),
+    ...(detail.inReplyTo !== undefined ? { inReplyTo: String(detail.inReplyTo) } : {}),
+    ...(detail.references ? { references: stringList(detail.references) } : {}),
+    ...(detail.headers ? {
+      headers: Object.fromEntries(Object.entries(detail.headers).map(([name, value]) => [
+        name,
+        Array.isArray(value) ? value.map(String) : String(value),
+      ])),
+    } : {}),
+    attachments: detail.attachments.map((attachment) => ({
+      ...(attachment.id !== undefined ? { id: String(attachment.id) } : {}),
+      ...(attachment.index !== undefined ? { index: Number(attachment.index) } : {}),
+      ...(attachment.name !== undefined ? { name: String(attachment.name) } : {}),
+      ...(attachment.filename !== undefined ? { filename: String(attachment.filename) } : {}),
+      ...(attachment.mimeType !== undefined ? { mimeType: String(attachment.mimeType) } : {}),
+      ...(attachment.contentType !== undefined ? { contentType: String(attachment.contentType) } : {}),
+      size: attachment.size === null ? null : Number(attachment.size),
+      ...(attachment.inline !== undefined ? { inline: Boolean(attachment.inline) } : {}),
+      ...(attachment.contentId !== undefined ? {
+        contentId: attachment.contentId === null ? null : String(attachment.contentId),
+      } : {}),
+    })),
+  };
+}
+
+function disabledCleanup(skipped = true): EmailCacheCleanupResult {
+  return { enabled: false, skipped, deletedLists: 0, deletedMessages: 0 };
+}
+
+const DISABLED_EMAIL_CACHE_STORE: EmailCacheStore = {
+  enabled: false,
+  async getMailboxGeneration() { return null; },
+  async bumpMailboxGeneration() { return null; },
+  async reactivateAccount() { return null; },
+  async getList() { return miss(false); },
+  async acquireListRefreshLease() {
+    return { enabled: false, acquired: false, generation: null, leaseUntil: null };
+  },
+  async putList() { return { enabled: false, stored: false, reason: 'disabled' }; },
+  async releaseListRefreshLease() { return false; },
+  async getMessage() { return miss(false); },
+  async getMessages() { return []; },
+  async acquireMessageRefreshLease() {
+    return { enabled: false, acquired: false, generation: null, leaseUntil: null };
+  },
+  async putMessage() { return { enabled: false, stored: false, reason: 'disabled' }; },
+  async releaseMessageRefreshLease() { return false; },
+  async purgeAccount() {
+    return {
+      enabled: false,
+      tombstoned: false,
+      generation: null,
+      deletedLists: 0,
+      deletedMessages: 0,
+    };
+  },
+  async cleanup() { return disabledCleanup(false); },
+  async maybeCleanup() { return disabledCleanup(); },
+};
+
+export class PostgresEmailCacheStore implements EmailCacheStore {
+  readonly enabled = true;
+  private nextCleanupAt = 0;
+  private cleanupPromise: Promise<EmailCacheCleanupResult> | null = null;
+
+  constructor(private readonly postgres: EmailCachePostgresQueryable) {}
+
+  private async query<Row>(sql: string, values?: unknown[]): Promise<QueryResult<Row>> {
+    return this.postgres.query(sql, values) as unknown as Promise<QueryResult<Row>>;
+  }
+
+  async getMailboxGeneration(input: MailboxInput & { now?: number }): Promise<number | null> {
+    const mailbox = normalizeMailbox(input);
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const result = await this.query<{ generation: number | string }>(`
+      INSERT INTO email_cache_mailboxes (
+        user_id, account_source, account_id, generation, last_accessed_at, created_at, updated_at
+      ) VALUES ($1, $2, $3, 1, $4, $4, $4)
+      ON CONFLICT (user_id, account_source, account_id) DO UPDATE
+      SET last_accessed_at = EXCLUDED.last_accessed_at,
+          updated_at = EXCLUDED.updated_at
+      WHERE email_cache_mailboxes.active = true
+      RETURNING generation
+    `, [mailbox.userId, mailbox.accountSource, mailbox.accountId, now]);
+    return numberOrNull(result.rows[0]?.generation);
+  }
+
+  async bumpMailboxGeneration(input: MailboxInput & { now?: number }): Promise<number | null> {
+    const mailbox = normalizeMailbox(input);
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const result = await this.query<{ generation: number | string }>(`
+      INSERT INTO email_cache_mailboxes (
+        user_id, account_source, account_id, generation, last_accessed_at, created_at, updated_at
+      ) VALUES ($1, $2, $3, 1, $4, $4, $4)
+      ON CONFLICT (user_id, account_source, account_id) DO UPDATE
+      SET generation = email_cache_mailboxes.generation + 1,
+          last_accessed_at = EXCLUDED.last_accessed_at,
+          updated_at = EXCLUDED.updated_at
+      WHERE email_cache_mailboxes.active = true
+      RETURNING generation
+    `, [mailbox.userId, mailbox.accountSource, mailbox.accountId, now]);
+    return numberOrNull(result.rows[0]?.generation);
+  }
+
+  async reactivateAccount(input: MailboxInput & { now?: number }): Promise<number> {
+    const mailbox = normalizeMailbox(input);
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const result = await this.query<{ generation: number | string }>(`
+      INSERT INTO email_cache_mailboxes (
+        user_id, account_source, account_id, generation, active, disconnected_at,
+        last_accessed_at, created_at, updated_at
+      ) VALUES ($1, $2, $3, 1, true, NULL, $4, $4, $4)
+      ON CONFLICT (user_id, account_source, account_id) DO UPDATE
+      SET generation = email_cache_mailboxes.generation + 1,
+          active = true,
+          disconnected_at = NULL,
+          last_accessed_at = EXCLUDED.last_accessed_at,
+          updated_at = EXCLUDED.updated_at
+      RETURNING generation
+    `, [mailbox.userId, mailbox.accountSource, mailbox.accountId, now]);
+    return Number(result.rows[0].generation);
+  }
+
+  async getList(
+    input: EmailListCacheScopeInput & { now?: number },
+  ): Promise<EmailCacheReadResult<EmailCachedListSnapshot>> {
+    const scope = normalizeEmailListCacheScope(input);
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const result = await this.query<CacheRow & {
+      refs_json: NormalizedEmailMessageRef[];
+      total_count: number | string | null;
+    }>(`
+      UPDATE email_cache_lists AS list
+      SET last_accessed_at = $5,
+          updated_at = $5
+      FROM email_cache_mailboxes AS mailbox
+      WHERE list.user_id = $1
+        AND list.account_source = $2
+        AND list.account_id = $3
+        AND list.cache_key = $4
+        AND mailbox.user_id = list.user_id
+        AND mailbox.account_source = list.account_source
+        AND mailbox.account_id = list.account_id
+        AND mailbox.active = true
+        AND mailbox.generation = list.generation
+        AND list.refs_json IS NOT NULL
+        AND list.expires_at > $5
+      RETURNING list.generation, list.fetched_at, list.stale_at, list.expires_at,
+        list.refs_json, list.total_count
+    `, [scope.userId, scope.accountSource, scope.accountId, scope.cacheKey, now]);
+    const row = result.rows[0];
+    if (!row) return miss(true);
+    return {
+      enabled: true,
+      ...readMetadata(row, now),
+      value: {
+        refs: row.refs_json,
+        totalCount: numberOrNull(row.total_count),
+      },
+    };
+  }
+
+  async acquireListRefreshLease(
+    input: EmailListCacheScopeInput & { owner: string; leaseMs: number; now?: number },
+  ): Promise<EmailCacheLeaseResult> {
+    const scope = normalizeEmailListCacheScope(input);
+    const owner = requiredText(input.owner, 'owner');
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const leaseUntil = now + positiveInteger(input.leaseMs, 'leaseMs');
+    const result = await this.query<{
+      generation: number | string;
+      acquired: boolean;
+      lease_until: number | string | null;
+    }>(`
+      WITH mailbox AS MATERIALIZED (
+        INSERT INTO email_cache_mailboxes (
+          user_id, account_source, account_id, generation, last_accessed_at, created_at, updated_at
+        ) VALUES ($1, $2, $3, 1, $11, $11, $11)
+        ON CONFLICT (user_id, account_source, account_id) DO UPDATE
+        SET last_accessed_at = EXCLUDED.last_accessed_at,
+            updated_at = EXCLUDED.updated_at
+        WHERE email_cache_mailboxes.active = true
+        RETURNING generation
+      ), claimed AS (
+        INSERT INTO email_cache_lists (
+          user_id, account_source, account_id, cache_key, schema_version, folder, filter_json,
+          search_query, page_offset, page_limit, generation, refresh_owner,
+          refresh_lease_until, last_accessed_at, created_at, updated_at
+        )
+        SELECT $1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10,
+          mailbox.generation, $12, $13, $11, $11, $11
+        FROM mailbox
+        ON CONFLICT (user_id, account_source, account_id, cache_key) DO UPDATE
+        SET refresh_owner = EXCLUDED.refresh_owner,
+            refresh_lease_until = EXCLUDED.refresh_lease_until,
+            last_accessed_at = EXCLUDED.last_accessed_at,
+            updated_at = EXCLUDED.updated_at
+        WHERE email_cache_lists.refresh_lease_until IS NULL
+           OR email_cache_lists.refresh_lease_until <= $11
+           OR email_cache_lists.refresh_owner = $12
+        RETURNING refresh_lease_until
+      )
+      SELECT mailbox.generation,
+        EXISTS(SELECT 1 FROM claimed) AS acquired,
+        COALESCE(
+          (SELECT refresh_lease_until FROM claimed),
+          (SELECT refresh_lease_until
+           FROM email_cache_lists
+           WHERE user_id = $1 AND account_source = $2 AND account_id = $3 AND cache_key = $4)
+        ) AS lease_until
+      FROM mailbox
+    `, [
+      scope.userId,
+      scope.accountSource,
+      scope.accountId,
+      scope.cacheKey,
+      scope.schemaVersion,
+      scope.folder,
+      JSON.stringify(scope.filter),
+      scope.query,
+      scope.offset,
+      scope.limit,
+      now,
+      owner,
+      leaseUntil,
+    ]);
+    const row = result.rows[0];
+    return {
+      enabled: true,
+      acquired: Boolean(row?.acquired),
+      generation: numberOrNull(row?.generation),
+      leaseUntil: numberOrNull(row?.lease_until),
+    };
+  }
+
+  async putList(
+    input: EmailListCacheScopeInput & {
+      refs: EmailMessageRefInput[];
+      totalCount?: number | null;
+      expectedGeneration: number;
+      leaseOwner?: string;
+      freshForMs?: number;
+      retainForMs?: number;
+      now?: number;
+    },
+  ): Promise<EmailCacheWriteResult> {
+    const scope = normalizeEmailListCacheScope(input);
+    const refs = input.refs.map(normalizeEmailMessageRef);
+    const expectedGeneration = positiveInteger(input.expectedGeneration, 'expectedGeneration');
+    const leaseOwner = input.leaseOwner ? requiredText(input.leaseOwner, 'leaseOwner') : null;
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const freshForMs = input.freshForMs ?? DEFAULT_EMAIL_CACHE_FRESH_MS;
+    const retainForMs = input.retainForMs ?? DEFAULT_EMAIL_CACHE_RETENTION_MS;
+    validateCacheWindow(now, freshForMs, retainForMs);
+    const staleAt = now + freshForMs;
+    const expiresAt = now + retainForMs;
+    const totalCount = input.totalCount === null || input.totalCount === undefined
+      ? null
+      : nonNegativeInteger(input.totalCount, 'totalCount');
+    const result = await this.query<{ cache_key: string }>(`
+      WITH mailbox AS MATERIALIZED (
+        INSERT INTO email_cache_mailboxes (
+          user_id, account_source, account_id, generation, last_accessed_at, created_at, updated_at
+        ) VALUES ($1, $2, $3, 1, $15, $15, $15)
+        ON CONFLICT (user_id, account_source, account_id) DO UPDATE
+        SET last_accessed_at = EXCLUDED.last_accessed_at,
+            updated_at = EXCLUDED.updated_at
+        WHERE email_cache_mailboxes.active = true
+        RETURNING generation
+      )
+      INSERT INTO email_cache_lists (
+        user_id, account_source, account_id, cache_key, schema_version, folder, filter_json,
+        search_query, page_offset, page_limit, refs_json, total_count, generation,
+        fetched_at, stale_at, expires_at, refresh_owner, refresh_lease_until,
+        last_accessed_at, created_at, updated_at
+      )
+      SELECT $1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11::jsonb, $12,
+        $13, $15, $16, $17, NULL, NULL, $15, $15, $15
+      FROM mailbox
+      WHERE mailbox.generation = $13
+      ON CONFLICT (user_id, account_source, account_id, cache_key) DO UPDATE
+      SET schema_version = EXCLUDED.schema_version,
+          folder = EXCLUDED.folder,
+          filter_json = EXCLUDED.filter_json,
+          search_query = EXCLUDED.search_query,
+          page_offset = EXCLUDED.page_offset,
+          page_limit = EXCLUDED.page_limit,
+          refs_json = EXCLUDED.refs_json,
+          total_count = EXCLUDED.total_count,
+          generation = EXCLUDED.generation,
+          fetched_at = EXCLUDED.fetched_at,
+          stale_at = EXCLUDED.stale_at,
+          expires_at = EXCLUDED.expires_at,
+          refresh_owner = NULL,
+          refresh_lease_until = NULL,
+          last_accessed_at = EXCLUDED.last_accessed_at,
+          updated_at = EXCLUDED.updated_at
+      WHERE ($14::text IS NULL OR email_cache_lists.refresh_owner = $14)
+      RETURNING cache_key
+    `, [
+      scope.userId,
+      scope.accountSource,
+      scope.accountId,
+      scope.cacheKey,
+      scope.schemaVersion,
+      scope.folder,
+      JSON.stringify(scope.filter),
+      scope.query,
+      scope.offset,
+      scope.limit,
+      JSON.stringify(refs),
+      totalCount,
+      expectedGeneration,
+      leaseOwner,
+      now,
+      staleAt,
+      expiresAt,
+    ]);
+    return result.rows.length
+      ? { enabled: true, stored: true, reason: 'stored' }
+      : { enabled: true, stored: false, reason: 'generation_changed_or_lease_lost' };
+  }
+
+  async releaseListRefreshLease(
+    input: EmailListCacheScopeInput & { owner: string; now?: number },
+  ): Promise<boolean> {
+    const scope = normalizeEmailListCacheScope(input);
+    const owner = requiredText(input.owner, 'owner');
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const result = await this.query(`
+      UPDATE email_cache_lists
+      SET refresh_owner = NULL,
+          refresh_lease_until = NULL,
+          updated_at = $6
+      WHERE user_id = $1 AND account_source = $2 AND account_id = $3
+        AND cache_key = $4 AND refresh_owner = $5
+      RETURNING 1
+    `, [scope.userId, scope.accountSource, scope.accountId, scope.cacheKey, owner, now]);
+    return result.rows.length > 0;
+  }
+
+  async getMessage(
+    input: MailboxInput & { ref: EmailMessageRefInput; part?: 'metadata' | 'detail'; now?: number },
+  ): Promise<EmailCacheReadResult<EmailCachedMessage>> {
+    const ref = normalizeEmailMessageRef(input.ref);
+    const messages = await this.getMessages({
+      ...input,
+      refs: [input.ref],
+    });
+    return messages.find((message) => message.messageKey === ref.messageKey) ?? miss(true);
+  }
+
+  async getMessages(
+    input: MailboxInput & { refs: EmailMessageRefInput[]; part?: 'metadata' | 'detail'; now?: number },
+  ): Promise<EmailCacheBatchMessageResult[]> {
+    if (input.refs.length === 0) return [];
+    const mailbox = normalizeMailbox(input);
+    const refs = input.refs.map(normalizeEmailMessageRef);
+    const messageKeys = [...new Set(refs.map((ref) => ref.messageKey))];
+    const part = input.part ?? 'detail';
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const payloadColumn = part === 'detail' ? 'detail_json' : 'metadata_json';
+    const fetchedColumn = part === 'detail' ? 'detail_fetched_at' : 'metadata_fetched_at';
+    const staleColumn = part === 'detail' ? 'detail_stale_at' : 'metadata_stale_at';
+    const result = await this.query<CacheRow & {
+      message_key: string;
+      provider: string;
+      provider_message_id: string | null;
+      folder: string | null;
+      uid_validity: string | null;
+      uid: number | string | null;
+      metadata_json: EmailCachedMessageMetadata | null;
+      detail_json: EmailCachedMessageDetail | null;
+    }>(`
+      UPDATE email_cache_messages AS message
+      SET last_accessed_at = $5,
+          updated_at = $5
+      FROM email_cache_mailboxes AS mailbox
+      WHERE message.user_id = $1
+        AND message.account_source = $2
+        AND message.account_id = $3
+        AND message.message_key = ANY($4::text[])
+        AND mailbox.user_id = message.user_id
+        AND mailbox.account_source = message.account_source
+        AND mailbox.account_id = message.account_id
+        AND mailbox.active = true
+        AND mailbox.generation = message.generation
+        AND message.${payloadColumn} IS NOT NULL
+        AND message.expires_at > $5
+      RETURNING message.message_key, message.generation, message.${fetchedColumn} AS fetched_at,
+        message.${staleColumn} AS stale_at, message.expires_at,
+        message.provider, message.provider_message_id, message.folder,
+        message.uid_validity, message.uid, message.metadata_json, message.detail_json
+    `, [mailbox.userId, mailbox.accountSource, mailbox.accountId, messageKeys, now]);
+    return result.rows.map((row) => ({
+      messageKey: row.message_key,
+      enabled: true,
+      ...readMetadata(row, now),
+      value: {
+        ref: {
+          messageKey: row.message_key,
+          provider: row.provider,
+          messageId: row.provider_message_id,
+          folder: row.folder,
+          uidValidity: row.uid_validity,
+          uid: numberOrNull(row.uid),
+        },
+        metadata: row.metadata_json,
+        detail: row.detail_json,
+      },
+    }));
+  }
+
+  async acquireMessageRefreshLease(
+    input: MailboxInput & { ref: EmailMessageRefInput; owner: string; leaseMs: number; now?: number },
+  ): Promise<EmailCacheLeaseResult> {
+    const mailbox = normalizeMailbox(input);
+    const ref = normalizeEmailMessageRef(input.ref);
+    const owner = requiredText(input.owner, 'owner');
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const leaseUntil = now + positiveInteger(input.leaseMs, 'leaseMs');
+    const result = await this.query<{
+      generation: number | string;
+      acquired: boolean;
+      lease_until: number | string | null;
+    }>(`
+      WITH mailbox AS MATERIALIZED (
+        INSERT INTO email_cache_mailboxes (
+          user_id, account_source, account_id, generation, last_accessed_at, created_at, updated_at
+        ) VALUES ($1, $2, $3, 1, $10, $10, $10)
+        ON CONFLICT (user_id, account_source, account_id) DO UPDATE
+        SET last_accessed_at = EXCLUDED.last_accessed_at,
+            updated_at = EXCLUDED.updated_at
+        WHERE email_cache_mailboxes.active = true
+        RETURNING generation
+      ), claimed AS (
+        INSERT INTO email_cache_messages (
+          user_id, account_source, account_id, message_key, provider, provider_message_id, folder,
+          uid_validity, uid, generation, refresh_owner, refresh_lease_until,
+          last_accessed_at, created_at, updated_at
+        )
+        SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, mailbox.generation,
+          $11, $12, $10, $10, $10
+        FROM mailbox
+        ON CONFLICT (user_id, account_source, account_id, message_key) DO UPDATE
+        SET refresh_owner = EXCLUDED.refresh_owner,
+            refresh_lease_until = EXCLUDED.refresh_lease_until,
+            last_accessed_at = EXCLUDED.last_accessed_at,
+            updated_at = EXCLUDED.updated_at
+        WHERE email_cache_messages.refresh_lease_until IS NULL
+           OR email_cache_messages.refresh_lease_until <= $10
+           OR email_cache_messages.refresh_owner = $11
+        RETURNING refresh_lease_until
+      )
+      SELECT mailbox.generation,
+        EXISTS(SELECT 1 FROM claimed) AS acquired,
+        COALESCE(
+          (SELECT refresh_lease_until FROM claimed),
+          (SELECT refresh_lease_until
+           FROM email_cache_messages
+           WHERE user_id = $1 AND account_source = $2 AND account_id = $3 AND message_key = $4)
+        ) AS lease_until
+      FROM mailbox
+    `, [
+      mailbox.userId,
+      mailbox.accountSource,
+      mailbox.accountId,
+      ref.messageKey,
+      ref.provider,
+      ref.messageId,
+      ref.folder,
+      ref.uidValidity,
+      ref.uid,
+      now,
+      owner,
+      leaseUntil,
+    ]);
+    const row = result.rows[0];
+    return {
+      enabled: true,
+      acquired: Boolean(row?.acquired),
+      generation: numberOrNull(row?.generation),
+      leaseUntil: numberOrNull(row?.lease_until),
+    };
+  }
+
+  async putMessage(
+    input: MailboxInput & {
+      ref: EmailMessageRefInput;
+      metadata?: EmailCachedMessageMetadata;
+      detail?: EmailCachedMessageDetail;
+      expectedGeneration: number;
+      leaseOwner?: string;
+      freshForMs?: number;
+      retainForMs?: number;
+      now?: number;
+    },
+  ): Promise<EmailCacheWriteResult> {
+    if (!input.metadata && !input.detail) {
+      throw new Error('putMessage requires metadata, detail, or both.');
+    }
+    const mailbox = normalizeMailbox(input);
+    const ref = normalizeEmailMessageRef(input.ref);
+    const expectedGeneration = positiveInteger(input.expectedGeneration, 'expectedGeneration');
+    const leaseOwner = input.leaseOwner ? requiredText(input.leaseOwner, 'leaseOwner') : null;
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const freshForMs = input.freshForMs ?? DEFAULT_EMAIL_CACHE_FRESH_MS;
+    const retainForMs = input.retainForMs ?? DEFAULT_EMAIL_MESSAGE_RETENTION_MS;
+    validateCacheWindow(now, freshForMs, retainForMs);
+    const staleAt = now + freshForMs;
+    const expiresAt = now + retainForMs;
+    const metadata = input.metadata ? normalizeCachedMessageMetadata(input.metadata) : null;
+    const detail = input.detail ? normalizeCachedMessageDetail(input.detail) : null;
+    const metadataJson = metadata ? JSON.stringify(metadata) : null;
+    const detailJson = detail ? JSON.stringify(detail) : null;
+    const result = await this.query<{ message_key: string }>(`
+      WITH mailbox AS MATERIALIZED (
+        INSERT INTO email_cache_mailboxes (
+          user_id, account_source, account_id, generation, last_accessed_at, created_at, updated_at
+        ) VALUES ($1, $2, $3, 1, $18, $18, $18)
+        ON CONFLICT (user_id, account_source, account_id) DO UPDATE
+        SET last_accessed_at = EXCLUDED.last_accessed_at,
+            updated_at = EXCLUDED.updated_at
+        WHERE email_cache_mailboxes.active = true
+        RETURNING generation
+      )
+      INSERT INTO email_cache_messages (
+        user_id, account_source, account_id, message_key, provider, provider_message_id, folder,
+        uid_validity, uid, sender, subject, message_date, preview, is_read,
+        metadata_json, detail_json, generation, metadata_fetched_at,
+        metadata_stale_at, detail_fetched_at, detail_stale_at, expires_at,
+        refresh_owner, refresh_lease_until, last_accessed_at, created_at, updated_at
+      )
+      SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9,
+        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $11::text END,
+        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $12::text END,
+        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $13::bigint END,
+        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $14::text END,
+        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $15::boolean END,
+        $10::jsonb, $16::jsonb, $17::bigint,
+        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $18::bigint END,
+        CASE WHEN $10::jsonb IS NULL THEN NULL ELSE $19::bigint END,
+        CASE WHEN $16::jsonb IS NULL THEN NULL ELSE $18::bigint END,
+        CASE WHEN $16::jsonb IS NULL THEN NULL ELSE $19::bigint END,
+        $20::bigint, NULL, NULL, $18::bigint, $18::bigint, $18::bigint
+      FROM mailbox
+      WHERE mailbox.generation = $17
+      ON CONFLICT (user_id, account_source, account_id, message_key) DO UPDATE
+      SET provider = EXCLUDED.provider,
+          provider_message_id = EXCLUDED.provider_message_id,
+          folder = EXCLUDED.folder,
+          uid_validity = EXCLUDED.uid_validity,
+          uid = EXCLUDED.uid,
+          sender = COALESCE(EXCLUDED.sender, email_cache_messages.sender),
+          subject = COALESCE(EXCLUDED.subject, email_cache_messages.subject),
+          message_date = COALESCE(EXCLUDED.message_date, email_cache_messages.message_date),
+          preview = COALESCE(EXCLUDED.preview, email_cache_messages.preview),
+          is_read = COALESCE(EXCLUDED.is_read, email_cache_messages.is_read),
+          metadata_json = COALESCE(EXCLUDED.metadata_json, email_cache_messages.metadata_json),
+          detail_json = COALESCE(EXCLUDED.detail_json, email_cache_messages.detail_json),
+          generation = EXCLUDED.generation,
+          metadata_fetched_at = COALESCE(EXCLUDED.metadata_fetched_at, email_cache_messages.metadata_fetched_at),
+          metadata_stale_at = COALESCE(EXCLUDED.metadata_stale_at, email_cache_messages.metadata_stale_at),
+          detail_fetched_at = COALESCE(EXCLUDED.detail_fetched_at, email_cache_messages.detail_fetched_at),
+          detail_stale_at = COALESCE(EXCLUDED.detail_stale_at, email_cache_messages.detail_stale_at),
+          expires_at = GREATEST(EXCLUDED.expires_at, email_cache_messages.expires_at),
+          refresh_owner = NULL,
+          refresh_lease_until = NULL,
+          last_accessed_at = EXCLUDED.last_accessed_at,
+          updated_at = EXCLUDED.updated_at
+      WHERE ($21::text IS NULL OR email_cache_messages.refresh_owner = $21)
+      RETURNING message_key
+    `, [
+      mailbox.userId,
+      mailbox.accountSource,
+      mailbox.accountId,
+      ref.messageKey,
+      ref.provider,
+      ref.messageId,
+      ref.folder,
+      ref.uidValidity,
+      ref.uid,
+      metadataJson,
+      metadata?.from ?? null,
+      metadata?.subject ?? null,
+      metadata?.dateTimestamp ?? null,
+      metadata?.snippet ?? null,
+      metadata?.isRead ?? null,
+      detailJson,
+      expectedGeneration,
+      now,
+      staleAt,
+      expiresAt,
+      leaseOwner,
+    ]);
+    return result.rows.length
+      ? { enabled: true, stored: true, reason: 'stored' }
+      : { enabled: true, stored: false, reason: 'generation_changed_or_lease_lost' };
+  }
+
+  async releaseMessageRefreshLease(
+    input: MailboxInput & { ref: EmailMessageRefInput; owner: string; now?: number },
+  ): Promise<boolean> {
+    const mailbox = normalizeMailbox(input);
+    const ref = normalizeEmailMessageRef(input.ref);
+    const owner = requiredText(input.owner, 'owner');
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const result = await this.query(`
+      UPDATE email_cache_messages
+      SET refresh_owner = NULL,
+          refresh_lease_until = NULL,
+          updated_at = $6
+      WHERE user_id = $1 AND account_source = $2 AND account_id = $3
+        AND message_key = $4 AND refresh_owner = $5
+      RETURNING 1
+    `, [mailbox.userId, mailbox.accountSource, mailbox.accountId, ref.messageKey, owner, now]);
+    return result.rows.length > 0;
+  }
+
+  async purgeAccount(input: MailboxInput & { now?: number }): Promise<EmailCachePurgeResult> {
+    const mailbox = normalizeMailbox(input);
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const result = await this.query<{
+      generation: number | string;
+      deleted_lists: number | string;
+      deleted_messages: number | string;
+    }>(`
+      WITH tombstone AS MATERIALIZED (
+        INSERT INTO email_cache_mailboxes (
+          user_id, account_source, account_id, generation, active, disconnected_at,
+          last_accessed_at, created_at, updated_at
+        ) VALUES ($1, $2, $3, 1, false, $4, $4, $4, $4)
+        ON CONFLICT (user_id, account_source, account_id) DO UPDATE
+        SET generation = email_cache_mailboxes.generation + 1,
+            active = false,
+            disconnected_at = $4,
+            last_accessed_at = $4,
+            updated_at = $4
+        RETURNING generation
+      ), deleted_lists AS (
+        DELETE FROM email_cache_lists AS list
+        USING tombstone
+        WHERE list.user_id = $1
+          AND list.account_source = $2
+          AND list.account_id = $3
+        RETURNING 1
+      ), deleted_messages AS (
+        DELETE FROM email_cache_messages AS message
+        USING tombstone
+        WHERE message.user_id = $1
+          AND message.account_source = $2
+          AND message.account_id = $3
+        RETURNING 1
+      )
+      SELECT tombstone.generation,
+        (SELECT COUNT(*) FROM deleted_lists) AS deleted_lists,
+        (SELECT COUNT(*) FROM deleted_messages) AS deleted_messages
+      FROM tombstone
+    `, [mailbox.userId, mailbox.accountSource, mailbox.accountId, now]);
+    const row = result.rows[0];
+    return {
+      enabled: true,
+      tombstoned: Boolean(row),
+      generation: numberOrNull(row?.generation),
+      deletedLists: numberOrNull(row?.deleted_lists) ?? 0,
+      deletedMessages: numberOrNull(row?.deleted_messages) ?? 0,
+    };
+  }
+
+  async cleanup(input: {
+    now?: number;
+    maxListsPerAccount?: number;
+    maxMessagesPerAccount?: number;
+    maxDeletesPerTable?: number;
+  } = {}): Promise<EmailCacheCleanupResult> {
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const maxLists = positiveInteger(input.maxListsPerAccount ?? 100, 'maxListsPerAccount');
+    const maxMessages = positiveInteger(input.maxMessagesPerAccount ?? 500, 'maxMessagesPerAccount');
+    const maxDeletes = positiveInteger(input.maxDeletesPerTable ?? 100, 'maxDeletesPerTable');
+    const listResult = await this.query(`
+      WITH ranked AS (
+        SELECT list.user_id, list.account_source, list.account_id, list.cache_key,
+          ROW_NUMBER() OVER (
+            PARTITION BY list.user_id, list.account_source, list.account_id
+            ORDER BY list.last_accessed_at DESC, list.cache_key
+          ) AS lru_rank,
+          mailbox.generation AS current_generation
+        FROM email_cache_lists AS list
+        JOIN email_cache_mailboxes AS mailbox
+          ON mailbox.user_id = list.user_id
+         AND mailbox.account_source = list.account_source
+         AND mailbox.account_id = list.account_id
+      ), victims AS (
+        SELECT list.user_id, list.account_source, list.account_id, list.cache_key
+        FROM email_cache_lists AS list
+        JOIN ranked USING (user_id, account_source, account_id, cache_key)
+        WHERE (list.expires_at IS NOT NULL AND list.expires_at <= $1)
+           OR list.generation <> ranked.current_generation
+           OR ranked.lru_rank > $2
+        ORDER BY list.last_accessed_at ASC
+        LIMIT $3
+      )
+      DELETE FROM email_cache_lists AS list
+      USING victims
+      WHERE list.user_id = victims.user_id
+        AND list.account_source = victims.account_source
+        AND list.account_id = victims.account_id
+        AND list.cache_key = victims.cache_key
+      RETURNING 1
+    `, [now, maxLists, maxDeletes]);
+    const messageResult = await this.query(`
+      WITH ranked AS (
+        SELECT message.user_id, message.account_source, message.account_id, message.message_key,
+          ROW_NUMBER() OVER (
+            PARTITION BY message.user_id, message.account_source, message.account_id
+            ORDER BY message.last_accessed_at DESC, message.message_key
+          ) AS lru_rank,
+          mailbox.generation AS current_generation
+        FROM email_cache_messages AS message
+        JOIN email_cache_mailboxes AS mailbox
+          ON mailbox.user_id = message.user_id
+         AND mailbox.account_source = message.account_source
+         AND mailbox.account_id = message.account_id
+      ), victims AS (
+        SELECT message.user_id, message.account_source, message.account_id, message.message_key
+        FROM email_cache_messages AS message
+        JOIN ranked USING (user_id, account_source, account_id, message_key)
+        WHERE (message.expires_at IS NOT NULL AND message.expires_at <= $1)
+           OR message.generation <> ranked.current_generation
+           OR ranked.lru_rank > $2
+        ORDER BY message.last_accessed_at ASC
+        LIMIT $3
+      )
+      DELETE FROM email_cache_messages AS message
+      USING victims
+      WHERE message.user_id = victims.user_id
+        AND message.account_source = victims.account_source
+        AND message.account_id = victims.account_id
+        AND message.message_key = victims.message_key
+      RETURNING 1
+    `, [now, maxMessages, maxDeletes]);
+    return {
+      enabled: true,
+      skipped: false,
+      deletedLists: listResult.rows.length,
+      deletedMessages: messageResult.rows.length,
+    };
+  }
+
+  async maybeCleanup(input: {
+    now?: number;
+    intervalMs?: number;
+    maxListsPerAccount?: number;
+    maxMessagesPerAccount?: number;
+    maxDeletesPerTable?: number;
+  } = {}): Promise<EmailCacheCleanupResult> {
+    const now = nonNegativeInteger(input.now ?? Date.now(), 'now');
+    const intervalMs = positiveInteger(
+      input.intervalMs ?? DEFAULT_EMAIL_CACHE_CLEANUP_INTERVAL_MS,
+      'intervalMs',
+    );
+    if (now < this.nextCleanupAt) {
+      return { enabled: true, skipped: true, deletedLists: 0, deletedMessages: 0 };
+    }
+    if (this.cleanupPromise) return this.cleanupPromise;
+    this.nextCleanupAt = now + intervalMs;
+    this.cleanupPromise = this.cleanup(input).finally(() => {
+      this.cleanupPromise = null;
+    });
+    return this.cleanupPromise;
+  }
+}
+
+export function createEmailCacheStore(options: {
+  provider?: DatabaseProvider;
+  postgres?: EmailCachePostgresQueryable;
+} = {}): EmailCacheStore {
+  const provider = options.provider ?? getDatabaseProvider();
+  if (provider !== 'postgres') return DISABLED_EMAIL_CACHE_STORE;
+  if (!options.postgres) {
+    throw new Error('PostgreSQL email caching requires an explicit PostgreSQL queryable.');
+  }
+  return new PostgresEmailCacheStore(options.postgres);
+}
+
+let runtimeEmailCacheStorePromise: Promise<EmailCacheStore> | null = null;
+
+/**
+ * Lazily binds the cache to the application's existing PostgreSQL pool.
+ * Build-time and SQLite runtimes resolve to the disabled store without loading
+ * the database singleton, while concurrent first callers share one store.
+ */
+export function getRuntimeEmailCacheStore(): Promise<EmailCacheStore> {
+  if (getDatabaseProvider() !== 'postgres') {
+    return Promise.resolve(DISABLED_EMAIL_CACHE_STORE);
+  }
+  if (!runtimeEmailCacheStorePromise) {
+    runtimeEmailCacheStorePromise = import('@/app/lib/db').then((database) => {
+      database.assertDatabaseAvailable();
+      const postgres = database.getPostgresRuntimeQueryable();
+      if (!postgres) throw new Error('PostgreSQL runtime pool is not initialized.');
+      return new PostgresEmailCacheStore(postgres);
+    }).catch((error) => {
+      runtimeEmailCacheStorePromise = null;
+      throw error;
+    });
+  }
+  return runtimeEmailCacheStorePromise;
+}

--- a/app/lib/email/imap-service.ts
+++ b/app/lib/email/imap-service.ts
@@ -31,7 +31,10 @@ import type { EmailAccountSmtpSecret } from '@/app/lib/email/secret-store';
 
 type ImapLock = { release(): void };
 
-type ImapClientLike = {
+export type ImapClientLike = {
+  readonly mailbox: false | {
+    uidValidity: bigint | number | string;
+  };
   connect(): Promise<void>;
   logout(): Promise<void>;
   close(): void;
@@ -58,7 +61,32 @@ type ImapClientLike = {
   ): Promise<unknown | false>;
 };
 
-type ImapClientFactory = (secret: EmailAccountSmtpSecret) => ImapClientLike;
+export type ImapClientFactory = (secret: EmailAccountSmtpSecret) => ImapClientLike;
+
+export type ParsedImapMessageReference = {
+  version: 0 | 1;
+  folder: string;
+  uidValidity: string | null;
+  uid: number;
+};
+
+export class ImapMailboxChangedError extends Error {
+  readonly code = 'EMAIL_MAILBOX_CHANGED';
+  readonly status = 409;
+
+  constructor(
+    readonly folder: string,
+    readonly expectedUidValidity: string,
+    readonly actualUidValidity: string,
+  ) {
+    super('The IMAP mailbox changed. Reload the message list before trying again.');
+    this.name = 'ImapMailboxChangedError';
+  }
+}
+
+export function isImapMailboxChangedError(error: unknown): error is ImapMailboxChangedError {
+  return error instanceof ImapMailboxChangedError;
+}
 
 export type EmailFolderRole = 'inbox' | 'sent' | 'drafts' | 'trash' | 'junk' | 'archive' | 'custom';
 
@@ -91,6 +119,8 @@ type ImapReadPolicyOptions = {
 const SEARCH_QUERY_MAX_LENGTH = 250;
 const SEARCH_SOURCE_MAX_BYTES = 64 * 1024;
 const READ_SOURCE_MAX_BYTES = 1024 * 1024;
+const IMAP_MESSAGE_REFERENCE_PREFIX = 'imap:v1:';
+const IMAP_MESSAGE_REFERENCE_MAX_LENGTH = 1024;
 
 let imapClientFactory: ImapClientFactory = (secret) => new ImapFlow(imapClientOptions(secret));
 
@@ -233,6 +263,109 @@ function parseUid(messageId: string): number {
   const uid = Number.parseInt(messageId, 10);
   if (!Number.isSafeInteger(uid)) throw new Error('Invalid IMAP message ID.');
   return uid;
+}
+
+function normalizeUidValidity(value: unknown): string {
+  let normalized = '';
+  if (typeof value === 'bigint') {
+    normalized = value.toString();
+  } else if (typeof value === 'number' && Number.isSafeInteger(value)) {
+    normalized = String(value);
+  } else if (typeof value === 'string') {
+    normalized = value;
+  }
+  if (!/^[1-9]\d*$/u.test(normalized)) {
+    throw new Error('IMAP mailbox UIDVALIDITY is unavailable.');
+  }
+  return normalized;
+}
+
+export function getImapMailboxUidValidity(client: Pick<ImapClientLike, 'mailbox'>): string {
+  if (!client.mailbox) throw new Error('IMAP mailbox UIDVALIDITY is unavailable.');
+  return normalizeUidValidity(client.mailbox.uidValidity);
+}
+
+export function createImapMessageReference(folder: string, uidValidity: bigint | number | string, uid: number): string {
+  const payload = JSON.stringify({
+    f: normalizeFolderPath(folder),
+    uv: normalizeUidValidity(uidValidity),
+    u: parseUid(String(uid)),
+  });
+  return `${IMAP_MESSAGE_REFERENCE_PREFIX}${Buffer.from(payload, 'utf8').toString('base64url')}`;
+}
+
+export function parseImapMessageReference(messageId: string, legacyFolder?: string): ParsedImapMessageReference {
+  if (/^[1-9]\d*$/u.test(messageId)) {
+    return {
+      version: 0,
+      folder: normalizeFolderPath(legacyFolder),
+      uidValidity: null,
+      uid: parseUid(messageId),
+    };
+  }
+  if (!messageId.startsWith(IMAP_MESSAGE_REFERENCE_PREFIX) || messageId.length > IMAP_MESSAGE_REFERENCE_MAX_LENGTH) {
+    throw new Error('Invalid IMAP message ID.');
+  }
+
+  const encoded = messageId.slice(IMAP_MESSAGE_REFERENCE_PREFIX.length);
+  if (!encoded || !/^[A-Za-z0-9_-]+$/u.test(encoded)) throw new Error('Invalid IMAP message ID.');
+
+  try {
+    const decoded = Buffer.from(encoded, 'base64url');
+    if (decoded.toString('base64url') !== encoded) throw new Error('Invalid IMAP message ID.');
+    const payload = JSON.parse(decoded.toString('utf8')) as { f?: unknown; uv?: unknown; u?: unknown };
+    if (typeof payload.f !== 'string' || normalizeFolderPath(payload.f) !== payload.f) {
+      throw new Error('Invalid IMAP message ID.');
+    }
+    return {
+      version: 1,
+      folder: payload.f,
+      uidValidity: normalizeUidValidity(payload.uv),
+      uid: parseUid(String(payload.u ?? '')),
+    };
+  } catch {
+    throw new Error('Invalid IMAP message ID.');
+  }
+}
+
+type ResolvedImapMessageReference = ParsedImapMessageReference & {
+  id: string;
+  currentUidValidity: string;
+};
+
+function foldersMatch(left: string, right: string): boolean {
+  if (left === right) return true;
+  return left.toLowerCase() === 'inbox' && right.toLowerCase() === 'inbox';
+}
+
+function resolveImapMessageReference(messageId: string, folder?: string): ParsedImapMessageReference & { id: string } {
+  const parsed = parseImapMessageReference(messageId, folder);
+  const requestedFolder = folder?.trim() ? normalizeFolderPath(folder) : null;
+  if (parsed.version === 1 && requestedFolder && !foldersMatch(requestedFolder, parsed.folder)) {
+    throw new Error('Invalid IMAP message ID.');
+  }
+  return {
+    ...parsed,
+    id: parsed.version === 1
+      ? createImapMessageReference(parsed.folder, parsed.uidValidity!, parsed.uid)
+      : String(parsed.uid),
+  };
+}
+
+async function withImapMessage<T>(
+  secret: EmailAccountSmtpSecret,
+  messageId: string,
+  folder: string | undefined,
+  callback: (client: ImapClientLike, reference: ResolvedImapMessageReference, folder: string) => Promise<T>,
+): Promise<T> {
+  const reference = resolveImapMessageReference(messageId, folder);
+  return withImapMailbox(secret, reference.folder, async (client, folderPath) => {
+    const currentUidValidity = getImapMailboxUidValidity(client);
+    if (reference.uidValidity && reference.uidValidity !== currentUidValidity) {
+      throw new ImapMailboxChangedError(folderPath, reference.uidValidity, currentUidValidity);
+    }
+    return callback(client, { ...reference, currentUidValidity }, folderPath);
+  });
 }
 
 function formatAddress(address: MessageAddressObject | undefined): string {
@@ -400,7 +533,7 @@ function mutationResult(
   account: StoredEmailAccount,
   secret: EmailAccountSmtpSecret,
   action: string,
-  messageId: number,
+  reference: ResolvedImapMessageReference,
   folder: string,
   destination?: string,
 ) {
@@ -409,7 +542,9 @@ function mutationResult(
     action,
     destination,
     folder,
-    messageId: String(messageId),
+    messageId: reference.id,
+    uid: String(reference.uid),
+    uidValidity: reference.currentUidValidity,
   };
 }
 
@@ -424,17 +559,16 @@ async function updateImapMessageFlag(
   const secret = await readStoredEmailAccountSecret(account);
   if (secret.authType !== 'smtp_imap') throw new Error('Email account is not an SMTP/IMAP account.');
   requireImapSecret(secret);
-  const uid = parseUid(messageId);
-  const result = await withImapMailbox(secret, folder, async (client, folderPath) => {
+  const result = await withImapMessage(secret, messageId, folder, async (client, reference, folderPath) => {
     const updated = enabled
-      ? await client.messageFlagsAdd([uid], [flag], { uid: true })
-      : await client.messageFlagsRemove([uid], [flag], { uid: true });
+      ? await client.messageFlagsAdd([reference.uid], [flag], { uid: true })
+      : await client.messageFlagsRemove([reference.uid], [flag], { uid: true });
 
     if (!updated) {
       throw new Error('Email message could not be updated.');
     }
 
-    return mutationResult(account, secret, action, uid, folderPath);
+    return mutationResult(account, secret, action, reference, folderPath);
   });
 
   return result;
@@ -450,16 +584,15 @@ async function moveImapMessageToFolder(
   const secret = await readStoredEmailAccountSecret(account);
   if (secret.authType !== 'smtp_imap') throw new Error('Email account is not an SMTP/IMAP account.');
   requireImapSecret(secret);
-  const uid = parseUid(messageId);
   const destinationFolder = normalizeDestinationFolderPath(destination);
-  const result = await withImapMailbox(secret, folder, async (client, folderPath) => {
-    const moved = await client.messageMove([uid], destinationFolder, { uid: true });
+  const result = await withImapMessage(secret, messageId, folder, async (client, reference, folderPath) => {
+    const moved = await client.messageMove([reference.uid], destinationFolder, { uid: true });
 
     if (!moved) {
       throw new Error('Email message could not be moved.');
     }
 
-    return mutationResult(account, secret, action, uid, folderPath, destinationFolder);
+    return mutationResult(account, secret, action, reference, folderPath, destinationFolder);
   });
 
   return result;
@@ -529,6 +662,7 @@ export async function listImapEmailMessages(account: StoredEmailAccount, input: 
   const enforceReadPolicy = options?.enforceReadPolicy !== false;
 
   const result = await withImapMailbox(secret, input.folder, async (client, folder) => {
+    const uidValidity = getImapMailboxUidValidity(client);
     const found = await client.search(query ? searchObjectForInput({ ...input, query }) : searchObjectForInput(input), { uid: true });
     const ordered = (found || []).slice().reverse();
     const candidateLimit = filter === 'attachments' ? Math.max(limit * 8, 200) : limit;
@@ -536,6 +670,7 @@ export async function listImapEmailMessages(account: StoredEmailAccount, input: 
     if (uids.length === 0) {
       return {
         folder,
+        uidValidity,
         messages: [],
         total: ordered.length,
         offset,
@@ -568,7 +703,7 @@ export async function listImapEmailMessages(account: StoredEmailAccount, input: 
       if (filter === 'attachments' && !hasAttachments) continue;
       const flags = publicFlags(message.flags);
       normalized.push({
-        id: String(message.uid),
+        id: createImapMessageReference(folder, uidValidity, message.uid),
         uid: String(message.uid),
         folder,
         threadId: message.threadId || String(message.uid),
@@ -588,6 +723,7 @@ export async function listImapEmailMessages(account: StoredEmailAccount, input: 
     }
     return {
       folder,
+      uidValidity,
       messages: normalized.slice(0, limit),
       total: ordered.length,
       offset,
@@ -617,10 +753,9 @@ export async function readImapEmailMessage(account: StoredEmailAccount, messageI
   const secret = await readStoredEmailAccountSecret(account);
   if (secret.authType !== 'smtp_imap') throw new Error('Email account is not an SMTP/IMAP account.');
   requireImapSecret(secret);
-  const uid = parseUid(messageId);
 
-  const message = await withImapMailbox(secret, folder, async (client, folderPath) => {
-    const fetched = await client.fetchOne(uid, {
+  const message = await withImapMessage(secret, messageId, folder, async (client, reference, folderPath) => {
+    const fetched = await client.fetchOne(reference.uid, {
       uid: true,
       flags: true,
       envelope: true,
@@ -630,6 +765,7 @@ export async function readImapEmailMessage(account: StoredEmailAccount, messageI
       threadId: true,
     }, { uid: true });
     if (!fetched) throw new EmailMessageNotFoundError();
+    if (fetched.uid !== reference.uid) throw new EmailMessageNotFoundError();
 
     const from = firstAddress(fetched.envelope);
     if (options?.enforceReadPolicy !== false) {
@@ -647,8 +783,9 @@ export async function readImapEmailMessage(account: StoredEmailAccount, messageI
     const flags = publicFlags(fetched.flags);
 
     return {
-      id: String(fetched.uid),
+      id: reference.id,
       uid: String(fetched.uid),
+      uidValidity: reference.currentUidValidity,
       folder: folderPath,
       threadId: fetched.threadId || String(fetched.uid),
       from,
@@ -709,16 +846,15 @@ export async function archiveImapEmailMessage(account: StoredEmailAccount, messa
   const secret = await readStoredEmailAccountSecret(account);
   if (secret.authType !== 'smtp_imap') throw new Error('Email account is not an SMTP/IMAP account.');
   requireImapSecret(secret);
-  const uid = parseUid(messageId);
-  const result = await withImapMailbox(secret, folder, async (client, folderPath) => {
+  const result = await withImapMessage(secret, messageId, folder, async (client, reference, folderPath) => {
     const destination = await resolveFolderByRole(client, 'archive', ['Archive']);
-    const moved = await client.messageMove([uid], destination, { uid: true });
+    const moved = await client.messageMove([reference.uid], destination, { uid: true });
 
     if (!moved) {
       throw new Error('Email message could not be archived.');
     }
 
-    return mutationResult(account, secret, 'archive', uid, folderPath, destination);
+    return mutationResult(account, secret, 'archive', reference, folderPath, destination);
   });
 
   return result;
@@ -728,16 +864,15 @@ export async function trashImapEmailMessage(account: StoredEmailAccount, message
   const secret = await readStoredEmailAccountSecret(account);
   if (secret.authType !== 'smtp_imap') throw new Error('Email account is not an SMTP/IMAP account.');
   requireImapSecret(secret);
-  const uid = parseUid(messageId);
-  const result = await withImapMailbox(secret, folder, async (client, folderPath) => {
+  const result = await withImapMessage(secret, messageId, folder, async (client, reference, folderPath) => {
     const destination = await resolveFolderByRole(client, 'trash', ['Trash', 'Deleted Items']);
-    const moved = await client.messageMove([uid], destination, { uid: true });
+    const moved = await client.messageMove([reference.uid], destination, { uid: true });
 
     if (!moved) {
       throw new Error('Email message could not be moved to trash.');
     }
 
-    return mutationResult(account, secret, 'trash', uid, folderPath, destination);
+    return mutationResult(account, secret, 'trash', reference, folderPath, destination);
   });
 
   return result;
@@ -747,15 +882,14 @@ export async function deleteImapEmailMessagePermanently(account: StoredEmailAcco
   const secret = await readStoredEmailAccountSecret(account);
   if (secret.authType !== 'smtp_imap') throw new Error('Email account is not an SMTP/IMAP account.');
   requireImapSecret(secret);
-  const uid = parseUid(messageId);
-  const result = await withImapMailbox(secret, folder, async (client, folderPath) => {
-    const deleted = await client.messageDelete([uid], { uid: true });
+  const result = await withImapMessage(secret, messageId, folder, async (client, reference, folderPath) => {
+    const deleted = await client.messageDelete([reference.uid], { uid: true });
 
     if (!deleted) {
       throw new Error('Email message could not be deleted.');
     }
 
-    return mutationResult(account, secret, 'permanent-delete', uid, folderPath);
+    return mutationResult(account, secret, 'permanent-delete', reference, folderPath);
   });
 
   return result;

--- a/app/lib/email/inbox-events.ts
+++ b/app/lib/email/inbox-events.ts
@@ -6,6 +6,10 @@ import { and, eq } from 'drizzle-orm';
 
 import { db } from '@/app/lib/db';
 import { emailAccounts, emailInboxEvents, workspaceEmailMailboxes } from '@/app/lib/db/schema';
+import {
+  resolveProviderMessageIdentity,
+  type ProviderMessageIdentity,
+} from '@/app/lib/email/provider-message-identity';
 
 type InboxMessage = {
   id: string;
@@ -13,7 +17,11 @@ type InboxMessage = {
   date?: string;
   folder?: string;
   hasAttachments?: boolean;
+  uid?: string;
+  uidValidity?: string;
 };
+
+type EmailInboxEvent = typeof emailInboxEvents.$inferSelect;
 
 type PollMailbox = {
   id: string;
@@ -31,17 +39,26 @@ export type EmailInboxPollResult = {
   failed: number;
 };
 
-function normalizedMessage(value: unknown): InboxMessage | null {
+function normalizedMessage(value: unknown, listUidValidity?: unknown): InboxMessage | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const record = value as Record<string, unknown>;
   const id = typeof record.id === 'string' ? record.id.trim() : '';
   if (!id) return null;
+  const uid = typeof record.uid === 'number' && Number.isSafeInteger(record.uid)
+    ? String(record.uid)
+    : typeof record.uid === 'string' ? record.uid.trim() : '';
+  const rawUidValidity = record.uidValidity ?? listUidValidity;
+  const uidValidity = typeof rawUidValidity === 'number' && Number.isSafeInteger(rawUidValidity)
+    ? String(rawUidValidity)
+    : typeof rawUidValidity === 'string' ? rawUidValidity.trim() : '';
   return {
     id,
     threadId: typeof record.threadId === 'string' ? record.threadId.trim() || undefined : undefined,
     date: typeof record.date === 'string' ? record.date : undefined,
     folder: typeof record.folder === 'string' ? record.folder : undefined,
     hasAttachments: record.hasAttachments === true,
+    uid: uid || undefined,
+    uidValidity: uidValidity || undefined,
   };
 }
 
@@ -52,6 +69,99 @@ function receivedAt(message: InboxMessage, fallback: Date): Date {
 
 function idempotencyKey(mailboxId: string, providerMessageId: string): string {
   return createHash('sha256').update(`${mailboxId}:${providerMessageId}`).digest('hex');
+}
+
+function inboxEventMetadata(message: InboxMessage, identity: ProviderMessageIdentity): string {
+  return JSON.stringify({
+    folder: identity.folder,
+    hasAttachments: Boolean(message.hasAttachments),
+    ...(identity.isImap ? {
+      identityVersion: 1,
+      uid: identity.uid,
+      uidValidity: identity.uidValidity,
+    } : {}),
+  });
+}
+
+function parseInboxEventMetadata(value: string | null): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function legacyInboxEventMatches(
+  event: EmailInboxEvent,
+  message: InboxMessage,
+  identity: ProviderMessageIdentity,
+  messageReceivedAt: Date,
+): boolean {
+  if (!identity.isImap || !identity.legacyId || event.providerMessageId !== identity.legacyId) return false;
+  if (event.receivedAt.getTime() !== messageReceivedAt.getTime()) return false;
+  const threadId = message.threadId?.trim();
+  if (!threadId || event.providerThreadId !== threadId) return false;
+
+  const metadata = parseInboxEventMetadata(event.metadataJson);
+  if (!metadata || metadata.folder !== identity.folder) return false;
+  if (Boolean(metadata.hasAttachments) !== Boolean(message.hasAttachments)) return false;
+  if (typeof metadata.uid === 'string' && metadata.uid !== identity.uid) return false;
+  if (typeof metadata.uidValidity === 'string' && metadata.uidValidity !== identity.uidValidity) return false;
+  return true;
+}
+
+async function migrateMatchingLegacyInboxEvent(input: {
+  mailboxId: string;
+  message: InboxMessage;
+  identity: ProviderMessageIdentity;
+  messageReceivedAt: Date;
+  canonicalKey: string;
+  metadataJson: string;
+  now: Date;
+}): Promise<boolean> {
+  const legacyId = input.identity.legacyId;
+  if (!input.identity.isImap || !legacyId || legacyId === input.identity.canonicalId) return false;
+  const legacyKey = idempotencyKey(input.mailboxId, legacyId);
+  const legacy = await db.query.emailInboxEvents.findFirst({
+    where: and(
+      eq(emailInboxEvents.mailboxId, input.mailboxId),
+      eq(emailInboxEvents.idempotencyKey, legacyKey),
+    ),
+  });
+  if (!legacy || !legacyInboxEventMatches(legacy, input.message, input.identity, input.messageReceivedAt)) {
+    return false;
+  }
+
+  try {
+    const migrated = await db
+      .update(emailInboxEvents)
+      .set({
+        providerMessageId: input.identity.canonicalId,
+        idempotencyKey: input.canonicalKey,
+        metadataJson: input.metadataJson,
+        updatedAt: input.now,
+      })
+      .where(and(
+        eq(emailInboxEvents.id, legacy.id),
+        eq(emailInboxEvents.idempotencyKey, legacyKey),
+      ))
+      .returning({ id: emailInboxEvents.id });
+    return migrated.length > 0;
+  } catch (error) {
+    const canonical = await db.query.emailInboxEvents.findFirst({
+      where: and(
+        eq(emailInboxEvents.mailboxId, input.mailboxId),
+        eq(emailInboxEvents.idempotencyKey, input.canonicalKey),
+      ),
+      columns: { id: true },
+    });
+    if (canonical) return true;
+    throw error;
+  }
 }
 
 async function listActiveMailboxes(limit: number): Promise<PollMailbox[]> {
@@ -90,8 +200,17 @@ export async function pollWorkspaceMailboxInboxEvents(options: {
               accountId: mailbox.accountId,
               folder: 'INBOX',
               limit: 50,
-            }, { enforceReadPolicy: true, workspaceId: mailbox.workspaceId }) as { messages?: unknown[] };
-            return listed.messages || [];
+            }, { enforceReadPolicy: true, workspaceId: mailbox.workspaceId }) as {
+              messages?: unknown[];
+              uidValidity?: unknown;
+            };
+            return (listed.messages || []).map((message) => {
+              if (!message || typeof message !== 'object' || Array.isArray(message)) return message;
+              const record = message as Record<string, unknown>;
+              return record.uidValidity === undefined && listed.uidValidity !== undefined
+                ? { ...record, uidValidity: listed.uidValidity }
+                : message;
+            });
           })();
       for (const rawMessage of rawMessages) {
         const message = normalizedMessage(rawMessage);
@@ -101,7 +220,9 @@ export async function pollWorkspaceMailboxInboxEvents(options: {
           result.historical += 1;
           continue;
         }
-        const key = idempotencyKey(mailbox.id, message.id);
+        const identity = resolveProviderMessageIdentity(message);
+        const key = idempotencyKey(mailbox.id, identity.canonicalId);
+        const metadataJson = inboxEventMetadata(message, identity);
         const existing = await db.query.emailInboxEvents.findFirst({
           where: and(eq(emailInboxEvents.mailboxId, mailbox.id), eq(emailInboxEvents.idempotencyKey, key)),
           columns: { id: true },
@@ -110,11 +231,23 @@ export async function pollWorkspaceMailboxInboxEvents(options: {
           result.duplicate += 1;
           continue;
         }
-        await db.insert(emailInboxEvents).values({
+        if (await migrateMatchingLegacyInboxEvent({
+          mailboxId: mailbox.id,
+          message,
+          identity,
+          messageReceivedAt,
+          canonicalKey: key,
+          metadataJson,
+          now,
+        })) {
+          result.duplicate += 1;
+          continue;
+        }
+        const inserted = await db.insert(emailInboxEvents).values({
           id: `email-event-${randomUUID()}`,
           mailboxId: mailbox.id,
           workspaceId: mailbox.workspaceId,
-          providerMessageId: message.id,
+          providerMessageId: identity.canonicalId,
           providerThreadId: message.threadId || null,
           idempotencyKey: key,
           eventType: 'message_received',
@@ -125,11 +258,12 @@ export async function pollWorkspaceMailboxInboxEvents(options: {
           nextAttemptAt: null,
           errorCode: null,
           caseId: null,
-          metadataJson: JSON.stringify({ folder: message.folder || 'INBOX', hasAttachments: Boolean(message.hasAttachments) }),
+          metadataJson,
           createdAt: now,
           updatedAt: now,
-        });
-        result.created += 1;
+        }).onConflictDoNothing().returning({ id: emailInboxEvents.id });
+        if (inserted.length > 0) result.created += 1;
+        else result.duplicate += 1;
       }
     } catch (error) {
       result.failed += 1;

--- a/app/lib/email/local-service.ts
+++ b/app/lib/email/local-service.ts
@@ -19,6 +19,7 @@ import {
   upsertOAuthEmailAccount,
   type StoredEmailAccount,
 } from '@/app/lib/email/account-store';
+import { reactivateEmailMailboxCache } from '@/app/lib/email/cache/consistency';
 import { isLikelyHtmlEmailContent, normalizeEmailHtmlContent } from '@/app/lib/email/html-content';
 import { EmailMessageNotFoundError, EmailProviderRequestError, isEmailProviderNotFoundError } from '@/app/lib/email/errors';
 import { htmlToPlainText, plainTextToEmailHtml } from '@/app/lib/email/html-conversion';
@@ -504,6 +505,7 @@ export async function completeLocalEmailOAuth(userId: string, code: string, stat
       expiresAt: token.expires_in ? new Date(Date.now() + token.expires_in * 1000).toISOString() : undefined,
     },
   });
+  await reactivateEmailMailboxCache({ userId, accountId: account.id, accountSource: 'local' });
   await fs.rm(userStatePath, { force: true }).catch(() => undefined);
   await fs.rm(legacyStatePath(state), { force: true }).catch(() => undefined);
   return { account: await publicLocalEmailAccount(account), returnUrl: stored.returnUrl };

--- a/app/lib/email/local-service.ts
+++ b/app/lib/email/local-service.ts
@@ -519,6 +519,14 @@ export async function listLocalEmailAccounts(userId: string) {
   return listPublicEmailAccountsForUser(userId);
 }
 
+export async function resolveLocalEmailCacheAccount(userId: string, accountId?: string) {
+  const account = await findLocalEmailAccount(userId, accountId);
+  return {
+    account: await publicLocalEmailAccount(account),
+    provider: account.authType === 'smtp_imap' ? 'imap' : account.provider,
+  };
+}
+
 async function findLocalEmailAccount(userId: string, accountId?: string): Promise<StoredEmailAccount> {
   await migrateLegacyEmailAccountsIfSafe(userId);
   return getEmailAccountForUser(userId, accountId);

--- a/app/lib/email/provider-message-identity.ts
+++ b/app/lib/email/provider-message-identity.ts
@@ -1,0 +1,108 @@
+import {
+  createImapMessageReference,
+  parseImapMessageReference,
+} from '@/app/lib/email/imap-service';
+
+const IMAP_MESSAGE_REFERENCE_PREFIX = 'imap:v1:';
+const MAX_IMAP_UINT32 = BigInt('4294967295');
+
+export type ProviderMessageIdentityInput = {
+  id: string;
+  uid?: string | number;
+  uidValidity?: string | number;
+  folder?: string;
+};
+
+export type ProviderMessageIdentity = {
+  canonicalId: string;
+  folder: string;
+  isImap: boolean;
+  legacyId: string | null;
+  uid: string | null;
+  uidValidity: string | null;
+};
+
+function normalizeFolder(value: unknown): string {
+  const normalized = (typeof value === 'string' ? value : 'INBOX')
+    .trim()
+    .replace(/[\u0000\r\n]/gu, '')
+    .slice(0, 240);
+  return normalized || 'INBOX';
+}
+
+function positiveUint32Text(value: unknown): string | null {
+  const normalized = typeof value === 'number' && Number.isSafeInteger(value)
+    ? String(value)
+    : typeof value === 'string' ? value.trim() : '';
+  if (!/^[1-9]\d*$/u.test(normalized)) return null;
+  return BigInt(normalized) <= MAX_IMAP_UINT32 ? normalized : null;
+}
+
+/**
+ * Resolves the durable provider identity used by poller idempotency. IMAP
+ * identities include folder, UIDVALIDITY and UID; the raw UID is returned only
+ * as a migration alias for records written before opaque references existed.
+ */
+export function resolveProviderMessageIdentity(input: ProviderMessageIdentityInput): ProviderMessageIdentity {
+  const id = input.id.trim();
+  if (!id) throw new Error('Provider message ID is required.');
+  const requestedFolder = normalizeFolder(input.folder);
+  const listedUid = positiveUint32Text(input.uid);
+  const listedUidValidity = positiveUint32Text(input.uidValidity);
+  const hasListedUid = input.uid !== undefined
+    && input.uid !== null
+    && String(input.uid).trim() !== '';
+  const hasListedUidValidity = input.uidValidity !== undefined
+    && input.uidValidity !== null
+    && String(input.uidValidity).trim() !== '';
+
+  if (id.startsWith(IMAP_MESSAGE_REFERENCE_PREFIX)) {
+    if ((hasListedUid && !listedUid) || (hasListedUidValidity && !listedUidValidity)) {
+      throw new Error('Invalid IMAP UID or UIDVALIDITY.');
+    }
+    const parsedReference = parseImapMessageReference(id);
+    const parsedUid = positiveUint32Text(parsedReference.uid);
+    const parsedUidValidity = positiveUint32Text(parsedReference.uidValidity);
+    if (parsedReference.version !== 1 || !parsedUid || !parsedUidValidity) {
+      throw new Error('Invalid IMAP message ID.');
+    }
+    if (
+      (listedUid && listedUid !== parsedUid)
+      || (listedUidValidity && listedUidValidity !== parsedUidValidity)
+      || (input.folder && requestedFolder !== parsedReference.folder)
+    ) {
+      throw new Error('Inconsistent IMAP message identity.');
+    }
+    return {
+      canonicalId: createImapMessageReference(parsedReference.folder, parsedUidValidity, Number(parsedUid)),
+      folder: parsedReference.folder,
+      isImap: true,
+      legacyId: parsedUid,
+      uid: parsedUid,
+      uidValidity: parsedUidValidity,
+    };
+  }
+
+  if (hasListedUidValidity && (!listedUid || !listedUidValidity)) {
+    throw new Error('Invalid IMAP UID or UIDVALIDITY.');
+  }
+  if (listedUid && listedUidValidity) {
+    return {
+      canonicalId: createImapMessageReference(requestedFolder, listedUidValidity, Number(listedUid)),
+      folder: requestedFolder,
+      isImap: true,
+      legacyId: listedUid,
+      uid: listedUid,
+      uidValidity: listedUidValidity,
+    };
+  }
+
+  return {
+    canonicalId: id,
+    folder: requestedFolder,
+    isImap: false,
+    legacyId: null,
+    uid: listedUid,
+    uidValidity: listedUidValidity,
+  };
+}

--- a/app/lib/email/reader-refresh.ts
+++ b/app/lib/email/reader-refresh.ts
@@ -45,3 +45,79 @@ export function emailMessageListScopeKey({
 }): string {
   return JSON.stringify([accountId, folder, filter, query, page]);
 }
+
+export function emailMessageDetailScopeKey({
+  accountId,
+  folder,
+  messageId,
+}: {
+  accountId: string;
+  folder: string;
+  messageId: string;
+}): string {
+  return JSON.stringify([accountId, folder, messageId]);
+}
+
+export const EMAIL_CACHE_FOLLOW_UP_DELAY_MS = 1_200;
+
+export type EmailClientCacheMetadata = {
+  state: 'fresh' | 'stale' | 'miss';
+  refreshQueued: boolean;
+  generation: number | null;
+  fetchedAt: string | null;
+  staleAt: string | null;
+};
+
+function cacheRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function cacheTimestamp(value: unknown): string | null {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value)) ? value : null;
+}
+
+export function parseEmailClientCacheMetadata(value: unknown): EmailClientCacheMetadata | null {
+  const candidate = cacheRecord(value);
+  if (!candidate || !['fresh', 'stale', 'miss'].includes(String(candidate.state))) return null;
+  const generation = candidate.generation === null || candidate.generation === undefined
+    ? null
+    : Number(candidate.generation);
+  return {
+    state: candidate.state as EmailClientCacheMetadata['state'],
+    refreshQueued: candidate.refreshQueued === true,
+    generation: generation !== null && Number.isSafeInteger(generation) ? generation : null,
+    fetchedAt: cacheTimestamp(candidate.fetchedAt),
+    staleAt: cacheTimestamp(candidate.staleAt),
+  };
+}
+
+export function emailCacheFollowUpKey(scopeKey: string, value: unknown): string | null {
+  const cache = parseEmailClientCacheMetadata(value);
+  if (!cache || cache.state !== 'stale' || !cache.refreshQueued) return null;
+  return JSON.stringify([scopeKey, cache.generation, cache.fetchedAt, cache.staleAt]);
+}
+
+export function claimEmailCacheFollowUp(seen: Set<string>, key: string | null, maxEntries = 200): boolean {
+  if (!key || seen.has(key)) return false;
+  seen.add(key);
+  while (seen.size > maxEntries) {
+    const oldest = seen.values().next().value;
+    if (typeof oldest !== 'string') break;
+    seen.delete(oldest);
+  }
+  return true;
+}
+
+export function shouldApplyEmailRefresh(input: {
+  requestEpoch: number;
+  currentEpoch: number;
+  mutationRevision: number;
+  currentMutationRevision: number;
+  mutationInFlight: boolean;
+}): boolean {
+  return !input.mutationInFlight
+    && input.requestEpoch === input.currentEpoch
+    && input.mutationRevision === input.currentMutationRevision;
+}

--- a/app/lib/email/service.ts
+++ b/app/lib/email/service.ts
@@ -15,6 +15,7 @@ import {
   listLocalEmailMessages,
   moveLocalEmailMessage,
   readLocalEmailMessage,
+  resolveLocalEmailCacheAccount,
   searchLocalEmail,
   sendLocalEmailDerivedMessage,
   sendLocalEmailDraft,
@@ -36,6 +37,15 @@ import {
   type EmailComposeAiInput,
   type EmailPolicy,
 } from '@/app/lib/email/local-service';
+import {
+  readThroughEmailDetail,
+  readThroughEmailList,
+  type EmailCacheBackgroundScheduler,
+  type EmailCacheMode,
+  type EmailDetailPayload,
+  type EmailListPayload,
+} from '@/app/lib/email/cache/read-through';
+import { getRuntimeEmailCacheStore, normalizeEmailCacheProvider } from '@/app/lib/email/cache/store';
 import { resolveEmailAttachments } from '@/app/lib/email/attachments';
 import { EmailMessageNotFoundError } from '@/app/lib/email/errors';
 import type { EmailDeliveryOrigin } from '@/app/lib/email/policy';
@@ -57,6 +67,8 @@ type EmailSearchInput = {
   filter?: string;
   query?: string;
   limit?: number;
+  from?: string;
+  hasAttachments?: boolean;
 };
 
 type EmailMessageListInput = EmailSearchInput & {
@@ -66,6 +78,8 @@ type EmailMessageListInput = EmailSearchInput & {
 type EmailReadPolicyOptions = {
   enforceReadPolicy?: boolean;
   workspaceId?: string | null;
+  cacheMode?: EmailCacheMode;
+  scheduleBackgroundTask?: EmailCacheBackgroundScheduler;
 };
 
 export type EmailDeliveryOptions = {
@@ -376,6 +390,40 @@ export async function testEmailAccount(userId: string, accountId: string) {
   return testStoredSmtpEmailAccount(userId, accountId);
 }
 
+function shouldUseEmailCache(options?: EmailReadPolicyOptions): boolean {
+  return options?.cacheMode === 'swr' && options.enforceReadPolicy === false;
+}
+
+function effectiveListLimit(input: EmailMessageListInput, managed: boolean): number {
+  const fallback = Number.isFinite(input.limit) ? Math.trunc(Number(input.limit)) : 10;
+  return Math.min(Math.max(fallback || 10, 1), managed ? 25 : 50);
+}
+
+function effectiveListOffset(input: EmailMessageListInput, managed: boolean): number {
+  if (managed) return 0;
+  const fallback = Number.isFinite(input.offset) ? Math.trunc(Number(input.offset)) : 0;
+  return Math.min(Math.max(fallback, 0), 10_000);
+}
+
+function effectiveListFolder(input: EmailMessageListInput, provider: string): string {
+  const fallback = normalizeEmailCacheProvider(provider) === 'microsoft' ? 'inbox' : 'INBOX';
+  const folder = (input.folder || fallback).trim().replace(/[\u0000\r\n]/gu, '').slice(0, 240);
+  return folder || fallback;
+}
+
+function effectiveListQuery(input: EmailMessageListInput, provider: string): string {
+  const query = (input.query || '').normalize('NFC').trim();
+  return normalizeEmailCacheProvider(provider) === 'imap' ? query.replace(/\s+/gu, ' ').slice(0, 250) : query;
+}
+
+function effectiveListFilter(input: EmailMessageListInput) {
+  return {
+    filter: (input.filter || 'all').trim().toLowerCase() || 'all',
+    from: (input.from || '').trim(),
+    hasAttachments: Boolean(input.hasAttachments),
+  };
+}
+
 export async function searchEmail(userId: string, input: EmailSearchInput, options?: EmailReadPolicyOptions) {
   const managedAccount = await findManagedEmailAccount(userId, input.accountId);
   if (managedAccount) {
@@ -395,48 +443,152 @@ export async function searchEmail(userId: string, input: EmailSearchInput, optio
 export async function listEmailMessages(userId: string, input: EmailMessageListInput, options?: EmailReadPolicyOptions) {
   const managedAccount = await findManagedEmailAccount(userId, input.accountId);
   if (managedAccount) {
-    const limit = Math.min(Math.max(input.limit || 10, 1), 25);
-    const payload = await managedEmailRequest<ManagedEmailSearchResponse>('/v1/managed/email/search', {
-      method: 'POST',
-      body: JSON.stringify({
+    const useCache = shouldUseEmailCache(options);
+    const limit = useCache
+      ? effectiveListLimit(input, true)
+      : Math.min(Math.max(input.limit || 10, 1), 25);
+    const folder = useCache
+      ? effectiveListFolder(input, managedAccount.provider)
+      : input.folder || 'INBOX';
+    const load = async () => {
+      const payload = await managedEmailRequest<ManagedEmailSearchResponse>('/v1/managed/email/search', {
+        method: 'POST',
+        body: JSON.stringify({
+          accountId: managedAccount.id,
+          query: input.query,
+          limit,
+        }),
+      }, managedEmailScope(userId));
+      const messages = Array.isArray(payload.messages)
+        ? payload.messages.map((message) => normalizeManagedMessage(message, folder))
+        : [];
+      return {
+        account: payload.account ? normalizeManagedAccount(payload.account) : undefined,
+        folder,
+        messages,
+        total: null,
+        offset: 0,
+        limit,
+      };
+    };
+    if (!useCache) return load();
+    const store = await getRuntimeEmailCacheStore();
+    return readThroughEmailList<EmailListPayload>({
+      runtime: { store, scheduleBackgroundTask: options?.scheduleBackgroundTask },
+      mailbox: {
+        userId,
         accountId: managedAccount.id,
-        query: input.query,
+        accountSource: 'managed',
+        provider: managedAccount.provider,
+      },
+      scope: {
+        folder,
+        filter: effectiveListFilter(input),
+        query: effectiveListQuery(input, managedAccount.provider),
+        offset: 0,
+        limit,
+      },
+      load,
+      fromCache: (messages, total) => ({
+        account: managedAccount,
+        folder,
+        messages,
+        total,
+        offset: 0,
         limit,
       }),
-    }, managedEmailScope(userId));
-    const messages = Array.isArray(payload.messages)
-      ? payload.messages.map((message) => normalizeManagedMessage(message, input.folder || 'INBOX'))
-      : [];
-    return {
-      account: payload.account ? normalizeManagedAccount(payload.account) : undefined,
-      folder: input.folder || 'INBOX',
-      messages,
-      total: null,
-      offset: 0,
-      limit,
-    };
+    });
+  }
+
+  if (shouldUseEmailCache(options)) {
+    const resolved = await resolveLocalEmailCacheAccount(userId, input.accountId);
+    const limit = effectiveListLimit(input, false);
+    const offset = effectiveListOffset(input, false);
+    const folder = effectiveListFolder(input, resolved.provider);
+    const store = await getRuntimeEmailCacheStore();
+    return readThroughEmailList<EmailListPayload>({
+      runtime: { store, scheduleBackgroundTask: options?.scheduleBackgroundTask },
+      mailbox: {
+        userId,
+        accountId: resolved.account.id,
+        accountSource: 'local',
+        provider: resolved.provider,
+      },
+      scope: {
+        folder,
+        filter: effectiveListFilter(input),
+        query: effectiveListQuery(input, resolved.provider),
+        offset,
+        limit,
+      },
+      load: () => listLocalEmailMessages(userId, input, options),
+      fromCache: (messages, total) => ({
+        account: resolved.account,
+        folder,
+        messages,
+        total,
+        offset,
+        limit,
+      }),
+    });
   }
   return listLocalEmailMessages(userId, input, options);
 }
 
 export async function readEmailMessage(userId: string, accountId: string, messageId: string, folder?: string, options?: EmailReadPolicyOptions) {
-  if (await findManagedEmailAccount(userId, accountId)) {
-    let payload: ManagedEmailReadResponse;
-    try {
-      payload = await managedEmailRequest<ManagedEmailReadResponse>(
-        `/v1/managed/email/accounts/${encodeURIComponent(accountId)}/messages/${encodeURIComponent(messageId)}`,
-        undefined,
-        managedEmailScope(userId),
-      );
-    } catch (error) {
-      if (error instanceof ManagedEmailRequestError && error.status === 404) throw new EmailMessageNotFoundError();
-      throw error;
-    }
-    return {
-      ...payload,
-      account: payload.account ? normalizeManagedAccount(payload.account) : undefined,
-      message: payload.message ? normalizeManagedMessage(payload.message, folder || 'INBOX') : undefined,
+  const managedAccount = await findManagedEmailAccount(userId, accountId);
+  if (managedAccount) {
+    const load = async () => {
+      let payload: ManagedEmailReadResponse;
+      try {
+        payload = await managedEmailRequest<ManagedEmailReadResponse>(
+          `/v1/managed/email/accounts/${encodeURIComponent(accountId)}/messages/${encodeURIComponent(messageId)}`,
+          undefined,
+          managedEmailScope(userId),
+        );
+      } catch (error) {
+        if (error instanceof ManagedEmailRequestError && error.status === 404) throw new EmailMessageNotFoundError();
+        throw error;
+      }
+      return {
+        ...payload,
+        account: payload.account ? normalizeManagedAccount(payload.account) : undefined,
+        message: payload.message ? normalizeManagedMessage(payload.message, folder || 'INBOX') : undefined,
+      };
     };
+    if (!shouldUseEmailCache(options)) return load();
+    const store = await getRuntimeEmailCacheStore();
+    return readThroughEmailDetail<EmailDetailPayload>({
+      runtime: { store, scheduleBackgroundTask: options?.scheduleBackgroundTask },
+      mailbox: {
+        userId,
+        accountId: managedAccount.id,
+        accountSource: 'managed',
+        provider: managedAccount.provider,
+      },
+      messageId,
+      folder,
+      load,
+      fromCache: (message) => ({ account: managedAccount, message }),
+    });
+  }
+
+  if (shouldUseEmailCache(options)) {
+    const resolved = await resolveLocalEmailCacheAccount(userId, accountId);
+    const store = await getRuntimeEmailCacheStore();
+    return readThroughEmailDetail<EmailDetailPayload>({
+      runtime: { store, scheduleBackgroundTask: options?.scheduleBackgroundTask },
+      mailbox: {
+        userId,
+        accountId: resolved.account.id,
+        accountSource: 'local',
+        provider: resolved.provider,
+      },
+      messageId,
+      folder,
+      load: () => readLocalEmailMessage(userId, accountId, messageId, folder, options),
+      fromCache: (message) => ({ account: resolved.account, message }),
+    });
   }
   return readLocalEmailMessage(userId, accountId, messageId, folder, options);
 }

--- a/app/lib/email/service.ts
+++ b/app/lib/email/service.ts
@@ -45,6 +45,12 @@ import {
   type EmailDetailPayload,
   type EmailListPayload,
 } from '@/app/lib/email/cache/read-through';
+import {
+  invalidateEmailMailboxCache,
+  purgeEmailMailboxCache,
+  reactivateEmailMailboxCache,
+  runLocalEmailMailboxMutation,
+} from '@/app/lib/email/cache/consistency';
 import { getRuntimeEmailCacheStore, normalizeEmailCacheProvider } from '@/app/lib/email/cache/store';
 import { resolveEmailAttachments } from '@/app/lib/email/attachments';
 import { EmailMessageNotFoundError } from '@/app/lib/email/errors';
@@ -367,19 +373,26 @@ export async function setEmailMainAccount(userId: string, accountId: string) {
 }
 
 export async function disconnectEmailAccount(userId: string, accountId: string) {
-  if (await findManagedEmailAccount(userId, accountId)) {
+  const managedAccount = await findManagedEmailAccount(userId, accountId);
+  if (managedAccount) {
     await managedEmailRequest<{ success: boolean }>(
       `/v1/managed/email/accounts/${encodeURIComponent(accountId)}`,
       { method: 'DELETE' },
       managedEmailScope(userId),
     );
+    await purgeEmailMailboxCache({ userId, accountId: managedAccount.id, accountSource: 'managed' });
     return { success: true };
   }
-  return disconnectLocalEmailAccount(userId, accountId);
+  const localAccount = await resolveLocalEmailCacheAccount(userId, accountId);
+  const result = await disconnectLocalEmailAccount(userId, localAccount.account.id);
+  await purgeEmailMailboxCache({ userId, accountId: localAccount.account.id, accountSource: 'local' });
+  return result;
 }
 
 export async function saveEmailSmtpAccount(userId: string, input: SmtpAccountInput, options?: { verify?: boolean }) {
-  return saveSmtpEmailAccount(userId, input, options);
+  const account = await saveSmtpEmailAccount(userId, input, options);
+  await reactivateEmailMailboxCache({ userId, accountId: account.id, accountSource: 'local' });
+  return account;
 }
 
 export async function testEmailSmtpConnection(userId: string, input: SmtpAccountInput) {
@@ -422,6 +435,24 @@ function effectiveListFilter(input: EmailMessageListInput) {
     from: (input.from || '').trim(),
     hasAttachments: Boolean(input.hasAttachments),
   };
+}
+
+function localMailboxAccountFromResult(result: unknown): { id: string; authType: string } | null {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return null;
+  const account = (result as { account?: unknown }).account;
+  if (!account || typeof account !== 'object' || Array.isArray(account)) return null;
+  const id = (account as { id?: unknown }).id;
+  const authType = (account as { authType?: unknown }).authType;
+  if (typeof id !== 'string' || !id.trim() || typeof authType !== 'string') return null;
+  return { id: id.trim(), authType };
+}
+
+async function invalidateLocalOAuthMailboxResult<T>(userId: string, result: T): Promise<T> {
+  const account = localMailboxAccountFromResult(result);
+  if (account && account.authType !== 'smtp_imap') {
+    await invalidateEmailMailboxCache({ userId, accountId: account.id, accountSource: 'local' });
+  }
+  return result;
 }
 
 export async function searchEmail(userId: string, input: EmailSearchInput, options?: EmailReadPolicyOptions) {
@@ -600,7 +631,10 @@ export async function setEmailMessageRead(
   folder: string | undefined,
   read: boolean,
 ) {
-  return setLocalEmailMessageRead(userId, accountId, messageId, folder, read);
+  return runLocalEmailMailboxMutation(
+    { userId, accountId },
+    () => setLocalEmailMessageRead(userId, accountId, messageId, folder, read),
+  );
 }
 
 export async function setEmailMessageAnswered(
@@ -610,23 +644,38 @@ export async function setEmailMessageAnswered(
   folder: string | undefined,
   answered: boolean,
 ) {
-  return setLocalEmailMessageAnswered(userId, accountId, messageId, folder, answered);
+  return runLocalEmailMailboxMutation(
+    { userId, accountId },
+    () => setLocalEmailMessageAnswered(userId, accountId, messageId, folder, answered),
+  );
 }
 
 export async function archiveEmailMessage(userId: string, accountId: string, messageId: string, folder?: string) {
-  return archiveLocalEmailMessage(userId, accountId, messageId, folder);
+  return runLocalEmailMailboxMutation(
+    { userId, accountId },
+    () => archiveLocalEmailMessage(userId, accountId, messageId, folder),
+  );
 }
 
 export async function moveEmailMessage(userId: string, accountId: string, messageId: string, folder: string | undefined, destination: string) {
-  return moveLocalEmailMessage(userId, accountId, messageId, folder, destination);
+  return runLocalEmailMailboxMutation(
+    { userId, accountId },
+    () => moveLocalEmailMessage(userId, accountId, messageId, folder, destination),
+  );
 }
 
 export async function trashEmailMessage(userId: string, accountId: string, messageId: string, folder?: string) {
-  return trashLocalEmailMessage(userId, accountId, messageId, folder);
+  return runLocalEmailMailboxMutation(
+    { userId, accountId },
+    () => trashLocalEmailMessage(userId, accountId, messageId, folder),
+  );
 }
 
 export async function deleteEmailMessagePermanently(userId: string, accountId: string, messageId: string, folder?: string) {
-  return deleteLocalEmailMessagePermanently(userId, accountId, messageId, folder);
+  return runLocalEmailMailboxMutation(
+    { userId, accountId },
+    () => deleteLocalEmailMessagePermanently(userId, accountId, messageId, folder),
+  );
 }
 
 export async function summarizeEmailMessage(userId: string, accountId: string, messageId: string, folder?: string, options?: EmailReadPolicyOptions) {
@@ -652,7 +701,8 @@ export async function createEmailDerivedDraft(
   overrides?: EmailDerivedDraftOverrides,
   options?: EmailReadPolicyOptions & EmailDeliveryOptions,
 ) {
-  return createLocalEmailDerivedDraft(userId, accountId, messageId, folder, mode, overrides, options);
+  const result = await createLocalEmailDerivedDraft(userId, accountId, messageId, folder, mode, overrides, options);
+  return invalidateLocalOAuthMailboxResult(userId, result);
 }
 
 export async function sendEmailDerivedMessage(
@@ -664,7 +714,8 @@ export async function sendEmailDerivedMessage(
   overrides?: EmailDerivedDraftOverrides,
   options?: EmailReadPolicyOptions & EmailDeliveryOptions,
 ) {
-  return sendLocalEmailDerivedMessage(userId, accountId, messageId, folder, mode, overrides, options);
+  const result = await sendLocalEmailDerivedMessage(userId, accountId, messageId, folder, mode, overrides, options);
+  return invalidateLocalOAuthMailboxResult(userId, result);
 }
 
 export async function generateEmailAiReplyBody(userId: string, accountId: string, messageId: string, folder?: string, instruction?: string, options?: EmailReadPolicyOptions) {
@@ -695,7 +746,8 @@ export async function streamEmailComposeBody(
 }
 
 export async function createEmailAiReplyDraft(userId: string, accountId: string, messageId: string, folder?: string, instruction?: string, options?: EmailReadPolicyOptions) {
-  return createLocalEmailAiReplyDraft(userId, accountId, messageId, folder, instruction, options);
+  const result = await createLocalEmailAiReplyDraft(userId, accountId, messageId, folder, instruction, options);
+  return invalidateLocalOAuthMailboxResult(userId, result);
 }
 
 export async function createEmailDraft(userId: string, input: EmailDraftInput, options?: EmailDeliveryOptions) {
@@ -705,7 +757,8 @@ export async function createEmailDraft(userId: string, input: EmailDraftInput, o
       body: JSON.stringify(await managedDraftInput(input)),
     }, managedEmailScope(userId));
   }
-  return createLocalEmailDraft(userId, input, options?.deliveryOrigin);
+  const result = await createLocalEmailDraft(userId, input, options?.deliveryOrigin);
+  return invalidateLocalOAuthMailboxResult(userId, result);
 }
 
 export async function updateEmailDraft(userId: string, draftId: string, input: EmailDraftInput, options?: EmailDeliveryOptions) {
@@ -715,7 +768,8 @@ export async function updateEmailDraft(userId: string, draftId: string, input: E
       body: JSON.stringify(await managedDraftInput(input)),
     }, managedEmailScope(userId));
   }
-  return updateLocalEmailDraft(userId, draftId, input, options?.deliveryOrigin);
+  const result = await updateLocalEmailDraft(userId, draftId, input, options?.deliveryOrigin);
+  return invalidateLocalOAuthMailboxResult(userId, result);
 }
 
 export async function sendEmailMessage(userId: string, input: EmailDraftInput, options?: EmailDeliveryOptions) {
@@ -727,7 +781,8 @@ export async function sendEmailMessage(userId: string, input: EmailDraftInput, o
     if (!draftId) throw new Error('Managed email draft response did not include a draft ID.');
     return sendEmailDraft(userId, accountId, draftId, options);
   }
-  return sendLocalEmailMessage(userId, input, options?.deliveryOrigin);
+  const result = await sendLocalEmailMessage(userId, input, options?.deliveryOrigin);
+  return invalidateLocalOAuthMailboxResult(userId, result);
 }
 
 export async function sendEmailDraft(userId: string, accountId: string, draftId: string, options?: EmailDeliveryOptions) {
@@ -737,5 +792,6 @@ export async function sendEmailDraft(userId: string, accountId: string, draftId:
       body: JSON.stringify({ accountId }),
     }, managedEmailScope(userId));
   }
-  return sendLocalEmailDraft(userId, accountId, draftId, options?.deliveryOrigin);
+  const result = await sendLocalEmailDraft(userId, accountId, draftId, options?.deliveryOrigin);
+  return invalidateLocalOAuthMailboxResult(userId, result);
 }

--- a/app/lib/home/workspace-email-widget.ts
+++ b/app/lib/home/workspace-email-widget.ts
@@ -1,0 +1,224 @@
+import 'server-only';
+
+import type {
+  EmailCacheBackgroundScheduler,
+  EmailResponseCacheMetadata,
+} from '@/app/lib/email/cache/read-through';
+import type { HomeWidgetEmail } from '@/app/lib/home/workspace-widget-data';
+
+type HomeEmailAccount = {
+  id: string;
+  displayName?: string | null;
+  emailAddress?: string | null;
+};
+
+type HomeEmailListPayload = {
+  cache?: EmailResponseCacheMetadata;
+  folder?: unknown;
+  messages?: unknown[];
+};
+
+export type HomeEmailServices = {
+  listAccounts: (userId: string) => Promise<{ accounts?: unknown[] }>;
+  listMessages: (
+    userId: string,
+    input: { accountId: string; filter: 'unread'; limit: number },
+    options: {
+      enforceReadPolicy: false;
+      cacheMode: 'swr';
+      scheduleBackgroundTask?: EmailCacheBackgroundScheduler;
+    },
+  ) => Promise<HomeEmailListPayload>;
+};
+
+export type HomeWidgetEmailCacheMetadata = {
+  enabled: boolean;
+  state: EmailResponseCacheMetadata['state'];
+  source: EmailResponseCacheMetadata['source'] | 'mixed' | 'none';
+  fetchedAt: string | null;
+  staleAt: string | null;
+  expiresAt: string | null;
+  refreshQueued: boolean;
+  refreshToken: string;
+  partial: boolean;
+  accountCount: number;
+  successfulAccountCount: number;
+};
+
+export type HomeWidgetEmailResult = {
+  data: HomeWidgetEmail[];
+  cachedAt: string;
+  stale: boolean;
+  cache: HomeWidgetEmailCacheMetadata;
+};
+
+type AccountResult = {
+  accountId: string;
+  cache: EmailResponseCacheMetadata;
+  messages: HomeWidgetEmail[];
+};
+
+const MISSING_CACHE_METADATA: EmailResponseCacheMetadata = {
+  enabled: false,
+  scope: 'list',
+  state: 'miss',
+  source: 'bypass',
+  generation: null,
+  fetchedAt: null,
+  staleAt: null,
+  expiresAt: null,
+  refreshQueued: false,
+  bypassReason: 'cache_error',
+};
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function account(value: unknown): HomeEmailAccount | null {
+  const candidate = record(value);
+  const id = typeof candidate?.id === 'string' ? candidate.id : '';
+  if (!id.trim()) return null;
+  return {
+    id,
+    displayName: typeof candidate?.displayName === 'string' ? candidate.displayName : null,
+    emailAddress: typeof candidate?.emailAddress === 'string' ? candidate.emailAddress : null,
+  };
+}
+
+function timestamp(value: string | null | undefined): number {
+  const parsed = value ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function earliestIso(values: Array<string | null>): string | null {
+  if (values.length === 0 || values.some((value) => value === null)) return null;
+  return values.reduce<string | null>((earliest, value) => (
+    !earliest || timestamp(value) < timestamp(earliest) ? value : earliest
+  ), null);
+}
+
+function stableToken(value: unknown): string {
+  const input = JSON.stringify(value);
+  let forward = 0x811c9dc5;
+  let backward = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    forward = Math.imul(forward ^ input.charCodeAt(index), 0x01000193) >>> 0;
+    backward = Math.imul(backward ^ input.charCodeAt(input.length - index - 1), 0x01000193) >>> 0;
+  }
+  return `home-email-v1-${forward.toString(16).padStart(8, '0')}${backward.toString(16).padStart(8, '0')}`;
+}
+
+function aggregateHomeWidgetEmailCache(
+  accountIds: string[],
+  results: PromiseSettledResult<AccountResult>[],
+): HomeWidgetEmailCacheMetadata {
+  const successful = results.flatMap((result) => result.status === 'fulfilled' ? [result.value] : []);
+  const metadata = successful.map((result) => result.cache);
+  const state = metadata.some((cache) => cache.state === 'stale')
+    ? 'stale'
+    : metadata.some((cache) => cache.state === 'miss')
+      ? 'miss'
+      : 'fresh';
+  const sources = new Set(metadata.map((cache) => cache.source));
+  const source = sources.size === 0 ? 'none' : sources.size === 1 ? [...sources][0]! : 'mixed';
+  const tokenEntries = results
+    .map((result, index) => ({ accountId: accountIds[index] || '', result }))
+    .sort((left, right) => left.accountId < right.accountId ? -1 : left.accountId > right.accountId ? 1 : 0)
+    .map(({ accountId, result }) => result.status === 'rejected'
+      ? { accountId, status: 'error' as const }
+      : {
+        accountId,
+        state: result.value.cache.state,
+        source: result.value.cache.source,
+        generation: result.value.cache.generation,
+        fetchedAt: result.value.cache.fetchedAt,
+        messages: result.value.messages
+          .map((message) => [message.folder || '', message.id, message.date])
+          .sort((left, right) => {
+            const leftKey = JSON.stringify(left);
+            const rightKey = JSON.stringify(right);
+            return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+          }),
+      });
+
+  return {
+    enabled: metadata.length > 0 && metadata.every((cache) => cache.enabled),
+    state,
+    source,
+    fetchedAt: earliestIso(metadata.map((cache) => cache.fetchedAt)),
+    staleAt: earliestIso(metadata.map((cache) => cache.staleAt)),
+    expiresAt: earliestIso(metadata.map((cache) => cache.expiresAt)),
+    refreshQueued: metadata.some((cache) => cache.refreshQueued),
+    refreshToken: stableToken(tokenEntries),
+    partial: successful.length !== accountIds.length,
+    accountCount: accountIds.length,
+    successfulAccountCount: successful.length,
+  };
+}
+
+export async function loadHomeWidgetEmails(
+  userId: string,
+  options: {
+    scheduleBackgroundTask?: EmailCacheBackgroundScheduler;
+    services: HomeEmailServices;
+  },
+): Promise<HomeWidgetEmailResult> {
+  const services = options.services;
+  const accountsPayload = await services.listAccounts(userId);
+  const accounts = (accountsPayload.accounts ?? []).flatMap((value) => {
+    const normalized = account(value);
+    return normalized ? [normalized] : [];
+  });
+
+  const results = await Promise.allSettled(accounts.map(async (emailAccount): Promise<AccountResult> => {
+    const payload = await services.listMessages(userId, {
+      accountId: emailAccount.id,
+      filter: 'unread',
+      limit: 3,
+    }, {
+      enforceReadPolicy: false,
+      cacheMode: 'swr',
+      ...(options.scheduleBackgroundTask ? { scheduleBackgroundTask: options.scheduleBackgroundTask } : {}),
+    });
+    const fallbackFolder = typeof payload.folder === 'string' ? payload.folder : undefined;
+    const accountLabel = emailAccount.displayName?.trim() || emailAccount.emailAddress?.trim() || emailAccount.id;
+    const messages = (payload.messages ?? []).flatMap((value): HomeWidgetEmail[] => {
+      const message = record(value);
+      if (typeof message?.id !== 'string' || !message.id.trim() || message.isRead !== false) return [];
+      const folder = typeof message.folder === 'string' && message.folder ? message.folder : fallbackFolder;
+      return [{
+        id: message.id,
+        accountId: emailAccount.id,
+        accountLabel,
+        ...(folder ? { folder } : {}),
+        from: typeof message.from === 'string' ? message.from.trim() : '',
+        subject: typeof message.subject === 'string' ? message.subject.trim() : '',
+        date: typeof message.date === 'string' && message.date ? message.date : null,
+      }];
+    });
+    return {
+      accountId: emailAccount.id,
+      cache: payload.cache ?? MISSING_CACHE_METADATA,
+      messages,
+    };
+  }));
+
+  if (accounts.length > 0 && results.every((result) => result.status === 'rejected')) {
+    throw new Error('Email widget data could not be loaded.');
+  }
+
+  const cache = aggregateHomeWidgetEmailCache(accounts.map((value) => value.id), results);
+  const data = results
+    .flatMap((result) => result.status === 'fulfilled' ? result.value.messages : [])
+    .sort((left, right) => timestamp(right.date) - timestamp(left.date))
+    .slice(0, 3);
+  return {
+    data,
+    cachedAt: cache.fetchedAt ?? new Date().toISOString(),
+    stale: cache.state === 'stale',
+    cache,
+  };
+}

--- a/app/lib/home/workspace-widget-data.ts
+++ b/app/lib/home/workspace-widget-data.ts
@@ -59,57 +59,6 @@ function timestamp(value: string | null | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-export async function loadHomeWidgetEmails(fetcher: Fetcher, signal?: AbortSignal): Promise<HomeWidgetEmail[]> {
-  const accountsPayload = await readJson<{ accounts?: Array<{ id?: string; emailAddress?: string; displayName?: string }> }>(
-    fetcher,
-    '/api/email/accounts',
-    { credentials: 'include', cache: 'no-store', signal },
-  );
-  const accounts = (accountsPayload.accounts ?? []).filter((account): account is { id: string; emailAddress?: string; displayName?: string } => Boolean(account.id));
-  if (accounts.length === 0) return [];
-
-  const accountResults = await Promise.allSettled(accounts.map(async (account) => {
-    const foldersPayload = await readJson<{ folders?: Array<{ path?: string; role?: string }> }>(
-      fetcher,
-      `/api/email/folders?accountId=${encodeURIComponent(account.id)}`,
-      { credentials: 'include', cache: 'no-store', signal },
-    );
-    const folder = foldersPayload.folders?.find((candidate) => candidate.role === 'inbox')?.path;
-    const messagesPayload = await readJson<{ messages?: Array<{ id?: string; folder?: string; from?: string; subject?: string; date?: string; isRead?: boolean }> }>(
-      fetcher,
-      '/api/email/messages/list',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        cache: 'no-store',
-        signal,
-        body: JSON.stringify({ accountId: account.id, ...(folder ? { folder } : {}), filter: 'unread', limit: 3 }),
-      },
-    );
-    const accountLabel = account.displayName?.trim() || account.emailAddress?.trim() || account.id;
-    return (messagesPayload.messages ?? [])
-      .filter((message): message is typeof message & { id: string } => Boolean(message.id) && message.isRead === false)
-      .map((message) => ({
-        id: message.id,
-        accountId: account.id,
-        accountLabel,
-        ...(message.folder || folder ? { folder: message.folder || folder } : {}),
-        from: message.from?.trim() || '',
-        subject: message.subject?.trim() || '',
-        date: message.date || null,
-      }));
-  }));
-
-  if (accountResults.every((result) => result.status === 'rejected')) {
-    throw new Error('Email widget data could not be loaded.');
-  }
-  return accountResults
-    .flatMap((result) => result.status === 'fulfilled' ? result.value : [])
-    .sort((a, b) => timestamp(b.date) - timestamp(a.date))
-    .slice(0, 3);
-}
-
 export async function loadHomeWidgetTodos(fetcher: Fetcher, workspaceId: string, signal?: AbortSignal): Promise<HomeWidgetTodo[]> {
   const params = new URLSearchParams({ workspaceId, scope: 'workspace', status: 'active', limit: '3' });
   const todos = await readJson<Array<{ id: string; title: string; priority?: string; dueAt?: string | null; readState?: string }>>(

--- a/app/lib/home/workspace-widget-request.ts
+++ b/app/lib/home/workspace-widget-request.ts
@@ -1,0 +1,32 @@
+export const HOME_WIDGET_NAMES = ['emails', 'todos', 'automation', 'studio'] as const;
+
+export type HomeWidgetName = typeof HOME_WIDGET_NAMES[number];
+
+export function isHomeWidgetName(value: unknown): value is HomeWidgetName {
+  return typeof value === 'string' && HOME_WIDGET_NAMES.some((name) => name === value);
+}
+
+export function parseHomeWidgetSelection(
+  value: string | null,
+  fallback: readonly HomeWidgetName[],
+): HomeWidgetName[] | null {
+  if (value === null) return [...fallback];
+  const entries = value.split(',').map((entry) => entry.trim()).filter(Boolean);
+  if (entries.length === 0 || entries.some((entry) => !isHomeWidgetName(entry))) return null;
+  return HOME_WIDGET_NAMES.filter((name) => entries.includes(name));
+}
+
+export function claimHomeWidgetRefreshToken(
+  seen: Set<string>,
+  key: string | null,
+  maxEntries = 200,
+): boolean {
+  if (!key || seen.has(key)) return false;
+  seen.add(key);
+  while (seen.size > maxEntries) {
+    const oldest = seen.values().next().value;
+    if (typeof oldest !== 'string') break;
+    seen.delete(oldest);
+  }
+  return true;
+}

--- a/app/lib/todos/email-reply-watchers.ts
+++ b/app/lib/todos/email-reply-watchers.ts
@@ -10,6 +10,10 @@ import {
   todoEmailReplyEvents,
   todoEmailReplyWatchers,
 } from '@/app/lib/db/schema';
+import {
+  resolveProviderMessageIdentity,
+  type ProviderMessageIdentity,
+} from '@/app/lib/email/provider-message-identity';
 import { readEmailMessage, listEmailMessages } from '@/app/lib/email/service';
 import { sendFollowUpMessage } from '@/app/lib/pi/runtime-service';
 import { assertUnambiguousOwnedPiSessionForRuntime } from '@/app/lib/pi/session-runtime-access';
@@ -33,6 +37,8 @@ type EmailListMessage = {
   subject?: string;
   date?: string;
   snippet?: string;
+  uid?: string;
+  uidValidity?: string;
 };
 
 type EmailReadMessage = EmailListMessage & {
@@ -87,13 +93,20 @@ function normalizeText(value: unknown, maxLength: number): string | null {
   return normalized ? normalized.slice(0, maxLength) : null;
 }
 
-function normalizeEmailListMessage(value: unknown): EmailListMessage | null {
+function normalizeEmailListMessage(value: unknown, listUidValidity?: unknown): EmailListMessage | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const record = value as Record<string, unknown>;
   const id = typeof record.id === 'string' && record.id.trim()
     ? record.id.trim()
     : typeof record.uid === 'string' && record.uid.trim() ? record.uid.trim() : null;
   if (!id) return null;
+  const uid = typeof record.uid === 'number' && Number.isSafeInteger(record.uid)
+    ? String(record.uid)
+    : normalizeText(record.uid, 20);
+  const rawUidValidity = record.uidValidity ?? listUidValidity;
+  const uidValidity = typeof rawUidValidity === 'number' && Number.isSafeInteger(rawUidValidity)
+    ? String(rawUidValidity)
+    : normalizeText(rawUidValidity, 20);
 
   return {
     id,
@@ -103,6 +116,8 @@ function normalizeEmailListMessage(value: unknown): EmailListMessage | null {
     subject: normalizeText(record.subject, 500) || undefined,
     date: normalizeText(record.date, 120) || undefined,
     snippet: normalizeText(record.snippet, 1000) || undefined,
+    uid: uid || undefined,
+    uidValidity: uidValidity || undefined,
   };
 }
 
@@ -130,8 +145,15 @@ function normalizeEmailReadMessage(value: unknown, fallback: EmailListMessage): 
 }
 
 function providerMessageKey(message: EmailListMessage): string {
-  const folder = (message.folder || 'INBOX').trim() || 'INBOX';
-  return `${folder}:${message.id}`;
+  const identity = resolveProviderMessageIdentity(message);
+  return `${identity.folder}:${identity.canonicalId}`;
+}
+
+function legacyProviderMessageKey(message: EmailListMessage): string | null {
+  const identity = resolveProviderMessageIdentity(message);
+  return identity.isImap && identity.legacyId
+    ? `${identity.folder}:${identity.legacyId}`
+    : null;
 }
 
 function includesCaseInsensitive(value: string | null | undefined, needle: string): boolean {
@@ -308,6 +330,58 @@ async function getExistingEvent(watcherId: string, accountId: string, providerMe
   return event ?? null;
 }
 
+function legacyReplyEventMatches(
+  event: TodoEmailReplyEvent,
+  message: EmailReadMessage,
+  identity: ProviderMessageIdentity,
+  replyText: string,
+): boolean {
+  const receivedAt = parseDate(message.date);
+  const fromAddress = normalizeText(message.from, 500);
+  const subject = normalizeText(message.subject, 500);
+  const threadId = normalizeText(message.threadId, 500);
+  if (!identity.isImap || !receivedAt || !fromAddress || !subject || !threadId) return false;
+  return event.folder === identity.folder
+    && event.receivedAt?.getTime() === receivedAt.getTime()
+    && event.fromAddress === fromAddress
+    && event.subject === subject
+    && event.threadId === threadId
+    && (event.replyText || '') === replyText;
+}
+
+async function migrateMatchingLegacyReplyEvent(input: {
+  watcher: TodoEmailReplyWatcher;
+  message: EmailReadMessage;
+  canonicalProviderMessageId: string;
+  replyText: string;
+}): Promise<boolean> {
+  const identity = resolveProviderMessageIdentity(input.message);
+  const legacyProviderMessageId = legacyProviderMessageKey(input.message);
+  if (!legacyProviderMessageId || legacyProviderMessageId === input.canonicalProviderMessageId) return false;
+  const legacy = await getExistingEvent(input.watcher.id, input.watcher.accountId, legacyProviderMessageId);
+  if (!legacy || !legacyReplyEventMatches(legacy, input.message, identity, input.replyText)) return false;
+
+  try {
+    const migrated = await db
+      .update(todoEmailReplyEvents)
+      .set({
+        providerMessageId: input.canonicalProviderMessageId,
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(todoEmailReplyEvents.id, legacy.id),
+        eq(todoEmailReplyEvents.providerMessageId, legacyProviderMessageId),
+      ))
+      .returning({ id: todoEmailReplyEvents.id });
+    return migrated.length > 0;
+  } catch (error) {
+    if (await getExistingEvent(input.watcher.id, input.watcher.accountId, input.canonicalProviderMessageId)) {
+      return true;
+    }
+    throw error;
+  }
+}
+
 async function createReplyEvent(params: {
   watcher: TodoEmailReplyWatcher;
   message: EmailReadMessage;
@@ -337,8 +411,8 @@ async function createReplyEvent(params: {
     dispatchedAt: null,
     createdAt: now,
     updatedAt: now,
-  }).returning();
-  return created;
+  }).onConflictDoNothing().returning();
+  return created ?? null;
 }
 
 async function markReplyEvent(eventId: string, status: 'dispatched' | 'failed', values: { error?: string | null } = {}): Promise<void> {
@@ -407,6 +481,14 @@ async function processMessageCandidate(watcher: TodoEmailReplyWatcher, candidate
   }
 
   const replyText = extractTodoEmailReplyText(readMessage.body || readMessage.snippet || '', watcher.replyToken);
+  if (await migrateMatchingLegacyReplyEvent({
+    watcher,
+    message: readMessage,
+    canonicalProviderMessageId: providerMessageId,
+    replyText,
+  })) {
+    return 'skipped';
+  }
   if (!replyText) {
     const event = await createReplyEvent({ watcher, message: readMessage, providerMessageId, replyText: '' });
     if (event) {
@@ -443,10 +525,13 @@ async function pollWatcher(watcher: TodoEmailReplyWatcher): Promise<'processed' 
     query: watcher.replyToken,
     limit: MAX_MESSAGES_PER_WATCHER,
   });
-  const rawMessages = Array.isArray((searchResult as { messages?: unknown[] }).messages)
-    ? (searchResult as { messages: unknown[] }).messages
+  const typedSearchResult = searchResult as { messages?: unknown[]; uidValidity?: unknown };
+  const rawMessages = Array.isArray(typedSearchResult.messages)
+    ? typedSearchResult.messages
     : [];
-  const candidates = rawMessages.map(normalizeEmailListMessage).filter((entry): entry is EmailListMessage => Boolean(entry));
+  const candidates = rawMessages
+    .map((message) => normalizeEmailListMessage(message, typedSearchResult.uidValidity))
+    .filter((entry): entry is EmailListMessage => Boolean(entry));
 
   for (const candidate of candidates) {
     const result = await processMessageCandidate(watcher, candidate);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "testenv:status": "bash \"${CODEX_HOME:-$HOME/.codex}/skills/canvas-local-team-seat-dev/scripts/status-local.sh\"",
     "testenv:stop": "bash \"${CODEX_HOME:-$HOME/.codex}/skills/canvas-local-team-seat-dev/scripts/stop-local.sh\"",
     "lint": "eslint",
-    "test:home": "tsx --conditions react-server scripts/file-quick-access-test.ts && tsx scripts/file-visit-open-flow-test.ts && tsx scripts/home-notifications-test.ts && tsx scripts/notification-source-resilience-test.ts && tsx --conditions react-server scripts/home-workspace-widget-cache-test.ts && tsx scripts/home-start-component-test.tsx",
+    "test:home": "tsx --conditions react-server scripts/file-quick-access-test.ts && tsx scripts/file-visit-open-flow-test.ts && tsx scripts/home-notifications-test.ts && tsx scripts/notification-source-resilience-test.ts && tsx --conditions react-server scripts/home-workspace-widget-cache-test.ts && tsx --conditions react-server scripts/home-workspace-widgets-test.ts && tsx scripts/home-workspace-widgets-hook-test.tsx && tsx scripts/home-start-component-test.tsx",
     "test:home:api": "node scripts/home-quick-access-api-test.mjs",
     "test:smoke": "node scripts/smoke-test.mjs",
     "test:integration": "node scripts/integration-test.mjs",

--- a/scripts/email-account-workspace-binding-test.ts
+++ b/scripts/email-account-workspace-binding-test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import Module from 'node:module';
 import os from 'node:os';
@@ -178,6 +179,107 @@ async function main() {
     assert.equal(storedEvent?.provider_thread_id, 'thread-1');
     assert.equal(storedEvent?.status, 'pending');
     assert.ok(storedEvent?.id);
+
+    const mailboxRow = sqlite.prepare(`
+      SELECT id FROM workspace_email_mailboxes WHERE email_account_id = ? AND status = 'active'
+    `).get(created.id) as { id: string } | undefined;
+    assert.ok(mailboxRow?.id);
+    const { createImapMessageReference } = await import('../app/lib/email/imap-service');
+    const legacyInboxKey = (uid: string) => createHash('sha256')
+      .update(`${mailboxRow.id}:${uid}`)
+      .digest('hex');
+    const seedLegacyInboxEvent = (input: {
+      date: Date;
+      id: string;
+      threadId: string;
+      uid: string;
+    }) => {
+      const timestamp = Math.floor(input.date.getTime() / 1_000);
+      sqlite.prepare(`
+        INSERT INTO email_inbox_events (
+          id, mailbox_id, workspace_id, provider_message_id, provider_thread_id,
+          idempotency_key, event_type, received_at, status, attempt_count,
+          metadata_json, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 'message_received', ?, 'processed', 0, ?, ?, ?)
+      `).run(
+        input.id,
+        mailboxRow.id,
+        ownerWorkspace.id,
+        input.uid,
+        input.threadId,
+        legacyInboxKey(input.uid),
+        timestamp,
+        JSON.stringify({ folder: 'INBOX', hasAttachments: false }),
+        timestamp,
+        timestamp,
+      );
+    };
+
+    const legacyMatchDate = new Date(Math.floor((pollNow.getTime() + 2_000) / 1_000) * 1_000);
+    const legacyMatchId = createImapMessageReference('INBOX', '7001', 51);
+    seedLegacyInboxEvent({
+      date: legacyMatchDate,
+      id: 'legacy-inbox-match',
+      threadId: 'imap-thread-51',
+      uid: '51',
+    });
+    const legacyMatchPoll = await pollWorkspaceMailboxInboxEvents({
+      now: new Date(legacyMatchDate.getTime() + 1_000),
+      fetchMessages: async () => [{
+        id: legacyMatchId,
+        uid: '51',
+        uidValidity: '7001',
+        threadId: 'imap-thread-51',
+        date: legacyMatchDate.toISOString(),
+        folder: 'INBOX',
+        hasAttachments: false,
+      }],
+    });
+    assert.deepEqual(legacyMatchPoll, { checked: 1, created: 0, duplicate: 1, historical: 0, failed: 0 });
+    const migratedLegacy = sqlite.prepare(`
+      SELECT provider_message_id, metadata_json FROM email_inbox_events WHERE id = 'legacy-inbox-match'
+    `).get() as { metadata_json: string; provider_message_id: string };
+    assert.equal(migratedLegacy.provider_message_id, legacyMatchId);
+    assert.deepEqual(JSON.parse(migratedLegacy.metadata_json), {
+      folder: 'INBOX',
+      hasAttachments: false,
+      identityVersion: 1,
+      uid: '51',
+      uidValidity: '7001',
+    });
+
+    const reusedLegacyDate = new Date(Math.floor((pollNow.getTime() + 4_000) / 1_000) * 1_000);
+    const reusedCurrentDate = new Date(Math.floor((pollNow.getTime() + 5_000) / 1_000) * 1_000);
+    const reusedCanonicalId = createImapMessageReference('INBOX', '8002', 52);
+    seedLegacyInboxEvent({
+      date: reusedLegacyDate,
+      id: 'legacy-inbox-reused-uid',
+      threadId: 'old-imap-thread-52',
+      uid: '52',
+    });
+    const reusedUidPoll = await pollWorkspaceMailboxInboxEvents({
+      now: new Date(reusedCurrentDate.getTime() + 1_000),
+      fetchMessages: async () => [{
+        id: reusedCanonicalId,
+        uid: '52',
+        uidValidity: '8002',
+        threadId: 'new-imap-thread-52',
+        date: reusedCurrentDate.toISOString(),
+        folder: 'INBOX',
+        hasAttachments: false,
+      }],
+    });
+    assert.deepEqual(reusedUidPoll, { checked: 1, created: 1, duplicate: 0, historical: 0, failed: 0 });
+    const reusedRows = sqlite.prepare(`
+      SELECT provider_message_id FROM email_inbox_events
+      WHERE id = 'legacy-inbox-reused-uid' OR provider_message_id = ?
+      ORDER BY provider_message_id
+    `).all(reusedCanonicalId) as Array<{ provider_message_id: string }>;
+    assert.deepEqual(reusedRows.map((row) => row.provider_message_id).sort(), ['52', reusedCanonicalId].sort());
+    sqlite.prepare(`
+      UPDATE email_inbox_events SET status = 'processed', processed_at = ? WHERE provider_message_id = ?
+    `).run(Math.floor(reusedCurrentDate.getTime() / 1_000), reusedCanonicalId);
+
     const activeMailbox = sqlite.prepare(`
       SELECT id, workspace_id, status, created_by_user_id, last_edited_by_user_id
       FROM workspace_email_mailboxes

--- a/scripts/email-accounts-service-test.ts
+++ b/scripts/email-accounts-service-test.ts
@@ -97,7 +97,7 @@ async function main() {
   const { getManagedEmailUserId } = await import('../app/lib/email/managed-client');
   const { emailAccountSecretRef, readEmailAccountSecret, writeEmailAccountSecret } = await import('../app/lib/email/secret-store');
   const { setSmtpTransportFactoryForTests } = await import('../app/lib/email/smtp-service');
-  const { setImapClientFactoryForTests } = await import('../app/lib/email/imap-service');
+  const { parseImapMessageReference, setImapClientFactoryForTests } = await import('../app/lib/email/imap-service');
 
   await insertUser('owner-user', 'owner@example.test');
   await writeLegacyAccounts([legacyAccount()]);
@@ -408,6 +408,7 @@ async function main() {
     }],
   ]);
   setImapClientFactoryForTests(() => ({
+    mailbox: { uidValidity: BigInt(77) },
     connect: async () => {
       imapConnectCalls += 1;
     },
@@ -544,7 +545,12 @@ async function main() {
   assert.equal((searchResult as { account?: { id?: string } }).account?.id, smtpImapAccount.id);
   const searchMessages = (searchResult as { messages?: Array<{ id: string; from: string; snippet: string }> }).messages || [];
   assert.equal(searchMessages.length, 1);
-  assert.equal(searchMessages[0].id, '1002');
+  assert.deepEqual(parseImapMessageReference(searchMessages[0].id), {
+    version: 1,
+    folder: 'INBOX',
+    uidValidity: '77',
+    uid: 1002,
+  });
   assert.match(searchMessages[0].from, /allowed@example\.test/u);
   assert.match(searchMessages[0].snippet, /Allowed body text/u);
   assert.equal(imapReleaseCalls, 1);

--- a/scripts/email-cache-consistency-test.ts
+++ b/scripts/email-cache-consistency-test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+
+import {
+  invalidateEmailMailboxCache,
+  purgeEmailMailboxCache,
+  reactivateEmailMailboxCache,
+  runLocalEmailMailboxMutation,
+  setEmailCacheConsistencyStoreFactoryForTests,
+} from '../app/lib/email/cache/consistency';
+import type { EmailCacheStore } from '../app/lib/email/cache/store';
+
+type CacheCall = {
+  operation: 'bump' | 'purge' | 'reactivate';
+  userId: string;
+  accountId: string;
+  accountSource?: 'local' | 'managed';
+};
+
+type CacheMailboxInput = {
+  userId: string;
+  accountId: string;
+  accountSource?: 'local' | 'managed';
+  now?: number;
+};
+
+function cacheStore(calls: CacheCall[], options?: { failBump?: boolean }): EmailCacheStore {
+  return {
+    enabled: true,
+    async bumpMailboxGeneration(input: CacheMailboxInput) {
+      calls.push({ operation: 'bump', ...input });
+      if (options?.failBump) throw new Error('cache unavailable');
+      return 2;
+    },
+    async purgeAccount(input: CacheMailboxInput) {
+      calls.push({ operation: 'purge', ...input });
+      return { enabled: true, tombstoned: true, generation: 2, deletedLists: 1, deletedMessages: 1 };
+    },
+    async reactivateAccount(input: CacheMailboxInput) {
+      calls.push({ operation: 'reactivate', ...input });
+      return 3;
+    },
+  } as unknown as EmailCacheStore;
+}
+
+async function main() {
+  const calls: CacheCall[] = [];
+  const providerOrder: string[] = [];
+  setEmailCacheConsistencyStoreFactoryForTests(async () => cacheStore(calls));
+
+  const result = await runLocalEmailMailboxMutation(
+    { userId: 'user-1', accountId: 'local-1' },
+    async () => {
+      providerOrder.push('provider');
+      assert.equal(calls.length, 0);
+      return { ok: true };
+    },
+  );
+  providerOrder.push('returned');
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(providerOrder, ['provider', 'returned']);
+  assert.deepEqual(calls, [{ operation: 'bump', userId: 'user-1', accountId: 'local-1', accountSource: 'local' }]);
+
+  calls.length = 0;
+  const providerError = new Error('provider failed');
+  await assert.rejects(
+    runLocalEmailMailboxMutation(
+      { userId: 'user-1', accountId: 'local-1' },
+      async () => { throw providerError; },
+    ),
+    (error) => error === providerError,
+  );
+  assert.deepEqual(calls, []);
+
+  calls.length = 0;
+  const mailboxChanged = Object.assign(new Error('The IMAP mailbox changed.'), {
+    code: 'EMAIL_MAILBOX_CHANGED',
+    status: 409,
+  });
+  await assert.rejects(
+    runLocalEmailMailboxMutation(
+      { userId: 'user-1', accountId: 'imap-1' },
+      async () => { throw mailboxChanged; },
+    ),
+    (error) => error === mailboxChanged,
+  );
+  assert.deepEqual(calls, [{ operation: 'bump', userId: 'user-1', accountId: 'imap-1', accountSource: 'local' }]);
+
+  calls.length = 0;
+  const originalWarn = console.warn;
+  console.warn = () => undefined;
+  try {
+    setEmailCacheConsistencyStoreFactoryForTests(async () => cacheStore(calls, { failBump: true }));
+    const successDespiteCacheFailure = await runLocalEmailMailboxMutation(
+      { userId: 'user-1', accountId: 'local-1' },
+      async () => 'provider-success',
+    );
+    assert.equal(successDespiteCacheFailure, 'provider-success');
+    await assert.rejects(
+      runLocalEmailMailboxMutation(
+        { userId: 'user-1', accountId: 'imap-1' },
+        async () => { throw mailboxChanged; },
+      ),
+      (error) => error === mailboxChanged,
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  const failingLifecycleStore = {
+    enabled: true,
+    async purgeAccount() { throw new Error('purge unavailable'); },
+    async reactivateAccount() { throw new Error('reactivation unavailable'); },
+  } as unknown as EmailCacheStore;
+  console.warn = () => undefined;
+  try {
+    setEmailCacheConsistencyStoreFactoryForTests(async () => failingLifecycleStore);
+    await purgeEmailMailboxCache({ userId: 'user-1', accountId: 'local-1', accountSource: 'local' });
+    await reactivateEmailMailboxCache({ userId: 'user-1', accountId: 'local-1', accountSource: 'local' });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  calls.length = 0;
+  setEmailCacheConsistencyStoreFactoryForTests(async () => cacheStore(calls));
+  await invalidateEmailMailboxCache({ userId: 'user-1', accountId: 'local-1', accountSource: 'local' });
+  await purgeEmailMailboxCache({ userId: 'user-1', accountId: 'shared-id', accountSource: 'managed' });
+  await reactivateEmailMailboxCache({ userId: 'user-1', accountId: 'shared-id', accountSource: 'local' });
+  assert.deepEqual(calls, [
+    { operation: 'bump', userId: 'user-1', accountId: 'local-1', accountSource: 'local' },
+    { operation: 'purge', userId: 'user-1', accountId: 'shared-id', accountSource: 'managed' },
+    { operation: 'reactivate', userId: 'user-1', accountId: 'shared-id', accountSource: 'local' },
+  ]);
+
+  setEmailCacheConsistencyStoreFactoryForTests(null);
+  console.log('email-cache-consistency-test: ok');
+}
+
+main().catch((error) => {
+  setEmailCacheConsistencyStoreFactoryForTests(null);
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/email-cache-oauth-reconnect-test.ts
+++ b/scripts/email-cache-oauth-reconnect-test.ts
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Module from 'node:module';
+
+import type { EmailCacheStore } from '../app/lib/email/cache/store';
+
+type LoadFn = (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+
+const moduleInternals = Module as typeof Module & { _load: LoadFn };
+const originalLoad = moduleInternals._load;
+
+moduleInternals._load = function loadWithEmailMocks(request, parent, isMain) {
+  if (request === 'server-only') return {};
+  if (request === '@earendil-works/pi-ai' || request === '@earendil-works/pi-ai/compat') {
+    return {
+      completeSimple: async () => { throw new Error('Unexpected AI call.'); },
+      getModels: () => [],
+      getProviders: () => [],
+      isContextOverflow: () => false,
+      registerBuiltInApiProviders: () => undefined,
+      streamSimple: async function* () { throw new Error('Unexpected AI call.'); },
+    };
+  }
+  if (request === '@earendil-works/pi-ai/oauth') return {};
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+async function main() {
+  const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-email-cache-oauth-'));
+  const integrationsPath = path.join(dataRoot, 'secrets', 'Canvas-Integrations.env');
+  const originalFetch = global.fetch;
+  process.env.DATA = dataRoot;
+  process.env.CANVAS_DATA_ROOT = dataRoot;
+  process.env.INTEGRATIONS_ENV_PATH = integrationsPath;
+  process.env.CANVAS_MCP_DIRECT_ENABLED = 'false';
+  process.env.BETTER_AUTH_BASE_URL = 'https://canvas.example.test';
+  await fs.mkdir(path.dirname(integrationsPath), { recursive: true });
+  await fs.writeFile(
+    integrationsPath,
+    'GOOGLE_OAUTH_CLIENT_ID=client-id\nGOOGLE_OAUTH_CLIENT_SECRET=client-secret\n',
+    'utf8',
+  );
+
+  try {
+    const cacheCalls: Array<{ operation: string; accountId: string; accountSource?: string }> = [];
+    const cacheStore = {
+      enabled: true,
+      async purgeAccount(input: { accountId: string; accountSource?: string }) {
+        cacheCalls.push({ operation: 'purge', accountId: input.accountId, accountSource: input.accountSource });
+        return { enabled: true, tombstoned: true, generation: 2, deletedLists: 0, deletedMessages: 0 };
+      },
+      async reactivateAccount(input: { accountId: string; accountSource?: string }) {
+        cacheCalls.push({ operation: 'reactivate', accountId: input.accountId, accountSource: input.accountSource });
+        return 3;
+      },
+    } as unknown as EmailCacheStore;
+    const { setEmailCacheConsistencyStoreFactoryForTests } = await import('../app/lib/email/cache/consistency');
+    setEmailCacheConsistencyStoreFactoryForTests(async () => cacheStore);
+
+    const { db } = await import('../app/lib/db');
+    const { user } = await import('../app/lib/db/schema');
+    const { upsertOAuthEmailAccount } = await import('../app/lib/email/account-store');
+    const { completeLocalEmailOAuth } = await import('../app/lib/email/local-service');
+    const { disconnectEmailAccount, startEmailOAuth } = await import('../app/lib/email/service');
+    const now = new Date();
+    await db.insert(user).values({
+      id: 'user-1',
+      name: 'User One',
+      email: 'owner@example.test',
+      emailVerified: true,
+      image: null,
+      role: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const initialAccount = await upsertOAuthEmailAccount({
+      userId: 'user-1',
+      provider: 'google',
+      providerAccountId: 'google-user-1',
+      emailAddress: 'owner@example.test',
+      secret: {
+        authType: 'oauth',
+        tokenType: 'Bearer',
+        accessToken: 'old-access-token',
+        refreshToken: 'old-refresh-token',
+        scope: 'email profile',
+      },
+    });
+
+    await disconnectEmailAccount('user-1', initialAccount.id);
+    assert.deepEqual(cacheCalls, [
+      { operation: 'purge', accountId: initialAccount.id, accountSource: 'local' },
+    ]);
+
+    const oauthStart = await startEmailOAuth('user-1', {
+      provider: 'google',
+      requestOrigin: 'https://canvas.example.test',
+    });
+    const state = new URL(oauthStart.authorizationUrl).searchParams.get('state');
+    assert.ok(state);
+
+    global.fetch = async (input) => {
+      const url = String(input);
+      if (url === 'https://oauth2.googleapis.com/token') {
+        return new Response(JSON.stringify({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          token_type: 'Bearer',
+          scope: 'email profile',
+          expires_in: 3600,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url === 'https://openidconnect.googleapis.com/v1/userinfo') {
+        return new Response(JSON.stringify({
+          sub: 'google-user-1',
+          email: 'owner@example.test',
+          name: 'Owner',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    const completed = await completeLocalEmailOAuth('user-1', 'authorization-code', state);
+    assert.equal(completed.account.id, initialAccount.id);
+    assert.deepEqual(cacheCalls, [
+      { operation: 'purge', accountId: initialAccount.id, accountSource: 'local' },
+      { operation: 'reactivate', accountId: initialAccount.id, accountSource: 'local' },
+    ]);
+
+    setEmailCacheConsistencyStoreFactoryForTests(null);
+    console.log('email-cache-oauth-reconnect-test: ok');
+  } finally {
+    global.fetch = originalFetch;
+    moduleInternals._load = originalLoad;
+    await fs.rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  moduleInternals._load = originalLoad;
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/email-cache-persistence-test.ts
+++ b/scripts/email-cache-persistence-test.ts
@@ -1,0 +1,574 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { PGlite } from '@electric-sql/pglite';
+
+import { runEmailCachePostgresMigration } from '../app/lib/email/cache/postgres-migration';
+import {
+  createEmailCacheStore,
+  getRuntimeEmailCacheStore,
+  normalizeEmailListCacheScope,
+  normalizeEmailMessageRef,
+  PostgresEmailCacheStore,
+} from '../app/lib/email/cache/store';
+
+async function installBaseEmailSchema(postgres: PGlite): Promise<void> {
+  await postgres.exec(`
+    CREATE TABLE "user" (
+      id text PRIMARY KEY
+    );
+    CREATE TABLE email_accounts (
+      id text PRIMARY KEY,
+      user_id text NOT NULL REFERENCES "user"(id) ON DELETE CASCADE
+    );
+    INSERT INTO "user" (id) VALUES ('user-1'), ('user-2');
+    INSERT INTO email_accounts (id, user_id)
+    VALUES ('account-1', 'user-1'), ('account-2', 'user-2');
+  `);
+}
+
+async function testMigration(postgres: PGlite): Promise<void> {
+  await runEmailCachePostgresMigration(postgres as never);
+  await runEmailCachePostgresMigration(postgres as never);
+
+  const columns = await postgres.query<{
+    table_name: string;
+    column_name: string;
+    data_type: string;
+  }>(`
+    SELECT table_name, column_name, data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name IN ('email_cache_mailboxes', 'email_cache_lists', 'email_cache_messages')
+    ORDER BY table_name, ordinal_position
+  `);
+  assert.equal(new Set(columns.rows.map((row) => row.table_name)).size, 3);
+  assert.equal(
+    columns.rows.find((row) => row.table_name === 'email_cache_lists' && row.column_name === 'refs_json')?.data_type,
+    'jsonb',
+  );
+  assert.equal(
+    columns.rows.find((row) => row.table_name === 'email_cache_messages' && row.column_name === 'detail_json')?.data_type,
+    'jsonb',
+  );
+
+  const indexes = await postgres.query<{ indexname: string }>(`
+    SELECT indexname FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename IN ('email_cache_mailboxes', 'email_cache_lists', 'email_cache_messages')
+  `);
+  assert.ok(indexes.rows.some((row) => row.indexname === 'idx_email_cache_lists_refresh_lease'));
+  assert.ok(indexes.rows.some((row) => row.indexname === 'idx_email_cache_messages_account_lru'));
+
+  // Managed accounts live in the Control Plane and therefore intentionally do
+  // not need a local email_accounts row. The email service must authorize this
+  // (user, source, account) tuple before it calls the cache.
+  await postgres.exec(`
+    INSERT INTO email_cache_mailboxes (
+      user_id, account_source, account_id, generation, last_accessed_at, created_at, updated_at
+    ) VALUES ('user-1', 'managed', 'managed-account-1', 1, 1, 1, 1)
+  `);
+  await assert.rejects(
+    postgres.exec(`
+      INSERT INTO email_cache_mailboxes (
+        user_id, account_source, account_id, generation, last_accessed_at, created_at, updated_at
+      ) VALUES ('missing-user', 'managed', 'managed-account-2', 1, 1, 1, 1)
+    `),
+  );
+
+  const postgresMigrationSource = await readFile(
+    path.join(process.cwd(), 'app', 'lib', 'db', 'postgres.ts'),
+    'utf8',
+  );
+  assert.match(postgresMigrationSource, /await runEmailCachePostgresMigration\(pool\)/u);
+  const databaseIndexSource = await readFile(
+    path.join(process.cwd(), 'app', 'lib', 'db', 'index.ts'),
+    'utf8',
+  );
+  assert.match(databaseIndexSource, /function getPostgresRuntimeQueryable/u);
+  assert.doesNotMatch(databaseIndexSource, /getPostgresRuntimeQueryable[\s\S]{0,300}createPostgresPool\(/u);
+}
+
+async function testNormalizedKeys(): Promise<void> {
+  const first = normalizeEmailListCacheScope({
+    userId: 'user-1',
+    accountId: 'account-1',
+    folder: 'INBOX',
+    filter: { unread: true, labels: ['important'] },
+    query: '  quarterly report  ',
+    offset: 0,
+    limit: 25,
+  });
+  const reordered = normalizeEmailListCacheScope({
+    userId: 'user-1',
+    accountId: 'account-1',
+    folder: 'INBOX',
+    filter: { labels: ['important'], unread: true },
+    query: 'quarterly report',
+    offset: 0,
+    limit: 25,
+  });
+  const nextPage = normalizeEmailListCacheScope({
+    ...reordered,
+    offset: 25,
+  });
+  assert.equal(first.cacheKey, reordered.cacheKey);
+  assert.notEqual(first.cacheKey, nextPage.cacheKey);
+
+  const imap = normalizeEmailMessageRef({
+    provider: 'imap',
+    folder: 'INBOX',
+    uidValidity: 42,
+    uid: 7,
+    messageId: 'imap:v1:inbox:42:7',
+  });
+  assert.notEqual(imap.messageKey, normalizeEmailMessageRef({
+    provider: 'imap',
+    folder: 'INBOX',
+    uidValidity: 43,
+    uid: 7,
+    messageId: 'imap:v1:inbox:43:7',
+  }).messageKey);
+  assert.notEqual(imap.messageKey, normalizeEmailMessageRef({
+    provider: 'imap',
+    folder: 'Archive',
+    uidValidity: 42,
+    uid: 7,
+    messageId: 'imap:v1:archive:42:7',
+  }).messageKey);
+  assert.equal(normalizeEmailMessageRef({
+    provider: 'smtp_imap',
+    folder: 'INBOX',
+    uidValidity: '42',
+    uid: 7,
+    messageId: 'imap:v1:inbox:42:7',
+  }).provider, 'imap');
+  assert.throws(() => normalizeEmailMessageRef({
+    provider: 'imap',
+    folder: 'INBOX',
+    uidValidity: '0',
+    uid: 7,
+    messageId: 'imap:v1:inbox:0:7',
+  }));
+  assert.throws(() => normalizeEmailMessageRef({
+    provider: 'imap',
+    folder: 'INBOX',
+    uidValidity: '42',
+    uid: 7,
+    messageId: '7',
+  }));
+}
+
+async function testPostgresStore(postgres: PGlite): Promise<void> {
+  const store = new PostgresEmailCacheStore(postgres as never);
+  const competingStore = new PostgresEmailCacheStore(postgres as never);
+  const scope = {
+    userId: 'user-1',
+    accountId: 'account-1',
+    folder: 'INBOX',
+    filter: { unread: true },
+    query: '',
+    offset: 0,
+    limit: 25,
+  } as const;
+  const ref = { provider: 'gmail', messageId: 'message-1', folder: 'INBOX' } as const;
+
+  assert.equal((await store.getList({ ...scope, now: 1_000 })).state, 'miss');
+  const firstLease = await store.acquireListRefreshLease({
+    ...scope,
+    owner: 'worker-a',
+    leaseMs: 1_000,
+    now: 1_000,
+  });
+  assert.deepEqual(firstLease, {
+    enabled: true,
+    acquired: true,
+    generation: 1,
+    leaseUntil: 2_000,
+  });
+  assert.deepEqual(await competingStore.acquireListRefreshLease({
+    ...scope,
+    owner: 'worker-b',
+    leaseMs: 1_000,
+    now: 1_001,
+  }), {
+    enabled: true,
+    acquired: false,
+    generation: 1,
+    leaseUntil: 2_000,
+  });
+
+  assert.equal((await store.putList({
+    ...scope,
+    refs: [ref],
+    totalCount: 1,
+    expectedGeneration: 1,
+    leaseOwner: 'worker-a',
+    freshForMs: 60,
+    retainForMs: 600,
+    now: 1_010,
+  })).stored, true);
+  const fresh = await store.getList({ ...scope, now: 1_020 });
+  assert.equal(fresh.state, 'fresh');
+  assert.equal(fresh.value?.totalCount, 1);
+  assert.equal(fresh.value?.refs[0].messageId, 'message-1');
+  assert.equal((await store.getList({ ...scope, now: 1_071 })).state, 'stale');
+  assert.equal((await store.getList({ ...scope, now: 1_611 })).state, 'miss');
+
+  assert.equal(await store.bumpMailboxGeneration({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    now: 2_000,
+  }), 2);
+  assert.equal((await store.putList({
+    ...scope,
+    refs: [],
+    totalCount: 0,
+    expectedGeneration: 1,
+    freshForMs: 60,
+    retainForMs: 600,
+    now: 2_001,
+  })).stored, false);
+  assert.equal((await store.getList({ ...scope, now: 2_002 })).state, 'miss');
+
+  const secondLease = await store.acquireListRefreshLease({
+    ...scope,
+    owner: 'worker-b',
+    leaseMs: 1_000,
+    now: 2_100,
+  });
+  assert.equal(secondLease.generation, 2);
+  assert.equal(secondLease.acquired, true);
+  assert.equal((await store.putList({
+    ...scope,
+    refs: [],
+    totalCount: 0,
+    expectedGeneration: 2,
+    leaseOwner: 'worker-b',
+    freshForMs: 60,
+    retainForMs: 600,
+    now: 2_101,
+  })).stored, true);
+  assert.deepEqual((await store.getList({ ...scope, now: 2_102 })).value?.refs, []);
+
+  const messageLease = await store.acquireMessageRefreshLease({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref,
+    owner: 'worker-a',
+    leaseMs: 1_000,
+    now: 3_000,
+  });
+  assert.equal(messageLease.acquired, true);
+  assert.deepEqual(await competingStore.acquireMessageRefreshLease({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref,
+    owner: 'worker-b',
+    leaseMs: 1_000,
+    now: 3_001,
+  }), {
+    enabled: true,
+    acquired: false,
+    generation: 2,
+    leaseUntil: 4_000,
+  });
+  assert.equal((await store.putMessage({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref,
+    metadata: {
+      from: 'sender@example.com',
+      subject: 'Cached subject',
+      date: '1970-01-01T00:00:02.900Z',
+      dateTimestamp: 2_900,
+      snippet: 'Cached preview',
+      isRead: false,
+      isAnswered: true,
+      isFlagged: true,
+      hasAttachments: true,
+      size: 1_024,
+      threadId: 'thread-1',
+      to: ['user@example.com'],
+      cc: ['copy@example.com'],
+      flags: ['\\Answered', '\\Flagged'],
+    },
+    expectedGeneration: 2,
+    leaseOwner: 'worker-a',
+    freshForMs: 60,
+    retainForMs: 600,
+    now: 3_010,
+  })).stored, true);
+  assert.equal((await store.getMessage({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref,
+    part: 'metadata',
+    now: 3_020,
+  })).state, 'fresh');
+  assert.equal((await store.getMessage({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref,
+    part: 'detail',
+    now: 3_020,
+  })).state, 'miss');
+
+  assert.equal((await store.putMessage({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref,
+    detail: {
+      body: 'Message body',
+      bodyHtml: '<p>Message body</p>',
+      to: ['user@example.com'],
+      cc: [],
+      messageId: '<message-1@example.com>',
+      inReplyTo: '<original@example.com>',
+      references: ['<original@example.com>'],
+      attachments: [{
+        id: 'attachment-1',
+        index: 0,
+        filename: 'invoice.pdf',
+        contentType: 'application/pdf',
+        size: 128,
+        ...({ contentBase64: 'must-not-be-persisted' } as Record<string, unknown>),
+      }],
+    },
+    expectedGeneration: 2,
+    freshForMs: 60,
+    retainForMs: 600,
+    now: 3_030,
+  })).stored, true);
+  const detail = await store.getMessage({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref,
+    part: 'detail',
+    now: 3_040,
+  });
+  assert.equal(detail.value?.detail?.body, 'Message body');
+  assert.equal(detail.value?.metadata?.threadId, 'thread-1');
+  assert.equal(detail.value?.metadata?.isAnswered, true);
+  assert.equal(detail.value?.metadata?.isFlagged, true);
+  assert.equal(detail.value?.metadata?.hasAttachments, true);
+  assert.deepEqual(detail.value?.detail?.attachments[0], {
+    id: 'attachment-1',
+    index: 0,
+    filename: 'invoice.pdf',
+    contentType: 'application/pdf',
+    size: 128,
+  });
+  assert.equal('contentBase64' in (detail.value?.detail?.attachments[0] || {}), false);
+
+  const secondRef = { provider: 'gmail', messageId: 'message-2', folder: 'INBOX' } as const;
+  assert.equal((await store.putMessage({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref: secondRef,
+    metadata: {
+      from: 'second@example.com',
+      subject: 'Second subject',
+      date: '1970-01-01T00:00:03.000Z',
+      dateTimestamp: 3_000,
+      snippet: 'Second preview',
+      isRead: true,
+      isAnswered: false,
+      isFlagged: false,
+      hasAttachments: false,
+      size: null,
+    },
+    expectedGeneration: 2,
+    freshForMs: 60,
+    retainForMs: 600,
+    now: 3_050,
+  })).stored, true);
+  let batchQueryCount = 0;
+  const batchStore = new PostgresEmailCacheStore({
+    query: async (...args: Parameters<PGlite['query']>) => {
+      batchQueryCount += 1;
+      return postgres.query(...args);
+    },
+  } as never);
+  const batch = await batchStore.getMessages({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    refs: [secondRef, ref],
+    part: 'metadata',
+    now: 3_051,
+  });
+  assert.equal(batchQueryCount, 1);
+  assert.deepEqual(
+    new Map(batch.map((entry) => [entry.messageKey, entry.value?.metadata?.subject])),
+    new Map([
+      [normalizeEmailMessageRef(ref).messageKey, 'Cached subject'],
+      [normalizeEmailMessageRef(secondRef).messageKey, 'Second subject'],
+    ]),
+  );
+
+  // Add two more exact list scopes, then prove per-account LRU cleanup is both
+  // capacity-bound and delete-bound.
+  for (let offset = 25; offset <= 50; offset += 25) {
+    const pageScope = { ...scope, offset };
+    const lease = await store.acquireListRefreshLease({
+      ...pageScope,
+      owner: `cleanup-${offset}`,
+      leaseMs: 100,
+      now: 4_000 + offset,
+    });
+    assert.equal((await store.putList({
+      ...pageScope,
+      refs: [],
+      expectedGeneration: lease.generation!,
+      leaseOwner: `cleanup-${offset}`,
+      freshForMs: 60,
+      retainForMs: 600,
+      now: 4_001 + offset,
+    })).stored, true);
+  }
+  const firstCleanup = await store.cleanup({
+    now: 4_100,
+    maxListsPerAccount: 1,
+    maxMessagesPerAccount: 10,
+    maxDeletesPerTable: 1,
+  });
+  assert.equal(firstCleanup.deletedLists, 1);
+  const listCount = await postgres.query<{ count: string }>(
+    'SELECT COUNT(*)::text AS count FROM email_cache_lists',
+  );
+  assert.equal(listCount.rows[0].count, '2');
+
+  const purge = await store.purgeAccount({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    now: 5_000,
+  });
+  assert.deepEqual(purge, {
+    enabled: true,
+    tombstoned: true,
+    generation: 3,
+    deletedLists: 2,
+    deletedMessages: 1,
+  });
+  const remaining = await postgres.query<{ list_count: string; message_count: string }>(`
+    SELECT
+      (SELECT COUNT(*) FROM email_cache_lists)::text AS list_count,
+      (SELECT COUNT(*) FROM email_cache_messages)::text AS message_count
+  `);
+  assert.deepEqual(remaining.rows[0], { list_count: '0', message_count: '0' });
+
+  // A provider refresh that started before disconnect cannot recreate data or
+  // acquire a new lease while the tombstone is active.
+  assert.equal((await store.putList({
+    ...scope,
+    refs: [],
+    expectedGeneration: 2,
+    freshForMs: 60,
+    retainForMs: 600,
+    now: 5_001,
+  })).stored, false);
+  assert.deepEqual(await store.acquireListRefreshLease({
+    ...scope,
+    owner: 'late-worker',
+    leaseMs: 1_000,
+    now: 5_002,
+  }), {
+    enabled: true,
+    acquired: false,
+    generation: null,
+    leaseUntil: null,
+  });
+  assert.equal(await store.getMailboxGeneration({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    now: 5_003,
+  }), null);
+
+  // Managed and local account namespaces are independent even when the account
+  // identifier is not backed by local email_accounts.
+  assert.equal(await store.getMailboxGeneration({
+    userId: 'user-1',
+    accountSource: 'managed',
+    accountId: 'managed-account-1',
+    now: 5_004,
+  }), 1);
+
+  assert.equal(await store.reactivateAccount({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    now: 6_000,
+  }), 4);
+  const reactivatedLease = await store.acquireListRefreshLease({
+    ...scope,
+    owner: 'reconnected-worker',
+    leaseMs: 1_000,
+    now: 6_001,
+  });
+  assert.equal(reactivatedLease.generation, 4);
+  assert.equal(reactivatedLease.acquired, true);
+  assert.equal((await store.putList({
+    ...scope,
+    refs: [],
+    expectedGeneration: 4,
+    leaseOwner: 'reconnected-worker',
+    freshForMs: 60,
+    retainForMs: 600,
+    now: 6_002,
+  })).stored, true);
+}
+
+async function testSqliteBypass(): Promise<void> {
+  const store = createEmailCacheStore({ provider: 'sqlite' });
+  assert.equal(store.enabled, false);
+  assert.deepEqual(await store.getList({
+    userId: 'user-1',
+    accountId: 'account-1',
+    folder: 'INBOX',
+    limit: 25,
+  }), {
+    state: 'miss',
+    enabled: false,
+    generation: null,
+    fetchedAt: null,
+    staleAt: null,
+    expiresAt: null,
+    value: null,
+  });
+  assert.deepEqual(await store.putList({
+    userId: 'user-1',
+    accountId: 'account-1',
+    folder: 'INBOX',
+    limit: 25,
+    refs: [],
+    expectedGeneration: 1,
+  }), { enabled: false, stored: false, reason: 'disabled' });
+
+  const previousProvider = process.env.CANVAS_DATABASE_PROVIDER;
+  process.env.CANVAS_DATABASE_PROVIDER = 'sqlite';
+  try {
+    assert.equal((await getRuntimeEmailCacheStore()).enabled, false);
+  } finally {
+    if (previousProvider === undefined) delete process.env.CANVAS_DATABASE_PROVIDER;
+    else process.env.CANVAS_DATABASE_PROVIDER = previousProvider;
+  }
+}
+
+async function main(): Promise<void> {
+  await testNormalizedKeys();
+  await testSqliteBypass();
+  const postgres = new PGlite();
+  try {
+    await installBaseEmailSchema(postgres);
+    await testMigration(postgres);
+    await testPostgresStore(postgres);
+  } finally {
+    await postgres.close();
+  }
+  console.log('email-cache-persistence-test: ok');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/email-cache-persistence-test.ts
+++ b/scripts/email-cache-persistence-test.ts
@@ -407,6 +407,144 @@ async function testPostgresStore(postgres: PGlite): Promise<void> {
     ]),
   );
 
+  const heldDetailLease = await store.acquireMessageRefreshLease({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref,
+    owner: 'detail-worker',
+    leaseMs: 1_000,
+    now: 3_060,
+  });
+  assert.equal(heldDetailLease.acquired, true);
+  const thirdRef = { provider: 'gmail', messageId: 'message-3', folder: 'INBOX' } as const;
+  const fourthRef = { provider: 'gmail', messageId: 'message-4', folder: 'INBOX' } as const;
+  batchQueryCount = 0;
+  const batchWrite = await batchStore.putMessages({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    expectedGeneration: 2,
+    freshForMs: 60,
+    retainForMs: 10_000,
+    now: 3_061,
+    messages: [{
+      // This unleased list-metadata update must not clear the detail lease.
+      ref,
+      metadata: {
+        from: 'sender@example.com',
+        subject: 'Updated cached subject',
+        date: '1970-01-01T00:00:03.061Z',
+        dateTimestamp: 3_061,
+        snippet: 'Updated cached preview',
+        isRead: true,
+        isAnswered: true,
+        isFlagged: true,
+        hasAttachments: true,
+        size: 1_024,
+      },
+    }, {
+      ref: thirdRef,
+      detail: {
+        body: 'Third body',
+        bodyHtml: '<p>Third body</p>',
+        to: ['user@example.com'],
+        cc: [],
+        attachments: [{
+          index: 0,
+          filename: 'third.pdf',
+          contentType: 'application/pdf',
+          size: 256,
+          ...({ contentBase64: 'batch-must-not-persist' } as Record<string, unknown>),
+        }],
+      },
+    }, {
+      ref: fourthRef,
+      metadata: {
+        from: 'fourth@example.com',
+        subject: 'Fourth subject',
+        date: '1970-01-01T00:00:03.061Z',
+        dateTimestamp: 3_061,
+        snippet: 'Fourth preview',
+        isRead: false,
+        isAnswered: false,
+        isFlagged: false,
+        hasAttachments: false,
+        size: null,
+      },
+    }],
+  });
+  assert.equal(batchQueryCount, 1);
+  assert.equal(batchWrite.reason, 'stored');
+  assert.equal(batchWrite.storedCount, 3);
+  assert.equal(batchWrite.rejectedMessageKeys.length, 0);
+  const persistedLease = await postgres.query<{
+    refresh_owner: string | null;
+    refresh_lease_until: string | number | null;
+  }>(`
+    SELECT refresh_owner, refresh_lease_until
+    FROM email_cache_messages
+    WHERE user_id = 'user-1' AND account_source = 'local' AND account_id = 'account-1'
+      AND message_key = $1
+  `, [normalizeEmailMessageRef(ref).messageKey]);
+  assert.equal(persistedLease.rows[0].refresh_owner, 'detail-worker');
+  assert.equal(Number(persistedLease.rows[0].refresh_lease_until), 4_060);
+  const batchDetail = await store.getMessage({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    ref: thirdRef,
+    part: 'detail',
+    now: 3_062,
+  });
+  assert.equal(batchDetail.value?.detail?.body, 'Third body');
+  assert.equal('contentBase64' in (batchDetail.value?.detail?.attachments[0] || {}), false);
+
+  batchQueryCount = 0;
+  const wrongGenerationBatch = await batchStore.putMessages({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    expectedGeneration: 1,
+    now: 3_063,
+    messages: [{
+      ref: fourthRef,
+      metadata: {
+        from: 'ignored@example.com',
+        subject: 'Must not publish',
+        date: '',
+        dateTimestamp: null,
+        snippet: '',
+        isRead: false,
+        isAnswered: false,
+        isFlagged: false,
+        hasAttachments: false,
+        size: null,
+      },
+    }],
+  });
+  assert.equal(batchQueryCount, 1);
+  assert.equal(wrongGenerationBatch.reason, 'generation_changed_or_tombstoned');
+  assert.equal(wrongGenerationBatch.storedCount, 0);
+  batchQueryCount = 0;
+  await assert.rejects(batchStore.putMessages({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    expectedGeneration: 2,
+    messages: Array.from({ length: 51 }, (_, index) => ({
+      ref: { provider: 'gmail', messageId: `overflow-${index}`, folder: 'INBOX' },
+      metadata: {
+        from: 'overflow@example.com',
+        subject: '',
+        date: '',
+        dateTimestamp: null,
+        snippet: '',
+        isRead: false,
+        isAnswered: false,
+        isFlagged: false,
+        hasAttachments: false,
+        size: null,
+      },
+    })),
+  }));
+  assert.equal(batchQueryCount, 0);
+
   // Add two more exact list scopes, then prove per-account LRU cleanup is both
   // capacity-bound and delete-bound.
   for (let offset = 25; offset <= 50; offset += 25) {
@@ -449,7 +587,7 @@ async function testPostgresStore(postgres: PGlite): Promise<void> {
     tombstoned: true,
     generation: 3,
     deletedLists: 2,
-    deletedMessages: 1,
+    deletedMessages: 3,
   });
   const remaining = await postgres.query<{ list_count: string; message_count: string }>(`
     SELECT
@@ -468,6 +606,29 @@ async function testPostgresStore(postgres: PGlite): Promise<void> {
     retainForMs: 600,
     now: 5_001,
   })).stored, false);
+  const tombstonedBatch = await store.putMessages({
+    userId: scope.userId,
+    accountId: scope.accountId,
+    expectedGeneration: 2,
+    now: 5_001,
+    messages: [{
+      ref: fourthRef,
+      metadata: {
+        from: 'ignored@example.com',
+        subject: 'Must remain purged',
+        date: '',
+        dateTimestamp: null,
+        snippet: '',
+        isRead: false,
+        isAnswered: false,
+        isFlagged: false,
+        hasAttachments: false,
+        size: null,
+      },
+    }],
+  });
+  assert.equal(tombstonedBatch.reason, 'generation_changed_or_tombstoned');
+  assert.equal(tombstonedBatch.storedCount, 0);
   assert.deepEqual(await store.acquireListRefreshLease({
     ...scope,
     owner: 'late-worker',

--- a/scripts/email-cache-read-through-test.ts
+++ b/scripts/email-cache-read-through-test.ts
@@ -1,0 +1,391 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import {
+  readThroughEmailDetail,
+  readThroughEmailList,
+} from '../app/lib/email/cache/read-through';
+import {
+  normalizeEmailMessageRef,
+  type EmailCachedMessageDetail,
+  type EmailCachedMessageMetadata,
+  type EmailCacheReadResult,
+  type EmailCacheStore,
+  type EmailMessageRefInput,
+} from '../app/lib/email/cache/store';
+import { createImapMessageReference } from '../app/lib/email/imap-service';
+
+const googleRef: EmailMessageRefInput = { provider: 'google', messageId: 'g-1', folder: 'INBOX' };
+const normalizedGoogleRef = normalizeEmailMessageRef(googleRef);
+
+function metadata(subject = 'Cached subject'): EmailCachedMessageMetadata {
+  return {
+    from: 'sender@example.test',
+    subject,
+    date: '2026-09-08T10:00:00.000Z',
+    dateTimestamp: Date.parse('2026-09-08T10:00:00.000Z'),
+    snippet: 'Cached snippet',
+    isRead: false,
+    isAnswered: false,
+    isFlagged: false,
+    hasAttachments: false,
+    size: null,
+    to: ['owner@example.test'],
+    cc: [],
+    threadId: 'thread-1',
+    flags: [],
+  };
+}
+
+function detail(): EmailCachedMessageDetail {
+  return {
+    body: 'Cached body',
+    bodyHtml: '<p>Cached body</p>',
+    to: ['owner@example.test'],
+    cc: [],
+    messageId: '<g-1@example.test>',
+    inReplyTo: '',
+    references: [],
+    attachments: [{ index: 0, filename: 'brief.pdf', contentType: 'application/pdf', size: 123 }],
+  };
+}
+
+function readResult<T>(value: T | null, state: 'fresh' | 'stale' | 'miss' = value ? 'fresh' : 'miss'): EmailCacheReadResult<T> {
+  return {
+    enabled: true,
+    state,
+    generation: value ? 1 : null,
+    fetchedAt: value ? 100 : null,
+    staleAt: value ? 200 : null,
+    expiresAt: value ? 10_000 : null,
+    value,
+  };
+}
+
+type FakeOverrides = Partial<EmailCacheStore>;
+
+function fakeStore(overrides: FakeOverrides = {}): EmailCacheStore {
+  const store: EmailCacheStore = {
+    enabled: true,
+    async getMailboxGeneration() { return 1; },
+    async bumpMailboxGeneration() { return 2; },
+    async reactivateAccount() { return 1; },
+    async getList() { return readResult(null); },
+    async acquireListRefreshLease() { return { enabled: true, acquired: true, generation: 1, leaseUntil: 15_000 }; },
+    async putList() { return { enabled: true, stored: true, reason: 'stored' }; },
+    async releaseListRefreshLease() { return true; },
+    async getMessage() { return readResult(null); },
+    async getMessages() { return []; },
+    async acquireMessageRefreshLease() { return { enabled: true, acquired: true, generation: 1, leaseUntil: 20_000 }; },
+    async putMessage() { return { enabled: true, stored: true, reason: 'stored' }; },
+    async putMessages(input) {
+      const keys = input.messages.map((message) => normalizeEmailMessageRef(message.ref).messageKey);
+      return {
+        enabled: true,
+        requestedCount: keys.length,
+        storedCount: keys.length,
+        storedMessageKeys: keys,
+        rejectedMessageKeys: [],
+        reason: 'stored',
+      };
+    },
+    async releaseMessageRefreshLease() { return true; },
+    async purgeAccount() {
+      return { enabled: true, tombstoned: true, generation: 2, deletedLists: 0, deletedMessages: 0 };
+    },
+    async cleanup() { return { enabled: true, skipped: false, deletedLists: 0, deletedMessages: 0 }; },
+    async maybeCleanup() { return { enabled: true, skipped: true, deletedLists: 0, deletedMessages: 0 }; },
+  };
+  return Object.assign(store, overrides);
+}
+
+const localMailbox = {
+  userId: 'owner-user',
+  accountId: 'local-google',
+  accountSource: 'local' as const,
+  provider: 'google',
+};
+
+const listScope = {
+  folder: 'INBOX',
+  filter: { filter: 'all', from: '', hasAttachments: false },
+  query: '',
+  offset: 0,
+  limit: 10,
+};
+
+function cachedListStore(state: 'fresh' | 'stale' = 'fresh', overrides: FakeOverrides = {}) {
+  return fakeStore({
+    async getList() {
+      return readResult({ refs: [normalizedGoogleRef], totalCount: 1 }, state);
+    },
+    async getMessages() {
+      return [{
+        ...readResult({ ref: normalizedGoogleRef, metadata: metadata(), detail: null }, state),
+        messageKey: normalizedGoogleRef.messageKey,
+      }];
+    },
+    ...overrides,
+  });
+}
+
+async function main() {
+  let providerLoads = 0;
+  const fresh = await readThroughEmailList({
+    runtime: { store: cachedListStore('fresh') },
+    mailbox: localMailbox,
+    scope: listScope,
+    load: async () => {
+      providerLoads += 1;
+      return { messages: [], total: 0 };
+    },
+    fromCache: (messages, total) => ({ messages, total }),
+  });
+  assert.equal(providerLoads, 0, 'fresh cache hits must not call the provider');
+  assert.equal(fresh.cache.state, 'fresh');
+  assert.equal(fresh.cache.source, 'cache');
+  assert.equal((fresh.messages?.[0] as { subject: string }).subject, 'Cached subject');
+
+  const scheduled: Array<() => Promise<void>> = [];
+  const writeOrder: string[] = [];
+  const stale = await readThroughEmailList({
+    runtime: {
+      store: cachedListStore('stale', {
+        async putMessages(input) {
+          writeOrder.push('messages');
+          const keys = input.messages.map((message) => normalizeEmailMessageRef(message.ref).messageKey);
+          return { enabled: true, requestedCount: keys.length, storedCount: keys.length, storedMessageKeys: keys, rejectedMessageKeys: [], reason: 'stored' };
+        },
+        async putList() {
+          writeOrder.push('list');
+          return { enabled: true, stored: true, reason: 'stored' };
+        },
+      }),
+      scheduleBackgroundTask: (task) => scheduled.push(task),
+    },
+    mailbox: localMailbox,
+    scope: listScope,
+    load: async () => {
+      providerLoads += 1;
+      return {
+        messages: [{
+          id: 'g-1', uid: 'g-1', folder: 'INBOX', from: 'sender@example.test', subject: 'Fresh subject',
+          date: '2026-09-08T11:00:00.000Z', snippet: 'Fresh', isRead: true, isAnswered: false,
+          isFlagged: false, hasAttachments: false, flags: [],
+        }],
+        total: 1,
+      };
+    },
+    fromCache: (messages, total) => ({ messages, total }),
+  });
+  assert.equal(stale.cache.state, 'stale');
+  assert.equal(stale.cache.refreshQueued, true);
+  assert.equal(providerLoads, 0, 'stale response must return before revalidation');
+  assert.equal(scheduled.length, 1);
+  await scheduled[0]();
+  assert.equal(providerLoads, 1);
+  assert.deepEqual(writeOrder, ['messages', 'list'], 'metadata batch must be durable before the list snapshot');
+
+  const staleWithLeaseFailure = await readThroughEmailList({
+    runtime: {
+      store: cachedListStore('stale', {
+        async acquireListRefreshLease() { throw new Error('database unavailable'); },
+      }),
+      scheduleBackgroundTask: () => assert.fail('failed leases must not schedule work'),
+    },
+    mailbox: localMailbox,
+    scope: listScope,
+    load: async () => assert.fail('stale lease errors must not call provider inline'),
+    fromCache: (messages, total) => ({ messages, total }),
+  });
+  assert.equal(staleWithLeaseFailure.cache.state, 'stale');
+  assert.equal(staleWithLeaseFailure.cache.refreshQueued, false);
+
+  const missWrites: string[] = [];
+  const miss = await readThroughEmailList({
+    runtime: {
+      store: fakeStore({
+        async putMessages(input) {
+          missWrites.push(`${input.accountSource}:messages`);
+          const keys = input.messages.map((message) => normalizeEmailMessageRef(message.ref).messageKey);
+          return { enabled: true, requestedCount: keys.length, storedCount: keys.length, storedMessageKeys: keys, rejectedMessageKeys: [], reason: 'stored' };
+        },
+        async putList(input) {
+          missWrites.push(`${input.accountSource}:list`);
+          return { enabled: true, stored: true, reason: 'stored' };
+        },
+      }),
+    },
+    mailbox: { ...localMailbox, accountSource: 'managed' },
+    scope: listScope,
+    load: async () => ({
+      messages: [{
+        id: 'g-1', uid: 'g-1', folder: 'INBOX', from: 'sender@example.test', subject: 'Provider subject',
+        date: '2026-09-08T12:00:00.000Z', snippet: 'Provider', isRead: true, isAnswered: false,
+        isFlagged: false, hasAttachments: false,
+      }],
+      total: 1,
+    }),
+    fromCache: (messages, total) => ({ messages, total }),
+  });
+  assert.equal(miss.cache.state, 'fresh', 'a successful provider fill is fresh to the caller');
+  assert.equal(miss.cache.source, 'provider');
+  assert.deepEqual(missWrites, ['managed:messages', 'managed:list']);
+
+  let raceNow = 100;
+  let raceFilled = false;
+  let raceAcquireCount = 0;
+  let raceProviderLoads = 0;
+  const raceStore = fakeStore({
+    async getList() {
+      return raceFilled ? readResult({ refs: [normalizedGoogleRef], totalCount: 1 }) : readResult(null);
+    },
+    async getMessages() {
+      return raceFilled ? [{
+        ...readResult({ ref: normalizedGoogleRef, metadata: metadata('Race winner'), detail: null }),
+        messageKey: normalizedGoogleRef.messageKey,
+      }] : [];
+    },
+    async acquireListRefreshLease() {
+      raceAcquireCount += 1;
+      return { enabled: true, acquired: false, generation: 1, leaseUntil: 500 };
+    },
+  });
+  const race = await readThroughEmailList({
+    runtime: {
+      store: raceStore,
+      now: () => raceNow,
+      sleep: async (milliseconds) => {
+        raceNow += milliseconds;
+        raceFilled = true;
+      },
+    },
+    mailbox: localMailbox,
+    scope: listScope,
+    load: async () => {
+      raceProviderLoads += 1;
+      return { messages: [], total: 0 };
+    },
+    fromCache: (messages, total) => ({ messages, total }),
+  });
+  assert.equal(raceAcquireCount, 1);
+  assert.equal(raceProviderLoads, 0, 'a lease loser must consume the winner result instead of duplicating provider work');
+  assert.equal((race.messages?.[0] as { subject: string }).subject, 'Race winner');
+
+  const partialStore = fakeStore({
+    async getList() {
+      const second = normalizeEmailMessageRef({ provider: 'google', messageId: 'g-2', folder: 'INBOX' });
+      return readResult({ refs: [normalizedGoogleRef, second], totalCount: 2 });
+    },
+    async getMessages() {
+      return [{
+        ...readResult({ ref: normalizedGoogleRef, metadata: metadata(), detail: null }),
+        messageKey: normalizedGoogleRef.messageKey,
+      }];
+    },
+  });
+  let partialProviderLoads = 0;
+  await readThroughEmailList({
+    runtime: { store: partialStore },
+    mailbox: localMailbox,
+    scope: listScope,
+    load: async () => {
+      partialProviderLoads += 1;
+      return { messages: [], total: 0 };
+    },
+    fromCache: (messages, total) => ({ messages, total }),
+  });
+  assert.equal(partialProviderLoads, 1, 'incomplete cached lists must be treated as a miss');
+
+  const cachedDetailStore = fakeStore({
+    async getMessage() {
+      return readResult({ ref: normalizedGoogleRef, metadata: metadata(), detail: detail() });
+    },
+  });
+  let detailProviderLoads = 0;
+  const detailHit = await readThroughEmailDetail({
+    runtime: { store: cachedDetailStore },
+    mailbox: localMailbox,
+    messageId: 'g-1',
+    folder: 'INBOX',
+    load: async () => {
+      detailProviderLoads += 1;
+      return { message: {} };
+    },
+    fromCache: (message) => ({ message }),
+  });
+  assert.equal(detailProviderLoads, 0);
+  assert.equal(detailHit.cache.source, 'cache');
+  assert.equal((detailHit.message as { body: string }).body, 'Cached body');
+
+  let legacyCacheReads = 0;
+  let legacyProviderLoads = 0;
+  const legacy = await readThroughEmailDetail({
+    runtime: {
+      store: fakeStore({
+        async getMessage() {
+          legacyCacheReads += 1;
+          return readResult(null);
+        },
+      }),
+    },
+    mailbox: { ...localMailbox, provider: 'imap' },
+    messageId: '42',
+    folder: 'INBOX',
+    load: async () => {
+      legacyProviderLoads += 1;
+      return { message: { id: '42', body: 'Legacy' } };
+    },
+    fromCache: (message) => ({ message }),
+  });
+  assert.equal(legacyCacheReads, 0);
+  assert.equal(legacyProviderLoads, 1);
+  assert.equal(legacy.cache.bypassReason, 'legacy_imap_reference');
+
+  const imapId = createImapMessageReference('INBOX', '77', 42);
+  let imapWrites = 0;
+  await readThroughEmailDetail({
+    runtime: {
+      store: fakeStore({
+        async putMessage(input) {
+          imapWrites += 1;
+          assert.equal(normalizeEmailMessageRef(input.ref).uidValidity, '77');
+          assert.equal('contentBase64' in (input.detail?.attachments[0] || {}), false);
+          return { enabled: true, stored: true, reason: 'stored' };
+        },
+      }),
+    },
+    mailbox: { ...localMailbox, provider: 'imap' },
+    messageId: imapId,
+    folder: 'INBOX',
+    load: async () => ({
+      message: {
+        id: imapId, uid: '42', uidValidity: '77', folder: 'INBOX', from: 'sender@example.test',
+        subject: 'IMAP', date: '2026-09-08T12:00:00.000Z', snippet: 'IMAP', body: 'Body', bodyHtml: '',
+        attachments: [{ filename: 'safe.txt', size: 4, contentBase64: 'must-not-be-cached' }],
+      },
+    }),
+    fromCache: (message) => ({ message }),
+  });
+  assert.equal(imapWrites, 1);
+
+  const serviceSource = await readFile(new URL('../app/lib/email/service.ts', import.meta.url), 'utf8');
+  assert.match(serviceSource, /options\?\.cacheMode === 'swr' && options\.enforceReadPolicy === false/u,
+    'cache must be opt-in and forbidden for policy-enforced agent/poller reads');
+  const listSource = serviceSource.slice(serviceSource.indexOf('export async function listEmailMessages'), serviceSource.indexOf('export async function readEmailMessage'));
+  assert.ok(listSource.indexOf('findManagedEmailAccount') < listSource.indexOf('getRuntimeEmailCacheStore'), 'managed ownership must resolve before cache access');
+  assert.ok(listSource.indexOf('resolveLocalEmailCacheAccount') < listSource.lastIndexOf('getRuntimeEmailCacheStore'), 'local ownership must resolve before cache access');
+  const routeSource = await readFile(new URL('../app/api/email/messages/list/route.ts', import.meta.url), 'utf8');
+  const detailRouteSource = await readFile(new URL('../app/api/email/accounts/[accountId]/messages/[messageId]/route.ts', import.meta.url), 'utf8');
+  for (const source of [routeSource, detailRouteSource]) {
+    assert.match(source, /cacheMode: 'swr'/u);
+    assert.match(source, /scheduleBackgroundTask: after/u);
+  }
+
+  console.log('email cache read-through tests passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/email-cache-service-consistency-test.ts
+++ b/scripts/email-cache-service-consistency-test.ts
@@ -1,0 +1,279 @@
+import assert from 'node:assert/strict';
+import Module from 'node:module';
+
+import {
+  setEmailCacheConsistencyStoreFactoryForTests,
+} from '../app/lib/email/cache/consistency';
+import type { EmailCacheStore } from '../app/lib/email/cache/store';
+
+type LoadFn = (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+type Account = { id: string; provider: string; authType: string; emailAddress: string; isPrimary: boolean; status: string };
+
+const events: Array<{ name: string; accountId?: string; accountSource?: string }> = [];
+const localAccount: Account = {
+  id: 'shared-account',
+  provider: 'google',
+  authType: 'oauth',
+  emailAddress: 'local@example.test',
+  isPrimary: true,
+  status: 'active',
+};
+const managedAccount: Account = {
+  id: 'shared-account',
+  provider: 'google',
+  authType: 'oauth',
+  emailAddress: 'managed@example.test',
+  isPrimary: true,
+  status: 'active',
+};
+
+let localAccounts: Account[] = [localAccount];
+let managedAvailable = false;
+let managedAccounts: Account[] = [];
+let nextLocalError: Error | null = null;
+let nextDisconnectError: Error | null = null;
+let nextManagedDisconnectError: Error | null = null;
+let localResultAuthType = 'oauth';
+
+function providerResult(accountId = localAccount.id) {
+  return { account: { ...localAccount, id: accountId, authType: localResultAuthType }, ok: true };
+}
+
+async function localMutation(name: string) {
+  events.push({ name });
+  if (nextLocalError) {
+    const error = nextLocalError;
+    nextLocalError = null;
+    throw error;
+  }
+  return providerResult();
+}
+
+const cacheStore = {
+  enabled: true,
+  async bumpMailboxGeneration(input: { accountId: string; accountSource?: string }) {
+    events.push({ name: 'cache:bump', accountId: input.accountId, accountSource: input.accountSource });
+    return 2;
+  },
+  async purgeAccount(input: { accountId: string; accountSource?: string }) {
+    events.push({ name: 'cache:purge', accountId: input.accountId, accountSource: input.accountSource });
+    return { enabled: true, tombstoned: true, generation: 2, deletedLists: 0, deletedMessages: 0 };
+  },
+  async reactivateAccount(input: { accountId: string; accountSource?: string }) {
+    events.push({ name: 'cache:reactivate', accountId: input.accountId, accountSource: input.accountSource });
+    return 3;
+  },
+} as unknown as EmailCacheStore;
+
+const moduleInternals = Module as typeof Module & { _load: LoadFn };
+const originalLoad = moduleInternals._load;
+
+moduleInternals._load = function loadWithEmailServiceMocks(request, parent, isMain) {
+  if (request === 'server-only') return {};
+  if (request === '@/app/lib/email/local-service') {
+    return {
+      archiveLocalEmailMessage: () => localMutation('provider:archive'),
+      createLocalEmailAiReplyDraft: () => localMutation('provider:create-ai-draft'),
+      createLocalEmailDerivedDraft: () => localMutation('provider:create-derived-draft'),
+      createLocalEmailDraft: () => localMutation('provider:create-draft'),
+      deleteLocalEmailMessagePermanently: () => localMutation('provider:delete'),
+      disconnectLocalEmailAccount: async (_userId: string, accountId: string) => {
+        events.push({ name: 'provider:disconnect-local', accountId });
+        if (nextDisconnectError) {
+          const error = nextDisconnectError;
+          nextDisconnectError = null;
+          throw error;
+        }
+        return true;
+      },
+      listLocalEmailAccounts: async () => localAccounts,
+      moveLocalEmailMessage: () => localMutation('provider:move'),
+      resolveLocalEmailCacheAccount: async (_userId: string, accountId?: string) => {
+        const account = localAccounts.find((candidate) => candidate.id === accountId);
+        if (!account) throw new Error('Email account not found.');
+        return { account, provider: account.provider };
+      },
+      sendLocalEmailDerivedMessage: () => localMutation('provider:send-derived'),
+      sendLocalEmailDraft: () => localMutation('provider:send-draft'),
+      sendLocalEmailMessage: () => localMutation('provider:send-message'),
+      setLocalEmailMessageAnswered: () => localMutation('provider:answered'),
+      setLocalEmailMessageRead: () => localMutation('provider:read'),
+      trashLocalEmailMessage: () => localMutation('provider:trash'),
+      updateLocalEmailDraft: () => localMutation('provider:update-draft'),
+    };
+  }
+  if (request === '@/app/lib/email/cache/read-through') {
+    return {
+      readThroughEmailDetail: async () => { throw new Error('Unexpected detail cache read.'); },
+      readThroughEmailList: async () => { throw new Error('Unexpected list cache read.'); },
+    };
+  }
+  if (request === '@/app/lib/email/attachments') return { resolveEmailAttachments: async () => [] };
+  if (request === '@/app/lib/email/errors') {
+    return { EmailMessageNotFoundError: class EmailMessageNotFoundError extends Error {} };
+  }
+  if (request === '@/app/lib/email/logging') return { logEmailClientEvent: () => undefined };
+  if (request === '@/app/lib/email/managed-client') {
+    return {
+      getManagedEmailOAuthRedirectUri: () => null,
+      isManagedEmailAvailable: () => managedAvailable,
+      ManagedEmailRequestError: class ManagedEmailRequestError extends Error {},
+      managedEmailRequest: async (path: string, init?: { method?: string }) => {
+        if (path === '/v1/managed/email/accounts' && !init) return { accounts: managedAccounts };
+        if (init?.method === 'DELETE') {
+          events.push({ name: 'provider:disconnect-managed', accountId: path.split('/').at(-1) });
+          if (nextManagedDisconnectError) {
+            const error = nextManagedDisconnectError;
+            nextManagedDisconnectError = null;
+            throw error;
+          }
+          return { success: true };
+        }
+        throw new Error(`Unexpected managed request: ${path}`);
+      },
+    };
+  }
+  if (request === '@/app/lib/email/smtp-service') {
+    return {
+      saveSmtpEmailAccount: async () => {
+        events.push({ name: 'provider:save-smtp' });
+        return { ...localAccount, id: 'smtp-account', provider: 'smtp_imap', authType: 'smtp_imap' };
+      },
+      testSmtpConnection: async () => ({ ok: true }),
+      testStoredSmtpEmailAccount: async () => ({ ok: true }),
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+async function main() {
+  setEmailCacheConsistencyStoreFactoryForTests(async () => cacheStore);
+  try {
+    const service = await import('../app/lib/email/service');
+
+    const actions: Array<[string, () => Promise<unknown>]> = [
+      ['provider:read', () => service.setEmailMessageRead('user-1', localAccount.id, 'message-1', 'INBOX', true)],
+      ['provider:answered', () => service.setEmailMessageAnswered('user-1', localAccount.id, 'message-1', 'INBOX', true)],
+      ['provider:archive', () => service.archiveEmailMessage('user-1', localAccount.id, 'message-1', 'INBOX')],
+      ['provider:move', () => service.moveEmailMessage('user-1', localAccount.id, 'message-1', 'INBOX', 'Archive')],
+      ['provider:trash', () => service.trashEmailMessage('user-1', localAccount.id, 'message-1', 'INBOX')],
+      ['provider:delete', () => service.deleteEmailMessagePermanently('user-1', localAccount.id, 'message-1', 'INBOX')],
+    ];
+    for (const [providerEvent, action] of actions) {
+      events.length = 0;
+      await action();
+      assert.deepEqual(events, [
+        { name: providerEvent },
+        { name: 'cache:bump', accountId: localAccount.id, accountSource: 'local' },
+      ]);
+    }
+
+    events.length = 0;
+    nextLocalError = new Error('provider failed');
+    await assert.rejects(actions[0][1], /provider failed/u);
+    assert.deepEqual(events, [{ name: 'provider:read' }]);
+
+    events.length = 0;
+    const mailboxChanged = Object.assign(new Error('The IMAP mailbox changed.'), {
+      code: 'EMAIL_MAILBOX_CHANGED',
+      status: 409,
+    });
+    nextLocalError = mailboxChanged;
+    await assert.rejects(actions[0][1], (error) => error === mailboxChanged);
+    assert.deepEqual(events, [
+      { name: 'provider:read' },
+      { name: 'cache:bump', accountId: localAccount.id, accountSource: 'local' },
+    ]);
+
+    events.length = 0;
+    localAccounts = [localAccount];
+    managedAvailable = true;
+    managedAccounts = [managedAccount];
+    await service.disconnectEmailAccount('user-1', localAccount.id);
+    assert.deepEqual(events, [
+      { name: 'provider:disconnect-local', accountId: localAccount.id },
+      { name: 'cache:purge', accountId: localAccount.id, accountSource: 'local' },
+    ]);
+
+    events.length = 0;
+    nextDisconnectError = new Error('disconnect failed');
+    await assert.rejects(service.disconnectEmailAccount('user-1', localAccount.id), /disconnect failed/u);
+    assert.deepEqual(events, [{ name: 'provider:disconnect-local', accountId: localAccount.id }]);
+
+    events.length = 0;
+    localAccounts = [];
+    await service.disconnectEmailAccount('user-1', managedAccount.id);
+    assert.deepEqual(events, [
+      { name: 'provider:disconnect-managed', accountId: managedAccount.id },
+      { name: 'cache:purge', accountId: managedAccount.id, accountSource: 'managed' },
+    ]);
+
+    events.length = 0;
+    nextManagedDisconnectError = new Error('managed disconnect failed');
+    await assert.rejects(service.disconnectEmailAccount('user-1', managedAccount.id), /managed disconnect failed/u);
+    assert.deepEqual(events, [{ name: 'provider:disconnect-managed', accountId: managedAccount.id }]);
+
+    events.length = 0;
+    await service.listEmailAccounts('user-1');
+    assert.equal(events.some((event) => event.name === 'cache:reactivate'), false);
+
+    events.length = 0;
+    nextLocalError = new Error('Email account not found.');
+    await assert.rejects(
+      service.setEmailMessageRead('user-1', managedAccount.id, 'message-1', 'INBOX', true),
+      /not found/u,
+    );
+    assert.equal(events.some((event) => event.name.startsWith('cache:')), false);
+
+    events.length = 0;
+    managedAccounts = [];
+    await assert.rejects(service.disconnectEmailAccount('user-1', managedAccount.id), /not found/u);
+    assert.equal(events.some((event) => event.name.startsWith('cache:')), false);
+
+    events.length = 0;
+    managedAvailable = false;
+    localAccounts = [localAccount];
+    await service.saveEmailSmtpAccount('user-1', { emailAddress: 'smtp@example.test' });
+    assert.deepEqual(events, [
+      { name: 'provider:save-smtp' },
+      { name: 'cache:reactivate', accountId: 'smtp-account', accountSource: 'local' },
+    ]);
+
+    const draftInput = { accountId: localAccount.id, to: [], subject: '', body: '' };
+    localResultAuthType = 'oauth';
+    const localMailboxWrites: Array<[string, () => Promise<unknown>]> = [
+      ['provider:create-derived-draft', () => service.createEmailDerivedDraft('user-1', localAccount.id, 'message-1', 'INBOX', 'reply')],
+      ['provider:send-derived', () => service.sendEmailDerivedMessage('user-1', localAccount.id, 'message-1', 'INBOX', 'reply')],
+      ['provider:create-ai-draft', () => service.createEmailAiReplyDraft('user-1', localAccount.id, 'message-1', 'INBOX')],
+      ['provider:create-draft', () => service.createEmailDraft('user-1', draftInput)],
+      ['provider:update-draft', () => service.updateEmailDraft('user-1', 'draft-1', draftInput)],
+      ['provider:send-message', () => service.sendEmailMessage('user-1', draftInput)],
+      ['provider:send-draft', () => service.sendEmailDraft('user-1', localAccount.id, 'draft-1')],
+    ];
+    for (const [providerEvent, write] of localMailboxWrites) {
+      events.length = 0;
+      await write();
+      assert.deepEqual(events, [
+        { name: providerEvent },
+        { name: 'cache:bump', accountId: localAccount.id, accountSource: 'local' },
+      ]);
+    }
+
+    events.length = 0;
+    localResultAuthType = 'smtp_imap';
+    await service.createEmailDraft('user-1', draftInput);
+    assert.deepEqual(events, [{ name: 'provider:create-draft' }]);
+
+    console.log('email-cache-service-consistency-test: ok');
+  } finally {
+    moduleInternals._load = originalLoad;
+    setEmailCacheConsistencyStoreFactoryForTests(null);
+  }
+}
+
+main().catch((error) => {
+  moduleInternals._load = originalLoad;
+  setEmailCacheConsistencyStoreFactoryForTests(null);
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/email-client-swr-refresh-test.ts
+++ b/scripts/email-client-swr-refresh-test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import {
+  claimEmailCacheFollowUp,
+  emailCacheFollowUpKey,
+  emailMessageDetailScopeKey,
+  parseEmailClientCacheMetadata,
+  shouldApplyEmailRefresh,
+} from '../app/lib/email/reader-refresh';
+
+const staleCache = {
+  state: 'stale',
+  refreshQueued: true,
+  generation: 7,
+  fetchedAt: '2026-09-08T10:00:00.000Z',
+  staleAt: '2026-09-08T10:01:00.000Z',
+};
+
+assert.deepEqual(parseEmailClientCacheMetadata(staleCache), staleCache);
+assert.equal(parseEmailClientCacheMetadata(null), null);
+assert.equal(parseEmailClientCacheMetadata({ state: 'unknown', refreshQueued: true }), null);
+assert.equal(emailCacheFollowUpKey('list-scope', { ...staleCache, state: 'fresh' }), null);
+assert.equal(emailCacheFollowUpKey('list-scope', { ...staleCache, refreshQueued: false }), null);
+
+const stableKey = emailCacheFollowUpKey('list-scope', staleCache);
+assert.ok(stableKey);
+assert.equal(stableKey, emailCacheFollowUpKey('list-scope', { ...staleCache, expiresAt: 'later' }));
+assert.notEqual(stableKey, emailCacheFollowUpKey('other-scope', staleCache));
+assert.notEqual(stableKey, emailCacheFollowUpKey('list-scope', { ...staleCache, generation: 8 }));
+assert.notEqual(stableKey, emailCacheFollowUpKey('list-scope', { ...staleCache, fetchedAt: '2026-09-08T10:02:00.000Z' }));
+assert.notEqual(stableKey, emailCacheFollowUpKey('list-scope', { ...staleCache, staleAt: '2026-09-08T10:03:00.000Z' }));
+
+const seen = new Set<string>();
+assert.equal(claimEmailCacheFollowUp(seen, stableKey), true);
+assert.equal(claimEmailCacheFollowUp(seen, stableKey), false, 'one cache identity may schedule only once');
+assert.equal(claimEmailCacheFollowUp(seen, null), false);
+for (let index = 0; index < 5; index += 1) {
+  claimEmailCacheFollowUp(seen, `key-${index}`, 3);
+}
+assert.equal(seen.size, 3, 'the identity guard must remain bounded');
+
+assert.equal(shouldApplyEmailRefresh({
+  requestEpoch: 3,
+  currentEpoch: 3,
+  mutationRevision: 4,
+  currentMutationRevision: 4,
+  mutationInFlight: false,
+}), true);
+assert.equal(shouldApplyEmailRefresh({
+  requestEpoch: 2,
+  currentEpoch: 3,
+  mutationRevision: 4,
+  currentMutationRevision: 4,
+  mutationInFlight: false,
+}), false, 'superseded requests must not apply');
+assert.equal(shouldApplyEmailRefresh({
+  requestEpoch: 3,
+  currentEpoch: 3,
+  mutationRevision: 3,
+  currentMutationRevision: 4,
+  mutationInFlight: false,
+}), false, 'responses predating an optimistic mutation must not apply');
+assert.equal(shouldApplyEmailRefresh({
+  requestEpoch: 3,
+  currentEpoch: 3,
+  mutationRevision: 4,
+  currentMutationRevision: 4,
+  mutationInFlight: true,
+}), false, 'responses must not apply while a mutation is running');
+
+assert.equal(emailMessageDetailScopeKey({
+  accountId: 'account:1',
+  folder: 'Folder/With Spaces',
+  messageId: 'imap:v1:opaque/id',
+}), '["account:1","Folder/With Spaces","imap:v1:opaque/id"]');
+
+async function sourceContractTests() {
+  const source = await readFile(new URL('../app/apps/email/components/EmailClient.tsx', import.meta.url), 'utf8');
+  const refreshStart = source.indexOf('const refreshSelectedMessage');
+  const listStart = source.indexOf('const loadMessages');
+  const markReadStart = source.indexOf('const markMessageReadOnOpen');
+  const detailStart = source.indexOf('const loadMessage =');
+  const effectsStart = source.indexOf('useEffect(() => {', detailStart);
+  const refreshSource = source.slice(refreshStart, listStart);
+  const listSource = source.slice(listStart, markReadStart);
+  const detailSource = source.slice(detailStart, effectsStart);
+
+  assert.match(listSource, /scheduleListFollowUp\(scopeKey, payload\.data\?\.cache, requestEpoch\)/u);
+  assert.match(listSource, /if \(!options\?\.swrFollowUp\) void refreshSelectedMessage\(\)/u,
+    'the stale-list follow-up must not cascade into a detail refresh');
+  assert.match(listSource, /shouldApplyEmailRefresh/u);
+  assert.match(refreshSource, /scheduleDetailFollowUp/u);
+  assert.match(refreshSource, /shouldApplyEmailRefresh/u);
+  assert.doesNotMatch(refreshSource, /markMessageReadOnOpen/u,
+    'detail follow-ups must never repeat mark-read-on-open');
+  assert.match(detailSource, /scheduleDetailFollowUp/u);
+  assert.match(detailSource, /markMessageReadOnOpen/u,
+    'the initial open path must retain its single mark-read behavior');
+  assert.match(source, /cancelListFollowUp\(\);\s+listRequestEpochRef\.current \+= 1;\s+listRequestRef\.current\?\.abort\(\);/u,
+    'scope changes must invalidate list timers and requests');
+  assert.match(source, /cancelDetailFollowUp\(\);\s+detailRequestEpochRef\.current \+= 1;/u,
+    'reader changes must invalidate detail timers');
+  assert.match(source, /pendingDetailFollowUpRef\.current/u,
+    'a follow-up blocked by mark-read must resume after the mutation completes');
+}
+
+sourceContractTests().then(() => {
+  console.log('email client SWR refresh tests passed');
+}).catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/email-mailbox-changed-route-test.ts
+++ b/scripts/email-mailbox-changed-route-test.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import Module from 'node:module';
+
+import { NextRequest } from 'next/server';
+
+type LoadFn = (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+
+const moduleInternals = Module as typeof Module & { _load: LoadFn };
+const originalLoad = moduleInternals._load;
+const mailboxChangedMessage = 'The IMAP mailbox changed. Reload the message list before trying again.';
+let serviceError: Error & { code?: string; status?: number } = Object.assign(new Error(mailboxChangedMessage), {
+  code: 'EMAIL_MAILBOX_CHANGED',
+  status: 409,
+});
+
+const failWithServiceError = async () => {
+  throw serviceError;
+};
+
+moduleInternals._load = function loadWithEmailRouteMocks(request, parent, isMain) {
+  if (request === 'server-only') return {};
+  if (request === '@/app/lib/auth') {
+    return { auth: { api: { getSession: async () => ({ user: { id: 'user-1' } }) } } };
+  }
+  if (request === '@/app/lib/email/ai-route-guard') {
+    return { requireEmailAiRouteSession: async () => ({ user: { id: 'user-1' } }) };
+  }
+  if (request === '@/app/lib/email/ai-request-body') {
+    return {
+      emailAiRequestBodyErrorStatus: () => undefined,
+      readEmailAiJsonObject: async (input: Request) => input.json(),
+    };
+  }
+  if (request === '@/app/lib/email/attachments') {
+    return { normalizeEmailAttachmentInputs: () => [] };
+  }
+  if (request === '@/app/lib/email/errors') {
+    return { isEmailMessageNotFoundError: (error: unknown) => (error as { code?: unknown })?.code === 'EMAIL_MESSAGE_NOT_FOUND' };
+  }
+  if (request === '@/app/lib/email/imap-service') {
+    return {
+      isImapMailboxChangedError: (error: unknown) => {
+        const candidate = error as { code?: unknown; status?: unknown };
+        return candidate?.code === 'EMAIL_MAILBOX_CHANGED' && candidate.status === 409;
+      },
+    };
+  }
+  if (request === '@/app/lib/email/logging') {
+    return { logEmailClientEvent: () => undefined };
+  }
+  if (request === '@/app/lib/email/service') {
+    return {
+      archiveEmailMessage: failWithServiceError,
+      createEmailAiReplyDraft: failWithServiceError,
+      createEmailDerivedDraft: failWithServiceError,
+      deleteEmailMessagePermanently: failWithServiceError,
+      generateEmailAiReplyBody: failWithServiceError,
+      moveEmailMessage: failWithServiceError,
+      readEmailMessage: failWithServiceError,
+      sendEmailDerivedMessage: failWithServiceError,
+      setEmailMessageAnswered: failWithServiceError,
+      setEmailMessageRead: failWithServiceError,
+      streamEmailAiReplyBody: failWithServiceError,
+      summarizeEmailMessage: failWithServiceError,
+      trashEmailMessage: failWithServiceError,
+    };
+  }
+  if (request === '@/app/lib/utils/rate-limit') {
+    return { rateLimit: () => ({ ok: true }) };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+async function expectMailboxChanged(response: Response) {
+  assert.equal(response.status, 409);
+  assert.deepEqual(await response.json(), {
+    success: false,
+    code: 'EMAIL_MAILBOX_CHANGED',
+    error: mailboxChangedMessage,
+  });
+}
+
+async function main() {
+  try {
+    const { GET: getMessage } = await import('../app/api/email/accounts/[accountId]/messages/[messageId]/route');
+    const { POST: postMessageAction } = await import('../app/api/email/accounts/[accountId]/messages/[messageId]/actions/route');
+    const { POST: postAiReply } = await import('../app/api/email/accounts/[accountId]/messages/[messageId]/ai-reply/route');
+    const { POST: postDraft } = await import('../app/api/email/accounts/[accountId]/messages/[messageId]/draft/route');
+    const { POST: postSummary } = await import('../app/api/email/accounts/[accountId]/messages/[messageId]/summary/route');
+    const { POST: postMessageOperation } = await import('../app/api/email/accounts/[accountId]/messages/actions/route');
+
+    await expectMailboxChanged(await getMessage(
+      new NextRequest('http://localhost/api/email/accounts/account-1/messages/reference-1?folder=INBOX'),
+      { params: Promise.resolve({ accountId: 'account-1', messageId: 'reference-1' }) },
+    ));
+
+    await expectMailboxChanged(await postMessageAction(
+      new NextRequest('http://localhost/api/email/accounts/account-1/messages/reference-1/actions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'mark-read', folder: 'INBOX' }),
+      }),
+      { params: Promise.resolve({ accountId: 'account-1', messageId: 'reference-1' }) },
+    ));
+
+    await expectMailboxChanged(await postMessageOperation(
+      new NextRequest('http://localhost/api/email/accounts/account-1/messages/actions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ operation: 'action', action: 'move', messageId: 'reference-1', folder: 'INBOX', destination: 'Archive' }),
+      }),
+      { params: Promise.resolve({ accountId: 'account-1' }) },
+    ));
+
+    await expectMailboxChanged(await postDraft(
+      new NextRequest('http://localhost/api/email/accounts/account-1/messages/reference-1/draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'reply', folder: 'INBOX' }),
+      }),
+      { params: Promise.resolve({ accountId: 'account-1', messageId: 'reference-1' }) },
+    ));
+
+    await expectMailboxChanged(await postAiReply(
+      new NextRequest('http://localhost/api/email/accounts/account-1/messages/reference-1/ai-reply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ folder: 'INBOX' }),
+      }),
+      { params: Promise.resolve({ accountId: 'account-1', messageId: 'reference-1' }) },
+    ));
+
+    await expectMailboxChanged(await postSummary(
+      new NextRequest('http://localhost/api/email/accounts/account-1/messages/reference-1/summary', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ folder: 'INBOX' }),
+      }),
+      { params: Promise.resolve({ accountId: 'account-1', messageId: 'reference-1' }) },
+    ));
+
+    serviceError = new Error('Generic provider failure');
+    const genericResponse = await postMessageAction(
+      new NextRequest('http://localhost/api/email/accounts/account-1/messages/reference-1/actions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'trash', folder: 'INBOX' }),
+      }),
+      { params: Promise.resolve({ accountId: 'account-1', messageId: 'reference-1' }) },
+    );
+    assert.equal(genericResponse.status, 500);
+    assert.deepEqual(await genericResponse.json(), { success: false, error: 'Generic provider failure' });
+
+    console.log('email-mailbox-changed-route-test: ok');
+  } finally {
+    moduleInternals._load = originalLoad;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/home-workspace-widget-cache-test.ts
+++ b/scripts/home-workspace-widget-cache-test.ts
@@ -54,8 +54,10 @@ async function main() {
   assert.doesNotMatch(routeSource, /widget:\s*'emails'/u, 'email must bypass the process-local Home cache');
   assert.match(routeSource, /loadHomeWidgetEmails\(access\.session\.user\.id/u);
   assert.match(routeSource, /services: \{ listAccounts: listEmailAccounts, listMessages: listEmailMessages \}/u);
+  assert.match(routeSource, /parseHomeWidgetSelection\(request\.nextUrl\.searchParams\.get\('widgets'\), HOME_WIDGET_NAMES\)/u);
+  assert.match(routeSource, /selected\.has\('emails'\)/u);
   for (const widget of ['todos', 'automation', 'studio']) {
-    assert.match(routeSource, new RegExp(`widget: '${widget}'`, 'u'), `${widget} should keep the Home cache`);
+    assert.match(routeSource, new RegExp(`selected\\.has\\('${widget}'\\)[\\s\\S]*widget: '${widget}'`, 'u'), `${widget} should remain independently selectable and cached`);
   }
 
   console.log('home-workspace-widget-cache-test: ok');

--- a/scripts/home-workspace-widget-cache-test.ts
+++ b/scripts/home-workspace-widget-cache-test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { loadCachedWorkspaceWidget } from '../app/lib/home/workspace-widget-cache';
 
@@ -35,7 +37,7 @@ async function main() {
   const concurrentInput = {
     userId: `user-c-${suffix}`,
     workspaceId: 'workspace-a',
-    widget: 'email',
+    widget: 'automation',
     ttlMs: 60_000,
     load: async () => { concurrentLoads += 1; await gate; return 'ready'; },
   };
@@ -44,6 +46,17 @@ async function main() {
   release();
   assert.deepEqual((await Promise.all([pendingA, pendingB])).map((result) => result.data), ['ready', 'ready']);
   assert.equal(concurrentLoads, 1, 'concurrent loads for the same user and workspace should be deduplicated');
+
+  const routeSource = fs.readFileSync(
+    path.join(process.cwd(), 'app', 'api', 'home', 'workspace-widgets', 'route.ts'),
+    'utf8',
+  );
+  assert.doesNotMatch(routeSource, /widget:\s*'emails'/u, 'email must bypass the process-local Home cache');
+  assert.match(routeSource, /loadHomeWidgetEmails\(access\.session\.user\.id/u);
+  assert.match(routeSource, /services: \{ listAccounts: listEmailAccounts, listMessages: listEmailMessages \}/u);
+  for (const widget of ['todos', 'automation', 'studio']) {
+    assert.match(routeSource, new RegExp(`widget: '${widget}'`, 'u'), `${widget} should keep the Home cache`);
+  }
 
   console.log('home-workspace-widget-cache-test: ok');
 }

--- a/scripts/home-workspace-widgets-hook-test.tsx
+++ b/scripts/home-workspace-widgets-hook-test.tsx
@@ -73,15 +73,14 @@ async function main() {
 
   const { cleanup, fireEvent, render } = await import('@testing-library/react');
   const {
-    HOME_EMAIL_STALE_FOLLOW_UP_MAX_ATTEMPTS,
     HOME_EMAIL_STALE_FOLLOW_UP_MAX_DELAY_MS,
     HOME_EMAIL_STALE_FOLLOW_UP_MS,
     homeEmailStaleFollowUpDelay,
     useHomeWorkspaceWidgets,
   } = await import('../app/components/home/useHomeWorkspaceWidgets');
-  assert.equal(HOME_EMAIL_STALE_FOLLOW_UP_MAX_ATTEMPTS, 8);
   assert.equal(homeEmailStaleFollowUpDelay(1), HOME_EMAIL_STALE_FOLLOW_UP_MS);
   assert.equal(homeEmailStaleFollowUpDelay(2), HOME_EMAIL_STALE_FOLLOW_UP_MS * 2);
+  assert.equal(homeEmailStaleFollowUpDelay(8), HOME_EMAIL_STALE_FOLLOW_UP_MAX_DELAY_MS);
   assert.equal(homeEmailStaleFollowUpDelay(20), HOME_EMAIL_STALE_FOLLOW_UP_MAX_DELAY_MS);
   const settle = async (delay = 30) => act(async () => { await new Promise((resolve) => setTimeout(resolve, delay)); });
 

--- a/scripts/home-workspace-widgets-hook-test.tsx
+++ b/scripts/home-workspace-widgets-hook-test.tsx
@@ -16,15 +16,20 @@ for (const key of ['self', 'window', 'document', 'navigator', 'HTMLElement', 'El
 Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
 Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true, configurable: true, writable: true });
 
-function emailResult(refreshToken: string, subject: string, refreshQueued = true) {
+function emailResult(
+  refreshToken: string,
+  subject: string,
+  refreshQueued = true,
+  state: 'fresh' | 'stale' = 'stale',
+) {
   return {
     status: 'ready' as const,
     data: [{ id: `message-${refreshToken}`, accountId: 'account', accountLabel: 'mail@example.test', folder: 'INBOX', from: 'sender@example.test', subject, date: '2026-09-08T10:00:00.000Z' }],
     cachedAt: '2026-09-08T10:00:00.000Z',
-    stale: true,
+    stale: state === 'stale',
     cache: {
       enabled: true,
-      state: 'stale' as const,
+      state,
       source: 'cache' as const,
       fetchedAt: '2026-09-08T10:00:00.000Z',
       staleAt: '2026-09-08T10:01:00.000Z',
@@ -67,7 +72,17 @@ async function main() {
   assert.equal(claimedTokens.has('token-204'), true);
 
   const { cleanup, fireEvent, render } = await import('@testing-library/react');
-  const { HOME_EMAIL_STALE_FOLLOW_UP_MS, useHomeWorkspaceWidgets } = await import('../app/components/home/useHomeWorkspaceWidgets');
+  const {
+    HOME_EMAIL_STALE_FOLLOW_UP_MAX_ATTEMPTS,
+    HOME_EMAIL_STALE_FOLLOW_UP_MAX_DELAY_MS,
+    HOME_EMAIL_STALE_FOLLOW_UP_MS,
+    homeEmailStaleFollowUpDelay,
+    useHomeWorkspaceWidgets,
+  } = await import('../app/components/home/useHomeWorkspaceWidgets');
+  assert.equal(HOME_EMAIL_STALE_FOLLOW_UP_MAX_ATTEMPTS, 8);
+  assert.equal(homeEmailStaleFollowUpDelay(1), HOME_EMAIL_STALE_FOLLOW_UP_MS);
+  assert.equal(homeEmailStaleFollowUpDelay(2), HOME_EMAIL_STALE_FOLLOW_UP_MS * 2);
+  assert.equal(homeEmailStaleFollowUpDelay(20), HOME_EMAIL_STALE_FOLLOW_UP_MAX_DELAY_MS);
   const settle = async (delay = 30) => act(async () => { await new Promise((resolve) => setTimeout(resolve, delay)); });
 
   function Probe({ workspaceId }: { workspaceId: string }) {
@@ -92,7 +107,11 @@ async function main() {
     const widgets = url.searchParams.get('widgets');
     if (widgets === 'emails') {
       emailRequests += 1;
-      return success({ emails: emailResult(emailRequests === 1 ? 'token-two' : 'token-two', 'Refreshed email') });
+      if (emailRequests === 1) {
+        return success({ emails: emailResult('token-one', 'Provider still refreshing') });
+      }
+      const token = emailRequests === 2 ? 'token-two' : 'token-four';
+      return success({ emails: emailResult(token, 'Refreshed email', false, 'fresh') });
     }
     if (widgets === 'todos') {
       return success({
@@ -101,8 +120,8 @@ async function main() {
     }
     assert.equal(widgets, HOME_WIDGET_NAMES.join(','));
     fullRequests += 1;
-    const token = fullRequests === 1 ? 'token-one' : 'token-two';
-    return success({ emails: emailResult(token, fullRequests === 1 ? 'Cached email' : 'Refreshed email'), ...otherWidgets });
+    const token = fullRequests === 1 ? 'token-one' : 'token-three';
+    return success({ emails: emailResult(token, fullRequests === 1 ? 'Cached email' : 'Cached again'), ...otherWidgets });
   };
 
   let screen = render(<Probe workspaceId="workspace-one" />);
@@ -115,23 +134,32 @@ async function main() {
   assert.equal(calls.length, 1);
 
   await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
-  assert.equal(calls.length, 2, 'a stale token should schedule one delayed follow-up');
+  assert.equal(calls.length, 2, 'a stale token should schedule a delayed follow-up');
   assert.equal(calls[1]?.searchParams.get('widgets'), 'emails');
   assert.equal(calls[1]?.searchParams.has('refresh'), false);
+  assert.equal(screen.getByTestId('email-token').textContent, 'token-one');
+  assert.equal(screen.getByTestId('email-subject').textContent, 'Provider still refreshing');
+
+  await settle(homeEmailStaleFollowUpDelay(2) + 80);
+  assert.equal(calls.length, 3, 'the same stale token should be polled again while its refresh is queued');
+  assert.equal(calls[2]?.searchParams.get('widgets'), 'emails');
   assert.equal(screen.getByTestId('email-token').textContent, 'token-two');
+  assert.equal(screen.getByTestId('email-subject').textContent, 'Refreshed email');
   await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
-  assert.equal(calls.length, 2, 'a stale follow-up response must not recurse');
+  assert.equal(calls.length, 3, 'polling must stop once the cache becomes fresh');
 
   document.dispatchEvent(new Event('visibilitychange'));
   await settle();
-  assert.equal(calls.length, 3);
+  assert.equal(calls.length, 4);
   await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
-  assert.equal(calls.length, 4, 'a new token may schedule one follow-up on a later natural refresh');
-  assert.equal(calls[3]?.searchParams.get('widgets'), 'emails');
+  assert.equal(calls.length, 5, 'a new token may schedule a follow-up on a later natural refresh');
+  assert.equal(calls[4]?.searchParams.get('widgets'), 'emails');
 
   document.dispatchEvent(new Event('visibilitychange'));
+  await settle();
+  assert.equal(calls.length, 6);
   await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
-  assert.equal(calls.length, 5, 'the same token must never schedule a second follow-up');
+  assert.equal(calls.length, 7, 'a completed token may be followed again after a new provider refresh is queued');
 
   fireEvent.click(screen.getByRole('button', { name: 'Retry todos' }));
   await settle();

--- a/scripts/home-workspace-widgets-hook-test.tsx
+++ b/scripts/home-workspace-widgets-hook-test.tsx
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+
+import {
+  claimHomeWidgetRefreshToken,
+  HOME_WIDGET_NAMES,
+  parseHomeWidgetSelection,
+} from '../app/lib/home/workspace-widget-request';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/' });
+for (const key of ['self', 'window', 'document', 'navigator', 'HTMLElement', 'Element', 'Node', 'CustomEvent', 'Event'] as const) {
+  Object.defineProperty(globalThis, key, { value: dom.window[key], configurable: true });
+}
+Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true, configurable: true, writable: true });
+
+function emailResult(refreshToken: string, subject: string, refreshQueued = true) {
+  return {
+    status: 'ready' as const,
+    data: [{ id: `message-${refreshToken}`, accountId: 'account', accountLabel: 'mail@example.test', folder: 'INBOX', from: 'sender@example.test', subject, date: '2026-09-08T10:00:00.000Z' }],
+    cachedAt: '2026-09-08T10:00:00.000Z',
+    stale: true,
+    cache: {
+      enabled: true,
+      state: 'stale' as const,
+      source: 'cache' as const,
+      fetchedAt: '2026-09-08T10:00:00.000Z',
+      staleAt: '2026-09-08T10:01:00.000Z',
+      expiresAt: '2026-09-15T10:00:00.000Z',
+      refreshQueued,
+      refreshToken,
+      partial: false,
+      accountCount: 1,
+      successfulAccountCount: 1,
+    },
+  };
+}
+
+const otherWidgets = {
+  todos: { status: 'ready' as const, data: [{ id: 'todo', title: 'Todo', priority: 'normal', dueAt: null, readState: 'read' }], cachedAt: '2026-09-08T10:00:00.000Z', stale: false },
+  automation: { status: 'ready' as const, data: null, cachedAt: '2026-09-08T10:00:00.000Z', stale: false },
+  studio: { status: 'ready' as const, data: null, cachedAt: '2026-09-08T10:00:00.000Z', stale: false },
+};
+
+function success(data: Record<string, unknown>) {
+  return Response.json({ success: true, data });
+}
+
+async function main() {
+  assert.deepEqual(parseHomeWidgetSelection(null, HOME_WIDGET_NAMES), HOME_WIDGET_NAMES);
+  assert.deepEqual(parseHomeWidgetSelection('studio,emails,studio', []), ['emails', 'studio']);
+  assert.equal(parseHomeWidgetSelection('emails,unknown', []), null);
+  assert.equal(parseHomeWidgetSelection('', []), null);
+
+  const claimedTokens = new Set<string>();
+  assert.equal(claimHomeWidgetRefreshToken(claimedTokens, 'token-0'), true);
+  assert.equal(claimHomeWidgetRefreshToken(claimedTokens, 'token-0'), false);
+  for (let index = 1; index < 205; index += 1) {
+    assert.equal(claimHomeWidgetRefreshToken(claimedTokens, `token-${index}`), true);
+  }
+  assert.equal(claimedTokens.size, 200);
+  assert.equal(claimedTokens.has('token-0'), false);
+  assert.equal(claimedTokens.has('token-4'), false);
+  assert.equal(claimedTokens.has('token-5'), true);
+  assert.equal(claimedTokens.has('token-204'), true);
+
+  const { cleanup, fireEvent, render } = await import('@testing-library/react');
+  const { HOME_EMAIL_STALE_FOLLOW_UP_MS, useHomeWorkspaceWidgets } = await import('../app/components/home/useHomeWorkspaceWidgets');
+  const settle = async (delay = 30) => act(async () => { await new Promise((resolve) => setTimeout(resolve, delay)); });
+
+  function Probe({ workspaceId }: { workspaceId: string }) {
+    const widgets = useHomeWorkspaceWidgets(workspaceId, true);
+    return <div>
+      <span data-testid="email-status">{widgets.emails.status}</span>
+      <span data-testid="email-subject">{widgets.emails.data[0]?.subject || ''}</span>
+      <span data-testid="email-token">{widgets.emails.cache?.refreshToken || ''}</span>
+      <span data-testid="email-source">{widgets.emails.cache?.source || ''}</span>
+      <span data-testid="email-partial">{String(widgets.emails.cache?.partial)}</span>
+      <span data-testid="todo-title">{widgets.todos.data[0]?.title || ''}</span>
+      <button type="button" onClick={() => widgets.retry('todos')}>Retry todos</button>
+    </div>;
+  }
+
+  const calls: URL[] = [];
+  let fullRequests = 0;
+  let emailRequests = 0;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input), 'http://localhost');
+    calls.push(url);
+    const widgets = url.searchParams.get('widgets');
+    if (widgets === 'emails') {
+      emailRequests += 1;
+      return success({ emails: emailResult(emailRequests === 1 ? 'token-two' : 'token-two', 'Refreshed email') });
+    }
+    if (widgets === 'todos') {
+      return success({
+        todos: { ...otherWidgets.todos, data: [{ ...otherWidgets.todos.data[0], title: 'Retried todo' }] },
+      });
+    }
+    assert.equal(widgets, HOME_WIDGET_NAMES.join(','));
+    fullRequests += 1;
+    const token = fullRequests === 1 ? 'token-one' : 'token-two';
+    return success({ emails: emailResult(token, fullRequests === 1 ? 'Cached email' : 'Refreshed email'), ...otherWidgets });
+  };
+
+  let screen = render(<Probe workspaceId="workspace-one" />);
+  await settle();
+  assert.equal(screen.getByTestId('email-status').textContent, 'ready');
+  assert.equal(screen.getByTestId('email-subject').textContent, 'Cached email');
+  assert.equal(screen.getByTestId('email-token').textContent, 'token-one');
+  assert.equal(screen.getByTestId('email-source').textContent, 'cache');
+  assert.equal(screen.getByTestId('email-partial').textContent, 'false');
+  assert.equal(calls.length, 1);
+
+  await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
+  assert.equal(calls.length, 2, 'a stale token should schedule one delayed follow-up');
+  assert.equal(calls[1]?.searchParams.get('widgets'), 'emails');
+  assert.equal(calls[1]?.searchParams.has('refresh'), false);
+  assert.equal(screen.getByTestId('email-token').textContent, 'token-two');
+  await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
+  assert.equal(calls.length, 2, 'a stale follow-up response must not recurse');
+
+  document.dispatchEvent(new Event('visibilitychange'));
+  await settle();
+  assert.equal(calls.length, 3);
+  await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
+  assert.equal(calls.length, 4, 'a new token may schedule one follow-up on a later natural refresh');
+  assert.equal(calls[3]?.searchParams.get('widgets'), 'emails');
+
+  document.dispatchEvent(new Event('visibilitychange'));
+  await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
+  assert.equal(calls.length, 5, 'the same token must never schedule a second follow-up');
+
+  fireEvent.click(screen.getByRole('button', { name: 'Retry todos' }));
+  await settle();
+  assert.equal(calls.at(-1)?.searchParams.get('widgets'), 'todos');
+  assert.equal(calls.at(-1)?.searchParams.get('refresh'), 'todos');
+  assert.equal(screen.getByTestId('todo-title').textContent, 'Retried todo');
+  cleanup();
+
+  const failureCalls: URL[] = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input), 'http://localhost');
+    failureCalls.push(url);
+    if (url.searchParams.get('widgets') === 'emails') return Response.json({ success: false }, { status: 503 });
+    return success({ emails: emailResult('failure-token', 'Preserved cached email'), ...otherWidgets });
+  };
+  screen = render(<Probe workspaceId="workspace-failure" />);
+  await settle();
+  await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
+  assert.equal(failureCalls.length, 2);
+  assert.equal(screen.getByTestId('email-status').textContent, 'ready');
+  assert.equal(screen.getByTestId('email-subject').textContent, 'Preserved cached email');
+  await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
+  assert.equal(failureCalls.length, 2, 'a failed follow-up must remain bounded');
+  cleanup();
+
+  const unmountCalls: URL[] = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input), 'http://localhost');
+    unmountCalls.push(url);
+    return success({ emails: emailResult('unmount-token', 'Unmounted email'), ...otherWidgets });
+  };
+  render(<Probe workspaceId="workspace-unmount" />);
+  await settle();
+  cleanup();
+  await settle(HOME_EMAIL_STALE_FOLLOW_UP_MS + 80);
+  assert.equal(unmountCalls.length, 1, 'unmount must cancel the pending follow-up timer');
+
+  let releaseOld!: () => void;
+  const oldResponse = new Promise<void>((resolve) => { releaseOld = resolve; });
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input), 'http://localhost');
+    const requestedWorkspace = url.searchParams.get('workspaceId');
+    if (requestedWorkspace === 'old') {
+      await oldResponse;
+      return success({ emails: emailResult('old-token', 'Old email', false), ...otherWidgets });
+    }
+    return success({ emails: emailResult('new-token', 'New email', false), ...otherWidgets });
+  };
+  screen = render(<Probe workspaceId="old" />);
+  screen.rerender(<Probe workspaceId="new" />);
+  await settle();
+  assert.equal(screen.getByTestId('email-subject').textContent, 'New email');
+  await act(async () => { releaseOld(); await oldResponse; });
+  assert.equal(screen.getByTestId('email-subject').textContent, 'New email', 'a late workspace response must not replace current data');
+  cleanup();
+
+  console.log('home-workspace-widgets-hook-test: ok');
+}
+
+void main();

--- a/scripts/home-workspace-widgets-test.ts
+++ b/scripts/home-workspace-widgets-test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
 
+import type { EmailResponseCacheMetadata } from '../app/lib/email/cache/read-through';
+import { loadHomeWidgetEmails } from '../app/lib/home/workspace-email-widget';
 import {
   loadHomeWidgetAutomation,
-  loadHomeWidgetEmails,
   loadHomeWidgetStudio,
   loadHomeWidgetTodos,
 } from '../app/lib/home/workspace-widget-data';
@@ -11,17 +12,26 @@ function response(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 }
 
+function cache(input: Partial<EmailResponseCacheMetadata> = {}): EmailResponseCacheMetadata {
+  return {
+    enabled: true,
+    scope: 'list',
+    state: 'fresh',
+    source: 'cache',
+    generation: 1,
+    fetchedAt: '2026-09-07T11:00:00.000Z',
+    staleAt: '2026-09-07T11:01:00.000Z',
+    expiresAt: '2026-09-14T11:00:00.000Z',
+    refreshQueued: false,
+    ...input,
+  };
+}
+
 async function main() {
   const calls: string[] = [];
-  const fetcher: typeof fetch = async (input, init) => {
+  const fetcher: typeof fetch = async (input) => {
     const url = String(input);
     calls.push(url);
-    if (url === '/api/email/accounts') return response({ success: true, data: { accounts: [{ id: 'a', emailAddress: 'a@example.com' }, { id: 'b', emailAddress: 'b@example.com' }] } });
-    if (url.startsWith('/api/email/folders')) return response({ success: true, data: { folders: [{ path: 'INBOX', role: 'inbox' }] } });
-    if (url === '/api/email/messages/list') {
-      const accountId = JSON.parse(String(init?.body)).accountId;
-      return response({ success: true, data: { messages: [{ id: accountId, subject: `Mail ${accountId}`, date: accountId === 'b' ? '2026-09-07T12:00:00Z' : '2026-09-07T11:00:00Z', isRead: false }] } });
-    }
     if (url.startsWith('/api/todos?')) return response({ success: true, data: [{ id: 'todo', title: 'Critical task', priority: 'high', dueAt: null, readState: 'unread' }] });
     if (url === '/api/automations/jobs') return response({ success: true, data: [{ id: 'other', name: 'Other', workspaceId: 'other', status: 'active', updatedAt: '2026-09-07T13:00:00Z' }, { id: 'job', name: 'Workspace job', workspaceId: 'workspace', status: 'active', lastRunAt: '2026-09-07T12:00:00Z', lastRunStatus: 'success' }] });
     if (url === '/api/automations/jobs/job/runs') return response({ success: true, data: [{ createdAt: '2026-09-07T12:00:00Z', resultText: 'Campaign updated' }] });
@@ -29,9 +39,100 @@ async function main() {
     return response({ success: false }, 404);
   };
 
-  const emails = await loadHomeWidgetEmails(fetcher);
-  assert.deepEqual(emails.map((email) => email.id), ['b', 'a']);
-  assert.equal(emails[0]?.accountLabel, 'b@example.com');
+  const listCalls: Array<{ accountId: string; input: Record<string, unknown>; options: Record<string, unknown> }> = [];
+  const scheduleBackgroundTask = () => undefined;
+  const services = {
+    listAccounts: async () => ({
+      accounts: [
+        { id: 'a', emailAddress: 'a@example.com' },
+        { id: 'b', emailAddress: 'b@example.com' },
+      ],
+    }),
+    listMessages: async (_userId: string, input: Record<string, unknown>, options: Record<string, unknown>) => {
+      const accountId = String(input.accountId);
+      listCalls.push({ accountId, input, options });
+      if (accountId === 'b') {
+        return {
+          folder: 'INBOX',
+          messages: [{ id: 'imap:v1:SU5CT1g:77:9001', folder: 'INBOX', subject: 'Mail b', date: '2026-09-07T12:00:00Z', isRead: false }],
+          cache: cache({
+            state: 'stale' as const,
+            source: 'cache' as const,
+            generation: 2,
+            fetchedAt: '2026-09-07T10:00:00.000Z',
+            staleAt: '2026-09-07T10:01:00.000Z',
+            refreshQueued: true,
+          }),
+        };
+      }
+      return {
+        folder: 'inbox',
+        messages: [{ id: 'provider-id-a', subject: 'Mail a', date: '2026-09-07T11:00:00Z', isRead: false }],
+        cache: cache({ source: 'provider' as const }),
+      };
+    },
+  };
+
+  const emails = await loadHomeWidgetEmails('user-a', { services, scheduleBackgroundTask });
+  assert.deepEqual(emails.data.map((email) => email.id), ['imap:v1:SU5CT1g:77:9001', 'provider-id-a']);
+  assert.equal(emails.data[0]?.id, 'imap:v1:SU5CT1g:77:9001', 'opaque provider IDs must be retained exactly');
+  assert.equal(emails.data[1]?.folder, 'inbox', 'the central list response supplies the provider default folder');
+  assert.deepEqual(listCalls.map((call) => call.accountId).sort(), ['a', 'b']);
+  for (const call of listCalls) {
+    assert.deepEqual(call.input, { accountId: call.accountId, filter: 'unread', limit: 3 });
+    assert.equal(call.options.enforceReadPolicy, false);
+    assert.equal(call.options.cacheMode, 'swr');
+    assert.equal(call.options.scheduleBackgroundTask, scheduleBackgroundTask);
+  }
+  assert.equal(emails.cache.state, 'stale');
+  assert.equal(emails.cache.source, 'mixed');
+  assert.equal(emails.cache.refreshQueued, true);
+  assert.equal(emails.cache.partial, false);
+  assert.equal(emails.cache.fetchedAt, '2026-09-07T10:00:00.000Z');
+  assert.equal(emails.stale, true);
+
+  const reordered = await loadHomeWidgetEmails('user-a', {
+    services: {
+      ...services,
+      listAccounts: async () => ({ accounts: [{ id: 'b', emailAddress: 'b@example.com' }, { id: 'a', emailAddress: 'a@example.com' }] }),
+    },
+    scheduleBackgroundTask,
+  });
+  assert.equal(reordered.cache.refreshToken, emails.cache.refreshToken, 'refresh tokens must not depend on account order');
+
+  const partial = await loadHomeWidgetEmails('user-a', {
+    services: {
+      listAccounts: services.listAccounts,
+      listMessages: async (userId, input, options) => {
+        if (input.accountId === 'b') throw new Error('provider unavailable');
+        return services.listMessages(userId, input, options);
+      },
+    },
+  });
+  assert.deepEqual(partial.data.map((email) => email.id), ['provider-id-a']);
+  assert.equal(partial.cache.partial, true);
+  assert.equal(partial.cache.accountCount, 2);
+  assert.equal(partial.cache.successfulAccountCount, 1);
+  assert.equal(partial.cache.state, 'fresh');
+  assert.equal(partial.cache.source, 'provider');
+
+  await assert.rejects(() => loadHomeWidgetEmails('user-a', {
+    services: {
+      listAccounts: services.listAccounts,
+      listMessages: async () => { throw new Error('provider unavailable'); },
+    },
+  }), /Email widget data could not be loaded/u);
+
+  const noAccounts = await loadHomeWidgetEmails('user-a', {
+    services: {
+      listAccounts: async () => ({ accounts: [] }),
+      listMessages: async () => assert.fail('an empty account list must not query messages'),
+    },
+  });
+  assert.deepEqual(noAccounts.data, []);
+  assert.equal(noAccounts.cache.source, 'none');
+  assert.equal(noAccounts.cache.state, 'fresh');
+  assert.equal(noAccounts.cache.partial, false);
 
   const todos = await loadHomeWidgetTodos(fetcher, 'workspace');
   assert.equal(todos[0]?.priority, 'high');

--- a/scripts/imap-message-reference-test.ts
+++ b/scripts/imap-message-reference-test.ts
@@ -1,0 +1,256 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Module from 'node:module';
+
+import type { StoredEmailAccount } from '../app/lib/email/account-store';
+import type { ImapClientLike } from '../app/lib/email/imap-service';
+
+const moduleInternals = Module as typeof Module & {
+  _load: (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+};
+const originalLoad = moduleInternals._load;
+moduleInternals._load = (request, parent, isMain) => {
+  if (request === 'server-only') return {};
+  return originalLoad(request, parent, isMain);
+};
+
+let tmpRoot = '';
+
+async function main() {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'canvas-imap-message-reference-'));
+  process.env.CANVAS_DATA_ROOT = tmpRoot;
+  process.env.INTEGRATIONS_ENV_MASTER_KEY = 'imap-message-reference-test-key';
+
+  const { writeEmailAccountSecret } = await import('../app/lib/email/secret-store');
+  const {
+    archiveImapEmailMessage,
+    createImapMessageReference,
+    deleteImapEmailMessagePermanently,
+    getImapMailboxUidValidity,
+    isImapMailboxChangedError,
+    listImapEmailMessages,
+    moveImapEmailMessage,
+    parseImapMessageReference,
+    readImapEmailMessage,
+    setImapClientFactoryForTests,
+    setImapEmailMessageRead,
+    trashImapEmailMessage,
+  } = await import('../app/lib/email/imap-service');
+
+  const secretRef = 'imap-reference-user/imap-reference-account.json.enc';
+  await writeEmailAccountSecret(secretRef, {
+    authType: 'smtp_imap',
+    smtp: {
+      host: 'smtp.example.test',
+      port: 587,
+      secure: false,
+      username: 'reader@example.test',
+      password: 'smtp-secret',
+    },
+    imap: {
+      host: 'imap.example.test',
+      port: 993,
+      secure: true,
+      username: 'reader@example.test',
+      password: 'imap-secret',
+    },
+  });
+
+  const now = new Date('2026-09-08T09:00:00.000Z');
+  const account = {
+    id: 'imap-reference-account',
+    userId: 'imap-reference-user',
+    provider: 'smtp_imap',
+    authType: 'smtp_imap',
+    emailAddress: 'reader@example.test',
+    displayName: 'IMAP Reader',
+    providerAccountId: null,
+    status: 'active',
+    policyJson: JSON.stringify({ readFrom: ['@example.test'], sendTo: ['@example.test'] }),
+    secretRef,
+    isPrimary: true,
+    accountScope: 'personal',
+    organizationId: null,
+    connectedByUserId: 'imap-reference-user',
+    automationEnabledAt: null,
+    workspaceId: null,
+    lastUsedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  } as StoredEmailAccount;
+
+  let currentUidValidity = BigInt(7001);
+  let connectCalls = 0;
+  let fetchOneCalls = 0;
+  let flagCalls = 0;
+  let moveCalls = 0;
+  let deleteCalls = 0;
+  const lockedFolders: string[] = [];
+  const source = Buffer.from([
+    'From: Sender <sender@example.test>',
+    'To: reader@example.test',
+    'Subject: Stable IMAP identity',
+    'Date: Tue, 08 Sep 2026 09:00:00 +0000',
+    '',
+    'Message body.',
+  ].join('\r\n'));
+  const fetchedMessage = {
+    uid: 41,
+    flags: new Set<string>(),
+    envelope: {
+      subject: 'Stable IMAP identity',
+      date: now,
+      from: [{ name: 'Sender', address: 'sender@example.test' }],
+      to: [{ address: 'reader@example.test' }],
+    },
+    internalDate: now,
+    source,
+  };
+
+  setImapClientFactoryForTests(() => {
+    const client: ImapClientLike = {
+      get mailbox() {
+        return { uidValidity: currentUidValidity };
+      },
+      connect: async () => {
+        connectCalls += 1;
+      },
+      logout: async () => undefined,
+      close: () => undefined,
+      list: async () => [
+        { path: 'Archive', name: 'Archive', flags: new Set(['\\Archive']), specialUse: '\\Archive' },
+        { path: 'Trash', name: 'Trash', flags: new Set(['\\Trash']), specialUse: '\\Trash' },
+      ] as never,
+      getMailboxLock: async (folder) => {
+        lockedFolders.push(Array.isArray(folder) ? folder.join('/') : folder);
+        return { release: () => undefined };
+      },
+      search: async () => [41],
+      fetch: async function* () {
+        yield fetchedMessage as never;
+      },
+      fetchOne: async () => {
+        fetchOneCalls += 1;
+        return fetchedMessage as never;
+      },
+      messageFlagsAdd: async () => {
+        flagCalls += 1;
+        return true;
+      },
+      messageFlagsRemove: async () => {
+        flagCalls += 1;
+        return true;
+      },
+      messageDelete: async () => {
+        deleteCalls += 1;
+        return true;
+      },
+      messageMove: async () => {
+        moveCalls += 1;
+        return true;
+      },
+    };
+    return client;
+  });
+
+  assert.equal(getImapMailboxUidValidity({ mailbox: { uidValidity: BigInt(7001) } }), '7001');
+  assert.throws(() => getImapMailboxUidValidity({ mailbox: false }), /UIDVALIDITY is unavailable/u);
+  const directlyCreated = createImapMessageReference(' Archive ', '7001', 41);
+  assert.deepEqual(parseImapMessageReference(directlyCreated), {
+    version: 1,
+    folder: 'Archive',
+    uidValidity: '7001',
+    uid: 41,
+  });
+  assert.deepEqual(parseImapMessageReference('41', ' Archive '), {
+    version: 0,
+    folder: 'Archive',
+    uidValidity: null,
+    uid: 41,
+  });
+  assert.throws(() => parseImapMessageReference('imap:v1:not+base64url'), /Invalid IMAP message ID/u);
+
+  const listed = await listImapEmailMessages(account, { folder: 'INBOX', limit: 5 });
+  assert.equal(listed.uidValidity, '7001');
+  assert.equal(listed.messages.length, 1);
+  assert.equal(listed.messages[0].uid, '41');
+  assert.notEqual(listed.messages[0].id, listed.messages[0].uid);
+  assert.deepEqual(parseImapMessageReference(listed.messages[0].id), {
+    version: 1,
+    folder: 'INBOX',
+    uidValidity: '7001',
+    uid: 41,
+  });
+
+  const reference = listed.messages[0].id;
+  const read = await readImapEmailMessage(account, reference);
+  assert.equal(read.message.id, reference);
+  assert.equal(read.message.uid, '41');
+  assert.equal(read.message.uidValidity, '7001');
+  assert.equal(lockedFolders.at(-1), 'INBOX');
+
+  const marked = await setImapEmailMessageRead(account, reference, 'inbox', true);
+  assert.equal(marked.messageId, reference);
+  assert.equal(marked.uid, '41');
+  assert.equal(marked.uidValidity, '7001');
+  assert.equal(flagCalls, 1);
+
+  const connectsBeforeFolderMismatch = connectCalls;
+  await assert.rejects(
+    () => readImapEmailMessage(account, reference, 'Archive'),
+    /Invalid IMAP message ID/u,
+  );
+  assert.equal(connectCalls, connectsBeforeFolderMismatch, 'folder mismatch must fail before connecting');
+
+  currentUidValidity = BigInt(7002);
+  const providerCallsBeforeStaleReference = {
+    fetchOneCalls,
+    flagCalls,
+    moveCalls,
+    deleteCalls,
+  };
+  const staleOperations = [
+    () => readImapEmailMessage(account, reference),
+    () => setImapEmailMessageRead(account, reference, undefined, true),
+    () => moveImapEmailMessage(account, reference, undefined, 'Archive'),
+    () => archiveImapEmailMessage(account, reference),
+    () => trashImapEmailMessage(account, reference),
+    () => deleteImapEmailMessagePermanently(account, reference),
+  ];
+  for (const operation of staleOperations) {
+    await assert.rejects(operation, (error: unknown) => {
+      assert.equal(isImapMailboxChangedError(error), true);
+      if (isImapMailboxChangedError(error)) {
+        assert.equal(error.code, 'EMAIL_MAILBOX_CHANGED');
+        assert.equal(error.status, 409);
+        assert.equal(error.folder, 'INBOX');
+        assert.equal(error.expectedUidValidity, '7001');
+        assert.equal(error.actualUidValidity, '7002');
+      }
+      return true;
+    });
+  }
+  assert.deepEqual({ fetchOneCalls, flagCalls, moveCalls, deleteCalls }, providerCallsBeforeStaleReference);
+
+  const legacyRead = await readImapEmailMessage(account, '41', 'INBOX');
+  assert.equal(legacyRead.message.id, '41');
+  assert.equal(legacyRead.message.uidValidity, '7002');
+  const legacyMarked = await setImapEmailMessageRead(account, '41', 'INBOX', true);
+  assert.equal(legacyMarked.messageId, '41');
+  assert.equal(legacyMarked.uid, '41');
+  assert.equal(legacyMarked.uidValidity, '7002');
+  assert.equal(flagCalls, providerCallsBeforeStaleReference.flagCalls + 1);
+
+  setImapClientFactoryForTests(null);
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+  tmpRoot = '';
+  console.log('imap-message-reference-test: ok');
+}
+
+main().catch(async (error) => {
+  if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => undefined);
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/todo-email-reply-watcher-test.ts
+++ b/scripts/todo-email-reply-watcher-test.ts
@@ -25,6 +25,10 @@ let activeBody = [
 ].join('\n');
 let activeDate = '2026-06-08T12:00:00.000Z';
 let activeInReplyTo: string | null = outboundMessageId;
+let activeProviderId: string | null = null;
+let activeThreadId: string | null = null;
+let activeUid: string | null = null;
+let activeUidValidity: string | null = null;
 const dispatches: Array<{
   sessionId: string;
   userId: string;
@@ -40,26 +44,30 @@ moduleInternals._load = (request, parent, isMain) => {
 
   if (request === '@/app/lib/email/service' || request.endsWith('/email/service')) {
     return {
-      listEmailMessages: async (_userId: string, input: { accountId: string; query?: string }) => ({
-        account: { id: input.accountId },
-        folder: 'INBOX',
-        messages: [{
-          id: `${activeToken}-msg`,
-          uid: `${activeToken}-msg`,
+      listEmailMessages: async (_userId: string, input: { accountId: string; query?: string }) => {
+        const messageId = activeProviderId || `${activeToken}-msg`;
+        return {
+          account: { id: input.accountId },
           folder: 'INBOX',
-          threadId: `${activeToken}-thread`,
-          from: 'owner@example.test',
-          subject: activeSubject,
-          date: activeDate,
-          snippet: activeBody.slice(0, 200),
-        }],
-      }),
+          ...(activeUidValidity ? { uidValidity: activeUidValidity } : {}),
+          messages: [{
+            id: messageId,
+            uid: activeUid || messageId,
+            folder: 'INBOX',
+            threadId: activeThreadId || `${activeToken}-thread`,
+            from: 'owner@example.test',
+            subject: activeSubject,
+            date: activeDate,
+            snippet: activeBody.slice(0, 200),
+          }],
+        };
+      },
       readEmailMessage: async (_userId: string, _accountId: string, messageId: string, folder?: string) => ({
         account: { id: _accountId },
         message: {
           id: messageId,
           folder: folder || 'INBOX',
-          threadId: `${activeToken}-thread`,
+          threadId: activeThreadId || `${activeToken}-thread`,
           from: 'owner@example.test',
           subject: activeSubject,
           date: activeDate,
@@ -363,6 +371,169 @@ async function main() {
   });
   assert.equal(ambiguousWatcher?.status, 'failed');
   assert.match(ambiguousWatcher?.error || '', /ambiguous across multiple agents/);
+
+  await db.update(todoEmailReplyWatchers).set({ status: 'completed' });
+
+  const { createImapMessageReference } = await import('../app/lib/email/imap-service');
+  const { resolveProviderMessageIdentity } = await import('../app/lib/email/provider-message-identity');
+  assert.deepEqual(resolveProviderMessageIdentity({ id: 'gmail-message-id', uid: 'gmail-message-id', folder: 'INBOX' }), {
+    canonicalId: 'gmail-message-id',
+    folder: 'INBOX',
+    isImap: false,
+    legacyId: null,
+    uid: null,
+    uidValidity: null,
+  });
+  assert.throws(
+    () => resolveProviderMessageIdentity({ id: '1', uid: '4294967296', uidValidity: '9', folder: 'INBOX' }),
+    /Invalid IMAP UID or UIDVALIDITY/u,
+  );
+  assert.throws(
+    () => resolveProviderMessageIdentity({ id: '1', uid: '1', uidValidity: '4294967296', folder: 'INBOX' }),
+    /Invalid IMAP UID or UIDVALIDITY/u,
+  );
+  assert.throws(
+    () => resolveProviderMessageIdentity({
+      id: createImapMessageReference('INBOX', '42', 1),
+      uid: '2',
+      uidValidity: '42',
+      folder: 'INBOX',
+    }),
+    /Inconsistent IMAP message identity/u,
+  );
+  assert.throws(
+    () => resolveProviderMessageIdentity({
+      id: createImapMessageReference('INBOX', '42', 1),
+      uid: 'not-a-uid',
+      folder: 'INBOX',
+    }),
+    /Invalid IMAP UID or UIDVALIDITY/u,
+  );
+  assert.throws(
+    () => resolveProviderMessageIdentity({
+      id: createImapMessageReference('INBOX', '42', 1),
+      uidValidity: '4294967296',
+      folder: 'INBOX',
+    }),
+    /Invalid IMAP UID or UIDVALIDITY/u,
+  );
+  activeToken = 'CTD-IMAPMIG1';
+  activeSubject = `Re: New Canvas to-do [${activeToken}]`;
+  activeBody = `Identical legacy IMAP reply.\n\nReply code ${activeToken}`;
+  activeDate = '2026-06-08T12:50:00.000Z';
+  activeInReplyTo = outboundMessageId;
+  activeUid = '71';
+  activeUidValidity = '9001';
+  activeThreadId = 'imap-thread-71';
+  activeProviderId = createImapMessageReference('INBOX', activeUidValidity, Number(activeUid));
+
+  await seedBase('reply-user-imap-migrate', 'reply-todo-imap-migrate', 'reply-session-imap-migrate');
+  await createTodoEmailReplyWatcher({
+    todoId: 'reply-todo-imap-migrate',
+    userId: 'reply-user-imap-migrate',
+    accountId: accountIdFor('reply-user-imap-migrate'),
+    replyToken: activeToken,
+    outboundMessageId,
+    sourceAgentId: 'canvas-agent',
+    sourceSessionId: 'reply-session-imap-migrate',
+    locale: 'en',
+    sentAt: new Date('2026-06-08T12:49:00.000Z'),
+  });
+  const migrationWatcher = await db.query.todoEmailReplyWatchers.findFirst({
+    where: eq(todoEmailReplyWatchers.todoId, 'reply-todo-imap-migrate'),
+  });
+  assert.ok(migrationWatcher);
+  const migrationReplyText = extractTodoEmailReplyText(activeBody, activeToken);
+  const migrationCreatedAt = new Date('2026-06-08T12:50:30.000Z');
+  await db.insert(todoEmailReplyEvents).values({
+    id: 'legacy-todo-reply-match',
+    watcherId: migrationWatcher.id,
+    todoId: migrationWatcher.todoId,
+    userId: migrationWatcher.userId,
+    accountId: migrationWatcher.accountId,
+    providerMessageId: `INBOX:${activeUid}`,
+    threadId: activeThreadId,
+    folder: 'INBOX',
+    fromAddress: 'owner@example.test',
+    subject: activeSubject,
+    receivedAt: new Date(activeDate),
+    replyText: migrationReplyText,
+    status: 'dispatched',
+    error: null,
+    dispatchedAt: migrationCreatedAt,
+    createdAt: migrationCreatedAt,
+    updatedAt: migrationCreatedAt,
+  });
+  const dispatchCountBeforeMigration = dispatches.length;
+  const migrationPoll = await pollTodoEmailReplies({ now: new Date('2026-06-08T12:51:00.000Z') });
+  assert.equal(migrationPoll.processed, 0);
+  assert.equal(migrationPoll.skipped, 1);
+  assert.equal(dispatches.length, dispatchCountBeforeMigration);
+  const migratedReplyEvent = await db.query.todoEmailReplyEvents.findFirst({
+    where: eq(todoEmailReplyEvents.id, 'legacy-todo-reply-match'),
+  });
+  assert.equal(migratedReplyEvent?.providerMessageId, `INBOX:${activeProviderId}`);
+  await db
+    .update(todoEmailReplyWatchers)
+    .set({ status: 'completed' })
+    .where(eq(todoEmailReplyWatchers.id, migrationWatcher.id));
+
+  activeToken = 'CTD-IMAPREUS';
+  activeSubject = `Re: New Canvas to-do [${activeToken}]`;
+  activeBody = `New message after UIDVALIDITY rollover.\n\nReply code ${activeToken}`;
+  activeDate = '2026-06-08T13:00:00.000Z';
+  activeUid = '72';
+  activeUidValidity = '9002';
+  activeThreadId = 'new-imap-thread-72';
+  activeProviderId = createImapMessageReference('INBOX', activeUidValidity, Number(activeUid));
+
+  await seedBase('reply-user-imap-reuse', 'reply-todo-imap-reuse', 'reply-session-imap-reuse');
+  await createTodoEmailReplyWatcher({
+    todoId: 'reply-todo-imap-reuse',
+    userId: 'reply-user-imap-reuse',
+    accountId: accountIdFor('reply-user-imap-reuse'),
+    replyToken: activeToken,
+    outboundMessageId,
+    sourceAgentId: 'canvas-agent',
+    sourceSessionId: 'reply-session-imap-reuse',
+    locale: 'en',
+    sentAt: new Date('2026-06-08T12:59:00.000Z'),
+  });
+  const reuseWatcher = await db.query.todoEmailReplyWatchers.findFirst({
+    where: eq(todoEmailReplyWatchers.todoId, 'reply-todo-imap-reuse'),
+  });
+  assert.ok(reuseWatcher);
+  const reuseCreatedAt = new Date('2026-06-08T12:58:30.000Z');
+  await db.insert(todoEmailReplyEvents).values({
+    id: 'legacy-todo-reply-reused-uid',
+    watcherId: reuseWatcher.id,
+    todoId: reuseWatcher.todoId,
+    userId: reuseWatcher.userId,
+    accountId: reuseWatcher.accountId,
+    providerMessageId: `INBOX:${activeUid}`,
+    threadId: 'old-imap-thread-72',
+    folder: 'INBOX',
+    fromAddress: 'different-sender@example.test',
+    subject: 'Old message in a previous UIDVALIDITY namespace',
+    receivedAt: new Date('2026-06-08T12:58:00.000Z'),
+    replyText: 'Old reply text.',
+    status: 'dispatched',
+    error: null,
+    dispatchedAt: reuseCreatedAt,
+    createdAt: reuseCreatedAt,
+    updatedAt: reuseCreatedAt,
+  });
+  const dispatchCountBeforeReuse = dispatches.length;
+  const reusePoll = await pollTodoEmailReplies({ now: new Date('2026-06-08T13:01:00.000Z') });
+  assert.equal(reusePoll.processed, 1);
+  assert.equal(reusePoll.failed, 0);
+  assert.equal(dispatches.length, dispatchCountBeforeReuse + 1);
+  const reuseEvents = await db.query.todoEmailReplyEvents.findMany({
+    where: eq(todoEmailReplyEvents.watcherId, reuseWatcher.id),
+  });
+  assert.equal(reuseEvents.length, 2);
+  assert.ok(reuseEvents.some((event) => event.providerMessageId === `INBOX:${activeUid}`));
+  assert.ok(reuseEvents.some((event) => event.providerMessageId === `INBOX:${activeProviderId}`));
 
   console.log('Todo email reply watcher test passed.');
 }


### PR DESCRIPTION
## Summary

- add a bounded PostgreSQL cache for email list snapshots, message metadata, and opened message bodies
- serve fresh or stale cached data immediately and deduplicate provider refreshes with mailbox-scoped leases
- keep cache generations consistent after message mutations, disconnects, and local account reconnects
- preserve IMAP identity with folder, UIDVALIDITY, and UID and return mailbox-change conflicts safely
- route the Home email widget and EmailClient through bounded stale follow-ups without refresh loops
- keep agent, poller, and policy-enforced reads provider-fresh by default

## Validation

- npm run lint
- npm run build
- email cache persistence, read-through, consistency, reconnect, and IMAP identity tests
- email inbox flow and client SWR refresh tests
- Home widget server, cache, and hook tests
- GitNexus impact and compare analysis

## Screenshots

Not included: the UI changes are behavior-only refresh orchestration and do not alter visual layout.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds PostgreSQL-backed email list and message caching with stale-while-revalidate reads, mailbox-scoped refresh leases, mutation consistency, and IMAP identity safeguards.
- Adds cache persistence, migrations, lease-based read-through refreshes, and cache-generation invalidation.
- Routes email APIs and the Home widget through stale-while-revalidate behavior.
- Adds client refresh orchestration and regression coverage for cache consistency, reconnects, mailbox changes, and widget behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/lib/email/cache/read-through.ts | Implements cache hits, stale responses, mailbox-scoped refresh leases, provider fallback, and background refresh persistence. |
| app/lib/email/cache/store.ts | Defines PostgreSQL cache storage, retention windows, generation checks, message persistence, and refresh-lease operations. |
| app/lib/email/service.ts | Integrates cache modes and consistency behavior into email list and message service operations. |
| app/apps/email/components/EmailClient.tsx | Adds generation-scoped list and detail follow-ups with mutation and request-order guards. |
| app/components/home/useHomeWorkspaceWidgets.ts | Adds per-widget requests, stale email follow-ups, request generations, and targeted retry behavior. |
| app/lib/email/imap-service.ts | Preserves IMAP message identity and surfaces mailbox-change conflicts through service boundaries. |
| app/lib/email/cache/postgres-migration.ts | Adds the PostgreSQL schema required for cached mailboxes, lists, messages, generations, and refresh leases. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Email UI / Home Widget
    participant API as Next.js API
    participant Cache as PostgreSQL Cache
    participant Provider as Email Provider
    UI->>API: Read messages
    API->>Cache: Read current generation
    alt Fresh snapshot
        Cache-->>API: Cached messages
        API-->>UI: Fresh cached response
    else Stale snapshot
        Cache-->>API: Stale messages + refresh metadata
        API-->>UI: Immediate stale response
        API->>Cache: Acquire mailbox refresh lease
        API->>Provider: Background refresh
        Provider-->>API: Updated messages
        API->>Cache: Persist snapshot and release lease
    else Cache miss
        API->>Provider: Synchronous read
        Provider-->>API: Messages
        API->>Cache: Persist snapshot
        API-->>UI: Provider response
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Keep polling queued home email refreshes"](https://github.com/canvascoding/canvas-notebook/commit/b2b00c31984c73eb17189ef5c075732b222ca188) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61587419)</sub>

<!-- /greptile_comment -->