### PR TITLE
Fix home widget loading and direct item links

### DIFF
--- a/app/[locale]/(routes)/studio/layout.tsx
+++ b/app/[locale]/(routes)/studio/layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { Suspense, type ReactNode } from 'react';
 
 import { StudioChatProvider } from '@/app/apps/studio/context/studio-chat-context';
 import { StudioWorkspaceBoundary } from '@/app/apps/studio/components/StudioWorkspaceBoundary';
@@ -7,10 +7,12 @@ import { isOnboardingHintsEnabled } from '@/app/lib/onboarding/status';
 
 export default function StudioLayout({ children }: { children: ReactNode }) {
   return (
-    <StudioWorkspaceBoundary>
-      <StudioChatProvider>
-        <StudioShell hintEnabled={isOnboardingHintsEnabled()}>{children}</StudioShell>
-      </StudioChatProvider>
-    </StudioWorkspaceBoundary>
+    <Suspense fallback={null}>
+      <StudioWorkspaceBoundary>
+        <StudioChatProvider>
+          <StudioShell hintEnabled={isOnboardingHintsEnabled()}>{children}</StudioShell>
+        </StudioChatProvider>
+      </StudioWorkspaceBoundary>
+    </Suspense>
   );
 }

--- a/app/api/home/workspace-widgets/route.ts
+++ b/app/api/home/workspace-widgets/route.ts
@@ -9,7 +9,8 @@ import {
   loadHomeWidgetTodos,
 } from '@/app/lib/home/workspace-widget-data';
 import { loadHomeWidgetEmails } from '@/app/lib/home/workspace-email-widget';
