### PR TITLE
Enable zero-config MCP app widgets

### DIFF
--- a/app/api/mcp/apps/route.ts
+++ b/app/api/mcp/apps/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/app/lib/auth';
 import { McpAccessError, mcpErrorStatus, requireMcpUserAccess } from '@/app/lib/mcp/access';
-import { isMcpAppsEnabled } from '@/app/lib/mcp/apps-config';
+import { isMcpAppsEnabled, mcpAppOrigins } from '@/app/lib/mcp/apps-config';
 import { issueMcpAppTicket, parseMcpAppDescriptor, requireMcpAppChatAccess } from '@/app/lib/mcp/apps-host';
 import { callMcpAppTool } from '@/app/lib/mcp/manager';
 import { mcpReconnectDetails } from '@/app/lib/mcp/connection-health';
-import { htmlPreviewOrigins } from '@/app/lib/html-preview-origin';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -39,7 +38,7 @@ export async function POST(request: Request) {
   let connectionId: string | undefined;
   let userId: string | undefined;
   try {
-    if (request.headers.get('origin') !== htmlPreviewOrigins().appOrigin) throw new McpAccessError('Cross-origin app access is not allowed.', 403);
+    if (request.headers.get('origin') !== mcpAppOrigins().appOrigin) throw new McpAccessError('Cross-origin app access is not allowed.', 403);
     const session = await auth.api.getSession({ headers: request.headers });
     if (!session) throw new McpAccessError('Sign in to use MCP apps.', 401);
     userId = session.user.id;

--- a/app/components/canvas-agent-chat/McpAppWidget.tsx
+++ b/app/components/canvas-agent-chat/McpAppWidget.tsx
@@ -55,8 +55,8 @@ export function McpAppWidget({ descriptor, input, result, sessionId, agentId }: 
         return;
       }
       const url = new URL(body.data.frameUrl);
-      if (url.origin !== body.data.frameOrigin || url.hostname === window.location.hostname
-        || !['http:', 'https:'].includes(url.protocol) || (window.location.protocol === 'https:' && url.protocol !== 'https:')
+      if (url.origin !== body.data.frameOrigin || !['http:', 'https:'].includes(url.protocol)
+        || (window.location.protocol === 'https:' && url.protocol !== 'https:')
         || !/^\/__preview\/[A-Za-z0-9_-]{43}\/mcp-app\/frame$/u.test(url.pathname) || url.search || url.hash || url.username || url.password) throw new Error();
       setFrame({ url: url.href, origin: url.origin });
     }).catch(() => { if (!abort.signal.aborted) setError('unavailable'); });

--- a/app/lib/html-preview-origin.ts
+++ b/app/lib/html-preview-origin.ts
@@ -9,6 +9,11 @@ function origin(value: string): URL {
   return parsed;
 }
 
+/** Uses the configured deployment origin only, never a request Host/forwarded header. */
+export function canvasAppOrigin(env: PreviewEnvironment = process.env): string {
+  return origin(env.BETTER_AUTH_BASE_URL || env.BASE_URL || `http://localhost:${env.PORT || '3000'}`).origin;
+}
+
 /** Uses configured deployment origins only, never a request Host/forwarded header. */
 export function htmlPreviewOrigins(env: PreviewEnvironment = process.env) {
   const app = origin(env.BETTER_AUTH_BASE_URL || env.BASE_URL || `http://localhost:${env.PORT || '3000'}`);

--- a/app/lib/mcp/apps-config.ts
+++ b/app/lib/mcp/apps-config.ts
@@ -1,11 +1,36 @@
 import 'server-only';
 
-import { htmlPreviewOrigins } from '@/app/lib/html-preview-origin';
+import { canvasAppOrigin, htmlPreviewOrigins } from '@/app/lib/html-preview-origin';
 
-export function isMcpAppsEnabled(env: Record<string, string | undefined> = process.env): boolean {
-  if (env.CANVAS_MCP_APPS_ENABLED !== 'true') return false;
+type McpAppsEnvironment = Record<string, string | undefined>;
+
+/**
+ * MCP Apps use the normal Canvas origin by default. The fixed Canvas relay then
+ * places provider HTML in a nested opaque-origin sandbox. Operators that have
+ * already provisioned an explicit preview origin retain that extra boundary.
+ */
+export function mcpAppOrigins(env: McpAppsEnvironment = process.env) {
+  const appOrigin = canvasAppOrigin(env);
+  const frameOrigin = env.CANVAS_HTML_PREVIEW_ORIGIN?.trim()
+    ? htmlPreviewOrigins(env).previewOrigin
+    : appOrigin;
+  return { appOrigin, frameOrigin };
+}
+
+export function isMcpAppFrameHost(host: string | null | undefined, env: McpAppsEnvironment = process.env): boolean {
+  if (!host || /[\s/@\\?#]/u.test(host)) return false;
   try {
-    htmlPreviewOrigins(env);
+    const frame = new URL(mcpAppOrigins(env).frameOrigin);
+    return new URL(`${frame.protocol}//${host}`).host === frame.host;
+  } catch {
+    return false;
+  }
+}
+
+export function isMcpAppsEnabled(env: McpAppsEnvironment = process.env): boolean {
+  if (env.CANVAS_MCP_APPS_ENABLED?.trim().toLowerCase() === 'false') return false;
+  try {
+    mcpAppOrigins(env);
     return true;
   } catch {
     return false;

--- a/app/lib/mcp/apps-host.ts
+++ b/app/lib/mcp/apps-host.ts
@@ -6,9 +6,8 @@ import { db } from '@/app/lib/db';
 import { piSessions, session as authSessions } from '@/app/lib/db/schema';
 import { requireAgentAccess } from '@/app/lib/agents/access';
 import { resolveAgentSessionWorkspaceForUser } from '@/app/lib/pi/session-workspace-context';
-import { htmlPreviewOrigins, isHtmlPreviewHost } from '@/app/lib/html-preview-origin';
 import { assertMcpConnectionAccess, McpAccessError } from '@/app/lib/mcp/access';
-import { isMcpAppsEnabled } from '@/app/lib/mcp/apps-config';
+import { isMcpAppFrameHost, isMcpAppsEnabled, mcpAppOrigins } from '@/app/lib/mcp/apps-config';
 import { isMcpAppResourceMimeType } from '@/app/lib/mcp/apps-metadata';
 import { readMcpAppResource } from '@/app/lib/mcp/manager';
 import type { McpAppInvocationDetails } from '@/app/lib/mcp/apps-types';
@@ -87,8 +86,8 @@ export async function issueMcpAppTicket(input: McpAppChat & {
     authSessionId: input.authSessionId, app: input.app, workspaceId,
     authVersion: connection.authVersion ?? 1, html: content.text, expiresAt,
   });
-  const { previewOrigin } = htmlPreviewOrigins();
-  return { frameUrl: `${previewOrigin}/__preview/${ticket}/mcp-app/frame`, frameOrigin: previewOrigin };
+  const { frameOrigin } = mcpAppOrigins();
+  return { frameUrl: `${frameOrigin}/__preview/${ticket}/mcp-app/frame`, frameOrigin };
 }
 
 async function resolveMcpAppTicket(ticket: string): Promise<AppTicket | null> {
@@ -114,9 +113,9 @@ const privateHeaders = {
   'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=(), clipboard-read=(), clipboard-write=()',
 };
 
-/** Trusted relay on the preview origin; the app itself has an opaque sandbox origin. */
+/** Trusted Canvas relay; the provider app itself has an opaque sandbox origin. */
 export function buildMcpAppSandboxDocument(canvasOrigin: string, documentPath: string, nonce: string): string {
-  // This relay is the preview-origin iframe. Its parent is the Canvas page, so
+  // This relay is trusted Canvas code. Its parent is the Canvas page, so
   // incoming parent messages and replies are intentionally bound to Canvas's
   // application origin. The nested app document below has an opaque origin.
   const config = JSON.stringify({ canvasOrigin, documentPath }).replace(/</gu, '\\u003c');
@@ -137,15 +136,16 @@ export function buildMcpAppSandboxDocument(canvasOrigin: string, documentPath: s
 
 export async function deliverMcpAppTicket(request: Request, ticket: string, mode: string): Promise<Response> {
   const unavailable = () => new Response(null, { status: 404, headers: privateHeaders });
-  if (!isHtmlPreviewHost(request.headers.get('host')) || !['frame', 'document'].includes(mode)) return unavailable();
+  if (!isMcpAppFrameHost(request.headers.get('host')) || !['frame', 'document'].includes(mode)) return unavailable();
   try {
     const record = await resolveMcpAppTicket(ticket);
     if (!record) return unavailable();
-    const { appOrigin, previewOrigin } = htmlPreviewOrigins();
+    const { appOrigin, frameOrigin } = mcpAppOrigins();
+    const frameAncestors = [...new Set([appOrigin, frameOrigin])].join(' ');
     const nonce = randomBytes(18).toString('base64');
     const csp = mode === 'frame'
       ? `default-src 'none'; script-src 'nonce-${nonce}'; style-src 'nonce-${nonce}'; frame-src 'self'; connect-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors ${appOrigin}; sandbox allow-scripts allow-same-origin`
-      : `default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; media-src data: blob:; connect-src 'none'; frame-src 'none'; worker-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors ${appOrigin} ${previewOrigin}; sandbox allow-scripts`;
+      : `default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; media-src data: blob:; connect-src 'none'; frame-src 'none'; worker-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors ${frameAncestors}; sandbox allow-scripts`;
     const body = mode === 'frame'
       ? buildMcpAppSandboxDocument(appOrigin, `/__preview/${ticket}/mcp-app/document`, nonce) : record.html;
     return new Response(body, { headers: { ...privateHeaders, 'Content-Type': 'text/html; charset=utf-8', 'Content-Security-Policy': csp } });

--- a/docs/security/mcp-apps.md
+++ b/docs/security/mcp-apps.md
@@ -1,17 +1,22 @@
 # MCP Apps security model
 
-Interactive MCP Apps are disabled by default. They are enabled only when
-`CANVAS_MCP_APPS_ENABLED=true` and Canvas can resolve its isolated HTML preview
-origin. If either condition is absent, the app API returns `404`.
+Interactive MCP Apps work after a normal Canvas update without additional DNS,
+subdomains, proxy routes, or environment settings. Set
+`CANVAS_MCP_APPS_ENABLED=false` only when an operator wants to disable them; the
+app API then returns `404`.
 
 ## Activation and routing
 
-Set `CANVAS_MCP_APPS_ENABLED=true` and configure a distinct preview origin, for
-example `CANVAS_HTML_PREVIEW_ORIGIN=https://preview.example.test`. The Canvas
-application origin comes from `BASE_URL` or `BETTER_AUTH_BASE_URL`. The preview
-host must route its `__preview/.../mcp-app/...` requests to the same Canvas
-server and process that issued the ticket; tickets are in memory, so a process
-restart invalidates them.
+By default, Canvas serves its fixed MCP relay through the normal application
+origin from `BASE_URL` or `BETTER_AUTH_BASE_URL`. The untrusted provider HTML
+does not inherit that origin: the relay places it in a nested iframe with a
+browser-enforced opaque origin and a restrictive CSP.
+
+An existing explicit `CANVAS_HTML_PREVIEW_ORIGIN` is still honored and adds a
+separate origin around the trusted relay. This is optional defense in depth for
+operators that already have the DNS and proxy route; MCP Apps do not require it.
+Both modes route `__preview/.../mcp-app/...` to the same Canvas process that
+issued the ticket. Tickets are in memory, so a process restart invalidates them.
 
 ## Eligibility and metadata
 
@@ -33,23 +38,24 @@ session and agent with current workspace `canRead` and `canRunAgent` access.
 It also checks the app connection for that same user before reading its
 resource. App HTML is limited to 2 MiB.
 
-Canvas returns a short-lived ticket URL on the isolated preview origin. Tickets
-expire after five minutes (or earlier with the login session), are kept only in
-process memory, and are limited to eight per user and 32 globally. Ticket use
-rechecks the login session, current connection authorization version, chat
-ownership, agent access, and workspace access.
+Canvas returns a short-lived ticket URL on its configured MCP frame origin.
+Tickets expire after five minutes (or earlier with the login session), are kept
+only in process memory, and are limited to eight per user and 32 globally.
+Ticket use rechecks the login session, current connection authorization version,
+chat ownership, agent access, and workspace access.
 
-The outer preview document is a relay. It embeds the app document in a nested
-`allow-scripts` sandbox, leaving the inner document with an opaque origin. The
-outer frame is limited to Canvas as an ancestor; the inner CSP permits no
-network connections, frames, workers, objects, forms, or external media/fonts.
+The outer document is fixed Canvas relay code. It embeds the provider document
+in a nested `allow-scripts` sandbox, leaving the inner document with an opaque
+origin. The outer frame is limited to Canvas as an ancestor; provider HTML is
+never inserted into that same-origin relay. The inner CSP permits no network
+connections, frames, workers, objects, forms, or external media/fonts.
 This also denies network access to domains an app might declare. Both layers
 use `no-referrer`; the browser permissions policy disables camera, microphone,
 geolocation, payment, USB, and clipboard access.
 
 Bridge messages are JSON-RPC objects only and are size capped at 2 MiB in the
 relay. The browser transport binds messages to the rendered iframe window and
-the ticket's preview origin. Canvas does not retain raw bridge message logs.
+the ticket's frame origin. Canvas does not retain raw bridge message logs.
 
 ## Tool calls and approvals
 

--- a/package.json
+++ b/package.json
@@ -483,7 +483,7 @@
     "test:security:public:http": "node scripts/security-public-http-test.mjs",
     "test:security:pdf": "tsx --conditions react-server scripts/pdf-security-test.ts",
     "test:security:pdf-network": "tsx --conditions react-server scripts/pdf-network-security-test.ts",
-    "test:security:html-preview": "tsx scripts/html-preview-assets-test.ts && tsx scripts/html-preview-origin-test.ts && tsx scripts/html-preview-boundary-test.ts",
+    "test:security:html-preview": "tsx scripts/html-preview-assets-test.ts && tsx scripts/html-preview-origin-test.ts && tsx scripts/html-preview-boundary-test.ts && tsx scripts/html-preview-proxy-test.ts",
     "test:security:workspaces": "tsx --conditions react-server scripts/security-workspace-scope-test.ts",
     "test:security:dependencies": "tsx scripts/security-dependencies-test.ts",
     "test:mcp:network": "tsx scripts/mcp-network-test.ts && tsx scripts/mcp-network-dns-test.ts"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "test:mcp:oauth": "tsx --conditions react-server scripts/mcp-oauth-test.ts",
     "test:mcp:member-access": "tsx --conditions react-server scripts/mcp-member-access-test.ts",
     "test:mcp:apps": "tsx --conditions react-server scripts/mcp-apps-test.ts",
-    "test:mcp:apps-host": "tsx --conditions react-server scripts/mcp-apps-host-test.ts",
+    "test:mcp:apps-host": "tsx --conditions react-server scripts/mcp-apps-config-test.ts && tsx --conditions react-server scripts/mcp-apps-host-test.ts",
     "test:mcp:message-projection": "tsx --conditions react-server scripts/mcp-message-projection-test.ts",
     "test:mcp:api-routes": "tsx --conditions react-server scripts/mcp-api-routes-test.ts",
     "test:mcp:health": "tsx --conditions react-server scripts/mcp-connection-health-test.ts && tsx --conditions react-server scripts/mcp-health-monitor-test.ts",

--- a/proxy.ts
+++ b/proxy.ts
@@ -36,6 +36,8 @@ const PUBLIC_SHARE_PREFIX_ROUTES = [
   '/public/markdown-pdf/',
   '/public/marp-preview/',
 ];
+const MCP_APP_TICKET_ROUTE = /^\/__preview\/[A-Za-z0-9_-]{43}\/mcp-app\/(?:frame|document)$/u;
+
 function isWebSocketRoute(pathname: string) {
   return pathname === '/ws/chat' || /^\/[a-z]{2}(?:-[A-Z]{2})?\/ws\/chat$/u.test(pathname);
 }
@@ -142,6 +144,7 @@ export default async function middleware(request: NextRequest) {
     if (['GET','HEAD'].includes(request.method) && /^\/__preview\/[A-Za-z0-9_-]{43}\//u.test(pathname)) return NextResponse.next();
     return new NextResponse(null,{status:404,headers:{'Cache-Control':'no-store'}});
   }
+  if (['GET','HEAD'].includes(request.method) && MCP_APP_TICKET_ROUTE.test(pathname)) return NextResponse.next();
   if (pathname.startsWith('/__preview/')) return new NextResponse(null,{status:404,headers:{'Cache-Control':'no-store'}});
 
   // Canvas Notebook handles mutations through API routes. A next-action POST here

--- a/scripts/html-preview-boundary-test.ts
+++ b/scripts/html-preview-boundary-test.ts
@@ -43,12 +43,17 @@ async function main() {
     }
     const post=await send(base+'/__preview/'+token+'/index.html',{method:'POST',headers:{host:previewHost}});
     assert.equal(post.status,404);await post.arrayBuffer();
+    const sameOriginMcp=await send(base+'/__preview/'+token+'/mcp-app/frame',{headers:{host:'app.example.test',cookie:'fixture'}});
+    assert.equal(sameOriginMcp.status,200);
+    assert.deepEqual(await sameOriginMcp.json(),{cookie:'fixture',authorization:null,internal:null});
+    const sameOriginMcpPost=await send(base+'/__preview/'+token+'/mcp-app/frame',{method:'POST',headers:{host:'app.example.test'}});
+    assert.equal(sameOriginMcpPost.status,404);await sameOriginMcpPost.arrayBuffer();
+    const sameOriginGeneric=await send(base+'/__preview/'+token+'/index.html',{headers:{host:'app.example.test'}});
+    assert.equal(sameOriginGeneric.status,404);await sameOriginGeneric.arrayBuffer();
     for(const headers of [{origin:'https://'+previewHost},{origin:'null'},{cookie:'fixture','sec-fetch-site':'same-site'},{cookie:'fixture','sec-fetch-site':'cross-site'}]) {
       const response=await send(base+'/api/files/write',{method:'POST',headers:{host:'app.example.test',...headers}});
       assert.equal(response.status,403);await response.arrayBuffer();
     }
-    const wrongHost=await send(base+'/__preview/'+token+'/index.html',{headers:{host:'app.example.test'}});
-    assert.equal(wrongHost.status,404);await wrongHost.arrayBuffer();
     for(const configured of ['https://app.example.test','http://192.0.2.1']) {
       process.env.BETTER_AUTH_BASE_URL=configured;
       const response=await send(base+'/api/health',{headers:{host:'app.example.test'}});

--- a/scripts/html-preview-proxy-test.ts
+++ b/scripts/html-preview-proxy-test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { NextRequest } from 'next/server';
+
+async function main(): Promise<void> {
+  process.env.BETTER_AUTH_BASE_URL = 'https://app.example.test';
+
+  const { default: middleware } = await import('../proxy');
+  const ticket = 'a'.repeat(43);
+
+  for (const [method, mode] of [['GET', 'frame'], ['HEAD', 'document']] as const) {
+    const response = await middleware(new NextRequest(
+      `https://app.example.test/__preview/${ticket}/mcp-app/${mode}`,
+      { method, headers: { host: 'app.example.test' } },
+    ));
+    assert.equal(response.headers.get('x-middleware-next'), '1', `${method} ${mode} must reach the ticket route`);
+  }
+
+  for (const [method, pathname] of [
+    ['POST', `/__preview/${ticket}/mcp-app/frame`],
+    ['GET', `/__preview/${ticket}/mcp-app/other`],
+    ['GET', `/__preview/${ticket}/index.html`],
+  ] as const) {
+    const response = await middleware(new NextRequest(`https://app.example.test${pathname}`, {
+      method,
+      headers: { host: 'app.example.test' },
+    }));
+    assert.equal(response.status, 404, `${method} ${pathname} must remain blocked on the app origin`);
+  }
+
+  const isolatedPreview = await middleware(new NextRequest(
+    `https://preview.app.example.test/__preview/${ticket}/index.html`,
+    { headers: { host: 'preview.app.example.test' } },
+  ));
+  assert.equal(isolatedPreview.headers.get('x-middleware-next'), '1');
+
+  console.log('HTML preview proxy boundary tests passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/mcp-apps-config-test.ts
+++ b/scripts/mcp-apps-config-test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+
+import { isMcpAppFrameHost, isMcpAppsEnabled, mcpAppOrigins } from '../app/lib/mcp/apps-config';
+
+const production = { BASE_URL: 'https://app.example.com' };
+
+assert.deepEqual(mcpAppOrigins(production), {
+  appOrigin: 'https://app.example.com',
+  frameOrigin: 'https://app.example.com',
+});
+assert.deepEqual(mcpAppOrigins({ BASE_URL: 'https://192.0.2.1' }), {
+  appOrigin: 'https://192.0.2.1',
+  frameOrigin: 'https://192.0.2.1',
+});
+assert.deepEqual(mcpAppOrigins({
+  ...production,
+  CANVAS_HTML_PREVIEW_ORIGIN: 'https://widgets.example.net',
+}), {
+  appOrigin: 'https://app.example.com',
+  frameOrigin: 'https://widgets.example.net',
+});
+
+assert.equal(isMcpAppsEnabled(production), true);
+assert.equal(isMcpAppsEnabled({ ...production, CANVAS_MCP_APPS_ENABLED: 'true' }), true);
+assert.equal(isMcpAppsEnabled({ ...production, CANVAS_MCP_APPS_ENABLED: ' FALSE ' }), false);
+assert.equal(isMcpAppsEnabled({
+  ...production,
+  CANVAS_HTML_PREVIEW_ORIGIN: 'https://app.example.com',
+}), false);
+
+assert.equal(isMcpAppFrameHost('app.example.com', production), true);
+assert.equal(isMcpAppFrameHost('app.example.com:443', production), true);
+assert.equal(isMcpAppFrameHost('app.example.com.evil.test', production), false);
+assert.equal(isMcpAppFrameHost('widgets.example.net', {
+  ...production,
+  CANVAS_HTML_PREVIEW_ORIGIN: 'https://widgets.example.net',
+}), true);
+
+console.log('mcp-apps-config-test: ok');

--- a/scripts/mcp-apps-host-test.ts
+++ b/scripts/mcp-apps-host-test.ts
@@ -46,7 +46,11 @@ moduleInternals._load = (request, parent, isMain) => {
     requireMcpUserAccess: async () => undefined,
     assertMcpConnectionAccess: async () => ({ connection: { authVersion } }),
   };
-  if (request.includes('mcp/apps-config')) return { isMcpAppsEnabled: () => enabled };
+  if (request.includes('mcp/apps-config')) return {
+    isMcpAppsEnabled: () => enabled,
+    mcpAppOrigins: () => ({ appOrigin: origin, frameOrigin: origin }),
+    isMcpAppFrameHost: (host: string | null) => host === 'localhost:3000',
+  };
   if (request.includes('mcp/apps-metadata')) return { isMcpAppResourceMimeType: (mime: unknown) => mime === 'text/html;profile=mcp-app' };
   if (request.includes('mcp/manager')) return {
     readMcpAppResource: async () => ({ contents: [{ uri: app.resourceUri, mimeType: 'text/html;profile=mcp-app', text: html }] }),
@@ -69,9 +73,10 @@ async function main(): Promise<void> {
   try {
     assert.throws(() => parseMcpAppDescriptor({ ...app, connectionId: 'bad' }), FixtureAccessError);
     const issued = await issueMcpAppTicket({ userId, sessionId, agentId, app, authSessionId: 'auth-1', authSessionExpiresAt: new Date(Date.now() + 60_000) });
+    assert.equal(issued.frameOrigin, origin);
     const ticket = issued.frameUrl.split('/')[4];
     assert.ok(ticket);
-    const frame = await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'preview.localhost:3000' } }), ticket, 'frame');
+    const frame = await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'localhost:3000' } }), ticket, 'frame');
     assert.equal(frame.status, 200);
     assert.match(frame.headers.get('content-security-policy') || '', /sandbox allow-scripts allow-same-origin/);
     assert.match(frame.headers.get('content-security-policy') || '', /frame-ancestors http:\/\/localhost:3000/);
@@ -82,17 +87,17 @@ async function main(): Promise<void> {
     assert.match(frameHtml, /http:\/\/localhost:3000/);
     assert.doesNotMatch(frameHtml, /config\.appOrigin/);
     assert.match(frameHtml, /frame\.sandbox='allow-scripts'/);
-    const document = await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'preview.localhost:3000' } }), ticket, 'document');
+    const document = await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'localhost:3000' } }), ticket, 'document');
     assert.equal(document.status, 200);
     assert.match(document.headers.get('content-security-policy') || '', /sandbox allow-scripts$/);
-    assert.equal(await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'localhost:3000' } }), ticket, 'frame').then((r) => r.status), 404);
-    assert.equal(await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'preview.localhost:3000' } }), 'bad', 'frame').then((r) => r.status), 404);
+    assert.equal(await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'preview.localhost:3000' } }), ticket, 'frame').then((r) => r.status), 404);
+    assert.equal(await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'localhost:3000' } }), 'bad', 'frame').then((r) => r.status), 404);
     authVersion += 1;
-    assert.equal(await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'preview.localhost:3000' } }), ticket, 'document').then((r) => r.status), 404);
+    assert.equal(await deliverMcpAppTicket(new Request(issued.frameUrl, { headers: { host: 'localhost:3000' } }), ticket, 'document').then((r) => r.status), 404);
     authVersion = 1;
     const revoked = await issueMcpAppTicket({ userId, sessionId, agentId, app, authSessionId: 'auth-1', authSessionExpiresAt: new Date(Date.now() + 60_000) });
     authSessionActive = false;
-    assert.equal(await deliverMcpAppTicket(new Request(revoked.frameUrl, { headers: { host: 'preview.localhost:3000' } }), revoked.frameUrl.split('/')[4], 'frame').then((r) => r.status), 404);
+    assert.equal(await deliverMcpAppTicket(new Request(revoked.frameUrl, { headers: { host: 'localhost:3000' } }), revoked.frameUrl.split('/')[4], 'frame').then((r) => r.status), 404);
     authSessionActive = true;
 
     let response = await POST(request({ action: 'call', app, sessionId, agentId, tool: 'submit_chart_filter', arguments: { minimum: 2 } }));

--- a/server/html-preview-boundary.ts
+++ b/server/html-preview-boundary.ts
@@ -1,6 +1,8 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { htmlPreviewOrigins, isHtmlPreviewHost } from '../app/lib/html-preview-origin';
 