-import { HOME_WIDGET_NAMES, parseHomeWidgetSelection } from '@/app/lib/home/workspace-widget-request';
+import { createWorkspaceWidgetFetcher } from '@/app/lib/home/workspace-widget-fetcher';
+import { HOME_WIDGET_NAMES, type HomeWidgetName, parseHomeWidgetSelection } from '@/app/lib/home/workspace-widget-request';
 import { requireRequestWorkspace } from '@/app/lib/workspaces/request';
 
 const TTL = {
@@ -18,20 +19,14 @@ const TTL = {
   studio: 30_000,
 } as const;
 
-function requestFetcher(request: NextRequest) {
-  return (input: RequestInfo | URL, init?: RequestInit) => {
-    const value = typeof input === 'string' || input instanceof URL ? input.toString() : input.url;
-    const headers = new Headers(init?.headers);
-    const cookie = request.headers.get('cookie');
-    if (cookie) headers.set('cookie', cookie);
-    return fetch(new URL(value, request.nextUrl.origin), { ...init, headers });
-  };
-}
-
-async function widgetResult<T>(load: () => Promise<T>) {
+async function widgetResult<T>(widget: HomeWidgetName, load: () => Promise<T>) {
   try {
     return { status: 'ready' as const, ...(await load()) };
-  } catch {
+  } catch (error) {
+    console.warn('[home-workspace-widgets] source unavailable', {
+      widget,
+      errorName: error instanceof Error ? error.name : 'UnknownError',
+    });
     return { status: 'error' as const, errorCode: 'source_unavailable' as const };
   }
 }
@@ -53,16 +48,16 @@ export async function GET(request: NextRequest) {
   if (!forceRefreshWidgets) return jsonError('Invalid workspace widget refresh selection', 400);
   const selected = new Set(requestedWidgets);
   const forced = new Set(forceRefreshWidgets);
-  const fetcher = requestFetcher(request);
+  const fetcher = createWorkspaceWidgetFetcher(request.headers);
   const [emails, todos, automation, studio] = await Promise.all([
     selected.has('emails')
-      ? widgetResult(() => loadHomeWidgetEmails(access.session.user.id, {
+      ? widgetResult('emails', () => loadHomeWidgetEmails(access.session.user.id, {
         scheduleBackgroundTask: after,
         services: { listAccounts: listEmailAccounts, listMessages: listEmailMessages },
       }))
       : undefined,
     selected.has('todos')
-      ? widgetResult(() => loadCachedWorkspaceWidget({
+      ? widgetResult('todos', () => loadCachedWorkspaceWidget({
         userId: access.session.user.id,
         workspaceId,
         forceRefresh: forced.has('todos'),
@@ -72,7 +67,7 @@ export async function GET(request: NextRequest) {
       }))
       : undefined,
     selected.has('automation')
-      ? widgetResult(() => loadCachedWorkspaceWidget({
+      ? widgetResult('automation', () => loadCachedWorkspaceWidget({
         userId: access.session.user.id,
         workspaceId,
         forceRefresh: forced.has('automation'),
@@ -82,7 +77,7 @@ export async function GET(request: NextRequest) {
       }))
       : undefined,
     selected.has('studio')
-      ? widgetResult(() => loadCachedWorkspaceWidget({
+      ? widgetResult('studio', () => loadCachedWorkspaceWidget({
         userId: access.session.user.id,
         workspaceId,
         forceRefresh: forced.has('studio'),

--- a/app/apps/studio/components/StudioWorkspaceBoundary.tsx
+++ b/app/apps/studio/components/StudioWorkspaceBoundary.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import { useLayoutEffect, type ReactNode } from 'react';
+import { useSearchParams } from 'next/navigation';
 
+import { workspaceScopedNavigationMatches } from '@/app/lib/workspaces/navigation-sync';
 import { useStudioGenerationsCacheStore } from '@/app/store/studio-generations-cache-store';
 import { useStudioGenerationStore } from '@/app/store/studio-generation-store';
 import { useWorkspaceStore } from '@/app/store/workspace-store';
 
 export function StudioWorkspaceBoundary({ children }: { children: ReactNode }) {
+  const searchParams = useSearchParams();
+  const requestedWorkspaceId = searchParams.get('workspaceId')?.trim() || null;
   const workspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
   const cacheWorkspaceId = useStudioGenerationsCacheStore((state) => state.workspaceId);
 
@@ -15,7 +19,10 @@ export function StudioWorkspaceBoundary({ children }: { children: ReactNode }) {
     useStudioGenerationStore.getState().resetWorkspaceContext();
   }, [workspaceId]);
 
-  if (cacheWorkspaceId !== workspaceId) return null;
+  if (
+    !workspaceScopedNavigationMatches(requestedWorkspaceId, workspaceId)
+    || cacheWorkspaceId !== workspaceId
+  ) return null;
 
   return <div key={workspaceId ?? 'loading'} className="contents">{children}</div>;
 }

--- a/app/components/home/HomeAppLinks.tsx
+++ b/app/components/home/HomeAppLinks.tsx
@@ -19,15 +19,18 @@ type WidgetCardProps = {
   icon: typeof Inbox;
   preview: ReactNode;
   footer: string;
+  freezeEnabled: boolean;
 };
 
-function WidgetCard({ id, title, description, href, icon: Icon, preview, footer }: WidgetCardProps) {
+function WidgetCard({ id, title, description, href, icon: Icon, preview, footer, freezeEnabled }: WidgetCardProps) {
   const t = useTranslations('home.workspaceWidgets');
   const [frozenContent, setFrozenContent] = useState<{ footer: string; href: string; preview: ReactNode } | null>(null);
   const pointerWithinRef = useRef(false);
   const focusWithinRef = useRef(false);
   const displayedContent = frozenContent ?? { footer, href, preview };
-  const freezeContent = () => setFrozenContent((current) => current ?? { footer, href, preview });
+  const freezeContent = () => {
+    if (freezeEnabled) setFrozenContent((current) => current ?? { footer, href, preview });
+  };
   const releaseContent = () => {
     if (!pointerWithinRef.current && !focusWithinRef.current) setFrozenContent(null);
   };
@@ -112,6 +115,15 @@ function plainPreviewText(value: string | null): string {
     .trim();
 }
 
+function studioHref(workspaceId: string, generation?: HomeWidgetStudio | null): string {
+  if (!generation) return `/studio?workspaceId=${encodeURIComponent(workspaceId)}`;
+  return `/studio?${new URLSearchParams({
+    workspaceId,
+    generation: generation.id,
+    ...(generation.output ? { output: generation.output.id } : {}),
+  })}`;
+}
+
 function isSafeApplicationMediaUrl(value: string): boolean {
   return value.startsWith('/') && !value.startsWith('//') && !value.includes('\\');
 }
@@ -133,7 +145,7 @@ function stateSummary<T>({ state, ready, onRetry }: { state: HomeWidgetState<T>;
 function EmailWidget({ state, onRetry }: { state: HomeWidgetState<HomeWidgetEmail[]>; onRetry: () => void }) {
   const t = useTranslations('home.workspaceWidgets.email');
   const messageHref = (message: HomeWidgetEmail) => `/emails?${new URLSearchParams({ accountId: message.accountId, messageId: message.id, ...(message.folder ? { folder: message.folder } : {}) })}`;
-  return <WidgetCard id="email" title={t('title')} description={t('description')} href="/emails" icon={Inbox} footer={t('openAll')}
+  return <WidgetCard id="email" title={t('title')} description={t('description')} href="/emails" icon={Inbox} footer={t('openAll')} freezeEnabled={state.status === 'ready'}
     preview={stateSummary({ state, onRetry, ready: data => <ListPreview countLabel={t('count', { count: data.length })}>{data.length ? <div className="divide-y divide-border/60">{data.slice(0, 2).map(message => <Link key={`${message.accountId}:${message.id}`} href={messageHref(message)} className="flex h-11 min-w-0 items-center gap-3 px-2 transition-colors hover:bg-muted/70 focus-visible:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"><MailOpen className="h-4 w-4 shrink-0 text-muted-foreground" /><span className="min-w-0 flex-1"><span className="block truncate text-sm font-medium leading-4">{message.subject || t('noSubject')}</span><span className="mt-0.5 block truncate text-xs leading-4 text-muted-foreground">{message.from || t('unknownSender')} · {message.accountLabel}</span></span></Link>)}</div> : <p className="px-2 py-5 text-sm text-muted-foreground">{t('empty')}</p>}</ListPreview> })}
   />;
 }
@@ -141,7 +153,7 @@ function EmailWidget({ state, onRetry }: { state: HomeWidgetState<HomeWidgetEmai
 function TodoWidget({ state, workspaceId, onRetry }: { state: HomeWidgetState<HomeWidgetTodo[]>; workspaceId: string; onRetry: () => void }) {
   const t = useTranslations('home.workspaceWidgets.todos');
   const format = useFormatter();
-  return <WidgetCard id="todos" title={t('title')} description={t('description')} href={`/todos?workspaceId=${encodeURIComponent(workspaceId)}`} icon={ListTodo} footer={t('openAll')}
+  return <WidgetCard id="todos" title={t('title')} description={t('description')} href={`/todos?workspaceId=${encodeURIComponent(workspaceId)}`} icon={ListTodo} footer={t('openAll')} freezeEnabled={state.status === 'ready'}
     preview={stateSummary({ state, onRetry, ready: data => <ListPreview countLabel={t('count', { count: data.length })}>{data.length ? <div className="divide-y divide-border/60">{data.slice(0, 2).map(todo => <Link key={todo.id} href={`/todos?todo=${encodeURIComponent(todo.id)}&workspaceId=${encodeURIComponent(workspaceId)}`} className="flex h-11 min-w-0 items-center gap-3 px-2 transition-colors hover:bg-muted/70 focus-visible:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"><span className={`h-2.5 w-2.5 shrink-0 rounded-full border ${todo.priority === 'high' ? 'border-destructive bg-destructive/15' : 'border-muted-foreground/50'}`} /><span className="min-w-0 flex-1"><span className="block truncate text-sm font-medium leading-4">{todo.title}</span><span className={`mt-0.5 block truncate text-xs leading-4 ${todo.priority === 'high' ? 'text-destructive' : 'text-muted-foreground'}`}>{todo.priority === 'high' ? t('highPriority') : todo.dueAt ? t('due', { time: relativeTime(format, todo.dueAt) }) : t('open')}</span></span></Link>)}</div> : <p className="px-2 py-5 text-sm text-muted-foreground">{t('empty')}</p>}</ListPreview> })}
   />;
 }
@@ -150,10 +162,11 @@ function AutomationWidget({ state, onRetry }: { state: HomeWidgetState<HomeWidge
   const t = useTranslations('home.workspaceWidgets.automation');
   const format = useFormatter();
   const automation = state.data;
+  const href = automation ? `/automations/${encodeURIComponent(automation.id)}` : '/automations';
   const runLabel = automation?.lastRunStatus ? t(`status.${automation.lastRunStatus}`) : t('notRun');
   const resultPreview = plainPreviewText(automation?.resultText || null);
-  return <WidgetCard id="automation" title={t('title')} description={t('description')} href="/automations" icon={Workflow} footer={t('openAll')}
-    preview={stateSummary({ state, onRetry, ready: data => data ? <div className="flex h-full min-h-0 flex-col justify-between gap-2 px-5 py-3.5"><div className="flex min-w-0 items-center justify-between gap-3"><div className="flex min-w-0 items-center gap-2"><span className={`h-2 w-2 shrink-0 rounded-full ${data.lastRunStatus === 'failed' ? 'bg-destructive' : data.lastRunStatus === 'running' || data.lastRunStatus === 'pending' ? 'bg-primary animate-pulse' : 'bg-muted-foreground/60'}`} /><span className="truncate text-xs font-medium text-muted-foreground">{runLabel}</span></div><span className="shrink-0 text-[0.7rem] text-muted-foreground">{data.lastRunAt ? t('lastRun', { time: relativeTime(format, data.lastRunAt) }) : t('notRun')}</span></div><div className="min-h-0"><p className="truncate text-sm font-semibold">{data.name}</p><p className="mt-1 line-clamp-2 break-words text-xs leading-5 text-muted-foreground">{resultPreview || t('noResult')}</p></div><div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground"><Clock3 className="h-3.5 w-3.5 shrink-0" /><span className="truncate">{data.nextRunAt ? t('nextRun', { time: relativeTime(format, data.nextRunAt) }) : t('noNextRun')}</span></div></div> : <div className="flex h-full items-end p-5"><p className="text-sm text-muted-foreground">{t('empty')}</p></div> })}
+  return <WidgetCard id="automation" title={t('title')} description={t('description')} href={href} icon={Workflow} footer={t('openAll')} freezeEnabled={state.status === 'ready'}
+    preview={stateSummary({ state, onRetry, ready: data => data ? <Link href={`/automations/${encodeURIComponent(data.id)}`} className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"><div className="flex h-full min-h-0 flex-col justify-between gap-2 px-5 py-3.5"><div className="flex min-w-0 items-center justify-between gap-3"><div className="flex min-w-0 items-center gap-2"><span className={`h-2 w-2 shrink-0 rounded-full ${data.lastRunStatus === 'failed' ? 'bg-destructive' : data.lastRunStatus === 'running' || data.lastRunStatus === 'pending' ? 'bg-primary animate-pulse' : 'bg-muted-foreground/60'}`} /><span className="truncate text-xs font-medium text-muted-foreground">{runLabel}</span></div><span className="shrink-0 text-[0.7rem] text-muted-foreground">{data.lastRunAt ? t('lastRun', { time: relativeTime(format, data.lastRunAt) }) : t('notRun')}</span></div><div className="min-h-0"><p className="truncate text-sm font-semibold">{data.name}</p><p className="mt-1 line-clamp-2 break-words text-xs leading-5 text-muted-foreground">{resultPreview || t('noResult')}</p></div><div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground"><Clock3 className="h-3.5 w-3.5 shrink-0" /><span className="truncate">{data.nextRunAt ? t('nextRun', { time: relativeTime(format, data.nextRunAt) }) : t('noNextRun')}</span></div></div></Link> : <div className="flex h-full items-end p-5"><p className="text-sm text-muted-foreground">{t('empty')}</p></div> })}
   />;
 }
 
@@ -161,9 +174,9 @@ function StudioWidget({ state, workspaceId, onRetry }: { state: HomeWidgetState<
   const t = useTranslations('home.workspaceWidgets.studio');
   const format = useFormatter();
   const generation = state.data;
-  const href = generation ? `/studio?${new URLSearchParams({ workspaceId, generation: generation.id })}` : `/studio?workspaceId=${encodeURIComponent(workspaceId)}`;
-  return <WidgetCard id="studio" title={t('title')} description={t('description')} href={href} icon={Sparkles} footer={generation ? t('openGeneration') : t('openStudio')}
-    preview={stateSummary({ state, onRetry, ready: data => data ? <div className="relative h-full min-h-40 overflow-hidden bg-muted">{data.output ? <SafeStudioImage key={data.output.mediaUrl} src={data.output.mediaUrl} /> : <div className="flex h-full items-center justify-center"><Sparkles className="h-8 w-8 text-muted-foreground" /></div>}<div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background via-background/90 to-transparent px-5 pb-4 pt-10"><p className="line-clamp-2 break-words text-sm font-medium">{data.prompt || t('untitled')}</p><p className="mt-1 truncate text-xs text-muted-foreground">{t('created', { time: relativeTime(format, data.createdAt) })}</p></div></div> : <div className="flex h-full items-end p-5"><p className="text-sm text-muted-foreground">{t('empty')}</p></div> })}
+  const href = studioHref(workspaceId, generation);
+  return <WidgetCard id="studio" title={t('title')} description={t('description')} href={href} icon={Sparkles} footer={generation ? t('openGeneration') : t('openStudio')} freezeEnabled={state.status === 'ready'}
+    preview={stateSummary({ state, onRetry, ready: data => data ? <Link href={studioHref(workspaceId, data)} className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"><div className="relative h-full min-h-40 overflow-hidden bg-muted">{data.output ? <SafeStudioImage key={data.output.mediaUrl} src={data.output.mediaUrl} /> : <div className="flex h-full items-center justify-center"><Sparkles className="h-8 w-8 text-muted-foreground" /></div>}<div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background via-background/90 to-transparent px-5 pb-4 pt-10"><p className="line-clamp-2 break-words text-sm font-medium">{data.prompt || t('untitled')}</p><p className="mt-1 truncate text-xs text-muted-foreground">{t('created', { time: relativeTime(format, data.createdAt) })}</p></div></div></Link> : <div className="flex h-full items-end p-5"><p className="text-sm text-muted-foreground">{t('empty')}</p></div> })}
   />;
 }
 

--- a/app/lib/home/workspace-widget-fetcher.ts
+++ b/app/lib/home/workspace-widget-fetcher.ts
@@ -1,0 +1,19 @@
+type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export function internalAppOrigin(port = process.env.PORT): string {
+  return `http://127.0.0.1:${port || '3000'}`;
+}
+
+export function createWorkspaceWidgetFetcher(
+  requestHeaders: Headers,
+  fetcher: Fetcher = fetch,
+  origin = internalAppOrigin(),
+): Fetcher {
+  return (input, init) => {
+    const value = typeof input === 'string' || input instanceof URL ? input.toString() : input.url;
+    const headers = new Headers(init?.headers);
+    const cookie = requestHeaders.get('cookie');
+    if (cookie) headers.set('cookie', cookie);
+    return fetcher(new URL(value, origin), { ...init, headers });
+  };
+}

--- a/scripts/home-workspace-widget-cache-test.ts
+++ b/scripts/home-workspace-widget-cache-test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { loadCachedWorkspaceWidget } from '../app/lib/home/workspace-widget-cache';
+import { createWorkspaceWidgetFetcher, internalAppOrigin } from '../app/lib/home/workspace-widget-fetcher';
 
 async function main() {
   const suffix = `${Date.now()}-${Math.random()}`;
@@ -47,6 +48,26 @@ async function main() {
   assert.deepEqual((await Promise.all([pendingA, pendingB])).map((result) => result.data), ['ready', 'ready']);
   assert.equal(concurrentLoads, 1, 'concurrent loads for the same user and workspace should be deduplicated');
 
+  assert.equal(internalAppOrigin(undefined), 'http://127.0.0.1:3000');
+  assert.equal(internalAppOrigin('4711'), 'http://127.0.0.1:4711');
+  let internalRequest: { url: string; init?: RequestInit } | undefined;
+  const internalFetcher = createWorkspaceWidgetFetcher(
+    new Headers({ cookie: 'session=test-session' }),
+    async (input, init) => {
+      internalRequest = { url: input.toString(), init };
+      return new Response(null, { status: 204 });
+    },
+    'http://127.0.0.1:3000',
+  );
+  await internalFetcher('/api/todos?workspaceId=workspace-a', {
+    cache: 'no-store',
+    headers: { accept: 'application/json' },
+  });
+  assert.equal(internalRequest?.url, 'http://127.0.0.1:3000/api/todos?workspaceId=workspace-a');
+  assert.equal(new Headers(internalRequest?.init?.headers).get('cookie'), 'session=test-session');
+  assert.equal(new Headers(internalRequest?.init?.headers).get('accept'), 'application/json');
+  assert.equal(internalRequest?.init?.cache, 'no-store');
+
   const routeSource = fs.readFileSync(
     path.join(process.cwd(), 'app', 'api', 'home', 'workspace-widgets', 'route.ts'),
     'utf8',
@@ -54,6 +75,8 @@ async function main() {
   assert.doesNotMatch(routeSource, /widget:\s*'emails'/u, 'email must bypass the process-local Home cache');
   assert.match(routeSource, /loadHomeWidgetEmails\(access\.session\.user\.id/u);
   assert.match(routeSource, /services: \{ listAccounts: listEmailAccounts, listMessages: listEmailMessages \}/u);
+  assert.match(routeSource, /createWorkspaceWidgetFetcher\(request\.headers\)/u, 'widget API requests must use the container-local fetcher');
+  assert.doesNotMatch(routeSource, /new URL\(value, request\.nextUrl\.origin\)/u, 'widget API requests must not use the externally mapped browser port');
   assert.match(routeSource, /parseHomeWidgetSelection\(request\.nextUrl\.searchParams\.get\('widgets'\), HOME_WIDGET_NAMES\)/u);
   assert.match(routeSource, /selected\.has\('emails'\)/u);
   for (const widget of ['todos', 'automation', 'studio']) {

--- a/tests/home-workspace-widgets.spec.ts
+++ b/tests/home-workspace-widgets.spec.ts
@@ -130,6 +130,71 @@ test('workspace widgets fill page two with stable, directly actionable previews'
   await page.screenshot({ path: info.outputPath('workspace-widgets-desktop.png'), animations: 'disabled' });
 });
 
+test('studio widget link switches workspace before opening the requested output', async ({ page }) => {
+  const workspace = await prepare(page);
+  const workspacesResponse = await page.request.get('/api/workspaces');
+  expect(workspacesResponse.ok()).toBeTruthy();
+  const workspacePayload = await workspacesResponse.json();
+  const previousWorkspace = {
+    ...workspace,
+    id: 'previous-workspace',
+    name: 'Previous workspace',
+    isDefault: false,
+  };
+
+  await mockWidgets(page, workspace.id);
+  await page.goto('/de');
+  await page.getByRole('button', { name: 'Zum Workspace', exact: true }).click();
+  const studioHref = await page.getByTestId('workspace-widget-studio')
+    .getByRole('link', { name: /Editoriales Produktbild für den Launch/ })
+    .getAttribute('href');
+  expect(studioHref).toBeTruthy();
+
+  await page.route('**/api/workspaces', route => route.fulfill({
+    json: {
+      ...workspacePayload,
+      activeWorkspaceId: previousWorkspace.id,
+      workspaces: [previousWorkspace, ...workspacePayload.workspaces],
+    },
+  }));
+  const generationWorkspaceIds: Array<string | undefined> = [];
+  await page.route('**/api/studio/generations/generation-latest', route => {
+    generationWorkspaceIds.push(route.request().headers()['x-canvas-workspace-id']);
+    return route.fulfill({ json: {
+      success: true,
+      generation: {
+        id: 'generation-latest',
+        userId: 'widget-test-user',
+        mode: 'image',
+        prompt: 'Editoriales Produktbild für den Launch',
+        rawPrompt: 'Editoriales Produktbild für den Launch',
+        provider: 'gemini',
+        model: 'gemini-3.1-flash-image',
+        aspectRatio: '1:1',
+        status: 'completed',
+        createdAt: '2026-09-07T12:00:00Z',
+        outputs: [{
+          id: 'output',
+          generationId: 'generation-latest',
+          type: 'image',
+          filePath: 'studio/outputs/widget-output.png',
+          fileName: 'widget-output.png',
+          mediaUrl: '/images/examples/aura_serum_produktfoto.png',
+          mimeType: 'image/png',
+          isFavorite: false,
+        }],
+      },
+    } });
+  });
+  await page.addInitScript(id => localStorage.setItem('canvas.activeWorkspaceId', id), previousWorkspace.id);
+  await page.goto(studioHref!);
+
+  await expect(page.getByRole('region', { name: 'Studio output preview' })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('canvas.activeWorkspaceId'))).toBe(workspace.id);
+  expect(generationWorkspaceIds.length).toBeGreaterThan(0);
+  expect(new Set(generationWorkspaceIds)).toEqual(new Set([workspace.id]));
+});
+
 test('touch layout keeps quick selections visible in one column', async ({ page }, info) => {
   await page.setViewportSize({ width: 390, height: 844 });
   const workspace = await prepare(page);

--- a/tests/home-workspace-widgets.spec.ts
+++ b/tests/home-workspace-widgets.spec.ts
@@ -101,12 +101,26 @@ test('workspace widgets fill page two with stable, directly actionable previews'
   const boxBeforeHover = await emailCard.boundingBox();
   await emailCard.hover();
   await expect(emailPreview.getByText('Launch-Freigabe')).toBeVisible();
-  expect(await emailCard.boundingBox()).toEqual(boxBeforeHover);
+  const boxAfterHover = await emailCard.boundingBox();
+  expect(boxAfterHover?.width).toBe(boxBeforeHover?.width);
+  expect(boxAfterHover?.height).toBe(boxBeforeHover?.height);
   await expect(emailCard.getByRole('link', { name: /Launch-Freigabe/ })).toHaveAttribute('href', /accountId=sales.*messageId=mail-sales/);
 
   const todoCard = page.getByTestId('workspace-widget-todos');
   await todoCard.getByRole('link', { name: 'To-dos öffnen', exact: true }).focus();
   await expect(todoCard.getByRole('link', { name: /Launch prüfen/ })).toHaveAttribute('href', new RegExp(`todo=todo-critical.*workspaceId=${workspace.id}`));
+
+  const automationCard = page.getByTestId('workspace-widget-automation');
+  await expect(automationCard.getByRole('link', { name: /Kampagnen-Report/ })).toHaveAttribute('href', '/de/automations/job-latest');
+  await expect(automationCard.getByRole('link', { name: 'Automationen öffnen', exact: true }).last()).toHaveAttribute('href', '/de/automations/job-latest');
+
+  const studioCard = page.getByTestId('workspace-widget-studio');
+  const studioPreviewHref = await studioCard.getByRole('link', { name: /Editoriales Produktbild für den Launch/ }).getAttribute('href');
+  const studioPreviewUrl = new URL(studioPreviewHref || '', 'http://localhost');
+  expect(studioPreviewUrl.pathname).toBe('/de/studio');
+  expect(studioPreviewUrl.searchParams.get('workspaceId')).toBe(workspace.id);
+  expect(studioPreviewUrl.searchParams.get('generation')).toBe('generation-latest');
+  expect(studioPreviewUrl.searchParams.get('output')).toBe('output');
 
   const firstBox = await cards.nth(0).boundingBox();
   const secondBox = await cards.nth(1).boundingBox();
@@ -119,11 +133,12 @@ test('workspace widgets fill page two with stable, directly actionable previews'
 test('touch layout keeps quick selections visible in one column', async ({ page }, info) => {
   await page.setViewportSize({ width: 390, height: 844 });
   const workspace = await prepare(page);
-  await mockWidgets(page, workspace.id);
+  const { widgetRequests } = await mockWidgets(page, workspace.id);
   await page.goto('/de');
   await page.getByRole('button', { name: 'Zum Workspace', exact: true }).click();
   const cards = page.locator('#home-workspace article[data-testid^="workspace-widget-"]');
   await expect(cards).toHaveCount(4);
+  await expect.poll(() => widgetRequests.map(request => new URL(request).searchParams.get('widgets'))).toContain('emails,todos,automation,studio');
   await expect(page.getByTestId('workspace-widget-email-preview').getByText('Schnellauswahl')).toBeVisible();
   const [firstBox, secondBox] = await cards.evaluateAll(elements => elements.slice(0, 2).map(element => {
     const box = element.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- route workspace widget self-fetches through the container-local Next.js port while preserving request cookies
- add safe widget-specific diagnostics when a source cannot be loaded
- open exact automation jobs and Studio generation outputs from Home previews
- only freeze already loaded card content so hover cannot pin a loading skeleton

## Root cause
The deployed version was current. The missing internal-origin fix existed only on an older unmerged branch. To-dos, Automations, and Studio used server-side self-fetches based on the externally mapped request origin, while Email loaded directly through its service.

## Verification
- npm run test:home
- npm run lint
- npm run build
- Playwright: tests/home-workspace-widgets.spec.ts (8 passed, including cross-workspace Studio navigation)
- visual check: desktop, mobile, and dark-mode Playwright screenshots
- GitNexus change analysis: LOW risk, no unexpected execution flows

## Notes
- Branch was rebased onto the latest origin/main before verification.
- No container was built or deployed.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repairs Home workspace-widget loading and makes Automation and Studio previews link directly to their represented items.
- Routes server-side widget requests through the container-local Next.js origin while preserving cookies and request headers.
- Adds source-specific, non-sensitive widget failure diagnostics.
- Links Automation previews to the exact job and Studio previews to the exact generation output.
- Prevents unresolved loading content from being frozen by hover or focus.
- Gates Studio rendering until URL-driven workspace selection has completed, resolving the previous cross-workspace deep-link finding.
- Extends cache and Playwright coverage for internal requests, responsive widgets, and cross-workspace Studio links.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the previous Studio cross-workspace deep-link defect fully addressed and no new actionable failures identified.

The Studio boundary prevents generation consumers from mounting until the requested workspace is active, while the root-level synchronizer remains available to complete or reject that switch. The internal widget fetcher preserves authentication and request options while replacing the deployment-sensitive external origin.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/home/workspace-widgets/route.ts | Uses a container-local authenticated fetcher and records safe source-specific widget failures. |
| app/lib/home/workspace-widget-fetcher.ts | Constructs internal application requests while preserving cookies and caller-provided headers. |
| app/components/home/HomeAppLinks.tsx | Adds direct Automation and Studio item links and freezes cards only after content is ready. |
| app/apps/studio/components/StudioWorkspaceBoundary.tsx | Delays Studio child mounting until URL-requested and active workspace contexts agree. |
| app/[locale]/(routes)/studio/layout.tsx | Adds the Suspense boundary required by the Studio boundary's search-parameter access. |
| scripts/home-workspace-widget-cache-test.ts | Verifies local-origin construction, cookie forwarding, and route integration. |
| tests/home-workspace-widgets.spec.ts | Covers exact preview links, responsive loading, and cross-workspace Studio navigation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant H as Home widget
  participant N as Studio navigation
  participant W as WorkspaceNavigationSync
  participant B as StudioWorkspaceBoundary
  participant S as Studio generation UI
  H->>N: Open workspaceId + generation + output
  N->>W: Read requested workspace
  B-->>S: Block while active workspace differs
  W->>W: Validate and activate requested workspace
  W-->>B: Active workspace updated
  B->>S: Mount Studio children
  S->>S: Load generation and selected output in target workspace
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Honor workspace in Studio deep links"](https://github.com/canvascoding/canvas-notebook/commit/15347226c6030e161f33200ce53030bb3f3468ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63504823)</sub>

<!-- /greptile_comment -->