+const mcpAppPath = /^\/__preview\/[A-Za-z0-9_-]{43}\/mcp-app\/(?:frame|document)$/u;
+
 /** Preview vhosts never expose the app router or receive its credentials. */
 export function handleHtmlPreviewBoundary(request: IncomingMessage, response: ServerResponse): boolean {
   const pathname=new URL(request.url || '/', 'http://localhost').pathname;
@@ -11,6 +13,9 @@ export function handleHtmlPreviewBoundary(request: IncomingMessage, response: Se
     if(['GET','HEAD'].includes(request.method || '') && /^\/__preview\/[A-Za-z0-9_-]{43}\//u.test(pathname)) return false;
     response.writeHead(404,{'Cache-Control':'no-store'});response.end();return true;
   }
+  // The trusted MCP relay may use the normal app origin. The route handler
+  // still validates the configured frame host, ticket, login and ownership.
+  if (['GET','HEAD'].includes(request.method || '') && mcpAppPath.test(pathname)) return false;
   if (pathname.startsWith('/__preview/')) {
     response.writeHead(404,{'Cache-Control':'no-store'});response.end();return true;
   }


### PR DESCRIPTION
MCP Apps currently require an opt-in flag and a separately routed preview subdomain, so an otherwise valid Canvas update cannot render widgets without extra DNS and proxy work. This change enables MCP Apps by default and serves the trusted Canvas relay on the existing application origin; provider HTML remains inside the nested opaque-origin sandbox with the same restrictive CSP and approval boundary.

An explicitly configured `CANVAS_HTML_PREVIEW_ORIGIN` is still honored as optional defense in depth, and `CANVAS_MCP_APPS_ENABLED=false` remains an explicit kill switch. The normal app host only admits exact GET/HEAD MCP ticket paths; generic HTML previews keep their separate-origin boundary.

Validation:

- `npm run test:mcp:apps-host`
- `npm run test:mcp:apps`
- `npm run test:security:html-preview`
- `npm run lint`
- `npm run build`
- Playwright MCP Apps acceptance harness: 12/12 checks at desktop and 390 px, including same-origin delivery, opaque sandbox isolation, forged-message rejection, approval, reconnect, reload, and disabled fallback

No visual layout changed; the existing desktop and mobile widget states were reviewed during Playwright QA.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables MCP Apps by default and serves their trusted relay on the normal Canvas origin unless a dedicated preview origin is configured.
- Adds default application-origin MCP frame routing and host validation.
- Preserves the nested opaque-origin provider sandbox and restrictive CSP.
- Adds configuration, host-boundary, and routing tests and updates security documentation.
- The same-origin request path remains blocked by the existing Next.js middleware.

<h3>Confidence Score: 4/5</h3>

This PR is not safe to merge until application-origin MCP relay requests are admitted by the Next.js middleware.

The default frame URL uses the application origin, but after the custom server admits it, the middleware unconditionally converts its `/__preview/` path into a 404, preventing zero-config widgets from loading.

**Files Needing Attention:** server/html-preview-boundary.ts and proxy.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| server/html-preview-boundary.ts | Admits exact MCP relay paths on the application host, but the downstream middleware still rejects those requests. |
| app/lib/mcp/apps-config.ts | Introduces default application-origin frame selection, explicit disable semantics, and exact frame-host validation. |
| app/lib/mcp/apps-host.ts | Issues tickets for the selected frame origin and preserves the nested sandbox and ticket authorization checks. |
| app/components/canvas-agent-chat/McpAppWidget.tsx | Allows validated same-host frame URLs while retaining protocol, path, credential, query, and fragment checks. |
| scripts/html-preview-boundary-test.ts | Tests the custom-server boundary directly but does not exercise the downstream Next.js middleware that blocks the new path. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Widget requests app-origin MCP frame] --> B[Custom server boundary]
  B -->|Exact GET/HEAD path admitted| C[Next.js middleware]
  C -->|Non-preview host plus /__preview/| D[404 response]
  D --> E[Widget reports unavailable]
  C -. Intended path .-> F[MCP ticket route]
  F --> G[Trusted relay]
  G --> H[Opaque-origin provider sandbox]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Enable zero-config MCP app widgets"](https://github.com/canvascoding/canvas-notebook/commit/070fca85239a5ee0e398403e1c0fcd5c26dc9c4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62202274)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->